### PR TITLE
refactor(tls): move PEM parsing from TlsUtil to certificate-test-support

### DIFF
--- a/kroxylicious-certificate-test-support/src/main/java/io/kroxylicious/testing/certificate/PemParser.java
+++ b/kroxylicious-certificate-test-support/src/main/java/io/kroxylicious/testing/certificate/PemParser.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMEncryptedKeyPair;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
@@ -82,7 +83,9 @@ public final class PemParser {
                     throw new IOException("Encrypted private key requires a password");
                 }
                 PrivateKeyInfo decrypted = encryptedInfo.decryptPrivateKeyInfo(
-                        new JceOpenSSLPKCS8DecryptorProviderBuilder().build(password));
+                        new JceOpenSSLPKCS8DecryptorProviderBuilder()
+                                .setProvider(new BouncyCastleProvider())
+                                .build(password));
                 return converter.getPrivateKey(decrypted);
             }
             else if (object instanceof PEMEncryptedKeyPair encryptedKeyPair) {
@@ -90,7 +93,9 @@ public final class PemParser {
                     throw new IOException("Encrypted private key requires a password");
                 }
                 PEMKeyPair decrypted = encryptedKeyPair.decryptKeyPair(
-                        new JcePEMDecryptorProviderBuilder().build(password));
+                        new JcePEMDecryptorProviderBuilder()
+                                .setProvider(new BouncyCastleProvider())
+                                .build(password));
                 return converter.getKeyPair(decrypted).getPrivate();
             }
             else {

--- a/kroxylicious-certificate-test-support/src/main/java/io/kroxylicious/testing/certificate/PemParser.java
+++ b/kroxylicious-certificate-test-support/src/main/java/io/kroxylicious/testing/certificate/PemParser.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.testing.certificate;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.openssl.PEMEncryptedKeyPair;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8DecryptorProviderBuilder;
+import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
+import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Parses PEM-encoded private keys and certificate chains.
+ */
+public final class PemParser {
+
+    private PemParser() {
+    }
+
+    /**
+     * Parses a PEM-encoded private key from a byte array.
+     *
+     * @param pemKeyBytes PEM-encoded private key bytes
+     * @return the parsed PrivateKey
+     * @throws IOException if the key cannot be parsed
+     */
+    @NonNull
+    public static PrivateKey parsePrivateKey(@NonNull byte[] pemKeyBytes) throws IOException {
+        return parsePrivateKey(pemKeyBytes, null);
+    }
+
+    /**
+     * Parses a PEM-encoded private key from a byte array, with optional password for encrypted keys.
+     *
+     * @param pemKeyBytes PEM-encoded private key bytes
+     * @param password password for decrypting the private key, or {@code null} if unencrypted
+     * @return the parsed PrivateKey
+     * @throws IOException if the key cannot be parsed
+     */
+    @NonNull
+    public static PrivateKey parsePrivateKey(@NonNull byte[] pemKeyBytes,
+                                             @Nullable char[] password)
+            throws IOException {
+        try (Reader reader = new InputStreamReader(new java.io.ByteArrayInputStream(pemKeyBytes), StandardCharsets.US_ASCII);
+                PEMParser pemParser = new PEMParser(reader)) {
+
+            Object object = pemParser.readObject();
+            if (object == null) {
+                throw new IOException("No private key found in PEM data");
+            }
+
+            JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+
+            if (object instanceof PEMKeyPair pemKeyPair) {
+                return converter.getKeyPair(pemKeyPair).getPrivate();
+            }
+            else if (object instanceof PrivateKeyInfo privateKeyInfo) {
+                return converter.getPrivateKey(privateKeyInfo);
+            }
+            else if (object instanceof PKCS8EncryptedPrivateKeyInfo encryptedInfo) {
+                if (password == null) {
+                    throw new IOException("Encrypted private key requires a password");
+                }
+                PrivateKeyInfo decrypted = encryptedInfo.decryptPrivateKeyInfo(
+                        new JceOpenSSLPKCS8DecryptorProviderBuilder().build(password));
+                return converter.getPrivateKey(decrypted);
+            }
+            else if (object instanceof PEMEncryptedKeyPair encryptedKeyPair) {
+                if (password == null) {
+                    throw new IOException("Encrypted private key requires a password");
+                }
+                PEMKeyPair decrypted = encryptedKeyPair.decryptKeyPair(
+                        new JcePEMDecryptorProviderBuilder().build(password));
+                return converter.getKeyPair(decrypted).getPrivate();
+            }
+            else {
+                throw new IOException("Unexpected PEM object type: " + object.getClass().getName());
+            }
+        }
+        catch (IOException e) {
+            throw e;
+        }
+        catch (Exception e) {
+            throw new IOException("Failed to parse private key: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Parses a PEM-encoded certificate chain from a byte array.
+     *
+     * @param pemBytes PEM-encoded certificate bytes
+     * @return array of parsed X509Certificates
+     * @throws IOException if the certificates cannot be parsed
+     */
+    @NonNull
+    public static X509Certificate[] parseCertificateChain(@NonNull byte[] pemBytes) throws IOException {
+        try (Reader reader = new InputStreamReader(new java.io.ByteArrayInputStream(pemBytes), StandardCharsets.US_ASCII);
+                PEMParser pemParser = new PEMParser(reader)) {
+
+            JcaX509CertificateConverter converter = new JcaX509CertificateConverter();
+            List<X509Certificate> certificates = new ArrayList<>();
+
+            Object object;
+            while ((object = pemParser.readObject()) != null) {
+                if (object instanceof X509CertificateHolder holder) {
+                    certificates.add(converter.getCertificate(holder));
+                }
+            }
+
+            if (certificates.isEmpty()) {
+                throw new IOException("No certificates found in PEM data");
+            }
+
+            return certificates.toArray(new X509Certificate[0]);
+        }
+        catch (IOException e) {
+            throw e;
+        }
+        catch (Exception e) {
+            throw new IOException("Failed to parse certificate chain: " + e.getMessage(), e);
+        }
+    }
+}

--- a/kroxylicious-certificate-test-support/src/test/java/io/kroxylicious/testing/certificate/PemParserTest.java
+++ b/kroxylicious-certificate-test-support/src/test/java/io/kroxylicious/testing/certificate/PemParserTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.testing.certificate;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.openssl.jcajce.JcaPKCS8Generator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PemParserTest {
+
+    private static KeyPair keyPair;
+    private static X509Certificate certificate;
+    private static byte[] pkcs8KeyPem;
+    private static byte[] pkcs1KeyPem;
+    private static byte[] certPem;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        keyPair = CertificateGenerator.generateRsaKeyPair();
+        certificate = CertificateGenerator.generateSelfSignedX509Certificate(keyPair);
+
+        pkcs1KeyPem = Files.readAllBytes(CertificateGenerator.writeRsaPrivateKeyPem(keyPair));
+        certPem = Files.readAllBytes(CertificateGenerator.generateCertPem(certificate));
+        pkcs8KeyPem = writePkcs8Pem(keyPair.getPrivate());
+    }
+
+    private static byte[] writePkcs8Pem(PrivateKey key) throws IOException {
+        StringWriter sw = new StringWriter();
+        try (JcaPEMWriter writer = new JcaPEMWriter(sw)) {
+            writer.writeObject(new JcaPKCS8Generator(key, null));
+        }
+        return sw.toString().getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+    }
+
+    @Nested
+    class ParsePrivateKey {
+
+        @Test
+        void parsesPkcs8RsaKey() throws Exception {
+            PrivateKey parsed = PemParser.parsePrivateKey(pkcs8KeyPem);
+            assertThat(parsed.getAlgorithm()).isEqualTo("RSA");
+            assertThat(parsed.getEncoded()).isEqualTo(keyPair.getPrivate().getEncoded());
+        }
+
+        @Test
+        void parsesPkcs1RsaKey() throws Exception {
+            PrivateKey parsed = PemParser.parsePrivateKey(pkcs1KeyPem);
+            assertThat(parsed.getAlgorithm()).isEqualTo("RSA");
+            assertThat(parsed.getEncoded()).isEqualTo(keyPair.getPrivate().getEncoded());
+        }
+
+        @Test
+        void rejectsEmptyPemData() {
+            assertThatThrownBy(() -> PemParser.parsePrivateKey("".getBytes()))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("No private key found");
+        }
+
+        @Test
+        void rejectsGarbageData() {
+            assertThatThrownBy(() -> PemParser.parsePrivateKey("not a pem file".getBytes()))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("No private key found");
+        }
+
+        @Test
+        void rejectsInvalidKeyData() {
+            String pem = "-----BEGIN PRIVATE KEY-----\nYWJj\n-----END PRIVATE KEY-----\n";
+            assertThatThrownBy(() -> PemParser.parsePrivateKey(pem.getBytes()))
+                    .isInstanceOf(IOException.class);
+        }
+
+        @Test
+        void handlesWhitespaceInPemBody() throws Exception {
+            String pemWithExtraSpace = "-----BEGIN PRIVATE KEY-----\n\n  "
+                    + Base64.getMimeEncoder(64, "\n".getBytes())
+                            .encodeToString(keyPair.getPrivate().getEncoded())
+                    + "\n  \n-----END PRIVATE KEY-----\n";
+            PrivateKey parsed = PemParser.parsePrivateKey(pemWithExtraSpace.getBytes());
+            assertThat(parsed.getAlgorithm()).isEqualTo("RSA");
+        }
+    }
+
+    @Nested
+    class ParseCertificateChain {
+
+        @Test
+        void parsesSingleCertificate() throws Exception {
+            X509Certificate[] chain = PemParser.parseCertificateChain(certPem);
+            assertThat(chain).hasSize(1);
+            assertThat(chain[0].getSubjectX500Principal()).isEqualTo(certificate.getSubjectX500Principal());
+        }
+
+        @Test
+        void parsesMultipleCertificates() throws Exception {
+            KeyPair otherPair = CertificateGenerator.generateRsaKeyPair();
+            X509Certificate otherCert = CertificateGenerator.generateSelfSignedX509Certificate(otherPair);
+            byte[] otherCertPem = Files.readAllBytes(CertificateGenerator.generateCertPem(otherCert));
+
+            byte[] multiPem = new byte[certPem.length + otherCertPem.length];
+            System.arraycopy(certPem, 0, multiPem, 0, certPem.length);
+            System.arraycopy(otherCertPem, 0, multiPem, certPem.length, otherCertPem.length);
+
+            X509Certificate[] chain = PemParser.parseCertificateChain(multiPem);
+            assertThat(chain).hasSize(2);
+        }
+
+        @Test
+        void rejectsEmptyData() {
+            assertThatThrownBy(() -> PemParser.parseCertificateChain("".getBytes()))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("No certificates found");
+        }
+
+        @Test
+        void rejectsGarbageData() {
+            assertThatThrownBy(() -> PemParser.parseCertificateChain("not a cert".getBytes()))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("No certificates found");
+        }
+    }
+}

--- a/kroxylicious-certificate-test-support/src/test/java/io/kroxylicious/testing/certificate/PemParserTest.java
+++ b/kroxylicious-certificate-test-support/src/test/java/io/kroxylicious/testing/certificate/PemParserTest.java
@@ -8,14 +8,21 @@ package io.kroxylicious.testing.certificate;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
+import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
+import java.security.spec.ECGenParameterSpec;
 import java.util.Base64;
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.openssl.jcajce.JcaPKCS8Generator;
+import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder;
+import org.bouncycastle.openssl.jcajce.JcePEMEncryptorBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PemParserTest {
 
-    private static KeyPair keyPair;
+    private static KeyPair rsaKeyPair;
     private static X509Certificate certificate;
     private static byte[] pkcs8KeyPem;
     private static byte[] pkcs1KeyPem;
@@ -33,12 +40,12 @@ class PemParserTest {
 
     @BeforeAll
     static void setUp() throws Exception {
-        keyPair = CertificateGenerator.generateRsaKeyPair();
-        certificate = CertificateGenerator.generateSelfSignedX509Certificate(keyPair);
+        rsaKeyPair = CertificateGenerator.generateRsaKeyPair();
+        certificate = CertificateGenerator.generateSelfSignedX509Certificate(rsaKeyPair);
 
-        pkcs1KeyPem = Files.readAllBytes(CertificateGenerator.writeRsaPrivateKeyPem(keyPair));
+        pkcs1KeyPem = Files.readAllBytes(CertificateGenerator.writeRsaPrivateKeyPem(rsaKeyPair));
         certPem = Files.readAllBytes(CertificateGenerator.generateCertPem(certificate));
-        pkcs8KeyPem = writePkcs8Pem(keyPair.getPrivate());
+        pkcs8KeyPem = writePkcs8Pem(rsaKeyPair.getPrivate());
     }
 
     private static byte[] writePkcs8Pem(PrivateKey key) throws IOException {
@@ -46,7 +53,33 @@ class PemParserTest {
         try (JcaPEMWriter writer = new JcaPEMWriter(sw)) {
             writer.writeObject(new JcaPKCS8Generator(key, null));
         }
-        return sw.toString().getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+        return sw.toString().getBytes(StandardCharsets.US_ASCII);
+    }
+
+    private static byte[] writeEncryptedPkcs8Pem(PrivateKey key, char[] password) throws Exception {
+        var encryptorBuilder = new JceOpenSSLPKCS8EncryptorBuilder(org.bouncycastle.asn1.nist.NISTObjectIdentifiers.id_aes256_CBC);
+        encryptorBuilder.setProvider(new BouncyCastleProvider());
+        encryptorBuilder.setPassword(password);
+        encryptorBuilder.setRandom(new SecureRandom());
+        StringWriter sw = new StringWriter();
+        try (JcaPEMWriter writer = new JcaPEMWriter(sw)) {
+            writer.writeObject(new JcaPKCS8Generator(key, encryptorBuilder.build()));
+        }
+        return sw.toString().getBytes(StandardCharsets.US_ASCII);
+    }
+
+    private static byte[] writeTraditionalEncryptedPem(KeyPair pair, char[] password) throws IOException {
+        StringWriter sw = new StringWriter();
+        try (JcaPEMWriter writer = new JcaPEMWriter(sw)) {
+            writer.writeObject(pair.getPrivate(), new JcePEMEncryptorBuilder("AES-128-CBC").setProvider(new BouncyCastleProvider()).build(password));
+        }
+        return sw.toString().getBytes(StandardCharsets.US_ASCII);
+    }
+
+    private static KeyPair generateEcKeyPair() throws Exception {
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("EC");
+        gen.initialize(new ECGenParameterSpec("secp256r1"), new SecureRandom());
+        return gen.generateKeyPair();
     }
 
     @Nested
@@ -56,14 +89,74 @@ class PemParserTest {
         void parsesPkcs8RsaKey() throws Exception {
             PrivateKey parsed = PemParser.parsePrivateKey(pkcs8KeyPem);
             assertThat(parsed.getAlgorithm()).isEqualTo("RSA");
-            assertThat(parsed.getEncoded()).isEqualTo(keyPair.getPrivate().getEncoded());
+            assertThat(parsed.getEncoded()).isEqualTo(rsaKeyPair.getPrivate().getEncoded());
         }
 
         @Test
         void parsesPkcs1RsaKey() throws Exception {
             PrivateKey parsed = PemParser.parsePrivateKey(pkcs1KeyPem);
             assertThat(parsed.getAlgorithm()).isEqualTo("RSA");
-            assertThat(parsed.getEncoded()).isEqualTo(keyPair.getPrivate().getEncoded());
+            assertThat(parsed.getEncoded()).isEqualTo(rsaKeyPair.getPrivate().getEncoded());
+        }
+
+        @Test
+        void parsesEcKey() throws Exception {
+            KeyPair ecPair = generateEcKeyPair();
+            byte[] ecPem = writePkcs8Pem(ecPair.getPrivate());
+            PrivateKey parsed = PemParser.parsePrivateKey(ecPem);
+            assertThat(parsed.getAlgorithm()).isEqualTo("EC");
+            assertThat(parsed.getEncoded()).isEqualTo(ecPair.getPrivate().getEncoded());
+        }
+
+        @Test
+        void parsesEncryptedPkcs8Key() throws Exception {
+            char[] password = "test-password".toCharArray();
+            byte[] encryptedPem = writeEncryptedPkcs8Pem(rsaKeyPair.getPrivate(), password);
+            PrivateKey parsed = PemParser.parsePrivateKey(encryptedPem, password);
+            assertThat(parsed.getAlgorithm()).isEqualTo("RSA");
+            assertThat(parsed.getEncoded()).isEqualTo(rsaKeyPair.getPrivate().getEncoded());
+        }
+
+        @Test
+        void parsesTraditionalEncryptedKey() throws Exception {
+            char[] password = "test-password".toCharArray();
+            byte[] encryptedPem = writeTraditionalEncryptedPem(rsaKeyPair, password);
+            PrivateKey parsed = PemParser.parsePrivateKey(encryptedPem, password);
+            assertThat(parsed.getAlgorithm()).isEqualTo("RSA");
+            assertThat(parsed.getEncoded()).isEqualTo(rsaKeyPair.getPrivate().getEncoded());
+        }
+
+        @Test
+        void rejectsEncryptedPkcs8KeyWithoutPassword() throws Exception {
+            char[] password = "test-password".toCharArray();
+            byte[] encryptedPem = writeEncryptedPkcs8Pem(rsaKeyPair.getPrivate(), password);
+            assertThatThrownBy(() -> PemParser.parsePrivateKey(encryptedPem))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("Encrypted private key requires a password");
+        }
+
+        @Test
+        void rejectsTraditionalEncryptedKeyWithoutPassword() throws Exception {
+            char[] password = "test-password".toCharArray();
+            byte[] encryptedPem = writeTraditionalEncryptedPem(rsaKeyPair, password);
+            assertThatThrownBy(() -> PemParser.parsePrivateKey(encryptedPem))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("Encrypted private key requires a password");
+        }
+
+        @Test
+        void rejectsEncryptedKeyWithWrongPassword() throws Exception {
+            char[] password = "correct-password".toCharArray();
+            byte[] encryptedPem = writeEncryptedPkcs8Pem(rsaKeyPair.getPrivate(), password);
+            assertThatThrownBy(() -> PemParser.parsePrivateKey(encryptedPem, "wrong-password".toCharArray()))
+                    .isInstanceOf(IOException.class);
+        }
+
+        @Test
+        void rejectsCertificatePemAsPrivateKey() {
+            assertThatThrownBy(() -> PemParser.parsePrivateKey(certPem))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("Unexpected PEM object type");
         }
 
         @Test
@@ -91,7 +184,7 @@ class PemParserTest {
         void handlesWhitespaceInPemBody() throws Exception {
             String pemWithExtraSpace = "-----BEGIN PRIVATE KEY-----\n\n  "
                     + Base64.getMimeEncoder(64, "\n".getBytes())
-                            .encodeToString(keyPair.getPrivate().getEncoded())
+                            .encodeToString(rsaKeyPair.getPrivate().getEncoded())
                     + "\n  \n-----END PRIVATE KEY-----\n";
             PrivateKey parsed = PemParser.parsePrivateKey(pemWithExtraSpace.getBytes());
             assertThat(parsed.getAlgorithm()).isEqualTo("RSA");
@@ -123,6 +216,35 @@ class PemParserTest {
         }
 
         @Test
+        void preservesChainOrder() throws Exception {
+            KeyPair pair1 = CertificateGenerator.generateRsaKeyPair();
+            KeyPair pair2 = CertificateGenerator.generateRsaKeyPair();
+            X509Certificate cert1 = CertificateGenerator.generateSelfSignedX509Certificate(pair1);
+            X509Certificate cert2 = CertificateGenerator.generateSelfSignedX509Certificate(pair2);
+            byte[] pem1 = Files.readAllBytes(CertificateGenerator.generateCertPem(cert1));
+            byte[] pem2 = Files.readAllBytes(CertificateGenerator.generateCertPem(cert2));
+
+            byte[] multiPem = new byte[pem1.length + pem2.length];
+            System.arraycopy(pem1, 0, multiPem, 0, pem1.length);
+            System.arraycopy(pem2, 0, multiPem, pem1.length, pem2.length);
+
+            X509Certificate[] chain = PemParser.parseCertificateChain(multiPem);
+            assertThat(chain[0]).isEqualTo(cert1);
+            assertThat(chain[1]).isEqualTo(cert2);
+        }
+
+        @Test
+        void ignoresNonCertificateObjects() throws Exception {
+            byte[] multiPem = new byte[pkcs8KeyPem.length + certPem.length];
+            System.arraycopy(pkcs8KeyPem, 0, multiPem, 0, pkcs8KeyPem.length);
+            System.arraycopy(certPem, 0, multiPem, pkcs8KeyPem.length, certPem.length);
+
+            X509Certificate[] chain = PemParser.parseCertificateChain(multiPem);
+            assertThat(chain).hasSize(1);
+            assertThat(chain[0].getSubjectX500Principal()).isEqualTo(certificate.getSubjectX500Principal());
+        }
+
+        @Test
         void rejectsEmptyData() {
             assertThatThrownBy(() -> PemParser.parseCertificateChain("".getBytes()))
                     .isInstanceOf(IOException.class)
@@ -132,6 +254,13 @@ class PemParserTest {
         @Test
         void rejectsGarbageData() {
             assertThatThrownBy(() -> PemParser.parseCertificateChain("not a cert".getBytes()))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("No certificates found");
+        }
+
+        @Test
+        void rejectsPemContainingOnlyPrivateKey() {
+            assertThatThrownBy(() -> PemParser.parseCertificateChain(pkcs8KeyPem))
                     .isInstanceOf(IOException.class)
                     .hasMessageContaining("No certificates found");
         }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/TlsCredentialSupplierIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/TlsCredentialSupplierIT.java
@@ -7,6 +7,8 @@
 package io.kroxylicious.it;
 
 import java.nio.file.Files;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
@@ -29,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.config.secret.InlinePassword;
 import io.kroxylicious.proxy.config.tls.TlsClientAuth;
+import io.kroxylicious.proxy.config.tls.TlsCredentialSupplierConfig;
 import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 import io.kroxylicious.proxy.plugin.Plugins;
@@ -39,6 +42,7 @@ import io.kroxylicious.proxy.tls.ServerTlsCredentialSupplierFactory;
 import io.kroxylicious.proxy.tls.ServerTlsCredentialSupplierFactoryContext;
 import io.kroxylicious.proxy.tls.TlsCredentials;
 import io.kroxylicious.testing.certificate.CertificateGenerator;
+import io.kroxylicious.testing.certificate.PemParser;
 import io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.Tls;
@@ -159,8 +163,8 @@ class TlsCredentialSupplierIT extends AbstractTlsIT {
                 try {
                     byte[] certBytes = Files.readAllBytes(keys.selfSignedCertificatePem());
                     byte[] keyBytes = Files.readAllBytes(keys.privateKeyPem());
-                    java.security.PrivateKey key = io.kroxylicious.proxy.internal.tls.TlsUtil.parsePrivateKey(keyBytes);
-                    java.security.cert.X509Certificate[] chain = io.kroxylicious.proxy.internal.tls.TlsUtil.parseCertificateChain(certBytes);
+                    PrivateKey key = PemParser.parsePrivateKey(keyBytes);
+                    X509Certificate[] chain = PemParser.parseCertificateChain(certBytes);
                     TlsCredentials creds = context.tlsCredentials(key, chain);
                     return CompletableFuture.completedFuture(creds);
                 }
@@ -173,8 +177,8 @@ class TlsCredentialSupplierIT extends AbstractTlsIT {
             try {
                 byte[] certBytes = Files.readAllBytes(sharedContext.defaultKeys.selfSignedCertificatePem());
                 byte[] keyBytes = Files.readAllBytes(sharedContext.defaultKeys.privateKeyPem());
-                java.security.PrivateKey key = io.kroxylicious.proxy.internal.tls.TlsUtil.parsePrivateKey(keyBytes);
-                java.security.cert.X509Certificate[] chain = io.kroxylicious.proxy.internal.tls.TlsUtil.parseCertificateChain(certBytes);
+                PrivateKey key = PemParser.parsePrivateKey(keyBytes);
+                X509Certificate[] chain = PemParser.parseCertificateChain(certBytes);
                 TlsCredentials creds = context.tlsCredentials(key, chain);
                 return CompletableFuture.completedFuture(creds);
             }
@@ -203,7 +207,7 @@ class TlsCredentialSupplierIT extends AbstractTlsIT {
                             .withNewTls()
                                 .withNewInsecureTlsTrust(true)
                                 // Configure TLS credential supplier using plugin name
-                                .withCredentialSupplier(new io.kroxylicious.proxy.config.tls.TlsCredentialSupplierConfig(
+                                .withCredentialSupplier(new TlsCredentialSupplierConfig(
                                     TestCredentialSupplierFactory.class.getName(),
                                     new TestSupplierConfig("demo", "default")))
                             .endTls()
@@ -251,7 +255,7 @@ class TlsCredentialSupplierIT extends AbstractTlsIT {
                             .withBootstrapServers(bootstrapServers)
                             .withNewTls()
                                 .withNewInsecureTlsTrust(true)
-                                .withCredentialSupplier(new io.kroxylicious.proxy.config.tls.TlsCredentialSupplierConfig(
+                                .withCredentialSupplier(new TlsCredentialSupplierConfig(
                                     TestCredentialSupplierFactory.class.getName(),
                                     new TestSupplierConfig("demo", "default")))
                             .endTls()
@@ -302,7 +306,7 @@ class TlsCredentialSupplierIT extends AbstractTlsIT {
                             .withBootstrapServers(bootstrapServers)
                             .withNewTls()
                                 .withNewInsecureTlsTrust(true)
-                                .withCredentialSupplier(new io.kroxylicious.proxy.config.tls.TlsCredentialSupplierConfig(
+                                .withCredentialSupplier(new TlsCredentialSupplierConfig(
                                     TestCredentialSupplierFactory.class.getName(),
                                     new TestSupplierConfig("demo", "tracking")))
                             .endTls()
@@ -355,7 +359,7 @@ class TlsCredentialSupplierIT extends AbstractTlsIT {
                             .withBootstrapServers(bootstrapServers)
                             .withNewTls()
                                 .withNewInsecureTlsTrust(true)
-                                .withCredentialSupplier(new io.kroxylicious.proxy.config.tls.TlsCredentialSupplierConfig(
+                                .withCredentialSupplier(new TlsCredentialSupplierConfig(
                                     TestCredentialSupplierFactory.class.getName(),
                                     new TestSupplierConfig("demo", "multi-client")))
                             .endTls()

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/tls/TlsUtil.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/tls/TlsUtil.java
@@ -6,33 +6,18 @@
 
 package io.kroxylicious.proxy.internal.tls;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.math.BigInteger;
-import java.security.AlgorithmParameters;
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 
-import javax.crypto.Cipher;
-import javax.crypto.EncryptedPrivateKeyInfo;
-import javax.crypto.SecretKey;
-import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.PBEKeySpec;
 import javax.security.auth.x500.X500Principal;
 
 import org.slf4j.Logger;
@@ -41,230 +26,15 @@ import org.slf4j.LoggerFactory;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * Utility class for TLS credential parsing and validation.
+ * Utility class for TLS credential validation.
  */
 @SuppressWarnings("java:S1192") // ignore dupe string literals is due to logger keys
 public class TlsUtil {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TlsUtil.class);
 
-    private static final String BEGIN_MARKER = "-----BEGIN ";
-    private static final String END_MARKER = "-----END ";
-    private static final String PRIVATE_KEY_SUFFIX = "PRIVATE KEY-----";
-
     private TlsUtil() {
         // Utility class
-    }
-
-    /**
-     * Parses a PEM-encoded private key from a byte array.
-     *
-     * @param pemKeyBytes PEM-encoded private key bytes
-     * @return The parsed PrivateKey
-     * @throws IOException if the key cannot be parsed
-     */
-    @NonNull
-    public static PrivateKey parsePrivateKey(@NonNull byte[] pemKeyBytes) throws IOException {
-        return parsePrivateKey(pemKeyBytes, null);
-    }
-
-    /**
-     * Parses a PEM-encoded private key from a byte array, with optional password for encrypted keys.
-     *
-     * @param pemKeyBytes PEM-encoded private key bytes
-     * @param password password for decrypting the private key, or {@code null} if unencrypted
-     * @return The parsed PrivateKey
-     * @throws IOException if the key cannot be parsed
-     */
-    @NonNull
-    public static PrivateKey parsePrivateKey(@NonNull byte[] pemKeyBytes, @edu.umd.cs.findbugs.annotations.Nullable char[] password) throws IOException {
-        try {
-            String pemString = new String(pemKeyBytes, java.nio.charset.StandardCharsets.US_ASCII);
-
-            // Find the BEGIN marker for a private key
-            int beginIdx = pemString.indexOf(BEGIN_MARKER);
-            if (beginIdx < 0 || !pemString.substring(beginIdx + BEGIN_MARKER.length()).contains(PRIVATE_KEY_SUFFIX)) {
-                throw new IOException("No private key found in PEM data");
-            }
-
-            // Extract the header type (e.g. "PRIVATE KEY", "RSA PRIVATE KEY")
-            int headerStart = beginIdx + BEGIN_MARKER.length();
-            int headerEnd = pemString.indexOf("-----", headerStart);
-            String headerType = pemString.substring(headerStart, headerEnd);
-
-            // Extract Base64 body between the markers
-            String beginLine = BEGIN_MARKER + headerType + "-----";
-            String endLine = END_MARKER + headerType + "-----";
-            int bodyStart = pemString.indexOf(beginLine) + beginLine.length();
-            int bodyEnd = pemString.indexOf(endLine);
-            if (bodyEnd < 0) {
-                throw new IOException("No matching END marker found for " + headerType);
-            }
-
-            String base64Key = pemString.substring(bodyStart, bodyEnd).replaceAll("\\s", "");
-            byte[] keyBytes = Base64.getDecoder().decode(base64Key);
-
-            // Handle encrypted PKCS#8 private keys
-            if (password != null) {
-                keyBytes = decryptPrivateKey(keyBytes, password);
-            }
-
-            // Handle PKCS#1 format ("RSA PRIVATE KEY") by converting to PKCS#8
-            if (headerType.startsWith("RSA")) {
-                return parsePkcs1RsaPrivateKey(keyBytes);
-            }
-
-            // Handle PKCS#8 format ("PRIVATE KEY") - try common key algorithms
-            return parsePkcs8PrivateKey(keyBytes);
-        }
-        catch (NoSuchAlgorithmException e) {
-            throw new IOException("Required cryptographic algorithm not available", e);
-        }
-    }
-
-    private static byte[] decryptPrivateKey(byte[] keyBytes, char[] password) throws IOException {
-        PBEKeySpec pbeKeySpec = null;
-        try {
-            EncryptedPrivateKeyInfo encryptedInfo = new EncryptedPrivateKeyInfo(keyBytes);
-            Cipher cipher = Cipher.getInstance(encryptedInfo.getAlgName());
-            SecretKeyFactory skf = SecretKeyFactory.getInstance(encryptedInfo.getAlgName());
-            pbeKeySpec = new PBEKeySpec(password);
-            SecretKey pbeKey = skf.generateSecret(pbeKeySpec);
-            AlgorithmParameters algParams = encryptedInfo.getAlgParameters();
-            cipher.init(Cipher.DECRYPT_MODE, pbeKey, algParams);
-            PKCS8EncodedKeySpec decryptedSpec = encryptedInfo.getKeySpec(cipher);
-            return decryptedSpec.getEncoded();
-        }
-        catch (Exception e) {
-            throw new IOException("Failed to decrypt encrypted private key: " + e.getMessage(), e);
-        }
-        finally {
-            if (pbeKeySpec != null) {
-                pbeKeySpec.clearPassword();
-            }
-        }
-    }
-
-    private static PrivateKey parsePkcs1RsaPrivateKey(byte[] keyBytes) throws IOException {
-        try {
-            byte[] pkcs8Bytes = convertPkcs1ToPkcs8(keyBytes);
-            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-            return keyFactory.generatePrivate(new PKCS8EncodedKeySpec(pkcs8Bytes));
-        }
-        catch (Exception e) {
-            throw new IOException("Failed to parse PKCS#1 RSA private key: " + e.getMessage(), e);
-        }
-    }
-
-    private static PrivateKey parsePkcs8PrivateKey(byte[] keyBytes) throws IOException, NoSuchAlgorithmException {
-        String[] algorithms = { "RSA", "EC", "DSA" };
-        for (String algorithm : algorithms) {
-            try {
-                KeyFactory keyFactory = KeyFactory.getInstance(algorithm);
-                PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
-                return keyFactory.generatePrivate(keySpec);
-            }
-            catch (InvalidKeySpecException e) {
-                LOGGER.atDebug()
-                        .addKeyValue("algorithm", algorithm)
-                        .log("Failed to parse private key for algorithm");
-
-            }
-        }
-        throw new IOException("Failed to parse private key with any supported algorithm");
-    }
-
-    /**
-     * Converts PKCS#1 RSA private key bytes to PKCS#8 format by wrapping with the RSA AlgorithmIdentifier.
-     * PKCS#8 = SEQUENCE { version INTEGER, algorithm AlgorithmIdentifier, privateKey OCTET STRING(PKCS#1) }
-     */
-    @SuppressWarnings("java:S125") // it's the ASN.1 schema, not commented-out code,
-    private static byte[] convertPkcs1ToPkcs8(byte[] pkcs1Bytes) {
-        // RSA OID: 1.2.840.113549.1.1.1
-        byte[] rsaOid = { 0x06, 0x09, 0x2a, (byte) 0x86, 0x48, (byte) 0x86, (byte) 0xf7, 0x0d, 0x01, 0x01, 0x01 };
-        // AlgorithmIdentifier: SEQUENCE { OID, NULL }
-        byte[] algorithmIdentifier = new byte[rsaOid.length + 4];
-        algorithmIdentifier[0] = 0x30; // SEQUENCE
-        algorithmIdentifier[1] = (byte) (rsaOid.length + 2);
-        System.arraycopy(rsaOid, 0, algorithmIdentifier, 2, rsaOid.length);
-        algorithmIdentifier[rsaOid.length + 2] = 0x05; // NULL
-        algorithmIdentifier[rsaOid.length + 3] = 0x00;
-
-        // OCTET STRING wrapping the PKCS#1 key
-        byte[] octetString = wrapInAsn1(0x04, pkcs1Bytes);
-        // version INTEGER 0
-        byte[] version = { 0x02, 0x01, 0x00 };
-
-        // SEQUENCE { version, algorithmIdentifier, privateKey }
-        byte[] innerContent = new byte[version.length + algorithmIdentifier.length + octetString.length];
-        int offset = 0;
-        System.arraycopy(version, 0, innerContent, offset, version.length);
-        offset += version.length;
-        System.arraycopy(algorithmIdentifier, 0, innerContent, offset, algorithmIdentifier.length);
-        offset += algorithmIdentifier.length;
-        System.arraycopy(octetString, 0, innerContent, offset, octetString.length);
-
-        return wrapInAsn1(0x30, innerContent);
-    }
-
-    private static byte[] wrapInAsn1(int tag, byte[] content) {
-        byte[] lengthBytes;
-        if (content.length < 128) {
-            lengthBytes = new byte[]{ (byte) content.length };
-        }
-        else if (content.length < 256) {
-            lengthBytes = new byte[]{ (byte) 0x81, (byte) content.length };
-        }
-        else if (content.length < 65536) {
-            lengthBytes = new byte[]{ (byte) 0x82, (byte) (content.length >> 8), (byte) (content.length & 0xFF) };
-        }
-        else {
-            lengthBytes = new byte[]{ (byte) 0x83, (byte) (content.length >> 16), (byte) ((content.length >> 8) & 0xFF), (byte) (content.length & 0xFF) };
-        }
-        byte[] result = new byte[1 + lengthBytes.length + content.length];
-        result[0] = (byte) tag;
-        System.arraycopy(lengthBytes, 0, result, 1, lengthBytes.length);
-        System.arraycopy(content, 0, result, 1 + lengthBytes.length, content.length);
-        return result;
-    }
-
-    /**
-     * Parses a PEM-encoded certificate chain from a byte array.
-     *
-     * @param pemBytes PEM-encoded certificate bytes
-     * @return Array of parsed X509Certificates
-     * @throws IOException if the certificates cannot be parsed
-     */
-    @NonNull
-    public static X509Certificate[] parseCertificateChain(@NonNull byte[] pemBytes) throws IOException {
-        try {
-            CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
-            List<X509Certificate> certificates = new ArrayList<>();
-
-            ByteArrayInputStream bais = new ByteArrayInputStream(pemBytes);
-
-            while (bais.available() > 0) {
-                try {
-                    java.security.cert.Certificate cert = certFactory.generateCertificate(bais);
-                    if (cert instanceof X509Certificate x509Cert) {
-                        certificates.add(x509Cert);
-                    }
-                }
-                catch (CertificateException e) {
-                    // No more certificates to read
-                    break;
-                }
-            }
-
-            if (certificates.isEmpty()) {
-                throw new IOException("No certificates found in PEM data");
-            }
-
-            return certificates.toArray(new X509Certificate[0]);
-        }
-        catch (CertificateException e) {
-            throw new IOException("Failed to parse certificate chain", e);
-        }
     }
 
     /**
@@ -274,7 +44,7 @@ public class TlsUtil {
      * @param certificate The certificate containing the public key
      * @throws BadTlsCredentialsException if the keys don't match
      */
-    public static void validateKeyAndCertMatch(@NonNull PrivateKey privateKey, @NonNull X509Certificate certificate) {
+    static void validateKeyAndCertMatch(@NonNull PrivateKey privateKey, @NonNull X509Certificate certificate) {
         PublicKey publicKey = certificate.getPublicKey();
 
         // Check if the algorithms match

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/tls/TlsUtilTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/tls/TlsUtilTest.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.proxy.internal.tls;
 
-import java.io.IOException;
 import java.math.BigInteger;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -24,7 +23,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -34,117 +32,10 @@ import static org.mockito.Mockito.when;
 class TlsUtilTest {
 
     private static TestCertificateUtil.KeyAndCert keyAndCert;
-    private static String certPem;
-    private static String keyPem;
 
     @BeforeAll
     static void setUp() throws Exception {
         keyAndCert = TestCertificateUtil.generateKeyStoreAndCert();
-        certPem = TestCertificateUtil.toPem(keyAndCert.cert());
-        keyPem = TestCertificateUtil.toPkcs8Pem(keyAndCert.privateKey());
-    }
-
-    @Nested
-    class ParsePrivateKey {
-
-        @Test
-        void parsesPkcs8RsaKey() throws Exception {
-            PrivateKey parsed = TlsUtil.parsePrivateKey(keyPem.getBytes());
-            assertThat(parsed.getAlgorithm()).isEqualTo("RSA");
-            assertThat(parsed.getEncoded()).isEqualTo(keyAndCert.privateKey().getEncoded());
-        }
-
-        @Test
-        void rejectsEmptyPemData() {
-            assertThatThrownBy(() -> TlsUtil.parsePrivateKey("".getBytes()))
-                    .isInstanceOf(IOException.class)
-                    .hasMessageContaining("No private key found");
-        }
-
-        @Test
-        void rejectsGarbageData() {
-            assertThatThrownBy(() -> TlsUtil.parsePrivateKey("not a pem file".getBytes()))
-                    .isInstanceOf(IOException.class)
-                    .hasMessageContaining("No private key found");
-        }
-
-        @Test
-        void rejectsMissingEndMarker() {
-            String broken = "-----BEGIN PRIVATE KEY-----\nMIIE==\n";
-            assertThatThrownBy(() -> TlsUtil.parsePrivateKey(broken.getBytes()))
-                    .isInstanceOf(IOException.class)
-                    .hasMessageContaining("No matching END marker");
-        }
-
-        @Test
-        void rejectsInvalidBase64InPkcs8() {
-            String pem = "-----BEGIN PRIVATE KEY-----\n!!invalid!!\n-----END PRIVATE KEY-----\n";
-            assertThatThrownBy(() -> TlsUtil.parsePrivateKey(pem.getBytes()))
-                    .isInstanceOf(Exception.class);
-        }
-
-        @Test
-        void rejectsInvalidKeyData() {
-            String pem = "-----BEGIN PRIVATE KEY-----\nYWJj\n-----END PRIVATE KEY-----\n";
-            assertThatThrownBy(() -> TlsUtil.parsePrivateKey(pem.getBytes()))
-                    .isInstanceOf(IOException.class)
-                    .hasMessageContaining("Failed to parse private key");
-        }
-
-        @Test
-        void parsesPkcs1RsaKey() throws Exception {
-            String pkcs1Pem = TestCertificateUtil.toPkcs1Pem(keyAndCert.privateKey());
-            PrivateKey parsed = TlsUtil.parsePrivateKey(pkcs1Pem.getBytes());
-            assertThat(parsed.getAlgorithm()).isEqualTo("RSA");
-            // The parsed key should produce the same encoded form as the original
-            assertThat(parsed.getEncoded()).isEqualTo(keyAndCert.privateKey().getEncoded());
-        }
-
-        @Test
-        void handlesWhitespaceInPemBody() throws Exception {
-            // Add extra whitespace/newlines - should still parse
-            String pemWithExtraSpace = "-----BEGIN PRIVATE KEY-----\n\n  " +
-                    java.util.Base64.getMimeEncoder(64, "\n".getBytes())
-                            .encodeToString(keyAndCert.privateKey().getEncoded())
-                    +
-                    "\n  \n-----END PRIVATE KEY-----\n";
-            PrivateKey parsed = TlsUtil.parsePrivateKey(pemWithExtraSpace.getBytes());
-            assertThat(parsed.getAlgorithm()).isEqualTo("RSA");
-        }
-    }
-
-    @Nested
-    class ParseCertificateChain {
-
-        @Test
-        void parsesSingleCertificate() throws Exception {
-            X509Certificate[] chain = TlsUtil.parseCertificateChain(certPem.getBytes());
-            assertThat(chain).hasSize(1);
-            assertThat(chain[0].getSubjectX500Principal()).isEqualTo(keyAndCert.cert().getSubjectX500Principal());
-        }
-
-        @Test
-        void parsesMultipleCertificates() throws Exception {
-            TestCertificateUtil.KeyAndCert other = TestCertificateUtil.generateKeyStoreAndCert("CN=other");
-            String multiPem = certPem + TestCertificateUtil.toPem(other.cert());
-
-            X509Certificate[] chain = TlsUtil.parseCertificateChain(multiPem.getBytes());
-            assertThat(chain).hasSize(2);
-        }
-
-        @Test
-        void rejectsEmptyData() {
-            assertThatThrownBy(() -> TlsUtil.parseCertificateChain("".getBytes()))
-                    .isInstanceOf(IOException.class)
-                    .hasMessageContaining("No certificates found");
-        }
-
-        @Test
-        void rejectsGarbageData() {
-            assertThatThrownBy(() -> TlsUtil.parseCertificateChain("not a cert".getBytes()))
-                    .isInstanceOf(IOException.class)
-                    .hasMessageContaining("No certificates found");
-        }
     }
 
     @Nested


### PR DESCRIPTION


### Type of change

- Refactoring

### Description

The parsePrivateKey and parseCertificateChain methods in TlsUtil were only called from test code. Move them to a new PemParser class in kroxylicious-certificate-test-support, reimplemented using the BouncyCastle PEMParser already available in that module. This removes the hand-rolled ASN.1/PKCS#1-to-PKCS#8 conversion code from the runtime module.

TlsUtil now contains only the validation methods used by production code; validateKeyAndCertMatch is reduced to package-private.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>
