### PR TITLE
refactor(operator): untangle some packages

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -49,7 +49,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceStatus;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterStatus;
-import io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.KafkaServiceStatusFactory;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -725,7 +724,7 @@ public class ResourcesUtil {
     }
 
     public static ResourceCheckResult<KafkaService> checkStrimziTrustAnchor(KafkaService resource, Context<KafkaService> context,
-                                                                            StrimziKafkaRef strimziKafkaRef, KafkaServiceStatusFactory statusFactory) {
+                                                                            StrimziKafkaRef strimziKafkaRef, StatusFactory<KafkaService> statusFactory) {
 
         String strimziCaCertSecretName = strimziKafkaRef.getRef().getName() + STRIMZI_CLUSTER_CA_CERT_SECRET_SUFFIX;
         // Strimzi creates CA certificate secrets in the same namespace as the Kafka CR.

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/RouteClusterIngressNetworkingModel.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/RouteClusterIngressNetworkingModel.java
@@ -29,7 +29,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses
 import io.kroxylicious.kubernetes.operator.Annotations;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.model.RouteHostDetails;
-import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy.ProxyDeploymentDependentResource;
 import io.kroxylicious.proxy.config.NodeIdentificationStrategyFactory;
 import io.kroxylicious.proxy.config.SniHostIdentifiesNodeIdentificationStrategy;
 import io.kroxylicious.proxy.service.HostPort;
@@ -93,7 +92,7 @@ public record RouteClusterIngressNetworkingModel(KafkaProxy proxy,
         return new ServiceBuilder()
                 .withMetadata(metadataBuilder.build())
                 .withNewSpec()
-                .withSelector(ProxyDeploymentDependentResource.podLabels(proxy))
+                .withSelector(standardLabels(proxy))
                 .withPorts(new ServicePortBuilder().withName(ResourcesUtil.name(cluster) + "-" + sharedSniPort).withProtocol("TCP").withPort(sharedSniPort)
                         .withTargetPort(new IntOrString(sharedSniPort)).build())
                 .endSpec();

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/TcpClusterIPClusterIngressNetworkingModel.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/TcpClusterIPClusterIngressNetworkingModel.java
@@ -28,7 +28,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRanges;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls;
 import io.kroxylicious.kubernetes.operator.Annotations;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
-import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy.ProxyDeploymentDependentResource;
 import io.kroxylicious.proxy.config.NamedRange;
 import io.kroxylicious.proxy.config.NodeIdentificationStrategyFactory;
 import io.kroxylicious.proxy.config.PortIdentifiesNodeIdentificationStrategy;
@@ -77,7 +76,7 @@ public record TcpClusterIPClusterIngressNetworkingModel(KafkaProxy proxy,
         var serviceSpecBuilder = new ServiceBuilder()
                 .withMetadata(serviceMetadata(serviceName))
                 .withNewSpec()
-                .withSelector(ProxyDeploymentDependentResource.podLabels(proxy));
+                .withSelector(standardLabels(proxy));
         for (int i = firstIdentifyingPort; i <= lastIdentifyingPort; i++) {
             serviceSpecBuilder = serviceSpecBuilder
                     .addNewPort()

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/TlsClusterIPClusterIngressNetworkingModel.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/TlsClusterIPClusterIngressNetworkingModel.java
@@ -27,7 +27,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRanges;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls;
 import io.kroxylicious.kubernetes.operator.Annotations;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
-import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy.ProxyDeploymentDependentResource;
 import io.kroxylicious.proxy.config.NodeIdentificationStrategyFactory;
 import io.kroxylicious.proxy.config.SniHostIdentifiesNodeIdentificationStrategy;
 import io.kroxylicious.proxy.service.HostPort;
@@ -92,7 +91,7 @@ public record TlsClusterIPClusterIngressNetworkingModel(KafkaProxy proxy,
         return new ServiceBuilder()
                 .withMetadata(metadataBuilder.build())
                 .withNewSpec()
-                .withSelector(ProxyDeploymentDependentResource.podLabels(proxy))
+                .withSelector(standardLabels(proxy))
                 .withPorts(new ServicePortBuilder().withProtocol("TCP").withPort(CLIENT_FACING_PORT).withTargetPort(new IntOrString(sharedSniPort)).build())
                 .endSpec();
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ClusterServiceDependentResource.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ClusterServiceDependentResource.java
@@ -120,7 +120,7 @@ public class ClusterServiceDependentResource
                     .withMetadata(sniLoadbalancerServiceMetadata(primary, serviceName, bootstraps))
                     .withNewSpec()
                     .withType("LoadBalancer")
-                    .withSelector(ProxyDeploymentDependentResource.podLabels(primary));
+                    .withSelector(standardLabels(primary));
             for (Integer loadBalancerPort : loadBalancerPorts) {
                 serviceSpecBuilder = serviceSpecBuilder
                         .addNewPort()

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyContext.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyContext.java
@@ -18,14 +18,14 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
+import io.kroxylicious.kubernetes.operator.StatusFactory;
 import io.kroxylicious.kubernetes.operator.model.ProxyModel;
-import io.kroxylicious.kubernetes.operator.reconciler.virtualkafkacluster.VirtualKafkaClusterStatusFactory;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
-public record KafkaProxyContext(VirtualKafkaClusterStatusFactory virtualKafkaClusterStatusFactory,
+public record KafkaProxyContext(StatusFactory<VirtualKafkaCluster> virtualKafkaClusterStatusFactory,
                                 ProxyModel model,
                                 Optional<Configuration> configuration,
                                 List<Volume> volumes,
@@ -35,7 +35,7 @@ public record KafkaProxyContext(VirtualKafkaClusterStatusFactory virtualKafkaClu
     static final String KEY_CTX = KafkaProxyContext.class.getName();
 
     static void init(Context<KafkaProxy> context,
-                     VirtualKafkaClusterStatusFactory virtualKafkaClusterStatusFactory,
+                     StatusFactory<VirtualKafkaCluster> virtualKafkaClusterStatusFactory,
                      ProxyModel model,
                      @Nullable ConfigurationFragment<Configuration> configuration) {
         var rc = context.managedWorkflowAndDependentResourceContext();

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconciler.java
@@ -75,7 +75,7 @@ import io.kroxylicious.kubernetes.operator.model.ProxyModelBuilder;
 import io.kroxylicious.kubernetes.operator.model.networking.ClusterIngressNetworkingModel;
 import io.kroxylicious.kubernetes.operator.model.networking.ProxyNetworkingModel;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxyingress.IsOpenshiftRouteSupportedActivationCondition;
-import io.kroxylicious.kubernetes.operator.reconciler.virtualkafkacluster.VirtualKafkaClusterStatusFactory;
+import io.kroxylicious.kubernetes.operator.reconciler.virtualkafkacluster.VirtualKafkaClusterReconciler;
 import io.kroxylicious.kubernetes.operator.resolver.ClusterResolutionResult;
 import io.kroxylicious.kubernetes.operator.resolver.ResolutionResult;
 import io.kroxylicious.proxy.config.Configuration;
@@ -183,7 +183,7 @@ public class KafkaProxyReconciler implements
             fragment = generateProxyConfig(model, proxy);
         }
         KafkaProxyContext.init(context,
-                new VirtualKafkaClusterStatusFactory(clock),
+                VirtualKafkaClusterReconciler.newStatusFactory(clock),
                 model,
                 fragment);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconciler.java
@@ -70,6 +70,7 @@ import io.kroxylicious.kubernetes.operator.OperatorLoggingKeys;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.SecureConfigInterpolator;
 import io.kroxylicious.kubernetes.operator.StaleReferentStatusException;
+import io.kroxylicious.kubernetes.operator.StatusFactory;
 import io.kroxylicious.kubernetes.operator.model.ProxyModel;
 import io.kroxylicious.kubernetes.operator.model.ProxyModelBuilder;
 import io.kroxylicious.kubernetes.operator.model.networking.ClusterIngressNetworkingModel;
@@ -169,6 +170,10 @@ public class KafkaProxyReconciler implements
         this.statusFactory = new KafkaProxyStatusFactory(Objects.requireNonNull(clock));
         this.clock = clock;
         this.secureConfigInterpolator = secureConfigInterpolator;
+    }
+
+     public static StatusFactory<KafkaProxy> newStatusFactory(Clock clock) {
+        return new KafkaProxyStatusFactory(clock);
     }
 
     @Override

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconciler.java
@@ -172,7 +172,7 @@ public class KafkaProxyReconciler implements
         this.secureConfigInterpolator = secureConfigInterpolator;
     }
 
-     public static StatusFactory<KafkaProxy> newStatusFactory(Clock clock) {
+    public static StatusFactory<KafkaProxy> newStatusFactory(Clock clock) {
         return new KafkaProxyStatusFactory(clock);
     }
 

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyStatusFactory.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyStatusFactory.java
@@ -20,9 +20,9 @@ import io.kroxylicious.kubernetes.operator.StatusFactory;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
-public class KafkaProxyStatusFactory extends StatusFactory<KafkaProxy> {
+class KafkaProxyStatusFactory extends StatusFactory<KafkaProxy> {
 
-    public KafkaProxyStatusFactory(Clock clock) {
+    KafkaProxyStatusFactory(Clock clock) {
         super(clock);
     }
 

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyConfigStateDependentResource.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyConfigStateDependentResource.java
@@ -21,11 +21,11 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.operator.ProxyConfigStateData;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
+import io.kroxylicious.kubernetes.operator.StatusFactory;
 import io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator;
 import io.kroxylicious.kubernetes.operator.model.ProxyModel;
 import io.kroxylicious.kubernetes.operator.model.networking.IngressConflictException;
 import io.kroxylicious.kubernetes.operator.model.networking.ProxyNetworkingModel;
-import io.kroxylicious.kubernetes.operator.reconciler.virtualkafkacluster.VirtualKafkaClusterStatusFactory;
 import io.kroxylicious.kubernetes.operator.resolver.ClusterResolutionResult;
 
 import static io.kroxylicious.kubernetes.operator.Labels.standardLabels;
@@ -74,7 +74,7 @@ public class ProxyConfigStateDependentResource
         // @formatter:on
     }
 
-    private static void addAcceptedConditions(VirtualKafkaClusterStatusFactory statusFactory, ProxyModel proxyModel, ProxyConfigStateData data) {
+    private static void addAcceptedConditions(StatusFactory<VirtualKafkaCluster> statusFactory, ProxyModel proxyModel, ProxyConfigStateData data) {
         var model = proxyModel.networkingModel();
         for (ProxyNetworkingModel.ClusterNetworkingModel clusterNetworkingModel : model.clusterNetworkingModels()) {
             VirtualKafkaCluster cluster = clusterNetworkingModel.cluster();
@@ -96,7 +96,7 @@ public class ProxyConfigStateDependentResource
         }
     }
 
-    private static void addResolvedRefsConditions(VirtualKafkaClusterStatusFactory statusFactory, ProxyModel proxyModel, ProxyConfigStateData data) {
+    private static void addResolvedRefsConditions(StatusFactory<VirtualKafkaCluster> statusFactory, ProxyModel proxyModel, ProxyConfigStateData data) {
         proxyModel.resolutionResult().clusterResolutionResults().stream()
                 .filter(result -> !result.allReferentsFullyResolved() || ResourcesUtil.hasFreshResolvedRefsFalseCondition(result.cluster()))
                 .forEach(clusterResolutionResult -> {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconciler.java
@@ -31,6 +31,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.operator.OperatorLoggingKeys;
 import io.kroxylicious.kubernetes.operator.ResourceState;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
+import io.kroxylicious.kubernetes.operator.StatusFactory;
 import io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator;
 
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
@@ -58,6 +59,10 @@ public class KafkaProxyIngressReconciler implements
 
     public KafkaProxyIngressReconciler(Clock clock) {
         this.statusFactory = new KafkaProxyIngressStatusFactory(Objects.requireNonNull(clock));
+    }
+
+    public static StatusFactory<KafkaProxyIngress> newStatusFactory(Clock clock) {
+        return new KafkaProxyIngressStatusFactory(clock);
     }
 
     @Override

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressStatusFactory.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressStatusFactory.java
@@ -20,9 +20,9 @@ import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.StatusFactory;
 import io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator;
 
-public class KafkaProxyIngressStatusFactory extends StatusFactory<KafkaProxyIngress> {
+class KafkaProxyIngressStatusFactory extends StatusFactory<KafkaProxyIngress> {
 
-    public KafkaProxyIngressStatusFactory(Clock clock) {
+    KafkaProxyIngressStatusFactory(Clock clock) {
         super(clock);
     }
 

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceReconciler.java
@@ -40,6 +40,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.Tls;
 import io.kroxylicious.kubernetes.operator.OperatorLoggingKeys;
 import io.kroxylicious.kubernetes.operator.ResourceCheckResult;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
+import io.kroxylicious.kubernetes.operator.StatusFactory;
 import io.kroxylicious.kubernetes.operator.checksum.Crc32ChecksumGenerator;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -77,6 +78,10 @@ public final class KafkaServiceReconciler implements
 
     public KafkaServiceReconciler(Clock clock) {
         this.statusFactory = new KafkaServiceStatusFactory(clock);
+    }
+
+    public static StatusFactory<KafkaService> newStatusFactory(Clock clock) {
+        return new KafkaServiceStatusFactory(clock);
     }
 
     @Override

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStatusFactory.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStatusFactory.java
@@ -23,9 +23,9 @@ import io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
-public class KafkaServiceStatusFactory extends StatusFactory<KafkaService> {
+class KafkaServiceStatusFactory extends StatusFactory<KafkaService> {
 
-    public KafkaServiceStatusFactory(Clock clock) {
+    KafkaServiceStatusFactory(Clock clock) {
         super(clock);
     }
 

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconciler.java
@@ -59,6 +59,7 @@ import io.kroxylicious.kubernetes.operator.OperatorLoggingKeys;
 import io.kroxylicious.kubernetes.operator.ProxyConfigStateData;
 import io.kroxylicious.kubernetes.operator.ResourceState;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
+import io.kroxylicious.kubernetes.operator.StatusFactory;
 import io.kroxylicious.kubernetes.operator.checksum.Crc32ChecksumGenerator;
 import io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator;
 import io.kroxylicious.kubernetes.operator.resolver.ClusterResolutionResult;
@@ -108,6 +109,10 @@ public final class VirtualKafkaClusterReconciler implements
     public VirtualKafkaClusterReconciler(Clock clock, DependencyResolver resolver) {
         this.statusFactory = new VirtualKafkaClusterStatusFactory(clock);
         this.resolver = resolver;
+    }
+
+    public static StatusFactory<VirtualKafkaCluster> newStatusFactory(Clock clock) {
+        return new VirtualKafkaClusterStatusFactory(clock);
     }
 
     @Override

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterStatusFactory.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterStatusFactory.java
@@ -19,9 +19,9 @@ import io.kroxylicious.kubernetes.operator.ResourceState;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.StatusFactory;
 
-public class VirtualKafkaClusterStatusFactory extends StatusFactory<VirtualKafkaCluster> {
+class VirtualKafkaClusterStatusFactory extends StatusFactory<VirtualKafkaCluster> {
 
-    public VirtualKafkaClusterStatusFactory(Clock clock) {
+    VirtualKafkaClusterStatusFactory(Clock clock) {
         super(clock);
     }
 

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ResourcesUtilTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ResourcesUtilTest.java
@@ -64,9 +64,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.Ingresses;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressesBuilder;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.KafkaServiceReconciler;
-import io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.KafkaServiceStatusFactory;
 import io.kroxylicious.kubernetes.operator.reconciler.virtualkafkacluster.VirtualKafkaClusterReconciler;
-import io.kroxylicious.kubernetes.operator.reconciler.virtualkafkacluster.VirtualKafkaClusterStatusFactory;
 import io.kroxylicious.testing.operator.assertj.KafkaServiceStatusAssert;
 import io.kroxylicious.testing.operator.assertj.VirtualKafkaClusterStatusAssert;
 
@@ -796,7 +794,7 @@ class ResourcesUtilTest {
         // When
         ResourceCheckResult<VirtualKafkaCluster> actual = ResourcesUtil.checkTrustAnchorRef(vkc, reconcilerContext,
                 VirtualKafkaClusterReconciler.CONFIG_MAPS_TRUST_ANCHOR_REF_EVENT_SOURCE_NAME, trustAnchorRef,
-                "spec.ingresses[].tls.trustAnchor", new VirtualKafkaClusterStatusFactory(TEST_CLOCK));
+                "spec.ingresses[].tls.trustAnchor", VirtualKafkaClusterReconciler.newStatusFactory(TEST_CLOCK));
 
         // Then
         assertThat(actual)
@@ -828,7 +826,7 @@ class ResourcesUtilTest {
         // When
         ResourceCheckResult<KafkaService> actual = ResourcesUtil.checkStrimziKafkaRef(service, reconcilerContext,
                 KafkaServiceReconciler.STRIMZI_KAFKA_EVENT_SOURCE_NAME, strimziKafkaRef,
-                "spec.strimziKafkaRef", new KafkaServiceStatusFactory(TEST_CLOCK));
+                "spec.strimziKafkaRef", KafkaServiceReconciler.newStatusFactory(TEST_CLOCK));
 
         // Then
         assertThat(actual)
@@ -868,7 +866,7 @@ class ResourcesUtilTest {
                 KafkaServiceReconciler.STRIMZI_KAFKA_EVENT_SOURCE_NAME,
                 strimziKafkaRef,
                 "spec.strimziKafkaRef",
-                new KafkaServiceStatusFactory(TEST_CLOCK));
+                KafkaServiceReconciler.newStatusFactory(TEST_CLOCK));
 
         // Then
         assertThat(actual)
@@ -899,7 +897,7 @@ class ResourcesUtilTest {
         // When
         ResourceCheckResult<VirtualKafkaCluster> actual = ResourcesUtil.checkTrustAnchorRef(vkc, reconcilerContext,
                 VirtualKafkaClusterReconciler.CONFIG_MAPS_TRUST_ANCHOR_REF_EVENT_SOURCE_NAME, trustAnchorRef,
-                "spec.ingresses[].tls.trustAnchor", new VirtualKafkaClusterStatusFactory(TEST_CLOCK));
+                "spec.ingresses[].tls.trustAnchor", VirtualKafkaClusterReconciler.newStatusFactory(TEST_CLOCK));
 
         // Then
         assertThat(actual).isNotNull()
@@ -1050,7 +1048,7 @@ class ResourcesUtilTest {
         when(client.secrets().inNamespace(namespace).withName(kafkaName + "-cluster-ca-cert")).thenReturn(mock());
         when(client.secrets().inNamespace(namespace).withName(kafkaName + "-cluster-ca-cert").get()).thenReturn(clusterCaSecret);
 
-        KafkaServiceStatusFactory statusFactory = new KafkaServiceStatusFactory(TEST_CLOCK);
+        StatusFactory<KafkaService> statusFactory = KafkaServiceReconciler.newStatusFactory(TEST_CLOCK);
 
         // When
         ResourceCheckResult<KafkaService> result = ResourcesUtil.checkStrimziTrustAnchor(service, context, strimziKafkaRef, statusFactory);
@@ -1092,7 +1090,7 @@ class ResourcesUtilTest {
         when(client.secrets().inNamespace(namespace).withName(kafkaName + "-cluster-ca-cert")).thenReturn(mock());
         when(client.secrets().inNamespace(namespace).withName(kafkaName + "-cluster-ca-cert").get()).thenReturn(null);
 
-        KafkaServiceStatusFactory statusFactory = new KafkaServiceStatusFactory(TEST_CLOCK);
+        StatusFactory<KafkaService> statusFactory = KafkaServiceReconciler.newStatusFactory(TEST_CLOCK);
 
         // When
         ResourceCheckResult<KafkaService> result = ResourcesUtil.checkStrimziTrustAnchor(service, context, strimziKafkaRef, statusFactory);
@@ -1148,7 +1146,7 @@ class ResourcesUtilTest {
         when(client.secrets().inNamespace(namespace).withName(kafkaName + "-cluster-ca-cert")).thenReturn(mock());
         when(client.secrets().inNamespace(namespace).withName(kafkaName + "-cluster-ca-cert").get()).thenReturn(clusterCaSecret);
 
-        KafkaServiceStatusFactory statusFactory = new KafkaServiceStatusFactory(TEST_CLOCK);
+        StatusFactory<KafkaService> statusFactory = KafkaServiceReconciler.newStatusFactory(TEST_CLOCK);
 
         // When
         ResourceCheckResult<KafkaService> result = ResourcesUtil.checkStrimziTrustAnchor(service, context, strimziKafkaRef, statusFactory);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
@@ -118,6 +118,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static io.kroxylicious.kubernetes.api.common.Protocol.TCP;
 import static io.kroxylicious.kubernetes.api.common.Protocol.TLS;
+import static io.kroxylicious.kubernetes.operator.Labels.standardLabels;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.findOnlyResourceNamed;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.generation;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
@@ -633,7 +634,7 @@ public class KafkaProxyReconcilerIT {
                         "Expect Service '" + serviceName + " to exist")
                 .extracting(svc -> svc.getSpec().getSelector())
                 .describedAs("Service's selector should select proxy pods")
-                .isEqualTo(ProxyDeploymentDependentResource.podLabels(proxy));
+                .isEqualTo(standardLabels(proxy));
         assertThat(service.getSpec().getType()).isEqualTo("ClusterIP");
         assertThat(service.getSpec().getPorts()).singleElement().satisfies(onlyPort -> {
             assertThat(onlyPort.getProtocol()).isEqualTo("TCP");
@@ -680,7 +681,7 @@ public class KafkaProxyReconcilerIT {
                             "Expect shared SNI Service for proxy '" + name(proxy) + " to exist")
                     .extracting(svc -> svc.getSpec().getSelector())
                     .describedAs("Service's selector should select proxy pods")
-                    .isEqualTo(ProxyDeploymentDependentResource.podLabels(proxy));
+                    .isEqualTo(standardLabels(proxy));
             assertThat(service.getSpec().getType()).isEqualTo("LoadBalancer");
             // cannot use equality because the ServicePort has a random nodePort assigned to it
             assertThat(service.getSpec().getPorts()).singleElement().satisfies(onlyPort -> {
@@ -838,7 +839,7 @@ public class KafkaProxyReconcilerIT {
                             "Expect Service for cluster '" + clusterName + "' and ingress '" + ingressName + "' to still exist")
                     .extracting(svc -> svc.getSpec().getSelector())
                     .describedAs("Service's selector should select proxy pods")
-                    .isEqualTo(ProxyDeploymentDependentResource.podLabels(proxy));
+                    .isEqualTo(standardLabels(proxy));
             ServicePort bootstrapServicePort = clusterIpServicePort(expectedBootstrapPort);
             ServicePort node0ServicePort = clusterIpServicePort(expectedBootstrapPort + 1);
             ServicePort node1ServicePort = clusterIpServicePort(expectedBootstrapPort + 2);
@@ -920,7 +921,7 @@ public class KafkaProxyReconcilerIT {
                             "Expect shared SNI Service for proxy '" + name(proxy) + " to exist")
                     .extracting(svc -> svc.getSpec().getSelector())
                     .describedAs("Service's selector should select proxy pods")
-                    .isEqualTo(ProxyDeploymentDependentResource.podLabels(proxy));
+                    .isEqualTo(standardLabels(proxy));
             assertThat(service.getSpec().getType()).isEqualTo("ClusterIP");
 
             assertThat(service.getSpec().getPorts()).singleElement().satisfies(onlyPort -> {
@@ -1252,7 +1253,7 @@ public class KafkaProxyReconcilerIT {
                             "Expect Service for cluster '" + clusterName + "' and ingress '" + ingressName + "' to still exist")
                     .extracting(svc -> svc.getSpec().getSelector())
                     .describedAs("Service's selector should select proxy pods")
-                    .isEqualTo(ProxyDeploymentDependentResource.podLabels(proxy));
+                    .isEqualTo(standardLabels(proxy));
             assertThat(service.getSpec().getPorts()).describedAs("number of ports").hasSize(4);
         });
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyDeploymentTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyDeploymentTest.java
@@ -36,7 +36,7 @@ import io.kroxylicious.kubernetes.operator.Annotations;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.model.ProxyModel;
 import io.kroxylicious.kubernetes.operator.model.networking.ProxyNetworkingModel;
-import io.kroxylicious.kubernetes.operator.reconciler.virtualkafkacluster.VirtualKafkaClusterStatusFactory;
+import io.kroxylicious.kubernetes.operator.reconciler.virtualkafkacluster.VirtualKafkaClusterReconciler;
 import io.kroxylicious.kubernetes.operator.resolver.ClusterResolutionResult;
 import io.kroxylicious.kubernetes.operator.resolver.ResolutionResult;
 import io.kroxylicious.testing.operator.assertj.OperatorAssertions;
@@ -179,7 +179,7 @@ class ProxyDeploymentTest {
 
     private void configureProxyModel(ProxyModel proxyModel) {
         resourceContext.put(KafkaProxyContext.KEY_CTX,
-                new KafkaProxyContext(new VirtualKafkaClusterStatusFactory(Clock.systemUTC()), proxyModel, Optional.empty(), List.of(), List.of()));
+                new KafkaProxyContext(VirtualKafkaClusterReconciler.newStatusFactory(Clock.systemUTC()), proxyModel, Optional.empty(), List.of(), List.of()));
     }
 
     @NonNull

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyDeploymentTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyDeploymentTest.java
@@ -80,18 +80,6 @@ class ProxyDeploymentTest {
                 .isEqualTo("quay.io/myorg/kroxylicious:1");
     }
 
-    // labels don't technically need to be ordered, but deterministic output reduces noise when comparing output YAML
-    @Test
-    void podLabelsDeterministicallyOrdered() {
-        // Given
-        LinkedHashMap<String, String> expected = expectedLabels();
-        // When
-        Map<String, String> labels = ProxyDeploymentDependentResource.podLabels(kafkaProxy);
-
-        // Then
-        assertThat(labels).containsExactlyEntriesOf(expected);
-    }
-
     @Test
     void proxyContainerInfrastructureResourcesPreferred() {
         // Given


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

- Changed `ProxyDeploymentDependentResource.podLabels()` to `standardLabels()` where appropriate.
- Added new public `<Reconciler>.newStatusFactory()` method to KPI, KS and VKC reconcilers.
  - Switched use of `???StatusFactory` (now package-private) to `StatusFactory<???>`.

### Additional Context

Resolves #3296

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] User facing documentation written/updated (where applicable).
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).