### PR TITLE
docs(admission): add wait step for KroxyliciousSidecarConfig Ready status

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-admission/packaging/examples/sidecar-injection-demo/README.md
+++ b/kroxylicious-kubernetes/kroxylicious-admission/packaging/examples/sidecar-injection-demo/README.md
@@ -45,6 +45,17 @@ kubectl wait --for=condition=ready pod -l name=strimzi-cluster-operator -n kafka
 kubectl apply -f 01-namespace.yaml
 kubectl apply -f 02-kafka.yaml
 kubectl apply -f 03-sidecar-config.yaml
+```
+
+Wait for the sidecar configuration to be accepted:
+
+```bash
+kubectl wait kroxylicioussidecarconfig/demo-config --for=condition=Ready -n demo-app --timeout=60s
+```
+
+Apply the application:
+
+```bash
 kubectl apply -f 04-app.yaml
 ```
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Updates the sidecar-inject-demo instructions to wait for the KroxyliciousSidecarConfig to become Ready before creating the application pod. This provides clearer feedback if the config is invalid, and delays pod creation until a webhook replica has been informed of the config.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] User facing documentation written/updated (where applicable).
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
