### PR TITLE
docs: use OCI URL for Strimzi Helm install in quick-start

### DIFF
--- a/kroxylicious-docs/docs/record-encryption-quick-start/index.adoc
+++ b/kroxylicious-docs/docs/record-encryption-quick-start/index.adoc
@@ -121,8 +121,7 @@ Let's install Strimzi next:
 
 [source,terminal,subs="attributes"]
 ----
-$ helm repo add --force-update strimzi https://strimzi.io/charts/
-$ helm upgrade --install strimzi-operator strimzi/strimzi-kafka-operator --namespace kafka --create-namespace --version {strimzi-version}
+$ helm upgrade --install strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator --namespace kafka --create-namespace --version {strimzi-version}
 ----
 
 [#install_the_operator]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Updates the Record Encryption quick-start guide to install Strimzi using the OCI registry on Quay.io, which is the method documented in Strimzi's own Helm chart README.

Replaces the two-step `helm repo add` + `helm upgrade --install strimzi/strimzi-kafka-operator` with the single OCI-based command:

```
helm upgrade --install strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator ...
```

### Additional Context

The legacy `https://strimzi.io/charts/` Helm repository returns intermittent 5xx errors in CI, causing flaky documentation test failures. Strimzi's current documentation only describes the OCI approach.

### Checklist

- [x] New tests written (where applicable).
- [x] User facing documentation written/updated (where applicable).
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).