### PR TITLE
fix(integration-tests): retry on coordinator load errors in group AuthzIT tests

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/AuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/AuthzIT.java
@@ -619,4 +619,9 @@ public abstract class AuthzIT extends BaseIT {
         }
     }
 
+    static boolean isTransientCoordinatorError(short errorCode) {
+        Errors error = Errors.forCode(errorCode);
+        return error == Errors.NOT_COORDINATOR || error == Errors.COORDINATOR_LOAD_IN_PROGRESS || error == Errors.COORDINATOR_NOT_AVAILABLE;
+    }
+
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/HeartbeatAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/HeartbeatAuthzIT.java
@@ -153,6 +153,14 @@ public class HeartbeatAuthzIT extends AuthzIT {
         }
 
         @Override
+        public boolean needsRetry(HeartbeatResponseData response) {
+            Errors error = Errors.forCode(response.errorCode());
+            return error == Errors.NOT_COORDINATOR
+                    || error == Errors.COORDINATOR_LOAD_IN_PROGRESS
+                    || error == Errors.COORDINATOR_NOT_AVAILABLE;
+        }
+
+        @Override
         public void assertUnproxiedResponses(Map<String, HeartbeatResponseData> unproxiedResponsesByUser) {
             Errors aliceError = Errors.forCode(unproxiedResponsesByUser.get(ALICE).errorCode());
             Errors bobError = Errors.forCode(unproxiedResponsesByUser.get(BOB).errorCode());

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/HeartbeatAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/HeartbeatAuthzIT.java
@@ -154,10 +154,7 @@ public class HeartbeatAuthzIT extends AuthzIT {
 
         @Override
         public boolean needsRetry(HeartbeatResponseData response) {
-            Errors error = Errors.forCode(response.errorCode());
-            return error == Errors.NOT_COORDINATOR
-                    || error == Errors.COORDINATOR_LOAD_IN_PROGRESS
-                    || error == Errors.COORDINATOR_NOT_AVAILABLE;
+            return isTransientCoordinatorError(response.errorCode());
         }
 
         @Override

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/JoinGroupAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/JoinGroupAuthzIT.java
@@ -156,7 +156,10 @@ public class JoinGroupAuthzIT extends AuthzIT {
 
         @Override
         public boolean needsRetry(JoinGroupResponseData response) {
-            return Errors.forCode(response.errorCode()) == Errors.NOT_COORDINATOR;
+            Errors error = Errors.forCode(response.errorCode());
+            return error == Errors.NOT_COORDINATOR
+                    || error == Errors.COORDINATOR_LOAD_IN_PROGRESS
+                    || error == Errors.COORDINATOR_NOT_AVAILABLE;
         }
 
         @Override

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/JoinGroupAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/JoinGroupAuthzIT.java
@@ -156,10 +156,7 @@ public class JoinGroupAuthzIT extends AuthzIT {
 
         @Override
         public boolean needsRetry(JoinGroupResponseData response) {
-            Errors error = Errors.forCode(response.errorCode());
-            return error == Errors.NOT_COORDINATOR
-                    || error == Errors.COORDINATOR_LOAD_IN_PROGRESS
-                    || error == Errors.COORDINATOR_NOT_AVAILABLE;
+            return isTransientCoordinatorError(response.errorCode());
         }
 
         @Override

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/LeaveGroupAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/LeaveGroupAuthzIT.java
@@ -162,6 +162,14 @@ class LeaveGroupAuthzIT extends AuthzIT {
         }
 
         @Override
+        public boolean needsRetry(LeaveGroupResponseData response) {
+            Errors error = Errors.forCode(response.errorCode());
+            return error == Errors.NOT_COORDINATOR
+                    || error == Errors.COORDINATOR_LOAD_IN_PROGRESS
+                    || error == Errors.COORDINATOR_NOT_AVAILABLE;
+        }
+
+        @Override
         public LeaveGroupRequestData requestData(String user, BaseClusterFixture clusterFixture) {
             LeaveGroupRequestData request = new LeaveGroupRequestData();
             request.setGroupId(group);

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/LeaveGroupAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/LeaveGroupAuthzIT.java
@@ -163,10 +163,7 @@ class LeaveGroupAuthzIT extends AuthzIT {
 
         @Override
         public boolean needsRetry(LeaveGroupResponseData response) {
-            Errors error = Errors.forCode(response.errorCode());
-            return error == Errors.NOT_COORDINATOR
-                    || error == Errors.COORDINATOR_LOAD_IN_PROGRESS
-                    || error == Errors.COORDINATOR_NOT_AVAILABLE;
+            return isTransientCoordinatorError(response.errorCode());
         }
 
         @Override

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/SyncGroupAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/SyncGroupAuthzIT.java
@@ -160,6 +160,14 @@ class SyncGroupAuthzIT extends AuthzIT {
         }
 
         @Override
+        public boolean needsRetry(SyncGroupResponseData response) {
+            Errors error = Errors.forCode(response.errorCode());
+            return error == Errors.NOT_COORDINATOR
+                    || error == Errors.COORDINATOR_LOAD_IN_PROGRESS
+                    || error == Errors.COORDINATOR_NOT_AVAILABLE;
+        }
+
+        @Override
         public SyncGroupRequestData requestData(String user, BaseClusterFixture clusterFixture) {
             SyncGroupRequestData request = new SyncGroupRequestData();
             request.setGroupId(group);

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/SyncGroupAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/SyncGroupAuthzIT.java
@@ -161,10 +161,7 @@ class SyncGroupAuthzIT extends AuthzIT {
 
         @Override
         public boolean needsRetry(SyncGroupResponseData response) {
-            Errors error = Errors.forCode(response.errorCode());
-            return error == Errors.NOT_COORDINATOR
-                    || error == Errors.COORDINATOR_LOAD_IN_PROGRESS
-                    || error == Errors.COORDINATOR_NOT_AVAILABLE;
+            return isTransientCoordinatorError(response.errorCode());
         }
 
         @Override


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Add or extend `needsRetry()` in JoinGroupAuthzIT, HeartbeatAuthzIT, SyncGroupAuthzIT, and LeaveGroupAuthzIT to handle coordinator transient errors: `COORDINATOR_LOAD_IN_PROGRESS`, `COORDINATOR_NOT_AVAILABLE`, and `NOT_COORDINATOR`.

All four tests share the same vulnerability: a race condition between `findCoordinator()` in `prepareCluster()` and the actual test request being sent on a different connection. During this window, the coordinator may transition to LOADING state while processing metadata updates, causing these transient errors.

Kafka source code analysis (`CoordinatorRuntime.withActiveContextOrThrow()` at line 2218) confirms that all group coordinator write operations (joinGroup, syncGroup, heartbeat, leaveGroup) throw `COORDINATOR_LOAD_IN_PROGRESS` when the coordinator is loading.

### Testing

All four modified tests pass successfully:
- JoinGroupAuthzIT: 20 tests ✅
- HeartbeatAuthzIT: 10 tests ✅
- SyncGroupAuthzIT: 12 tests ✅
- LeaveGroupAuthzIT: 12 tests ✅

### Additional Context

Fixes #3936

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>