### PR TITLE
Admission align with proposal part 2

### DIFF
--- a/kroxylicious-docs/docs/_modules/admission-webhook/con-admission-webhook-overview.adoc
+++ b/kroxylicious-docs/docs/_modules/admission-webhook/con-admission-webhook-overview.adoc
@@ -83,11 +83,11 @@ This ensures proper startup ordering (the sidecar starts before application cont
 On older clusters, the sidecar is injected as a regular container.
 The webhook detects the cluster version automatically at startup.
 
-For clusters running alpha versions of features (e.g. native sidecars on 1.28, OCI image volumes on 1.31-1.32), set the `FEATURE_GATES` environment variable on the webhook deployment to override version-based defaults (e.g. `FEATURE_GATES=SidecarContainers=true,ImageVolume=true`).
+For clusters running alpha versions of features (e.g. native sidecars on 1.28, OCI image volumes on 1.31-1.32), set the `K8S_FEATURE_GATES` environment variable on the webhook deployment to override version-based defaults (e.g. `K8S_FEATURE_GATES=SidecarContainers=true,ImageVolume=true`). This is an escape hatch for when version-based detection is insufficient; deployers are responsible for keeping it in sync with their cluster configuration.
 
 == Pod security context
 
-The webhook sets a container-level security context on the sidecar (`allowPrivilegeEscalation: false`, `capabilities: drop ALL`, `readOnlyRootFilesystem: true`) but does not set a pod-level `securityContext`.
+The webhook sets a container-level security context on the sidecar (`allowPrivilegeEscalation: false`, `capabilities: drop ALL`, `readOnlyRootFilesystem: true`, `seccompProfile: RuntimeDefault`) but does not set a pod-level `securityContext`.
 
 Pod-level security policies such as `runAsNonRoot` and `seccompProfile: RuntimeDefault` should be enforced using Kubernetes https://kubernetes.io/docs/concepts/security/pod-security-standards/[Pod Security Standards] via the `PodSecurity` admission controller.
 Label the namespace with the appropriate enforcement level:

--- a/kroxylicious-kubernetes/kroxylicious-admission/README.md
+++ b/kroxylicious-kubernetes/kroxylicious-admission/README.md
@@ -117,7 +117,7 @@ The webhook is configured via environment variables:
 | `TLS_KEY_PATH` | `/etc/webhook/tls/tls.key` | PEM private key file |
 | `KROXYLICIOUS_IMAGE` | (required) | Default proxy container image |
 | `FAILURE_POLICY` | `Fail` | Error handling policy: `Fail` (deny on error) or `Ignore` (allow on error) |
-| `FEATURE_GATES` | (auto-detect) | Comma-separated feature gate overrides, e.g. `SidecarContainers=false,ImageVolume=false` |
+| `K8S_FEATURE_GATES` | (auto-detect) | Comma-separated Kubernetes feature gate overrides, e.g. `SidecarContainers=false,ImageVolume=false`. Escape hatch for when version-based detection is insufficient; deployers are responsible for keeping it in sync with their cluster. |
 
 ## Deployment
 

--- a/kroxylicious-kubernetes/kroxylicious-admission/packaging/install/03.Deployment.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/packaging/install/03.Deployment.kroxylicious-webhook.yaml
@@ -52,8 +52,6 @@ spec:
               value: /etc/webhook/tls/tls.crt
             - name: TLS_KEY_PATH
               value: /etc/webhook/tls/tls.key
-            - name: FAILURE_POLICY
-              value: "Fail"
           volumeMounts:
             - name: tls
               mountPath: /etc/webhook/tls

--- a/kroxylicious-kubernetes/kroxylicious-admission/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/pom.xml
@@ -69,6 +69,11 @@
             <artifactId>kroxylicious-runtime</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <!-- Only for knowing what TLS key material is acceptable -->
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+        </dependency>
         <!-- fabric8 kubernetes client -->
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
@@ -44,24 +44,24 @@ class AdmissionHandler implements HttpHandler {
     private final String proxyImage;
     private final boolean useNativeSidecar;
     private final boolean useOciImageVolumes;
-    private final boolean failClosed;
+    private final boolean denyUninjected;
 
     AdmissionHandler(
                      @NonNull SidecarConfigResolver configResolver,
                      @NonNull String proxyImage,
                      KubernetesVersion kubernetesVersion,
-                     boolean failClosed) {
+                     boolean denyUninjected) {
         this.configResolver = configResolver;
         this.proxyImage = proxyImage;
         this.useNativeSidecar = kubernetesVersion.supportedNativeSidecar();
         this.useOciImageVolumes = kubernetesVersion.supportsOciImageVolumes();
-        this.failClosed = failClosed;
+        this.denyUninjected = denyUninjected;
     }
 
     AdmissionHandler(
                      @NonNull SidecarConfigResolver configResolver,
                      @NonNull String proxyImage) {
-        this(configResolver, proxyImage, new KubernetesVersion(1, 0), true);
+        this(configResolver, proxyImage, new KubernetesVersion(1, 0), false);
     }
 
     @Override
@@ -94,7 +94,14 @@ class AdmissionHandler implements HttpHandler {
             LOGGER.atError()
                     .setCause(e)
                     .log("Unexpected error handling admission request");
-            sendErrorResponse(exchange, null, "Failed to process admission request");
+            try {
+                exchange.sendResponseHeaders(500, -1);
+            }
+            catch (IOException ioe) {
+                LOGGER.atError()
+                        .setCause(ioe)
+                        .log("Failed to send 500 response");
+            }
         }
         finally {
             exchange.close();
@@ -141,6 +148,11 @@ class AdmissionHandler implements HttpHandler {
                     .log("Sidecar injection decision");
 
             if (decision != InjectionDecision.Decision.INJECT) {
+                if (denyUninjected && decision.isConfigUnavailable()) {
+                    return denyResponse(uid,
+                            "Sidecar injection skipped (" + decision.name()
+                                    + ") and UNINJECTED_POD_POLICY is Deny");
+                }
                 String skipLabel = decision.skipLabel();
                 if (skipLabel != null) {
                     String labelPatch = PodMutator.createSkipLabelPatch(pod, skipLabel);
@@ -188,7 +200,7 @@ class AdmissionHandler implements HttpHandler {
                     .setCause(e)
                     .addKeyValue("uid", uid)
                     .log("Error processing admission request");
-            return errorResponse(uid, "Error processing admission request: " + e.getMessage());
+            throw e;
         }
     }
 
@@ -220,31 +232,4 @@ class AdmissionHandler implements HttpHandler {
         return response;
     }
 
-    @NonNull
-    private AdmissionResponse errorResponse(String uid, String reason) {
-        if (failClosed) {
-            return denyResponse(uid, reason);
-        }
-        return allowResponse(uid);
-    }
-
-    private void sendErrorResponse(HttpExchange exchange, String uid, String reason) {
-        try {
-            AdmissionReview responseReview = new AdmissionReview();
-            responseReview.setApiVersion("admission.k8s.io/v1");
-            responseReview.setKind("AdmissionReview");
-            responseReview.setResponse(errorResponse(uid, reason));
-            byte[] responseBytes = MAPPER.writeValueAsBytes(responseReview);
-            exchange.getResponseHeaders().set("Content-Type", "application/json");
-            exchange.sendResponseHeaders(200, responseBytes.length);
-            try (OutputStream os = exchange.getResponseBody()) {
-                os.write(responseBytes);
-            }
-        }
-        catch (IOException e) {
-            LOGGER.atError()
-                    .setCause(e)
-                    .log("Failed to send error response");
-        }
-    }
 }

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/InjectionDecision.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/InjectionDecision.java
@@ -40,6 +40,10 @@ final class InjectionDecision {
         String skipLabel() {
             return skipLabel;
         }
+
+        boolean isConfigUnavailable() {
+            return this == SKIP_NO_CONFIG || this == SKIP_MULTIPLE_CONFIGS;
+        }
     }
 
     private InjectionDecision() {

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/InjectionDecision.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/InjectionDecision.java
@@ -22,10 +22,10 @@ final class InjectionDecision {
 
     enum Decision {
         INJECT(null),
-        SKIP_ALREADY_INJECTED("already-injected"),
+        SKIP_ALREADY_INJECTED("container-name-conflict"),
         SKIP_OPT_OUT(null),
-        SKIP_NO_CONFIG("no-config"),
-        SKIP_MULTIPLE_CONFIGS("multiple-configs");
+        SKIP_NO_CONFIG("no-KroxyliciousSidecarConfig"),
+        SKIP_MULTIPLE_CONFIGS("ambiguous-KroxyliciousSidecarConfig");
 
         private final String skipLabel;
 

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
@@ -285,6 +285,9 @@ class PodMutator {
                     .withNewCapabilities()
                     .addToDrop("ALL")
                     .endCapabilities()
+                    .withNewSeccompProfile()
+                    .withType("RuntimeDefault")
+                    .endSeccompProfile()
                     .endSecurityContext()
                     .build();
 
@@ -316,6 +319,9 @@ class PodMutator {
                 .withNewCapabilities()
                 .addToDrop("ALL")
                 .endCapabilities()
+                .withNewSeccompProfile()
+                .withType("RuntimeDefault")
+                .endSeccompProfile()
                 .endSecurityContext()
                 .addNewPort()
                 .withContainerPort(managementPort)

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolver.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolver.java
@@ -7,6 +7,8 @@
 package io.kroxylicious.kubernetes.webhook;
 
 import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -20,6 +22,7 @@ import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 import io.kroxylicious.sidecar.v1alpha1.KroxyliciousSidecarConfig;
+import io.kroxylicious.sidecar.v1alpha1.KroxyliciousSidecarConfigSpec;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -196,14 +199,45 @@ class SidecarConfigResolver implements Closeable {
         }
     }
 
+    @VisibleForTesting
+    static List<String> validate(@NonNull KroxyliciousSidecarConfig config) {
+        List<String> errors = new ArrayList<>();
+        KroxyliciousSidecarConfigSpec spec = config.getSpec();
+        if (spec == null) {
+            errors.add("spec is required");
+            return errors;
+        }
+        if (spec.getVirtualClusters() == null || spec.getVirtualClusters().isEmpty()) {
+            errors.add("spec.virtualClusters must contain at least one entry");
+        }
+        else {
+            var vc = spec.getVirtualClusters().get(0);
+            if (vc.getTargetBootstrapServers() == null || vc.getTargetBootstrapServers().isBlank()) {
+                errors.add("spec.virtualClusters[0].targetBootstrapServers is required");
+            }
+        }
+        return errors;
+    }
+
+    private void updateStatus(@NonNull KroxyliciousSidecarConfig config) {
+        if (statusUpdater == null) {
+            return;
+        }
+        List<String> errors = validate(config);
+        if (errors.isEmpty()) {
+            statusUpdater.setReady(config);
+        }
+        else {
+            statusUpdater.setNotReady(config, String.join("; ", errors));
+        }
+    }
+
     private class Handler implements ResourceEventHandler<KroxyliciousSidecarConfig> {
 
         @Override
         public void onAdd(KroxyliciousSidecarConfig obj) {
             put(obj);
-            if (statusUpdater != null) {
-                statusUpdater.setReady(obj);
-            }
+            updateStatus(obj);
             LOGGER.atInfo()
                     .addKeyValue(WebhookLoggingKeys.NAMESPACE, obj.getMetadata().getNamespace())
                     .addKeyValue(WebhookLoggingKeys.NAME, obj.getMetadata().getName())
@@ -215,9 +249,7 @@ class SidecarConfigResolver implements Closeable {
                              KroxyliciousSidecarConfig oldObj,
                              KroxyliciousSidecarConfig newObj) {
             put(newObj);
-            if (statusUpdater != null) {
-                statusUpdater.setReady(newObj);
-            }
+            updateStatus(newObj);
             LOGGER.atInfo()
                     .addKeyValue(WebhookLoggingKeys.NAMESPACE, newObj.getMetadata().getNamespace())
                     .addKeyValue(WebhookLoggingKeys.NAME, newObj.getMetadata().getName())

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/SidecarConfigStatusUpdater.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/SidecarConfigStatusUpdater.java
@@ -29,6 +29,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 class SidecarConfigStatusUpdater {
 
     static final String REASON_ACCEPTED = "Accepted";
+    static final String REASON_INVALID = "Invalid";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SidecarConfigStatusUpdater.class);
 
@@ -81,6 +82,57 @@ class SidecarConfigStatusUpdater {
                     .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
                     .addKeyValue(WebhookLoggingKeys.NAME, name)
                     .log("Set Ready condition on KroxyliciousSidecarConfig");
+        }
+        catch (Exception e) {
+            LOGGER.atWarn()
+                    .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
+                    .addKeyValue(WebhookLoggingKeys.NAME, name)
+                    .addKeyValue("error", e.getMessage())
+                    .setCause(LOGGER.isDebugEnabled() ? e : null)
+                    .log(LOGGER.isDebugEnabled()
+                            ? "Failed to update KroxyliciousSidecarConfig status"
+                            : "Failed to update KroxyliciousSidecarConfig status, increase log level to DEBUG for stacktrace");
+        }
+    }
+
+    /**
+     * Sets the {@code Ready=False} condition on the given config's status.
+     */
+    void setNotReady(
+                     @NonNull KroxyliciousSidecarConfig config,
+                     @NonNull String message) {
+        String namespace = config.getMetadata().getNamespace();
+        String name = config.getMetadata().getName();
+        try {
+            long generation = generation(config);
+            Condition readyCondition = new ConditionBuilder()
+                    .withType(Condition.Type.Ready)
+                    .withStatus(Condition.Status.FALSE)
+                    .withReason(REASON_INVALID)
+                    .withMessage(message)
+                    .withLastTransitionTime(clock.instant())
+                    .withObservedGeneration(generation)
+                    .build();
+
+            client.resources(KroxyliciousSidecarConfig.class)
+                    .inNamespace(namespace)
+                    .withName(name)
+                    .editStatus(existing -> {
+                        KroxyliciousSidecarConfigStatus status = existing.getStatus();
+                        if (status == null) {
+                            status = new KroxyliciousSidecarConfigStatus();
+                            existing.setStatus(status);
+                        }
+                        status.setConditions(List.of(readyCondition));
+                        status.setObservedGeneration(generation);
+                        return existing;
+                    });
+
+            LOGGER.atWarn()
+                    .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
+                    .addKeyValue(WebhookLoggingKeys.NAME, name)
+                    .addKeyValue("message", message)
+                    .log("Set Ready=False condition on KroxyliciousSidecarConfig");
         }
         catch (Exception e) {
             LOGGER.atWarn()

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
@@ -37,7 +37,7 @@ public class WebhookMain {
     private static final String TLS_KEY_PATH_VAR = "TLS_KEY_PATH";
     private static final String KROXYLICIOUS_IMAGE_VAR = "KROXYLICIOUS_IMAGE";
     private static final String FAILURE_POLICY_VAR = "FAILURE_POLICY";
-    static final String FEATURE_GATES_VAR = "FEATURE_GATES";
+    static final String FEATURE_GATES_VAR = "K8S_FEATURE_GATES";
 
     private static final String DEFAULT_BIND_ADDRESS = "0.0.0.0:8443";
     @SuppressWarnings("java:S1075") // there's nothing wrong with hard coding this path.

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
@@ -36,7 +36,7 @@ public class WebhookMain {
     private static final String TLS_CERT_PATH_VAR = "TLS_CERT_PATH";
     private static final String TLS_KEY_PATH_VAR = "TLS_KEY_PATH";
     private static final String KROXYLICIOUS_IMAGE_VAR = "KROXYLICIOUS_IMAGE";
-    private static final String FAILURE_POLICY_VAR = "FAILURE_POLICY";
+    private static final String UNINJECTED_POD_POLICY_VAR = "UNINJECTED_POD_POLICY";
     static final String FEATURE_GATES_VAR = "K8S_FEATURE_GATES";
 
     private static final String DEFAULT_BIND_ADDRESS = "0.0.0.0:8443";
@@ -85,17 +85,17 @@ public class WebhookMain {
         Path certPath = Path.of(env.getOrDefault(TLS_CERT_PATH_VAR, DEFAULT_CERT_PATH));
         Path keyPath = Path.of(env.getOrDefault(TLS_KEY_PATH_VAR, DEFAULT_KEY_PATH));
         String proxyImage = requiredEnv(env, KROXYLICIOUS_IMAGE_VAR);
-        boolean failClosed = parseFailClosed(env);
+        boolean denyUninjected = parseDenyUninjected(env);
         LOGGER.atInfo()
-                .addKeyValue("failurePolicy", failClosed ? "Fail" : "Ignore")
-                .log("Webhook failure policy configured");
+                .addKeyValue("uninjectedPodPolicy", denyUninjected ? "Deny" : "Admit")
+                .log("Uninjected pod policy configured");
 
         KubernetesClient kubeClient = new KubernetesClientBuilder().build();
         var kubernetesVersion = detectVersion(kubeClient, env);
         SidecarConfigStatusUpdater statusUpdater = new SidecarConfigStatusUpdater(kubeClient, Clock.systemUTC());
         SidecarConfigResolver configResolver = new SidecarConfigResolver(kubeClient, statusUpdater);
         AdmissionHandler admissionHandler = new AdmissionHandler(
-                configResolver, proxyImage, kubernetesVersion, failClosed);
+                configResolver, proxyImage, kubernetesVersion, denyUninjected);
         WebhookServer server = new WebhookServer(bindAddress, certPath, keyPath, admissionHandler);
 
         return new WebhookMain(server, configResolver, kubeClient);
@@ -187,14 +187,14 @@ public class WebhookMain {
     }
 
     @VisibleForTesting
-    static boolean parseFailClosed(@NonNull Map<String, String> env) {
-        String value = env.getOrDefault(FAILURE_POLICY_VAR, "Fail");
+    static boolean parseDenyUninjected(@NonNull Map<String, String> env) {
+        String value = env.getOrDefault(UNINJECTED_POD_POLICY_VAR, "Admit");
         return switch (value) {
-            case "Fail" -> true;
-            case "Ignore" -> false;
+            case "Deny" -> true;
+            case "Admit" -> false;
             default -> throw new IllegalStateException(
-                    "Invalid " + FAILURE_POLICY_VAR + " value '" + value
-                            + "': must be 'Fail' or 'Ignore'");
+                    "Invalid " + UNINJECTED_POD_POLICY_VAR + " value '" + value
+                            + "': must be 'Admit' or 'Deny'");
         };
     }
 }

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookServer.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookServer.java
@@ -8,29 +8,23 @@ package io.kroxylicious.kubernetes.webhook;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.InetSocketAddress;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.GeneralSecurityException;
-import java.security.KeyFactory;
-import java.security.KeyStore;
-import java.security.PrivateKey;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateFactory;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.List;
 
-import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
+
+import io.netty.handler.ssl.JdkSslContext;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -83,63 +77,21 @@ class WebhookServer implements Closeable {
                                        @NonNull Path certPath,
                                        @NonNull Path keyPath)
             throws GeneralSecurityException, IOException {
-
-        CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
-
-        // Load certificate chain
-        Collection<? extends Certificate> certs;
-        try (InputStream certStream = Files.newInputStream(certPath)) {
-            certs = certFactory.generateCertificates(certStream);
+        SslContext nettyCtx;
+        try {
+            nettyCtx = SslContextBuilder
+                    .forServer(certPath.toFile(), keyPath.toFile())
+                    .sslProvider(SslProvider.JDK)
+                    .build();
         }
-
-        // Load private key
-        PrivateKey privateKey = loadPrivateKey(keyPath);
-
-        // Build keystore
-        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-        keyStore.load(null, null);
-        keyStore.setKeyEntry("webhook",
-                privateKey,
-                new char[0],
-                certs.toArray(new Certificate[0]));
-
-        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-        kmf.init(keyStore, new char[0]);
-
-        SSLContext sslContext = SSLContext.getInstance("TLS");
-        sslContext.init(kmf.getKeyManagers(), null, null);
-        return sslContext;
-    }
-
-    @NonNull
-    private static PrivateKey loadPrivateKey(@NonNull Path keyPath) throws IOException, GeneralSecurityException {
-        String keyPem = Files.readString(keyPath);
-
-        // Detect PKCS1 format and fail fast
-        if (keyPem.contains("-----BEGIN RSA PRIVATE KEY-----") || keyPem.contains("-----BEGIN EC PRIVATE KEY-----")) {
-            throw new GeneralSecurityException("Private key at " + keyPath + " is in PKCS1 format, which is not supported." +
-                    "The only supported format is PKCS8. (if you are using cert-manager, you can set 'spec.privateKey.encoding' "
-                    + "on your Certificate to 'PKCS8')");
+        catch (SSLException | IllegalArgumentException e) {
+            throw new GeneralSecurityException(
+                    "Failed to load TLS credentials from cert=" + certPath + " key=" + keyPath, e);
         }
-
-        // Strip PEM headers/footers and whitespace
-        String keyBase64 = keyPem
-                .replace("-----BEGIN PRIVATE KEY-----", "")
-                .replace("-----END PRIVATE KEY-----", "")
-                .replaceAll("\\s", "");
-
-        byte[] keyBytes = Base64.getDecoder().decode(keyBase64);
-        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
-
-        // Try RSA first, then EC
-        for (String algorithm : List.of("RSA", "EC")) {
-            try {
-                return KeyFactory.getInstance(algorithm).generatePrivate(keySpec);
-            }
-            catch (GeneralSecurityException ignored) {
-                // Try next algorithm
-            }
+        if (nettyCtx instanceof JdkSslContext jdkCtx) {
+            return jdkCtx.context();
         }
-        throw new GeneralSecurityException("Unable to load private key from " + keyPath + " — unsupported key type");
+        throw new GeneralSecurityException(
+                "Expected JdkSslContext but got " + nettyCtx.getClass().getName());
     }
 }

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractPluginEndToEndKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractPluginEndToEndKT.java
@@ -46,7 +46,7 @@ import io.kroxylicious.kubernetes.api.admission.common.Condition;
 import io.kroxylicious.sidecar.v1alpha1.KroxyliciousSidecarConfig;
 import io.kroxylicious.sidecar.v1alpha1.KroxyliciousSidecarConfigBuilder;
 import io.kroxylicious.sidecar.v1alpha1.kroxylicioussidecarconfigspec.plugins.Image;
-import io.kroxylicious.test.ShellUtils;
+import io.kroxylicious.testing.integration.ShellUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
@@ -38,7 +38,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.kroxylicious.kubernetes.api.admission.common.Condition;
 import io.kroxylicious.sidecar.v1alpha1.KroxyliciousSidecarConfig;
 import io.kroxylicious.sidecar.v1alpha1.KroxyliciousSidecarConfigBuilder;
-import io.kroxylicious.test.ShellUtils;
+import io.kroxylicious.testing.integration.ShellUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
@@ -39,6 +39,7 @@ import io.kroxylicious.sidecar.v1alpha1.KroxyliciousSidecarConfigSpec;
 import io.kroxylicious.sidecar.v1alpha1.kroxylicioussidecarconfigspec.VirtualClusters;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -55,13 +56,10 @@ class AdmissionHandlerTest {
     private SidecarConfigResolver configResolver;
 
     private AdmissionHandler handler;
-    private AdmissionHandler failOpenHandler;
 
     @BeforeEach
     void setUp() {
         handler = new AdmissionHandler(configResolver, PROXY_IMAGE);
-        failOpenHandler = new AdmissionHandler(configResolver, PROXY_IMAGE,
-                new KubernetesVersion(1, 0), false);
     }
 
     // --- processReview() tests ---
@@ -163,6 +161,53 @@ class AdmissionHandlerTest {
     }
 
     @Test
+    void deniesWhenNoConfigAndPolicyIsDeny() {
+        var denyHandler = new AdmissionHandler(
+                configResolver, PROXY_IMAGE, new KubernetesVersion(1, 0), true);
+        when(configResolver.resolve(eq("test-ns"), isNull()))
+                .thenReturn(SidecarConfigResolver.Resolution.noConfig());
+
+        AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
+        AdmissionResponse response = denyHandler.processReview(review);
+
+        assertThat(response.getAllowed()).isFalse();
+        assertThat(response.getStatus().getCode()).isEqualTo(403);
+        assertThat(response.getStatus().getMessage()).contains("SKIP_NO_CONFIG");
+    }
+
+    @Test
+    void deniesWhenMultipleConfigsAndPolicyIsDeny() {
+        var denyHandler = new AdmissionHandler(
+                configResolver, PROXY_IMAGE, new KubernetesVersion(1, 0), true);
+        when(configResolver.resolve(eq("test-ns"), isNull()))
+                .thenReturn(SidecarConfigResolver.Resolution.multipleConfigs());
+
+        AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
+        AdmissionResponse response = denyHandler.processReview(review);
+
+        assertThat(response.getAllowed()).isFalse();
+        assertThat(response.getStatus().getCode()).isEqualTo(403);
+        assertThat(response.getStatus().getMessage()).contains("SKIP_MULTIPLE_CONFIGS");
+    }
+
+    @Test
+    void allowsOptOutEvenWhenPolicyIsDeny() {
+        var denyHandler = new AdmissionHandler(
+                configResolver, PROXY_IMAGE, new KubernetesVersion(1, 0), true);
+        when(configResolver.resolve(eq("test-ns"), isNull()))
+                .thenReturn(SidecarConfigResolver.Resolution.found(sidecarConfig("test-ns", "config")));
+
+        Pod pod = minimalPod();
+        pod.getMetadata().setLabels(
+                new HashMap<>(Map.of(Labels.SIDECAR_INJECTION, Labels.SIDECAR_INJECTION_DISABLED)));
+
+        AdmissionReview review = reviewWithPod(pod, "test-ns");
+        AdmissionResponse response = denyHandler.processReview(review);
+
+        assertThat(response.getAllowed()).isTrue();
+    }
+
+    @Test
     void usesExplicitConfigName() {
         KroxyliciousSidecarConfig config = sidecarConfig("test-ns", "my-config");
         when(configResolver.resolve("test-ns", "my-config")).thenReturn(SidecarConfigResolver.Resolution.found(config));
@@ -190,41 +235,14 @@ class AdmissionHandlerTest {
     }
 
     @Test
-    void failsClosedOnExceptionByDefault() {
+    void propagatesExceptionFromProcessReview() {
         when(configResolver.resolve(any(), isNull())).thenThrow(new RuntimeException("kaboom"));
 
         AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
-        AdmissionResponse response = handler.processReview(review);
 
-        assertThat(response.getAllowed()).isFalse();
-        assertThat(response.getStatus()).isNotNull();
-        assertThat(response.getStatus().getMessage()).contains("kaboom");
-        assertThat(response.getPatch()).isNull();
-    }
-
-    @Test
-    void failsOpenOnExceptionWhenConfigured() {
-        when(configResolver.resolve(any(), isNull())).thenThrow(new RuntimeException("kaboom"));
-
-        AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
-        AdmissionResponse response = failOpenHandler.processReview(review);
-
-        assertThat(response.getAllowed()).isTrue();
-        assertThat(response.getPatch()).isNull();
-    }
-
-    @Test
-    void denyResponseIncludesStatusDetails() {
-        when(configResolver.resolve(any(), isNull())).thenThrow(new RuntimeException("test error"));
-
-        AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
-        AdmissionResponse response = handler.processReview(review);
-
-        assertThat(response.getAllowed()).isFalse();
-        assertThat(response.getStatus()).isNotNull();
-        assertThat(response.getStatus().getCode()).isEqualTo(403);
-        assertThat(response.getStatus().getReason()).isEqualTo("Forbidden");
-        assertThat(response.getStatus().getMessage()).contains("test error");
+        assertThatThrownBy(() -> handler.processReview(review))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("kaboom");
     }
 
     @Test
@@ -306,20 +324,16 @@ class AdmissionHandlerTest {
     }
 
     @Test
-    void handleFailsClosedOnDeserialisationError() throws IOException {
+    void handleReturns500OnDeserialisationError() throws IOException {
         HttpExchange exchange = createMockExchange("POST", "not json".getBytes(StandardCharsets.UTF_8));
 
         handler.handle(exchange);
 
-        ByteArrayOutputStream responseBody = (ByteArrayOutputStream) exchange.getResponseBody();
-        JsonNode responseJson = MAPPER.readTree(responseBody.toByteArray());
-
-        assertThat(responseJson.get("response").get("allowed").asBoolean()).isFalse();
-        assertThat(responseJson.get("response").get("status").get("message").asText()).isNotEmpty();
+        verify(exchange).sendResponseHeaders(eq(500), eq(-1L));
     }
 
     @Test
-    void handleFailsClosedOnProcessReviewException() throws IOException {
+    void handleReturns500OnProcessReviewException() throws IOException {
         when(configResolver.resolve(any(), isNull())).thenThrow(new RuntimeException("kaboom"));
 
         AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
@@ -328,38 +342,7 @@ class AdmissionHandlerTest {
 
         handler.handle(exchange);
 
-        ByteArrayOutputStream responseBody = (ByteArrayOutputStream) exchange.getResponseBody();
-        JsonNode responseJson = MAPPER.readTree(responseBody.toByteArray());
-
-        assertThat(responseJson.get("response").get("allowed").asBoolean()).isFalse();
-    }
-
-    @Test
-    void handleFailsOpenOnDeserialisationErrorWhenConfigured() throws IOException {
-        HttpExchange exchange = createMockExchange("POST", "not json".getBytes(StandardCharsets.UTF_8));
-
-        failOpenHandler.handle(exchange);
-
-        ByteArrayOutputStream responseBody = (ByteArrayOutputStream) exchange.getResponseBody();
-        JsonNode responseJson = MAPPER.readTree(responseBody.toByteArray());
-
-        assertThat(responseJson.get("response").get("allowed").asBoolean()).isTrue();
-    }
-
-    @Test
-    void handleFailsOpenOnProcessReviewExceptionWhenConfigured() throws IOException {
-        when(configResolver.resolve(any(), isNull())).thenThrow(new RuntimeException("kaboom"));
-
-        AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
-        byte[] requestBody = MAPPER.writeValueAsBytes(review);
-        HttpExchange exchange = createMockExchange("POST", requestBody);
-
-        failOpenHandler.handle(exchange);
-
-        ByteArrayOutputStream responseBody = (ByteArrayOutputStream) exchange.getResponseBody();
-        JsonNode responseJson = MAPPER.readTree(responseBody.toByteArray());
-
-        assertThat(responseJson.get("response").get("allowed").asBoolean()).isTrue();
+        verify(exchange).sendResponseHeaders(eq(500), eq(-1L));
     }
 
     // --- helpers ---

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
@@ -108,7 +108,7 @@ class AdmissionHandlerTest {
         assertThat(response.getPatchType()).isEqualTo("JSONPatch");
         String patchJson = new String(java.util.Base64.getDecoder().decode(response.getPatch()));
         assertThat(patchJson).contains(Labels.INJECTION_SKIPPED);
-        assertThat(patchJson).contains("no-config");
+        assertThat(patchJson).contains("no-KroxyliciousSidecarConfig");
     }
 
     @Test
@@ -145,7 +145,7 @@ class AdmissionHandlerTest {
         assertThat(response.getPatchType()).isEqualTo("JSONPatch");
         String patchJson = new String(java.util.Base64.getDecoder().decode(response.getPatch()));
         assertThat(patchJson).contains(Labels.INJECTION_SKIPPED);
-        assertThat(patchJson).contains("already-injected");
+        assertThat(patchJson).contains("container-name-conflict");
     }
 
     @Test
@@ -159,7 +159,7 @@ class AdmissionHandlerTest {
         assertThat(response.getPatchType()).isEqualTo("JSONPatch");
         String patchJson = new String(java.util.Base64.getDecoder().decode(response.getPatch()));
         assertThat(patchJson).contains(Labels.INJECTION_SKIPPED);
-        assertThat(patchJson).contains("multiple-configs");
+        assertThat(patchJson).contains("ambiguous-KroxyliciousSidecarConfig");
     }
 
     @Test

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/KindPluginEndToEndKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/KindPluginEndToEndKT.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.condition.EnabledIf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.kroxylicious.test.ShellUtils;
+import io.kroxylicious.testing.integration.ShellUtils;
 
 /**
  * Runs the plugin end-to-end tests on a dedicated Kind cluster with the

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/KindWebhookInstallKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/KindWebhookInstallKT.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.condition.EnabledIf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.kroxylicious.test.ShellUtils;
+import io.kroxylicious.testing.integration.ShellUtils;
 
 /**
  * Webhook installation and sidecar injection test on a Kind cluster.

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/MinikubePluginEndToEndKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/MinikubePluginEndToEndKT.java
@@ -16,7 +16,7 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 
-import io.kroxylicious.test.ShellUtils;
+import io.kroxylicious.testing.integration.ShellUtils;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/MinikubeWebhookInstallKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/MinikubeWebhookInstallKT.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.condition.EnabledIf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.kroxylicious.test.ShellUtils;
+import io.kroxylicious.testing.integration.ShellUtils;
 
 /**
  * Webhook installation and sidecar injection test on a Minikube cluster.

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/PodMutatorTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/PodMutatorTest.java
@@ -120,6 +120,7 @@ class PodMutatorTest {
         assertThat(secCtx.path("allowPrivilegeEscalation").asBoolean()).isFalse();
         assertThat(secCtx.path("readOnlyRootFilesystem").asBoolean()).isTrue();
         assertThat(secCtx.path("capabilities").path("drop").get(0).asText()).isEqualTo("ALL");
+        assertThat(secCtx.path("seccompProfile").path("type").asText()).isEqualTo("RuntimeDefault");
     }
 
     @Test
@@ -393,6 +394,7 @@ class PodMutatorTest {
         assertThat(initContainer.path("name").asText()).isEqualTo("plugin-my-filter-copy");
         assertThat(initContainer.path("image").asText()).isEqualTo("reg.io/filter:v1@sha256:abc123");
         assertThat(initContainer.path("securityContext").path("allowPrivilegeEscalation").asBoolean()).isFalse();
+        assertThat(initContainer.path("securityContext").path("seccompProfile").path("type").asText()).isEqualTo("RuntimeDefault");
     }
 
     @Test
@@ -586,26 +588,26 @@ class PodMutatorTest {
     @Test
     void skipLabelPatchAddsLabelWhenNoExistingLabels() throws Exception {
         Pod pod = podWithAppContainer(null);
-        String patchStr = PodMutator.createSkipLabelPatch(pod, "no-config");
+        String patchStr = PodMutator.createSkipLabelPatch(pod, "no-KroxyliciousSidecarConfig");
         JsonNode patch = MAPPER.readTree(patchStr);
 
         List<JsonNode> ops = patchOps(patch, "add", "/metadata/labels");
         assertThat(ops).hasSize(1);
         assertThat(ops.get(0).path("value").path(Labels.INJECTION_SKIPPED).asText())
-                .isEqualTo("no-config");
+                .isEqualTo("no-KroxyliciousSidecarConfig");
     }
 
     @Test
     void skipLabelPatchAddsLabelWhenExistingLabels() throws Exception {
         Pod pod = podWithAppContainer(null);
         pod.getMetadata().setLabels(new HashMap<>(Map.of("app", "my-app")));
-        String patchStr = PodMutator.createSkipLabelPatch(pod, "already-injected");
+        String patchStr = PodMutator.createSkipLabelPatch(pod, "container-name-conflict");
         JsonNode patch = MAPPER.readTree(patchStr);
 
         String escapedKey = PodMutator.escapeJsonPointer(Labels.INJECTION_SKIPPED);
         List<JsonNode> ops = patchOps(patch, "add", "/metadata/labels/" + escapedKey);
         assertThat(ops).hasSize(1);
-        assertThat(ops.get(0).path("value").asText()).isEqualTo("already-injected");
+        assertThat(ops.get(0).path("value").asText()).isEqualTo("container-name-conflict");
     }
 
     // --- helpers ---

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolverTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolverTest.java
@@ -175,7 +175,7 @@ class SidecarConfigResolverTest {
     // --- status updater integration tests ---
 
     @Test
-    void onAddCallsStatusUpdater() {
+    void onAddCallsSetReadyForValidConfig() {
         SidecarConfigResolver resolver = new SidecarConfigResolver(statusUpdater);
         KroxyliciousSidecarConfig config = createConfig("ns1", "my-config");
 
@@ -187,7 +187,21 @@ class SidecarConfigResolverTest {
     }
 
     @Test
-    void onUpdateCallsStatusUpdater() {
+    void onAddCallsSetNotReadyForInvalidConfig() {
+        SidecarConfigResolver resolver = new SidecarConfigResolver(statusUpdater);
+        KroxyliciousSidecarConfig config = createConfigWithoutBootstrap("ns1", "my-config");
+
+        resolver.simulateAdd(config);
+
+        verify(statusUpdater).setNotReady(
+                org.mockito.ArgumentMatchers.eq(config),
+                org.mockito.ArgumentMatchers.contains("targetBootstrapServers"));
+        assertThat(resolver.resolve("ns1", "my-config").outcome())
+                .isEqualTo(SidecarConfigResolver.Resolution.Outcome.FOUND);
+    }
+
+    @Test
+    void onUpdateCallsSetReadyForValidConfig() {
         SidecarConfigResolver resolver = new SidecarConfigResolver(statusUpdater);
         KroxyliciousSidecarConfig oldConfig = createConfig("ns1", "my-config");
         KroxyliciousSidecarConfig newConfig = createConfig("ns1", "my-config");
@@ -200,6 +214,19 @@ class SidecarConfigResolverTest {
     }
 
     @Test
+    void onUpdateCallsSetNotReadyForInvalidConfig() {
+        SidecarConfigResolver resolver = new SidecarConfigResolver(statusUpdater);
+        KroxyliciousSidecarConfig oldConfig = createConfig("ns1", "my-config");
+        KroxyliciousSidecarConfig newConfig = createConfigWithoutBootstrap("ns1", "my-config");
+
+        resolver.simulateUpdate(oldConfig, newConfig);
+
+        verify(statusUpdater).setNotReady(
+                org.mockito.ArgumentMatchers.eq(newConfig),
+                org.mockito.ArgumentMatchers.contains("targetBootstrapServers"));
+    }
+
+    @Test
     void noStatusUpdaterDoesNotThrow() {
         SidecarConfigResolver resolver = new SidecarConfigResolver();
         KroxyliciousSidecarConfig config = createConfig("ns1", "my-config");
@@ -207,6 +234,44 @@ class SidecarConfigResolverTest {
         assertThatCode(() -> resolver.simulateAdd(config)).doesNotThrowAnyException();
         assertThat(resolver.resolve("ns1", "my-config").outcome())
                 .isEqualTo(SidecarConfigResolver.Resolution.Outcome.FOUND);
+    }
+
+    // --- validation tests ---
+
+    @Test
+    void validateAcceptsValidConfig() {
+        KroxyliciousSidecarConfig config = createConfig("ns1", "my-config");
+        assertThat(SidecarConfigResolver.validate(config)).isEmpty();
+    }
+
+    @Test
+    void validateRejectsNullSpec() {
+        KroxyliciousSidecarConfig config = new KroxyliciousSidecarConfig();
+        config.setMetadata(new ObjectMeta());
+        config.getMetadata().setNamespace("ns1");
+        config.getMetadata().setName("bad");
+
+        assertThat(SidecarConfigResolver.validate(config)).contains("spec is required");
+    }
+
+    @Test
+    void validateRejectsEmptyVirtualClusters() {
+        KroxyliciousSidecarConfig config = new KroxyliciousSidecarConfig();
+        config.setMetadata(new ObjectMeta());
+        config.getMetadata().setNamespace("ns1");
+        config.getMetadata().setName("bad");
+        config.setSpec(new KroxyliciousSidecarConfigSpec());
+        config.getSpec().setVirtualClusters(java.util.List.of());
+
+        assertThat(SidecarConfigResolver.validate(config))
+                .contains("spec.virtualClusters must contain at least one entry");
+    }
+
+    @Test
+    void validateRejectsMissingTargetBootstrapServers() {
+        KroxyliciousSidecarConfig config = createConfigWithoutBootstrap("ns1", "bad");
+        assertThat(SidecarConfigResolver.validate(config))
+                .contains("spec.virtualClusters[0].targetBootstrapServers is required");
     }
 
     private static KroxyliciousSidecarConfig createConfig(String namespace, String name) {
@@ -219,6 +284,20 @@ class SidecarConfigResolverTest {
         VirtualClusters vc = new VirtualClusters();
         vc.setName("sidecar");
         vc.setTargetBootstrapServers("kafka.example.com:9092");
+        spec.setVirtualClusters(java.util.List.of(vc));
+        config.setSpec(spec);
+        return config;
+    }
+
+    private static KroxyliciousSidecarConfig createConfigWithoutBootstrap(String namespace, String name) {
+        KroxyliciousSidecarConfig config = new KroxyliciousSidecarConfig();
+        ObjectMeta meta = new ObjectMeta();
+        meta.setNamespace(namespace);
+        meta.setName(name);
+        config.setMetadata(meta);
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        VirtualClusters vc = new VirtualClusters();
+        vc.setName("sidecar");
         spec.setVirtualClusters(java.util.List.of(vc));
         config.setSpec(spec);
         return config;

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/SidecarConfigStatusUpdaterTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/SidecarConfigStatusUpdaterTest.java
@@ -191,6 +191,50 @@ class SidecarConfigStatusUpdaterTest {
         assertThatCode(() -> updater.setReady(config)).doesNotThrowAnyException();
     }
 
+    // --- setNotReady tests ---
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void setNotReadySetsReadyFalseWithInvalidReason() {
+        KroxyliciousSidecarConfig config = createConfig(2L);
+        stubClientChain();
+        KroxyliciousSidecarConfig serverState = createConfig(2L);
+        when(resource.editStatus(any(UnaryOperator.class))).thenAnswer(invocation -> {
+            UnaryOperator<KroxyliciousSidecarConfig> op = invocation.getArgument(0);
+            return op.apply(serverState);
+        });
+
+        updater.setNotReady(config, "spec.virtualClusters[0].targetBootstrapServers is required");
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<UnaryOperator<KroxyliciousSidecarConfig>> captor = ArgumentCaptor.forClass(UnaryOperator.class);
+        verify(resource).editStatus(captor.capture());
+
+        KroxyliciousSidecarConfig result = captor.getValue().apply(createConfig(2L));
+        assertThat(result.getStatus()).isNotNull();
+        assertThat(result.getStatus().getObservedGeneration()).isEqualTo(2L);
+        assertThat(result.getStatus().getConditions()).hasSize(1);
+
+        Condition condition = result.getStatus().getConditions().get(0);
+        assertThat(condition.getType()).isEqualTo(Condition.Type.Ready);
+        assertThat(condition.getStatus()).isEqualTo(Condition.Status.FALSE);
+        assertThat(condition.getReason()).isEqualTo(SidecarConfigStatusUpdater.REASON_INVALID);
+        assertThat(condition.getMessage()).isEqualTo("spec.virtualClusters[0].targetBootstrapServers is required");
+        assertThat(condition.getLastTransitionTime()).isEqualTo(NOW);
+        assertThat(condition.getObservedGeneration()).isEqualTo(2L);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void setNotReadySwallowsExceptions() {
+        KroxyliciousSidecarConfig config = createConfig(1L);
+        stubClientChain();
+        when(resource.editStatus(any(UnaryOperator.class)))
+                .thenThrow(new RuntimeException("API server error"));
+
+        assertThatCode(() -> updater.setNotReady(config, "bad config")).doesNotThrowAnyException();
+    }
+
     // --- helpers ---
 
     @SuppressWarnings("unchecked")

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookMainTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookMainTest.java
@@ -134,39 +134,41 @@ class WebhookMainTest {
         assertThat(value).isEqualTo("my-image:latest");
     }
 
-    // --- parseFailClosed tests ---
+    // --- parseDenyUninjected tests ---
 
     @Test
-    void parseFailClosedDefaultsToTrue() {
-        boolean result = WebhookMain.parseFailClosed(Map.of());
-        assertThat(result).isTrue();
-    }
-
-    @Test
-    void parseFailClosedReturnsTrueForFail() {
-        boolean result = WebhookMain.parseFailClosed(Map.of("FAILURE_POLICY", "Fail"));
-        assertThat(result).isTrue();
-    }
-
-    @Test
-    void parseFailClosedReturnsFalseForIgnore() {
-        boolean result = WebhookMain.parseFailClosed(Map.of("FAILURE_POLICY", "Ignore"));
+    void parseDenyUninjectedDefaultsToFalse() {
+        boolean result = WebhookMain.parseDenyUninjected(Map.of());
         assertThat(result).isFalse();
     }
 
     @Test
-    void parseFailClosedThrowsForInvalidValue() {
-        assertThatThrownBy(() -> WebhookMain.parseFailClosed(
-                Map.of("FAILURE_POLICY", "invalid")))
+    void parseDenyUninjectedReturnsTrueForDeny() {
+        boolean result = WebhookMain.parseDenyUninjected(
+                Map.of("UNINJECTED_POD_POLICY", "Deny"));
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void parseDenyUninjectedReturnsFalseForAdmit() {
+        boolean result = WebhookMain.parseDenyUninjected(
+                Map.of("UNINJECTED_POD_POLICY", "Admit"));
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void parseDenyUninjectedThrowsForInvalidValue() {
+        assertThatThrownBy(() -> WebhookMain.parseDenyUninjected(
+                Map.of("UNINJECTED_POD_POLICY", "invalid")))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("FAILURE_POLICY")
+                .hasMessageContaining("UNINJECTED_POD_POLICY")
                 .hasMessageContaining("invalid");
     }
 
     @Test
-    void parseFailClosedIsCaseSensitive() {
-        assertThatThrownBy(() -> WebhookMain.parseFailClosed(
-                Map.of("FAILURE_POLICY", "fail")))
+    void parseDenyUninjectedIsCaseSensitive() {
+        assertThatThrownBy(() -> WebhookMain.parseDenyUninjected(
+                Map.of("UNINJECTED_POD_POLICY", "deny")))
                 .isInstanceOf(IllegalStateException.class);
     }
 

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookServerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookServerTest.java
@@ -39,7 +39,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionRequest;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReview;
 
-import io.kroxylicious.test.certificate.CertificateGenerator;
+import io.kroxylicious.testing.certificate.CertificateGenerator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookServerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookServerTest.java
@@ -100,7 +100,7 @@ class WebhookServerTest {
         Path missing = Path.of("/nonexistent/cert.pem");
 
         assertThatThrownBy(() -> WebhookServer.createSslContext(missing, keyPath))
-                .isInstanceOf(IOException.class);
+                .isInstanceOf(GeneralSecurityException.class);
     }
 
     @Test
@@ -108,7 +108,7 @@ class WebhookServerTest {
         Path missing = Path.of("/nonexistent/key.pem");
 
         assertThatThrownBy(() -> WebhookServer.createSslContext(certPath, missing))
-                .isInstanceOf(IOException.class);
+                .isInstanceOf(GeneralSecurityException.class);
     }
 
     @Test
@@ -125,36 +125,6 @@ class WebhookServerTest {
 
         assertThatThrownBy(() -> WebhookServer.createSslContext(certPath, badKey))
                 .isInstanceOf(GeneralSecurityException.class);
-    }
-
-    @Test
-    void createSslContextThrowsForPkcs1RsaKey(@TempDir Path tempDir) throws Exception {
-        Path pkcs1Key = tempDir.resolve("pkcs1-rsa.pem");
-        String pkcs1Pem = """
-                -----BEGIN RSA PRIVATE KEY-----
-                MIIEpAIBAAKCAQEA...
-                -----END RSA PRIVATE KEY-----
-                """;
-        Files.writeString(pkcs1Key, pkcs1Pem);
-
-        assertThatThrownBy(() -> WebhookServer.createSslContext(certPath, pkcs1Key))
-                .isInstanceOf(GeneralSecurityException.class)
-                .hasMessageContaining("is in PKCS1 format, which is not supported");
-    }
-
-    @Test
-    void createSslContextThrowsForPkcs1EcKey(@TempDir Path tempDir) throws Exception {
-        Path pkcs1Key = tempDir.resolve("pkcs1-ec.pem");
-        String pkcs1Pem = """
-                -----BEGIN EC PRIVATE KEY-----
-                MHcCAQEEIIGlRDpz...
-                -----END EC PRIVATE KEY-----
-                """;
-        Files.writeString(pkcs1Key, pkcs1Pem);
-
-        assertThatThrownBy(() -> WebhookServer.createSslContext(certPath, pkcs1Key))
-                .isInstanceOf(GeneralSecurityException.class)
-                .hasMessageContaining("is in PKCS1 format, which is not supported");
     }
 
     // --- Server lifecycle tests ---


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Address review feedback on sidecar injection webhook from Sam and Rob:

- Rename injection-skipped label values: `no-KroxyliciousSidecarConfig`, `ambiguous-KroxyliciousSidecarConfig`, `container-name-conflict`
- Add `Ready=False status` condition for invalid `KroxyliciousSidecarConfig` with validation in `SidecarConfigResolver`
- Rename `FEATURE_GATES` env var to `K8S_FEATURE_GATES`
- Set `seccompProfile: RuntimeDefault` on sidecar and plugin init containers
- Update end user docs and `README.md`
- Replace `FAILURE_POLICY` with `UNINJECTED_POD_POLICY`, delegate TLS to Netty. The webhook now supports
    the same key formats as the proxy.


### Additional Context

_Why are you making this pull request?_

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] User facing documentation written/updated (where applicable).
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
