### PR TITLE
build(admission-dist): include admission guide in distribution

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-admission-dist/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-admission-dist/pom.xml
@@ -32,6 +32,13 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-docs</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+            <type>pom</type>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/kroxylicious-kubernetes/kroxylicious-admission-dist/src/assembly/asset.xml
+++ b/kroxylicious-kubernetes/kroxylicious-admission-dist/src/assembly/asset.xml
@@ -27,5 +27,14 @@
             <directory>${project.basedir}/../kroxylicious-admission/target/packaged</directory>
             <outputDirectory>/</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>../../kroxylicious-docs/target/docs/</directory>
+            <outputDirectory>/docs</outputDirectory>
+            <includes>
+                <include>html/images/**</include>
+                <include>html/admission-webhook-guide/**</include>
+                <include>pdf/admission-webhook-guide/**</include>
+            </includes>
+        </fileSet>
     </fileSets>
 </assembly>


### PR DESCRIPTION

### Type of change

- Documentation

### Description

Adds admission webhook guide documentation (HTML and PDF) to the admission-dist distribution archive, mirroring the pattern used by operator-dist. End users installing from the distribution will now have the installation and usage guide bundled.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] User facing documentation written/updated (where applicable).
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
