### PR TITLE
docs(admission-webhook): fix documentation to match implementation

### DIFF
--- a/kroxylicious-docs/docs/_modules/admission-webhook/con-admission-webhook-overview.adoc
+++ b/kroxylicious-docs/docs/_modules/admission-webhook/con-admission-webhook-overview.adoc
@@ -56,17 +56,19 @@ Pods that already have a container named `kroxylicious-proxy` are also skipped t
 The webhook has two separate failure policies:
 
 **Internal error handling:**
-The webhook is fail-closed for internal errors.
+The webhook defaults to failing closed for internal errors.
 When an exception occurs during admission request processing, the webhook returns HTTP 500.
 The Kubernetes API server's behavior is controlled by the `MutatingWebhookConfiguration.failurePolicy` field (default: `Fail`), which blocks pod creation until the webhook becomes available again.
+The `failurePolicy` can be changed to `Ignore` if availability of pod creation in targeted namespaces is preferred over honoring the request for sidecar injection.
 
 **Unavailable configuration handling:**
-When no `KroxyliciousSidecarConfig` is available for a namespace, behavior is controlled by the `UNINJECTED_POD_POLICY` environment variable on the webhook `Deployment`:
+When a pod cannot be injected due to missing or invalid `KroxyliciousSidecarConfig` (no config, multiple configs, or invalid config), behavior is controlled by the `UNINJECTED_POD_POLICY` environment variable on the webhook `Deployment`:
 
 * `Admit` (default): Allow pod creation without sidecar injection
 * `Deny`: Reject pod creation
 
-Non-error paths (null request, null pod, opt-out, already injected) always allow pod creation regardless of these policies.
+This is separate from the internal error handling policy because it represents a configuration problem rather than a webhook failure.
+Administrators may want different responses: fail-open for misconfigured applications (allowing deployments to proceed), but fail-closed for webhook infrastructure failures (preventing potentially insecure pods).
 
 == Trust model
 

--- a/kroxylicious-docs/docs/_modules/admission-webhook/con-admission-webhook-overview.adoc
+++ b/kroxylicious-docs/docs/_modules/admission-webhook/con-admission-webhook-overview.adoc
@@ -51,15 +51,22 @@ sidecar.kroxylicious.io/injection: disabled
 
 Pods that already have a container named `kroxylicious-proxy` are also skipped to avoid double injection.
 
-== Failure policy
+== Failure policies
 
-By default, the webhook uses fail-closed semantics.
-If the webhook encounters an internal error while processing an admission request, it rejects the pod.
-The `MutatingWebhookConfiguration` uses `failurePolicy: Fail` so that if the webhook is unavailable pod creation is blocked until the webhook becomes available again.
-This ensures that pods in injection-enabled namespaces are never created without the expected sidecar.
+The webhook has two separate failure policies:
 
-The failure policy is controlled in two places that must be kept in sync: the `FAILURE_POLICY` environment variable on the webhook `Deployment`, and the `failurePolicy` field in the `MutatingWebhookConfiguration`.
-To switch to fail-open semantics, set both to `Ignore`.
+**Internal error handling:**
+The webhook is fail-closed for internal errors.
+When an exception occurs during admission request processing, the webhook returns HTTP 500.
+The Kubernetes API server's behavior is controlled by the `MutatingWebhookConfiguration.failurePolicy` field (default: `Fail`), which blocks pod creation until the webhook becomes available again.
+
+**Unavailable configuration handling:**
+When no `KroxyliciousSidecarConfig` is available for a namespace, behavior is controlled by the `UNINJECTED_POD_POLICY` environment variable on the webhook `Deployment`:
+
+* `Admit` (default): Allow pod creation without sidecar injection
+* `Deny`: Reject pod creation
+
+Non-error paths (null request, null pod, opt-out, already injected) always allow pod creation regardless of these policies.
 
 == Trust model
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The documentation introduced in commit 009750579 contained several inaccuracies that developed during implementation:

- Environment variable FAILURE_POLICY does not exist; the actual variable is UNINJECTED_POD_POLICY with values Admit/Deny
- Label keys use sidecar.kroxylicious.io/ prefix not kroxylicious.io/
- Pod opt-out uses same label key with value 'disabled', not a separate label
- Annotation keys use sidecar.kroxylicious.io/ prefix
- Several documented annotations do not exist in implementation

The failure policy section was rewritten to distinguish between internal error handling (always fail-closed, returns HTTP 500) and uninjected pod policy (configurable via UNINJECTED_POD_POLICY).

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] User facing documentation written/updated (where applicable).
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
