### PR TITLE
refactor(kms-tls-support): move to `io.kroxylicious.testing.kms.tls` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* refactor: move `kroxylicious-kms-tls-support` to `io.kroxylicious.testing.kms.tls`
 * [#3861](https://github.com/kroxylicious/kroxylicious/pull/3861): refactor: move test-support modules to `io.kroxylicious.testing`
 * [#3882](https://github.com/kroxylicious/kroxylicious/pull/3882): build(image): proxy container image renamed from `quay.io/kroxylicious/kroxylicious` to `quay.io/kroxylicious/proxy`
 * [#3236](https://github.com/kroxylicious/kroxylicious/issues/3236): build(deps): bump strimzi.version from 0.51.0 to 1.0.0
@@ -28,6 +29,7 @@ Format `<github issue/pr number>: <short description>`.
 ### Changes, deprecations and removals
 
 * [#3882](https://github.com/kroxylicious/kroxylicious/pull/3882): The primary proxy container image is now `quay.io/kroxylicious/proxy`. `quay.io/kroxylicious/kroxylicious` is deprecated and subject to removal following our deprecation policy. Users deploying the proxy image directly (without the operator) should update their deployment configurations to use the new image name. The operator will automatically use the new image name.
+* The `kroxylicious-kms-tls-support` module now uses the package `io.kroxylicious.testing.kms.tls` (was `io.kroxylicious.proxy.tls`). 3rd party KMS providers that depend on this module will need to update their imports.
 * [#3861](https://github.com/kroxylicious/kroxylicious/pull/3861): The `kroxylicious-*-test-support` modules now consistently use the package prefix `io.kroxylicious.testing`. Many of these modules modules are effectively internal, but 3rd party filters may have a dependency on `kroxylicious-filter-test-support` and 3rd party KMSes may have a dependency on `kroxylicious-kms-test-support`. When upgrading you will need to use the new package name in your tests.
 * [#3236](https://github.com/kroxylicious/kroxylicious/issues/3236): **BREAKING CHANGE** - If making use of the Strimzi integration feature in the KafkaService CR (`spec.strimziKafkaRef`), Strimzi 0.49.0 or later is now **required**. The Kroxylicious Operator now uses the Strimzi Kafka CR v1 API exclusively; v1beta2 API support has been dropped. Users running Strimzi versions prior to 0.49.0 must upgrade Strimzi.
 * [#3786](https://github.com/kroxylicious/kroxylicious/issues/3786): The deprecated method `StatusFactory#newTrueConditionStatusPatch(CustomResource, Condition.Type)` (two-parameter form) is removed. Use `StatusFactory#newTrueConditionStatusPatch(CustomResource, Condition.Type, String)` instead, passing `MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED` if no checksum tracking is needed.

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsService.java
@@ -16,7 +16,7 @@ import io.kroxylicious.kms.provider.aws.kms.credentials.CredentialsProviderFacto
 import io.kroxylicious.kms.service.KmsService;
 import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
-import io.kroxylicious.proxy.tls.TlsHttpClientConfigurator;
+import io.kroxylicious.testing.kms.tls.TlsHttpClientConfigurator;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/auth/OauthClientCredentialsTokenService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/auth/OauthClientCredentialsTokenService.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kroxylicious.kms.provider.azure.MalformedResponseBodyException;
 import io.kroxylicious.kms.provider.azure.UnexpectedHttpStatusCodeException;
 import io.kroxylicious.kms.provider.azure.config.auth.Oauth2ClientCredentialsConfig;
-import io.kroxylicious.proxy.tls.TlsHttpClientConfigurator;
+import io.kroxylicious.testing.kms.tls.TlsHttpClientConfigurator;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/keyvault/KeyVaultClient.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/keyvault/KeyVaultClient.java
@@ -26,7 +26,7 @@ import io.kroxylicious.kms.provider.azure.auth.BearerToken;
 import io.kroxylicious.kms.provider.azure.auth.BearerTokenService;
 import io.kroxylicious.kms.provider.azure.config.AzureKeyVaultConfig;
 import io.kroxylicious.kms.service.KmsException;
-import io.kroxylicious.proxy.tls.TlsHttpClientConfigurator;
+import io.kroxylicious.testing.kms.tls.TlsHttpClientConfigurator;
 
 public class KeyVaultClient implements AutoCloseable {
     public static final String API_VERSION = "7.4";

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/main/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKmsService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/main/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKmsService.java
@@ -18,7 +18,7 @@ import io.kroxylicious.kms.service.KmsService;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
-import io.kroxylicious.proxy.tls.TlsHttpClientConfigurator;
+import io.kroxylicious.testing.kms.tls.TlsHttpClientConfigurator;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 import io.kroxylicious.kms.provider.hashicorp.vault.config.Config;
 import io.kroxylicious.kms.service.KmsService;
 import io.kroxylicious.proxy.plugin.Plugin;
-import io.kroxylicious.proxy.tls.TlsHttpClientConfigurator;
+import io.kroxylicious.testing.kms.tls.TlsHttpClientConfigurator;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 

--- a/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/testing/kms/tls/InsecureTrustManager.java
+++ b/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/testing/kms/tls/InsecureTrustManager.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-package io.kroxylicious.proxy.tls;
+package io.kroxylicious.testing.kms.tls;
 
 import java.security.cert.X509Certificate;
 

--- a/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/testing/kms/tls/SslConfigurationException.java
+++ b/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/testing/kms/tls/SslConfigurationException.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-package io.kroxylicious.proxy.tls;
+package io.kroxylicious.testing.kms.tls;
 
 public class SslConfigurationException extends RuntimeException {
     public SslConfigurationException(Exception cause) {

--- a/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/testing/kms/tls/TlsHttpClientConfigurator.java
+++ b/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/testing/kms/tls/TlsHttpClientConfigurator.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-package io.kroxylicious.proxy.tls;
+package io.kroxylicious.testing.kms.tls;
 
 import java.io.FileInputStream;
 import java.net.http.HttpClient;

--- a/kroxylicious-kms-tls-support/src/test/java/io/kroxylicious/testing/kms/tls/TlsHttpClientConfiguratorTest.java
+++ b/kroxylicious-kms-tls-support/src/test/java/io/kroxylicious/testing/kms/tls/TlsHttpClientConfiguratorTest.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-package io.kroxylicious.proxy.tls;
+package io.kroxylicious.testing.kms.tls;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Eliminates the split package with `kroxylicious-api`'s `io.kroxylicious.proxy.tls`, consistent with the naming convention established in #3861 for test support modules.

Fixes #3885

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

