### PR TITLE
test(runtime): fix non-deterministic port binding in KafkaProxyShutdownOrderingTest

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -63,6 +63,7 @@ import io.kroxylicious.proxy.internal.VirtualClusterManager;
 import io.kroxylicious.proxy.internal.admin.ManagementInitializer;
 import io.kroxylicious.proxy.internal.config.Features;
 import io.kroxylicious.proxy.internal.net.DefaultNetworkBindingOperationProcessor;
+import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.EndpointRegistry;
 import io.kroxylicious.proxy.internal.net.NetworkBindingOperationProcessor;
 import io.kroxylicious.proxy.internal.util.Metrics;
@@ -465,6 +466,19 @@ public final class KafkaProxy implements AutoCloseable {
     @Nullable
     VirtualClusterLifecycleManager lifecycleManagerFor(String clusterName) {
         return virtualClusterManager.lifecycleManagerFor(clusterName);
+    }
+
+    /**
+     * Returns the actual local port that the proxy is listening on for the given configured port.
+     * Useful when the configured port is 0 (meaning the OS assigns an ephemeral port at startup).
+     * Must only be called after a successful {@link #startup()}.
+     *
+     * @param configuredPort the port number used in the proxy configuration (e.g. 0 for OS-assigned)
+     * @return the actual local port the proxy is listening on
+     */
+    @VisibleForTesting
+    int listeningPort(int configuredPort) {
+        return endpointRegistry.localPortFor(Endpoint.createEndpoint(configuredPort, false));
     }
 
     @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -83,12 +83,6 @@ public final class KafkaProxy implements AutoCloseable {
     private static final int JRE_FEATURE_VERSION = Runtime.version().feature();
     private static final TreeSet<Integer> TESTED_JRE_VERSIONS = new TreeSet<>(Set.of(21, 25));
 
-    /**
-     * Sentinel port value meaning "let the OS assign a free port at bind time".
-     * Pass to {@link #listeningPort(String, int)} to discover the actual port after startup.
-     */
-    public static final int OS_ASSIGNED_PORT = 0;
-
     @VisibleForTesting
     record EventGroupConfig(String name, EventLoopGroup bossGroup, EventLoopGroup workerGroup, Class<? extends ServerChannel> clazz,
                             Duration shutdownQuietPeriod, Duration shutdownTimeout) {
@@ -476,11 +470,11 @@ public final class KafkaProxy implements AutoCloseable {
 
     /**
      * Returns the actual local port that the proxy is listening on for the given bind address and configured port.
-     * Useful when the configured port is {@link #OS_ASSIGNED_PORT} (meaning the OS assigns an ephemeral port at startup).
+     * Useful when the configured port is {@link EndpointRegistry#OS_ASSIGNED_PORT} (meaning the OS assigns an ephemeral port at startup).
      * Must only be called after a successful {@link #startup()}.
      *
      * @param bindAddress the bind address used in the proxy configuration, or {@code null} for any-address bindings
-     * @param port the port number used in the proxy configuration (e.g. {@link #OS_ASSIGNED_PORT} for OS-assigned)
+     * @param port the port number used in the proxy configuration (e.g. {@link EndpointRegistry#OS_ASSIGNED_PORT} for OS-assigned)
      * @return the actual local port the proxy is listening on
      */
     @VisibleForTesting

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -83,6 +83,12 @@ public final class KafkaProxy implements AutoCloseable {
     private static final int JRE_FEATURE_VERSION = Runtime.version().feature();
     private static final TreeSet<Integer> TESTED_JRE_VERSIONS = new TreeSet<>(Set.of(21, 25));
 
+    /**
+     * Sentinel port value meaning "let the OS assign a free port at bind time".
+     * Pass to {@link #listeningPort(String, int)} to discover the actual port after startup.
+     */
+    public static final int OS_ASSIGNED_PORT = 0;
+
     @VisibleForTesting
     record EventGroupConfig(String name, EventLoopGroup bossGroup, EventLoopGroup workerGroup, Class<? extends ServerChannel> clazz,
                             Duration shutdownQuietPeriod, Duration shutdownTimeout) {
@@ -469,16 +475,17 @@ public final class KafkaProxy implements AutoCloseable {
     }
 
     /**
-     * Returns the actual local port that the proxy is listening on for the given configured port.
-     * Useful when the configured port is 0 (meaning the OS assigns an ephemeral port at startup).
+     * Returns the actual local port that the proxy is listening on for the given bind address and configured port.
+     * Useful when the configured port is {@link #OS_ASSIGNED_PORT} (meaning the OS assigns an ephemeral port at startup).
      * Must only be called after a successful {@link #startup()}.
      *
-     * @param configuredPort the port number used in the proxy configuration (e.g. 0 for OS-assigned)
+     * @param bindAddress the bind address used in the proxy configuration, or {@code null} for any-address bindings
+     * @param port the port number used in the proxy configuration (e.g. {@link #OS_ASSIGNED_PORT} for OS-assigned)
      * @return the actual local port the proxy is listening on
      */
     @VisibleForTesting
-    int listeningPort(int configuredPort) {
-        return endpointRegistry.localPortFor(Endpoint.createEndpoint(configuredPort, false));
+    int listeningPort(@Nullable String bindAddress, int port) {
+        return endpointRegistry.localPortFor(Endpoint.createEndpoint(Optional.ofNullable(bindAddress), port, false));
     }
 
     @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointRegistry.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.proxy.internal.net;
 
+import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -439,6 +440,15 @@ public class EndpointRegistry implements EndpointReconciler, EndpointBindingReso
     @VisibleForTesting
     int listeningChannelCount() {
         return listeningChannels.size();
+    }
+
+    @VisibleForTesting
+    public int localPortFor(Endpoint endpoint) {
+        var record = listeningChannels.get(endpoint);
+        if (record == null) {
+            throw new IllegalStateException("No listening channel for endpoint " + endpoint);
+        }
+        return ((InetSocketAddress) record.bindingStage().toCompletableFuture().join().localAddress()).getPort();
     }
 
     private CompletionStage<Endpoint> registerBinding(Endpoint key, String host, EndpointBinding virtualClusterBinding) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointRegistry.java
@@ -83,6 +83,13 @@ public class EndpointRegistry implements EndpointReconciler, EndpointBindingReso
     private static final Logger LOGGER = LoggerFactory.getLogger(EndpointRegistry.class);
     public static final String NO_CHANNEL_BINDINGS_MESSAGE = "No channel bindings found for";
     public static final String VIRTUAL_CLUSTER_CANNOT_BE_NULL_MESSAGE = "virtualCluster cannot be null";
+
+    /**
+     * Sentinel port value meaning "let the OS assign a free port at bind time".
+     * Use with {@link io.kroxylicious.proxy.KafkaProxy#listeningPort(String, int)} to discover
+     * the actual port after startup.
+     */
+    public static final int OS_ASSIGNED_PORT = 0;
     private final NetworkBindingOperationProcessor bindingOperationProcessor;
 
     interface RoutingKey {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyShutdownOrderingTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyShutdownOrderingTest.java
@@ -6,7 +6,6 @@
 package io.kroxylicious.proxy;
 
 import java.net.InetSocketAddress;
-import java.net.ServerSocket;
 import java.net.Socket;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -39,8 +38,6 @@ class KafkaProxyShutdownOrderingTest {
      */
     @Test
     void portIsUnboundBeforeDrainCompletes() throws Exception {
-        int proxyPort = freePort();
-
         var drainStarted = new CountDownLatch(1);
         var drainCanComplete = new CountDownLatch(1);
 
@@ -59,6 +56,10 @@ class KafkaProxyShutdownOrderingTest {
             }
         };
 
+        // Port 0 lets the OS assign a free port, eliminating the TOCTOU race of the
+        // find-then-bind pattern. nodeStartPort is set explicitly to keep it out of
+        // the OS ephemeral-port range (32768-60999 on Linux) and away from the fixed
+        // ports used by other test classes in this module (8192-9295).
         var config = """
                 virtualClusters:
                   - name: demo
@@ -68,11 +69,13 @@ class KafkaProxyShutdownOrderingTest {
                     gateways:
                     - name: default
                       portIdentifiesNode:
-                        bootstrapAddress: localhost:%d
-                """.formatted(proxyPort);
+                        bootstrapAddress: localhost:0
+                        nodeStartPort: 11000
+                """;
 
         try (var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures(), dc)) {
             proxy.startup();
+            int proxyPort = proxy.listeningPort(0);
 
             assertThat(canConnect(proxyPort))
                     .as("port should be reachable before shutdown")
@@ -107,8 +110,6 @@ class KafkaProxyShutdownOrderingTest {
      */
     @Test
     void drainFailureIsCaughtAndShutdownCompletes() throws Exception {
-        int proxyPort = freePort();
-
         var dc = new DrainCoordinator() {
             @Override
             public CompletableFuture<Void> drainCluster(String clusterName, Duration timeout) {
@@ -125,8 +126,9 @@ class KafkaProxyShutdownOrderingTest {
                     gateways:
                     - name: default
                       portIdentifiesNode:
-                        bootstrapAddress: localhost:%d
-                """.formatted(proxyPort);
+                        bootstrapAddress: localhost:0
+                        nodeStartPort: 11000
+                """;
 
         try (var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures(), dc)) {
             proxy.startup();
@@ -144,12 +146,6 @@ class KafkaProxyShutdownOrderingTest {
         }
         catch (Exception e) {
             return false;
-        }
-    }
-
-    private static int freePort() throws Exception {
-        try (var s = new ServerSocket(0)) {
-            return s.getLocalPort();
         }
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyShutdownOrderingTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyShutdownOrderingTest.java
@@ -75,7 +75,7 @@ class KafkaProxyShutdownOrderingTest {
 
         try (var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures(), dc)) {
             proxy.startup();
-            int proxyPort = proxy.listeningPort(0);
+            int proxyPort = proxy.listeningPort(null, KafkaProxy.OS_ASSIGNED_PORT);
 
             assertThat(canConnect(proxyPort))
                     .as("port should be reachable before shutdown")

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyShutdownOrderingTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyShutdownOrderingTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Timeout;
 import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.internal.DrainCoordinator;
 import io.kroxylicious.proxy.internal.config.Features;
+import io.kroxylicious.proxy.internal.net.EndpointRegistry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -75,7 +76,7 @@ class KafkaProxyShutdownOrderingTest {
 
         try (var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures(), dc)) {
             proxy.startup();
-            int proxyPort = proxy.listeningPort(null, KafkaProxy.OS_ASSIGNED_PORT);
+            int proxyPort = proxy.listeningPort(null, EndpointRegistry.OS_ASSIGNED_PORT);
 
             assertThat(canConnect(proxyPort))
                     .as("port should be reachable before shutdown")

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/net/EndpointRegistryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/net/EndpointRegistryTest.java
@@ -39,6 +39,7 @@ import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.service.HostPort;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -691,6 +692,25 @@ class EndpointRegistryTest {
         assertThat(rcf.isDone()).isTrue();
         assertThat(rcf.get()).isNull();
         assertThat(endpointRegistry.listeningChannelCount()).isEqualTo(2);
+    }
+
+    @Test
+    void localPortForReturnsActualPortAfterBinding() throws Exception {
+        configureVirtualClusterMock(virtualClusterModel1, DOWNSTREAM_BOOTSTRAP, UPSTREAM_BOOTSTRAP, false);
+        var rf = endpointRegistry.registerVirtualCluster(virtualClusterModel1).toCompletableFuture();
+        verifyAndProcessNetworkEventQueue(createTestNetworkBindRequest(DOWNSTREAM_BOOTSTRAP.port(), false));
+        verifyVirtualClusterRegisterFuture(DOWNSTREAM_BOOTSTRAP.port(), false, rf);
+
+        var endpoint = Endpoint.createEndpoint(DOWNSTREAM_BOOTSTRAP.port(), false);
+        assertThat(endpointRegistry.localPortFor(endpoint)).isEqualTo(DOWNSTREAM_BOOTSTRAP.port());
+    }
+
+    @Test
+    void localPortForThrowsWhenEndpointNotRegistered() {
+        var endpoint = Endpoint.createEndpoint(EndpointRegistry.OS_ASSIGNED_PORT, false);
+        assertThatThrownBy(() -> endpointRegistry.localPortFor(endpoint))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("No listening channel for endpoint");
     }
 
     private Channel createMockNettyChannel(int port) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes a non-deterministic `EADDRINUSE` failure in `KafkaProxyShutdownOrderingTest` caused by a TOCTOU race in the `freePort()` helper: it bound to port 0, noted the OS-assigned port, closed the socket, then passed that port number to the proxy config. In the window between socket close and proxy bind, another process (e.g. a parallel Surefire test class) could claim the port.

**Fix:** Both test configs now use `bootstrapAddress: localhost:0` so Netty asks the OS for an ephemeral port at bind time — no race window. `nodeStartPort` is set explicitly to `11000` to keep the node ports out of the Linux ephemeral range (32768–60999) and away from the fixed ports used by other test classes in this module (8192–9295).

`portIsUnboundBeforeDrainCompletes` queries the actual OS-assigned bootstrap port after startup via a new `@VisibleForTesting KafkaProxy.listeningPort(configuredPort)` helper, which delegates to `EndpointRegistry.localPortFor(Endpoint)`.

### Additional Context

Fixes #3880

### Checklist

- [x] New tests written (where applicable).
- [x] User facing documentation written/updated (where applicable).
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).