### PR TITLE
build(release): attach admission webhook artifacts to GitHub releases

### DIFF
--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -226,6 +226,7 @@ cp kroxylicious-api/target/japicmp/japicmp.html "${API_COMPATABILITY_REPORT}"
 # csplit will create a file for every version as we use ## to denote versions. We also use # CHANGELOG as a header so the current release is actually in the 01 file (zero based)
 APP_BINARY_DISTRIBUTION_ASSET="./kroxylicious-app/target/kroxylicious-app-${RELEASE_VERSION}-bin"
 OPERATOR_BINARY_DISTRIBUTION_ASSET="./kroxylicious-kubernetes/kroxylicious-operator-dist/target/kroxylicious-operator-${RELEASE_VERSION}"
+ADMISSION_BINARY_DISTRIBUTION_ASSET="./kroxylicious-kubernetes/kroxylicious-admission-dist/target/kroxylicious-admission-${RELEASE_VERSION}"
 gh release create --title "${RELEASE_TAG}" \
   --notes-file "${RELEASE_NOTES_DIR}/release-notes_01" \
   --draft "${RELEASE_TAG}" \
@@ -237,6 +238,10 @@ gh release create --title "${RELEASE_TAG}" \
   "${OPERATOR_BINARY_DISTRIBUTION_ASSET}.tar.gz.asc" \
   "${OPERATOR_BINARY_DISTRIBUTION_ASSET}.zip" \
   "${OPERATOR_BINARY_DISTRIBUTION_ASSET}.zip.asc" \
+  "${ADMISSION_BINARY_DISTRIBUTION_ASSET}.tar.gz" \
+  "${ADMISSION_BINARY_DISTRIBUTION_ASSET}.tar.gz.asc" \
+  "${ADMISSION_BINARY_DISTRIBUTION_ASSET}.zip" \
+  "${ADMISSION_BINARY_DISTRIBUTION_ASSET}.zip.asc" \
   "${API_COMPATABILITY_REPORT}"
 
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Include kroxylicious-admission-dist distribution artifacts (tar.gz and zip with signatures) in the GitHub release, following the same pattern as the operator distribution.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] User facing documentation written/updated (where applicable).
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
