### PR TITLE
fix(performance-tests): use rolling tag instead of SHA for proxy image

### DIFF
--- a/performance-tests/docker-compose.yaml
+++ b/performance-tests/docker-compose.yaml
@@ -52,7 +52,7 @@ services:
       retries: 5
       timeout: 10s
   kroxylicious:
-    image: ${KROXYLICIOUS_IMAGE:-quay.io/kroxylicious/proxy:0.21.0-SNAPSHOT@sha256:74e25f213dcd2e74b0c5811b0af353dbc990717e05be43a48e1ed44b1c6add3c}
+    image: ${KROXYLICIOUS_IMAGE:-quay.io/kroxylicious/proxy:0.21.0-SNAPSHOT}
     hostname: kroxylicious
     container_name: kroxylicious
     # this is to enable async_profiler

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -157,6 +157,7 @@ replaceInFile "s_:KroxyliciousGitRef:.*_:KroxyliciousGitRef: v${RELEASE_VERSION}
 replaceInFile "s_image: 'quay.io/kroxylicious/proxy:.*'_image: 'quay.io/kroxylicious/proxy:${RELEASE_VERSION}'_g" compose/kafka-compose.yaml
 
 updateVersionInBenchmarks "${RELEASE_VERSION}"
+replaceInFile "s_quay\.io/kroxylicious/proxy:[^}]*_quay.io/kroxylicious/proxy:${RELEASE_VERSION}_g" performance-tests/docker-compose.yaml
 
 echo "Validating things still build"
 mvn -q -B clean install -Pquick
@@ -203,6 +204,7 @@ replaceInFile "s_:KroxyliciousGitRef:.*_:KroxyliciousGitRef: main_g" kroxyliciou
 replaceInFile "s_image: 'quay.io/kroxylicious/proxy:.*'_image: 'quay.io/kroxylicious/proxy:${NEXT_VERSION}'_g" compose/kafka-compose.yaml
 
 updateVersionInBenchmarks "${NEXT_VERSION}"
+replaceInFile "s_quay\.io/kroxylicious/proxy:[^}]*_quay.io/kroxylicious/proxy:${NEXT_VERSION}_g" performance-tests/docker-compose.yaml
 
 # bump the reference version in kroxylicious-api
 mvn -q -B -pl :kroxylicious-api versions:set-property -Dproperty="ApiCompatability.ReferenceVersion" -DnewVersion="${RELEASE_VERSION}" -DgenerateBackupPoms=false


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Removes the SHA digest from the default Kroxylicious proxy image reference in `performance-tests/docker-compose.yaml`, using just the rolling tag instead.

### Additional Context

Raised in review of #3933 — pinning to a SHA digest creates churn on `main` because every push produces a new digest, causing an otherwise-trivial diff each time. Using the tag alone tracks the rolling SNAPSHOT image without that noise.

Closes #3933 (review comment r3228077891).

### Checklist

- [x] New tests written (where applicable).
- [x] User facing documentation written/updated (where applicable).
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).