### PR TITLE
docs(benchmarks): add Performance and Sizing Guide for record encryption

### DIFF
--- a/kroxylicious-docs/docs/_assets/attributes.adoc
+++ b/kroxylicious-docs/docs/_assets/attributes.adoc
@@ -189,3 +189,7 @@ ifndef::DocRoot[:DocRoot: ..]
 :ConnectionExpirationGuideUrl: {DocRoot}/connection-expiration-guide/
 :ConnectionExpirationGuideText: Connection Expiration guide
 :ConnectionExpirationGuide: link:{ConnectionExpirationGuideUrl}[{ConnectionExpirationGuideText}]
+
+:PerformanceGuideUrl: {DocRoot}/performance-guide/
+:PerformanceGuideText: Performance and Sizing guide
+:PerformanceGuide: link:{PerformanceGuideUrl}[{PerformanceGuideText}]

--- a/kroxylicious-docs/docs/index.adoc
+++ b/kroxylicious-docs/docs/index.adoc
@@ -20,3 +20,5 @@ This release of Kroxylicious is documented in the following guides:
 {RecordValidationGuide}:: Covers using the record validation filter.
 
 {DeveloperGuide}:: Covers writing plugins for the proxy in the Java programming language
+
+{PerformanceGuide}:: Covers sizing Kroxylicious for production deployments — passthrough overhead and record encryption CPU budgeting.

--- a/kroxylicious-openmessaging-benchmarks/SIZING-GUIDE.md
+++ b/kroxylicious-openmessaging-benchmarks/SIZING-GUIDE.md
@@ -1,0 +1,255 @@
+# Kroxylicious Sizing Guide
+
+## Overview
+
+This guide helps operators estimate the performance impact of deploying Kroxylicious as a proxy layer in front of Apache Kafka. It covers two configurations:
+
+1. **Passthrough proxy** (no filters) — the baseline cost of the proxy layer itself
+2. **Record encryption** — the additional cost of encrypting/decrypting record payloads
+
+The goal is to give you the data you need to right-size your deployment: how much additional latency to expect, and where the throughput ceiling sits.
+
+## Executive Summary
+
+- **Passthrough proxy (no filters):** negligible overhead. Average publish latency increased by ~0.2 ms (+6%), with no measurable throughput impact. The proxy layer itself is not a bottleneck.
+
+- **Record encryption (AES-256-GCM):** measurable but predictable overhead.
+  - **Throughput:** ~26% reduction per partition (~37k msg/sec vs ~50k msg/sec baseline with 1 KB messages)
+  - **Latency at sub-saturation rates:** average publish latency increased by 0.2–3 ms depending on load; p99 increased by 15–40 ms
+  - **CPU cost:** encryption added ~33% CPU overhead (13% direct crypto, 20% buffer management/GC/re-encoding), consistent with the throughput reduction
+  - **Scaling:** throughput scales linearly with CPU allocation — ~40,000 msg/s per core at 1 KB. Validated at 1, 2, and 4 cores. Set `requests == limits` for a predictable, stable thread count.
+
+## Methodology
+
+All benchmarks used [OpenMessaging Benchmark (OMB)](https://github.com/openmessaging/benchmark), an industry-standard tool for measuring messaging system performance. We ran three scenarios against the same Kafka cluster on the same hardware:
+
+- **Baseline**: OMB producers/consumers talked directly to Kafka
+- **Proxy (no filters)**: Traffic passed through Kroxylicious with no filter chain configured
+- **Encryption**: Traffic passed through Kroxylicious with the record encryption filter enabled (AES-256-GCM, Vault KMS)
+
+For throughput ceiling testing, we used **rate sweeps** — running the same workload at progressively higher producer rates and measuring where the system saturated (achieved rate dropped below 95% of target).
+
+The primary workload used a single topic with a single partition. This deliberately concentrates all traffic on a single broker, reaching the broker's per-partition throughput limit at lower absolute rates and making proxy overhead easier to isolate and measure. Multi-topic workloads were used to verify that the overhead characteristics hold when load is spread across brokers.
+
+### Workloads
+
+| Workload | Topics | Partitions per topic | Message size | Producer rate |
+|----------|--------|---------------------|--------------|---------------|
+| 1topic-1kb | 1 | 1 | 1 KB | 50,000 msg/sec |
+| 10topics-1kb | 10 | 1 | 1 KB | 5,000 msg/sec (per topic) |
+| 100topics-1kb | 100 | 1 | 1 KB | 500 msg/sec (per topic) |
+
+## Proxy Overhead (No Filters)
+
+The passthrough proxy added minimal overhead. At sub-saturation rates, the additional latency was sub-millisecond on average.
+
+### 10 topics, 1KB messages (5,000 msg/sec per topic)
+
+| Metric | Baseline | Proxy | Delta |
+|--------|----------|-------|-------|
+| Publish latency avg | 2.62 ms | 2.79 ms | +0.17 ms (+6.6%) |
+| Publish latency p99 | 14.09 ms | 15.17 ms | +1.08 ms (+7.7%) |
+| E2E latency avg | 94.87 ms | 95.34 ms | +0.47 ms (+0.5%) |
+| E2E latency p99 | 185.00 ms | 186.00 ms | +1.00 ms (+0.5%) |
+| Publish rate | 5,002 msg/s | 5,002 msg/s | 0 |
+
+### 100 topics, 1KB messages (500 msg/sec per topic)
+
+| Metric | Baseline | Proxy | Delta |
+|--------|----------|-------|-------|
+| Publish latency avg | 2.66 ms | 2.82 ms | +0.16 ms (+6.2%) |
+| Publish latency p99 | 5.54 ms | 6.07 ms | +0.53 ms (+9.5%) |
+| E2E latency avg | 253.16 ms | 253.76 ms | +0.60 ms (+0.2%) |
+| E2E latency p99 | 499.00 ms | 499.00 ms | 0 |
+| Publish rate | 500 msg/s | 500 msg/s | 0 |
+
+**Key takeaway**: The proxy layer itself added ~0.2 ms average publish latency and had no measurable impact on throughput. End-to-end latency was dominated by consumer fetch intervals, so the proxy's contribution was negligible in that metric.
+
+## Record Encryption Overhead
+
+Encryption added measurable latency and reduced the maximum sustainable throughput.
+
+### Latency impact at sub-saturation rates
+
+The encryption overhead scaled with producer rate. At lower rates the proxy had more headroom; as rate approached the saturation point, latency increased sharply.
+
+1 topic, 1KB messages, RF=3 — baseline vs encryption at three sub-saturation rates:
+
+| Rate | Metric | Baseline | Encryption | Delta |
+|------|--------|----------|------------|-------|
+| 10,400 | Publish latency p99 | 41 ms | 48 ms | +7 ms (+17%) |
+| 13,400 | Publish latency p99 | 44 ms | 54 ms | +10 ms (+23%) |
+| 14,600 | Publish latency p99 | 62 ms | 81 ms | +19 ms (+31%) |
+
+### Multi-topic latency (sub-saturation)
+
+At lower per-topic rates, encryption overhead is smaller in absolute terms.
+
+**10 topics, 5,000 msg/sec total (~500 msg/sec per topic), RF=3:**
+
+| Metric | Baseline | Encryption | Delta |
+|--------|----------|------------|-------|
+| Publish latency avg | 106 ms | 106 ms | 0 (noise) |
+| Publish latency p99 | 207 ms | 198 ms | -9 ms (noise) |
+| Publish latency p99.9 | 230 ms | 288 ms | +58 ms (+25%) |
+| Publish rate | 50,084 msg/s | 50,069 msg/s | statistically identical |
+
+At 500 msg/sec per partition, encryption overhead is invisible at p99 — latency is dominated
+by broker-side batching and consumer fetch intervals. Only the p99.9 tail shows meaningful
+increase.
+
+**100 topics, 500 msg/sec total (~5 msg/sec per topic), RF=3:**
+
+| Metric | Baseline | Encryption | Delta |
+|--------|----------|------------|-------|
+| Publish latency avg | 5.07 ms | 6.68 ms | +1.61 ms (+32%) |
+| Publish latency p99 | 23.41 ms | 25.94 ms | +2.53 ms (+11%) |
+| Publish latency p99.9 | 32.90 ms | 47.57 ms | +14.67 ms (+45%) |
+| E2E latency avg | 257 ms | 259 ms | +2 ms (+0.9%) |
+| E2E latency p99 | 503 ms | 506 ms | +3 ms (+0.6%) |
+| Publish rate | 50,036 msg/s | 50,072 msg/s | statistically identical |
+
+### Throughput ceiling
+
+Using rate sweeps on a single partition (1 topic, 1KB messages, RF=3, 5% steps from 8,000–20,000 msg/sec):
+
+- **Baseline**: sustained up to **19,400 msg/sec**. Saturated at 20,000 (19,334 achieved, p99=4,199 ms).
+- **Proxy (no filters)**: clean up to **18,200 msg/sec**. Noisy above that — some probes at 18,800 and 20,000 failed; 19,400 recovered. The ceiling is approximately 18,200 msg/sec.
+- **Encryption**: sustained up to **14,600 msg/sec** (81 ms p99). First saturation at 15,200 (14,932 achieved, p99=4,809 ms). Intermittent behaviour above that — some probes sustained, others saturated.
+
+**Estimated throughput cost of encryption: ~4,800 msg/sec (~25%) per partition.**
+
+The absolute ceiling is lower than single-host benchmarks because RF=3 Kafka ISR replication
+adds ~4 ms round-trip per ack, capping single-partition throughput to ~17–19k msg/sec regardless
+of proxy CPU. This is the realistic production ceiling; the proxy CPU ceiling is much higher
+(see [CPU sizing coefficient](#cpu-sizing-coefficient)).
+
+| Rate range | Behaviour |
+|------------|-----------|
+| 8,000–14,600 | Stable. All probes sustained, p99 38–81 ms |
+| 15,200 | First saturation (encryption); baseline still stable |
+| 15,800–18,200 | Encryption intermittent; baseline and no-filters stable |
+| 18,800–20,000 | All scenarios saturate |
+
+### Where the CPU goes
+
+Comparing CPU flamegraphs between the no-filter proxy and encryption showed that the no-filter proxy was almost entirely I/O-bound (59% of CPU in send/recv syscalls). Encryption added ~13% direct crypto cost (AES-256-GCM) plus ~20% indirect costs (buffer management, GC pressure, record re-encoding), totalling ~33% additional CPU — consistent with the ~26% throughput reduction.
+
+For a detailed breakdown, see [CPU-PROFILE-ANALYSIS.md](CPU-PROFILE-ANALYSIS.md).
+
+> **Caveat**: Each rate point was measured once. Environmental noise (pod scheduling, GC pauses) contributed to the intermittent behaviour above the knee. Multi-pass sweeps would give tighter bounds on the exact saturation point. See [Limitations](#limitations).
+
+### CPU sizing coefficient
+
+The per-partition ceiling understates aggregate proxy capacity because it conflates the Kafka broker partition limit with the proxy CPU limit. Using connection sweeps (fixed per-producer rate, increasing producer count, RF=1 workload to eliminate per-partition ceilings) we isolated the proxy's saturation point independent of any single partition — and validated that it scales linearly with CPU allocation.
+
+**Measured coefficient: ~10 millicores per MB/s of proxy throughput** on AMD EPYC-Rome at 2 GHz with AES-NI.
+
+This is a conservative planning figure derived from 10-topic workloads, which are more representative than single-topic benchmarks (where a single partition's throughput ceiling can artificially depress the measurement). More realistic deployments with many topics show lower overhead — see the validation table below.
+
+Encrypt and decrypt have the same per-byte cost, so the coefficient applies uniformly regardless of direction:
+
+**Sizing formula:**
+
+```
+CPU (millicores) = 10 × total_proxy_MB_per_s
+```
+
+where `total_proxy_MB_per_s` is the sum of all traffic flowing through the proxy — count produce throughput once (encrypted), and each consumer group's consume throughput once (decrypted independently). Fan-out is handled naturally: a topic with 1 producer at 100 MB/s and 5 consumer groups each reading 100 MB/s totals 600 MB/s × 10 mc = 6,000 mc.
+
+Equivalently: **~1 core per 100 MB/s of proxy traffic**, or **~40,000 msg/s per core at 1 KB per stream** (equivalent to 80 MB/s bidirectional per core for 1:1 produce/consume).
+
+Example sizing table (1 KB messages):
+
+| Scenario | Total proxy traffic | CPU required |
+|----------|---------------------|--------------|
+| 40k msg/s, 1 consumer group | 80 MB/s | 800 mc (~1 core) |
+| 100k msg/s, 1 consumer group | 200 MB/s | 2,000 mc (2 cores) |
+| 100k msg/s, 3 consumer groups | 400 MB/s | 4,000 mc (4 cores) |
+| 200k msg/s, 1 consumer group | 400 MB/s | 4,000 mc (4 cores) |
+
+Add ×1.3 headroom for GC pauses and burst traffic.
+
+**Empirical basis — validated across 9 configurations:**
+
+Connection sweeps were run at 1, 2, and 4 CPU cores across 1, 10, and 100 topic workloads (RF=1, 1 KB messages, 10k msg/s per producer, steps 1–32 producers). The coefficient was extracted from JFR CPU data using `analyze-cpu-coefficient.py`.
+
+| Config | Coefficient | Stdev | n |
+|--------|-------------|-------|---|
+| 1 core, 1 topic | 15.7 mc/MB/s | ±8.2 | 4 |
+| 2 core, 1 topic | 24.3 mc/MB/s | ±17.7 | 5 |
+| 4 core, 1 topic | 30.5 mc/MB/s | ±18.6 | 5 |
+| **1 core, 10 topics** | **10.0 mc/MB/s** | **±7.8** | **6** |
+| 2 core, 10 topics | 19.9 mc/MB/s | ±16.1 | 6 |
+| 4 core, 10 topics | 25.1 mc/MB/s | ±16.1 | 6 |
+| 1 core, 100 topics | 4.3 mc/MB/s | ±2.5 | 5 |
+| 2 core, 100 topics | 6.8 mc/MB/s | ±3.5 | 5 |
+| 4 core, 100 topics | 8.0 mc/MB/s | ±4.4 | 5 |
+
+The **1-core, 10-topic** measurement (10.0 mc/MB/s) is the basis for the sizing formula. The large stdev across all series reflects fixed per-connection overhead that is high at low producer counts and amortises as throughput scales — the coefficient is not constant but the mean is a reasonable planning figure.
+
+The 1-topic series has elevated coefficients because a single partition concentrates all traffic on one broker; the proxy runs hot while Kafka itself becomes the bottleneck. The 100-topic series (4–8 mc/MB/s) represents a more realistic production deployment where load is spread across many partitions and brokers — in practice, the proxy overhead is significantly lower than the formula suggests. The 10 mc/MB/s figure is deliberately conservative.
+
+The Kroxylicious event loop thread count defaults to `Runtime.getRuntime().availableProcessors()` (configurable via `NettySettings.workerThreadCount`). Each event loop thread handles its assigned connections serially, so proxy throughput scales with the number of threads and therefore with CPU allocation.
+
+On JDK 21 with `-XX:+UseContainerSupport` (on by default), `availableProcessors()` is computed from the container's CFS CPU quota: `ceil(cpu.cfs_quota_us / cpu.cfs_period_us)`. For `cpu: 1000m` this gives `ceil(100ms / 100ms) = 1`; for `cpu: 2000m`, `2`; and so on. Crucially, **only CPU limits drive this — CPU requests do not**. Since JDK 21, CPU shares/requests were removed from the processor count calculation entirely. A pod with a CPU request but no limit will cause the JVM to see all host CPUs and spawn far more event loop threads than the CPU budget can sustain. Setting `requests == limits` is therefore essential for predictable thread counts, not merely a scheduling nicety. For absolute certainty, set `NettySettings.workerThreadCount` explicitly.
+
+For 1:1 produce/consume this simplifies to `20 × produce_MB_per_s`; for fan-out, sum each consumer group separately.
+
+> **Hardware note**: AES-NI is present on the test CPUs. On CPUs without hardware AES acceleration the coefficient will be significantly higher. Always validate with a load test before committing to a production sizing.
+
+## Sizing Recommendations
+
+### Passthrough proxy
+
+The proxy layer adds negligible overhead. Size your Kafka cluster as you normally would — the proxy will not be the bottleneck.
+
+### Record encryption
+
+When planning for record encryption:
+
+1. **CPU sizing**: Use the coefficient formula from [CPU sizing coefficient](#cpu-sizing-coefficient):
+   ```
+   CPU (millicores) = 10 × total_proxy_MB_per_s
+   ```
+   where `total_proxy_MB_per_s` = produce MB/s + each consumer group's consume MB/s.
+   For balanced 1:1 workloads this is `20 × produce_MB_per_s`. For fan-out topics, sum
+   the full consume throughput across all consumer groups. Add ×1.3 headroom for GC
+   pauses and burst. Set CPU *requests* equal to *limits* (guaranteed QoS class).
+   Without a CPU limit, the JVM sees all host CPUs and spawns more event loop
+   threads than the CPU budget can sustain. For absolute certainty, set
+   `NettySettings.workerThreadCount` explicitly.
+
+2. **Throughput budget**: Expect ~25% throughput reduction per partition compared to direct Kafka access when the proxy has 1 core available. With more cores, the proxy ceases to be the bottleneck before the partition limit is reached.
+
+3. **Latency budget**: At sub-saturation rates, expect:
+   - Average publish latency to increase 2-34% depending on how close to the saturation point (~0.2-3 ms additional)
+   - p99 publish latency to increase 30-50% (~15-40 ms additional)
+   - Overhead scales with rate — well below saturation, encryption adds very little latency
+
+4. **Scaling**: The proxy scales vertically (more cores per pod) and horizontally (more pods). Both approaches are effective. Horizontal scaling reduces blast radius per pod.
+
+5. **KMS overhead**: DEK generation and caching means the KMS is not in the hot path for every record. In our tests, KMS operations were low (5-19 `generate_dek_pair` calls per benchmark run). KMS latency is unlikely to be a factor unless your KMS is very slow or unavailable.
+
+## Limitations
+
+- **Single-pass measurements**: Each rate point was measured once. Environmental noise (pod scheduling, GC pauses, noisy neighbours) can affect individual probes. Multi-pass aggregation would improve confidence.
+- **Single proxy pod**: All tests used a single proxy instance. Horizontal scaling characteristics are not yet measured.
+- **Single partition saturation**: The 1-topic rate sweep workload hits Kafka's per-partition throughput limit (~50k msg/sec), which is close to the encryption ceiling. The connection sweep and coefficient derivation used a 10-topic RF=1 workload to eliminate this ceiling.
+- **Hardware-specific**: Encryption is CPU-bound. Results will differ on other CPU architectures and clock speeds.
+- **Coefficient validated at 1, 2, and 4 cores across 1, 10, and 100 topic workloads**: The 10 mc/MB/s planning figure is anchored to the 10-topic, 1-core measurement. Behaviour beyond 4 cores is untested but expected to follow the same model.
+
+## Appendix: Test Environment
+
+| Component | Details |
+|-----------|---------|
+| Cluster | 8 nodes, 8 vCPUs / 15 GB RAM each |
+| CPU | AMD EPYC-Rome, 2000 MHz |
+| OS | Red Hat Enterprise Linux CoreOS 9.6 |
+| Kernel | 5.14.0-570.103.1.el9_6.x86_64 |
+| Kubernetes | v1.34.6 |
+| Kafka | 3 brokers (Strimzi) |
+| Kroxylicious | 0.20.0, single proxy pod |
+| KMS | HashiCorp Vault (in-cluster) |
+| Benchmark tool | OpenMessaging Benchmark |
+| Orchestrator | Linux amd64, 4 vCPUs, 7 GB RAM, AMD EPYC-Rome |

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/scenarios/connection-sweep-values.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/scenarios/connection-sweep-values.yaml
@@ -10,12 +10,12 @@
 # 5 min warmup allows JIT to stabilise before measurement begins.
 # 5 min test gives enough samples for stable p99 latency at typical rates.
 #
-# workerReplicas is raised to 6 to give headroom at high producer counts (up to
-# 8 producers + 8 consumers per step) without workers becoming the bottleneck.
-# OMB assigns ~1/3 of workers to producers and the rest to consumers, so 6 workers
-# gives 2 producer workers.  At 8 producers × 10k msg/s = 80k total, each producer
-# worker handles ~40k msg/s — the CPU limit is raised to 2000m to keep workers
-# well clear of saturation before the proxy CPU becomes the bottleneck.
+# workerReplicas is set to 4 to fit within an 8-node cluster alongside 3 Kafka
+# brokers and 1 proxy (all with hard pod anti-affinity requiring dedicated nodes).
+# OMB assigns ~1/3 of workers to producers and the rest to consumers, so 4 workers
+# gives 1-2 producer workers. At 16 producers × 10k msg/s = 160k total this is
+# sufficient — the CPU limit is raised to 2000m to keep workers well clear of
+# saturation before the proxy CPU becomes the bottleneck.
 #
 # Applied automatically by connection-sweep.sh unless overridden with --profile.
 
@@ -24,7 +24,7 @@ benchmark:
   warmupDurationMinutes: 5
 
 omb:
-  workerReplicas: 6
+  workerReplicas: 4
   resources:
     requests:
       cpu: "1000m"

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/scenarios/smoke-values.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/scenarios/smoke-values.yaml
@@ -44,14 +44,14 @@ omb:
         cpu: "500m"
   resources:
     requests:
-      memory: "1Gi"
+      memory: "2Gi"
       cpu: "250m"
     limits:
-      memory: "2Gi"
+      memory: "4Gi"
       cpu: "500m"
 
 # Short durations and reduced rate — just enough to confirm the pipeline works
 benchmark:
-  testDurationMinutes: 1
+  testDurationMinutes: 2
   warmupDurationMinutes: 0
   producerRate: 10000

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/omb-benchmark-job.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/omb-benchmark-job.yaml
@@ -14,7 +14,7 @@ metadata:
     app: omb-benchmark
 spec:
   backoffLimit: 0
-  activeDeadlineSeconds: {{ mul (add .Values.benchmark.testDurationMinutes .Values.benchmark.warmupDurationMinutes) 90 }}{{/* 90 = 60s/min × 1.5 — gives 1.5× the benchmark duration as a hang deadline */}}
+  activeDeadlineSeconds: {{ max 900 (mul (add .Values.benchmark.testDurationMinutes .Values.benchmark.warmupDurationMinutes) 90) }}{{/* 1.5× benchmark duration, minimum 15 min to cover worker startup overhead */}}
   template:
     metadata:
       labels:

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/values.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/values.yaml
@@ -47,7 +47,7 @@ kroxylicious:
 vault:
   provision: false
   token: benchmark-token  # Root token for the provisioned Vault dev instance
-  image: docker.io/hashicorp/vault:1.21.4@sha256:4e33b126a59c0c333b76fb4e894722462659a6bec7c48c9ee8cea56fccfd2569
+  image: docker.io/hashicorp/vault:2.0.0@sha256:e40c741ed95bb271425e3e6ca6c222d620cf8682f6f7a1b1e7c9d49d0aba484b
   imagePullPolicy: IfNotPresent
   resources:
     requests:
@@ -74,7 +74,7 @@ encryption:
 
 # OpenMessaging Benchmark workers
 omb:
-  workerReplicas: 3
+  workerReplicas: 2
   image: quay.io/kroxylicious/kroxylicious-omb:omb-8559989-krox-e329e4d-2@sha256:addb5ed87a1d1ed87e0a2df9223c25b33d25bf8331709c1d372124420572fe3c
   imagePullPolicy: IfNotPresent
   driver: baseline  # Can be 'baseline' or 'proxy'

--- a/kroxylicious-openmessaging-benchmarks/scripts/analyze-cpu-coefficient.py
+++ b/kroxylicious-openmessaging-benchmarks/scripts/analyze-cpu-coefficient.py
@@ -32,8 +32,11 @@ An operator can then estimate required proxy CPU as:
 
 Usage:
     python3 analyze-cpu-coefficient.py <sweep-output-dir> [--skip-first N]
+    python3 analyze-cpu-coefficient.py --compare <dir1> [<dir2> ...] [--skip-first N]
 
     sweep-output-dir  Root of a connection-sweep run, e.g. /tmp/results/conn-sweep/
+    --compare         Print a one-row-per-config summary table across multiple directories.
+                      Each dir may be prefixed with a label: "label:path"
     --skip-first N    Fallback: skip the first N CPU snapshots per probe when
                       phase timestamps are absent (default: 10)
 
@@ -221,36 +224,22 @@ def find_probes(sweep_dir):
     return probes
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Derive proxy CPU sizing coefficient from connection-sweep results"
-    )
-    parser.add_argument("sweep_dir", help="Root of a connection-sweep output directory")
-    parser.add_argument(
-        "--skip-first",
-        type=int,
-        default=10,
-        metavar="N",
-        help="Fallback: skip first N CPU snapshots when timestamps absent (default: 10)",
-    )
-    args = parser.parse_args()
+def analyze_sweep(sweep_dir, skip_first):
+    """Analyze a sweep directory; return (probe_rows, summary_stats, last_data).
 
-    probes = find_probes(args.sweep_dir)
-    if not probes:
-        print(f"No producers-N directories found under {args.sweep_dir}", file=sys.stderr)
-        sys.exit(1)
-
-    print(f"{'Producers':>9}  {'Achieved':>10}  {'Target':>10}  {'Sat':>4}  "
-          f"{'CPU (mc)':>9}  {'Snapshots':>11}  {'Filter':>10}  {'Source':>14}  {'Coeff (mc/MB/s)':>16}")
-    print("-" * 110)
-
+    probe_rows is a list of dicts for the per-probe table.
+    summary_stats is a dict with mean, stdev, n, sat, or None if no usable data.
+    """
+    probes = find_probes(sweep_dir)
+    rows = []
     coefficients = []
+    sat_count = 0
     last_data = None
 
     for n, probe_dir in probes:
-        data = load_probe(probe_dir, args.skip_first)
+        data = load_probe(probe_dir, skip_first)
         if data is None:
-            print(f"{n:>9}  (no data)")
+            rows.append({"producers": n, "no_data": True})
             continue
 
         achieved = data["achieved_rate"] * data.get("topics", 1)
@@ -261,31 +250,68 @@ def main():
 
         cpu_avg = statistics.mean(usable) if usable else float("nan")
         cpu_millicores = cpu_avg * 1000
-
         total_mb_per_s = (achieved * msg_size * 2) / 1_000_000
         coeff = cpu_millicores / total_mb_per_s if total_mb_per_s > 0 else float("nan")
 
-        sat_flag = "*" if saturated else " "
-        target_str = f"{target:>10,.0f}" if target else f"{'?':>10}"
-        snap_str = f"{len(usable)}/{data['all_snapshots']}"
-        print(f"{n:>9}  {achieved:>10,.0f}  {target_str}  {sat_flag:>4}  "
-              f"{cpu_millicores:>9.0f}  {snap_str:>11}  {data['filter_method']:>10}  "
-              f"{data.get('cpu_source','?'):>14}  {coeff:>16.1f}")
+        rows.append({
+            "producers": n,
+            "achieved": achieved,
+            "target": target,
+            "saturated": saturated,
+            "cpu_millicores": cpu_millicores,
+            "usable_count": len(usable),
+            "all_count": data["all_snapshots"],
+            "filter_method": data["filter_method"],
+            "cpu_source": data.get("cpu_source", "?"),
+            "coeff": coeff,
+        })
 
-        if not saturated:
+        if saturated:
+            sat_count += 1
+        else:
             coefficients.append(coeff)
         last_data = data
 
-    print()
-    if coefficients:
-        mean_coeff = statistics.mean(coefficients)
-        stdev_coeff = statistics.stdev(coefficients) if len(coefficients) > 1 else 0.0
+    if not coefficients:
+        return rows, None, last_data
 
-        print(f"Sizing coefficient (non-saturated probes only): {mean_coeff:.1f} mc/MB/s  "
-              f"(±{stdev_coeff:.1f} stdev, n={len(coefficients)})")
+    mean_coeff = statistics.mean(coefficients)
+    stdev_coeff = statistics.stdev(coefficients) if len(coefficients) > 1 else 0.0
+    summary = {
+        "mean": mean_coeff,
+        "stdev": stdev_coeff,
+        "n": len(coefficients),
+        "sat": sat_count,
+    }
+    return rows, summary, last_data
+
+
+def print_full_table(sweep_dir, skip_first):
+    """Print the detailed per-probe table for a single sweep directory."""
+    rows, summary, last_data = analyze_sweep(sweep_dir, skip_first)
+
+    print(f"{'Producers':>9}  {'Achieved':>10}  {'Target':>10}  {'Sat':>4}  "
+          f"{'CPU (mc)':>9}  {'Snapshots':>11}  {'Filter':>10}  {'Source':>14}  {'Coeff (mc/MB/s)':>16}")
+    print("-" * 110)
+
+    for row in rows:
+        if row.get("no_data"):
+            print(f"{row['producers']:>9}  (no data)")
+            continue
+        sat_flag = "*" if row["saturated"] else " "
+        target_str = f"{row['target']:>10,.0f}" if row["target"] else f"{'?':>10}"
+        snap_str = f"{row['usable_count']}/{row['all_count']}"
+        print(f"{row['producers']:>9}  {row['achieved']:>10,.0f}  {target_str}  {sat_flag:>4}  "
+              f"{row['cpu_millicores']:>9.0f}  {snap_str:>11}  {row['filter_method']:>10}  "
+              f"{row['cpu_source']:>14}  {row['coeff']:>16.1f}")
+
+    print()
+    if summary:
+        print(f"Sizing coefficient (non-saturated probes only): {summary['mean']:.1f} mc/MB/s  "
+              f"(±{summary['stdev']:.1f} stdev, n={summary['n']})")
         print()
         print("Sizing formula:")
-        print(f"  proxy_CPU_millicores = {mean_coeff:.0f} × (produce_MB_per_s + consume_MB_per_s)")
+        print(f"  proxy_CPU_millicores = {summary['mean']:.0f} × (produce_MB_per_s + consume_MB_per_s)")
         print()
         print("Notes:")
         print("  - Assumes encrypt ≈ decrypt CPU cost (bidirectional measurement)")
@@ -296,6 +322,80 @@ def main():
     else:
         print("No non-saturated probes found — cannot compute coefficient.")
         print("Run the sweep at a lower per-producer rate or with fewer steps.")
+
+
+def derive_label(path):
+    """Derive a short display label from a sweep directory path."""
+    parent = os.path.basename(os.path.dirname(os.path.abspath(path)))
+    label = re.sub(r"^conn-sweep-[^-]+-", "", parent)
+    label = re.sub(r"-rf\d+$", "", label)
+    return label or parent
+
+
+def parse_compare_arg(arg):
+    """Parse 'label:path' or plain 'path'; return (label, path)."""
+    if ":" in arg:
+        label, _, path = arg.partition(":")
+        return label.strip(), path.strip()
+    return derive_label(arg), arg
+
+
+def print_comparison_table(compare_args, skip_first):
+    """Print a one-row-per-config summary table."""
+    entries = [parse_compare_arg(a) for a in compare_args]
+
+    col_label = max(len(label) for label, _ in entries)
+    col_label = max(col_label, 6)
+
+    header = (f"{'Config':<{col_label}}  {'Coeff (mc/MB/s)':>16}  "
+              f"{'Stdev':>7}  {'n':>3}  {'Sat':>4}  Formula")
+    print(header)
+    print("-" * len(header))
+
+    for label, path in entries:
+        _, summary, _ = analyze_sweep(path, skip_first)
+        if summary is None:
+            print(f"{label:<{col_label}}  (no usable data)")
+            continue
+        sat_str = f"{summary['sat']}*" if summary["sat"] else "  -"
+        formula = f"{summary['mean']:.0f} × MB/s"
+        print(f"{label:<{col_label}}  {summary['mean']:>13.1f} mc/MB/s  "
+              f"±{summary['stdev']:>5.1f}  {summary['n']:>3}  {sat_str:>4}  {formula}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Derive proxy CPU sizing coefficient from connection-sweep results"
+    )
+    parser.add_argument(
+        "sweep_dir",
+        nargs="?",
+        help="Root of a connection-sweep output directory (single-run mode)",
+    )
+    parser.add_argument(
+        "--compare",
+        nargs="+",
+        metavar="DIR",
+        help="Compare multiple sweep directories (one row each). Each entry may be 'label:path'.",
+    )
+    parser.add_argument(
+        "--skip-first",
+        type=int,
+        default=10,
+        metavar="N",
+        help="Fallback: skip first N CPU snapshots when timestamps absent (default: 10)",
+    )
+    args = parser.parse_args()
+
+    if args.compare and args.sweep_dir:
+        parser.error("Specify either a sweep_dir or --compare, not both.")
+    if not args.compare and not args.sweep_dir:
+        parser.error("Specify a sweep_dir or use --compare.")
+
+    if args.compare:
+        print_comparison_table(args.compare, args.skip_first)
+    else:
+        print_full_table(args.sweep_dir, args.skip_first)
 
 
 if __name__ == "__main__":

--- a/kroxylicious-openmessaging-benchmarks/scripts/run-all-scenarios.sh
+++ b/kroxylicious-openmessaging-benchmarks/scripts/run-all-scenarios.sh
@@ -38,6 +38,8 @@ Options:
                              settings always win. Passed through to each run-benchmark.sh call.
   --profile <values-file>    Additional Helm values file layered on top of each scenario.
                              May be specified multiple times; files are applied in order.
+  --set <key=value>         Pass a Helm --set override. May be repeated. Passed through to
+                             each run-benchmark.sh call.
   -h, --help                 Show this help
 
 Environment:
@@ -55,6 +57,7 @@ EOF
 }
 
 PROFILE_VALUES=()
+SET_OVERRIDES=()
 CLUSTER_OVERRIDES=""
 POSITIONAL=()
 
@@ -66,6 +69,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --profile)
             PROFILE_VALUES+=("$2")
+            shift 2
+            ;;
+        --set)
+            SET_OVERRIDES+=(--set "$2")
             shift 2
             ;;
         -h|--help)
@@ -126,6 +133,7 @@ echo ""
 RUN_BENCHMARK_ARGS=()
 for profile_file in ${PROFILE_VALUES[@]+"${PROFILE_VALUES[@]}"}; do RUN_BENCHMARK_ARGS+=(--profile "${profile_file}"); done
 [[ -n "${CLUSTER_OVERRIDES}" ]] && RUN_BENCHMARK_ARGS+=(--cluster-overrides "${CLUSTER_OVERRIDES}")
+RUN_BENCHMARK_ARGS+=(${SET_OVERRIDES[@]+"${SET_OVERRIDES[@]}"})
 
 for SCENARIO in "${SCENARIOS[@]}"; do
     for WORKLOAD in "${WORKLOADS[@]}"; do

--- a/kroxylicious-openmessaging-benchmarks/scripts/run-benchmark.sh
+++ b/kroxylicious-openmessaging-benchmarks/scripts/run-benchmark.sh
@@ -569,7 +569,7 @@ else
     echo "Removing previous benchmark Job..."
     kubectl delete job omb-benchmark -n "${NAMESPACE}" --ignore-not-found --wait --timeout=60s
     echo "Restarting OMB workers for clean probe..."
-    kubectl delete pod -l app=omb-worker -n "${NAMESPACE}" --wait --timeout=60s
+    kubectl delete pod -l app=omb-worker -n "${NAMESPACE}" --grace-period=30 --wait --timeout=120s
     check_workers_healthy
     reset_topics
 fi
@@ -614,6 +614,17 @@ if [[ -n "${PROXY_POD}" && "${SKIP_DEPLOY}" == "false" ]]; then
             envsubst '${PROXY_DEPLOYMENT} ${NAMESPACE}' \
             < "${HELM_CHART}/patches/proxy-anti-affinity.yaml" \
             | kubectl apply --server-side --field-manager=benchmark-anti-affinity -f - >/dev/null
+    fi
+
+    # Force-delete the old proxy pod so the new one can schedule.
+    # Required when the proxy has a high CPU request (e.g. 4-core) that consumes
+    # most of its dedicated node: the rolling update default (maxUnavailable=0) would
+    # deadlock waiting for the new pod to be ready before evicting the old one, but
+    # the new pod cannot schedule while the old pod holds the node's CPU.
+    OLD_PROXY_POD=$(kubectl get pod -n "${NAMESPACE}" -l "${PROXY_POD_LABEL}" \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) || true
+    if [[ -n "${OLD_PROXY_POD}" ]]; then
+        kubectl delete pod "${OLD_PROXY_POD}" -n "${NAMESPACE}" --grace-period=30 2>/dev/null || true
     fi
 
     echo "Waiting for proxy deployment rollout after patch..."

--- a/kroxylicious-openmessaging-benchmarks/scripts/run-blog-suite.sh
+++ b/kroxylicious-openmessaging-benchmarks/scripts/run-blog-suite.sh
@@ -20,11 +20,8 @@ set -uo pipefail
 # Steps:
 #   Post 1 — Multi-topic latency  (run-all-scenarios, RF=3, 3 scenarios × 3 workloads)
 #   Post 1 — Rate sweep           (rate-sweep, RF=3, 1-core proxy, 8k–22k msg/s, 5% steps)
-#   Post 2 — Connection sweep, encryption, 1-core, 1-topic, RF=1
-#   Post 2 — Connection sweep, encryption, 4-core, 1-topic, RF=1
-#   Post 2 — Connection sweep, encryption, 4-core, 10-topics, RF=1
+#   Post 2 — CPU coefficient sweep (run-coefficient-sweep: 1/2/4 cores × 1/10/100 topics, RF=1)
 #   Post 2 — Connection sweep, proxy-no-filters, 4-core, 10-topics, RF=1
-#   Post 2 — CPU coefficient analysis (4-core sweeps)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MODULE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -36,7 +33,7 @@ usage() {
 Usage: $(basename "$0") [--cluster-overrides <file>] [--output-dir <dir>]
 
 Options:
-  --cluster-overrides <file>  Helm values for cluster-specific settings
+  --cluster-overrides <file>  Helm values for cluster-specific settings (e.g. vault image)
   --output-dir <dir>          Root directory for all results
                               (default: results/blog-suite-<timestamp>)
   -h, --help                  Show this help
@@ -92,17 +89,25 @@ run_step() {
     fi
 }
 
+# Proxy resource presets — passed as --set flags so cluster-overrides stays
+# cluster-specific (vault image, storage class) rather than run-specific.
+# Memory is held constant across core counts so only CPU varies between runs.
+PROXY_MEM="--set kroxylicious.resources.requests.memory=2Gi --set kroxylicious.resources.limits.memory=4Gi"
+PROXY_1CORE="--set kroxylicious.resources.requests.cpu=1000m --set kroxylicious.resources.limits.cpu=1000m ${PROXY_MEM}"
+PROXY_4CORE="--set kroxylicious.resources.requests.cpu=4000m --set kroxylicious.resources.limits.cpu=4000m ${PROXY_MEM}"
+
 # ---------------------------------------------------------------------------
-# Post 1 — Multi-topic latency (RF=3, 3 scenarios × 3 workloads, ~3 hours)
+# Post 1 — Multi-topic latency (RF=3, 1-core proxy, 3 scenarios × 3 workloads)
 # ---------------------------------------------------------------------------
 run_step "post1-multi-topic-latency" \
     scripts/run-all-scenarios.sh \
         baseline proxy-no-filters encryption \
         ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
+        ${PROXY_1CORE} \
         "${OUTPUT_DIR}/all-scenarios/"
 
 # ---------------------------------------------------------------------------
-# Post 1 — Rate sweep (RF=3, 1-core proxy, 8k–22k msg/s, 5% steps, ~10 hours)
+# Post 1 — Rate sweep (RF=3, 1-core proxy, 8k–22k msg/s, 5% steps)
 # ---------------------------------------------------------------------------
 run_step "post1-rate-sweep-1core-rf3" \
     scripts/rate-sweep.sh \
@@ -110,48 +115,20 @@ run_step "post1-rate-sweep-1core-rf3" \
         --scenarios baseline,proxy-no-filters,encryption \
         --workload 1topic-1kb \
         ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
-        --set kroxylicious.resources.requests.cpu=1000m \
-        --set kroxylicious.resources.limits.cpu=1000m \
+        ${PROXY_1CORE} \
         --output-dir "${OUTPUT_DIR}/rate-sweep-1core-rf3/"
 
 # ---------------------------------------------------------------------------
-# Post 2 — Connection sweeps (all RF=1, 10k msg/s per producer)
+# Post 2 — CPU coefficient sweep (1/2/4 cores × 1/10/100 topics, all RF=1)
 # ---------------------------------------------------------------------------
-run_step "post2-conn-sweep-encryption-1core-1topic" \
-    scripts/connection-sweep.sh \
-        --scenario encryption \
-        --per-producer-rate 10000 \
-        --steps 1,2,4,8,16 \
-        --workload 1topic-1kb \
+run_step "post2-cpu-coefficient-sweep" \
+    scripts/run-coefficient-sweep.sh \
         ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
-        --set kafka.replicationFactor=1 \
-        --set kafka.minInSyncReplicas=1 \
-        --set kroxylicious.resources.requests.cpu=1000m \
-        --set kroxylicious.resources.limits.cpu=1000m \
-        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-1core-1topic-rf1/"
+        --output-dir "${OUTPUT_DIR}/coefficient-sweep/"
 
-run_step "post2-conn-sweep-encryption-4core-1topic" \
-    scripts/connection-sweep.sh \
-        --scenario encryption \
-        --per-producer-rate 10000 \
-        --steps 1,2,4,8,16,32 \
-        --workload 1topic-1kb \
-        ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
-        --set kafka.replicationFactor=1 \
-        --set kafka.minInSyncReplicas=1 \
-        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-4core-1topic-rf1/"
-
-run_step "post2-conn-sweep-encryption-4core-10topics" \
-    scripts/connection-sweep.sh \
-        --scenario encryption \
-        --per-producer-rate 10000 \
-        --steps 1,2,4,8,16,32 \
-        --workload 10topics-1kb \
-        ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
-        --set kafka.replicationFactor=1 \
-        --set kafka.minInSyncReplicas=1 \
-        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-4core-10topics-rf1/"
-
+# ---------------------------------------------------------------------------
+# Post 2 — Proxy overhead baseline (no filters, 4-core, 10-topics, RF=1)
+# ---------------------------------------------------------------------------
 run_step "post2-conn-sweep-no-filters-4core-10topics" \
     scripts/connection-sweep.sh \
         --scenario proxy-no-filters \
@@ -161,27 +138,8 @@ run_step "post2-conn-sweep-no-filters-4core-10topics" \
         ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
         --set kafka.replicationFactor=1 \
         --set kafka.minInSyncReplicas=1 \
+        ${PROXY_4CORE} \
         --output-dir "${OUTPUT_DIR}/conn-sweep-no-filters-4core-10topics-rf1/"
-
-# ---------------------------------------------------------------------------
-# Post 2 — CPU coefficient (run against 4-core sweeps if they succeeded)
-# ---------------------------------------------------------------------------
-COEFF_1TOPIC="${OUTPUT_DIR}/conn-sweep-encryption-4core-1topic-rf1/encryption"
-COEFF_10TOPICS="${OUTPUT_DIR}/conn-sweep-encryption-4core-10topics-rf1/encryption"
-
-if [[ -d "${COEFF_1TOPIC}" ]]; then
-    run_step "post2-cpu-coefficient-1topic" \
-        python3 scripts/analyze-cpu-coefficient.py "${COEFF_1TOPIC}"
-else
-    echo "Skipping cpu-coefficient-1topic — sweep directory not found: ${COEFF_1TOPIC}"
-fi
-
-if [[ -d "${COEFF_10TOPICS}" ]]; then
-    run_step "post2-cpu-coefficient-10topics" \
-        python3 scripts/analyze-cpu-coefficient.py "${COEFF_10TOPICS}"
-else
-    echo "Skipping cpu-coefficient-10topics — sweep directory not found: ${COEFF_10TOPICS}"
-fi
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/kroxylicious-openmessaging-benchmarks/scripts/run-coefficient-sweep.sh
+++ b/kroxylicious-openmessaging-benchmarks/scripts/run-coefficient-sweep.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+set -uo pipefail
+
+# Runs a systematic CPU-coefficient validation sweep across proxy core counts and topic counts.
+#
+# Runs 9 connection sweeps (1/2/4 cores × 1/10/100 topics) then prints a
+# cross-configuration comparison table so you can verify the coefficient is
+# consistent across proxy sizes.
+#
+# Usage: scripts/run-coefficient-sweep.sh [--cluster-overrides <file>] [--output-dir <dir>]
+#
+# Run from: kroxylicious-openmessaging-benchmarks/
+#
+# Estimated runtime: ~9–18 hours depending on cluster speed.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODULE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${MODULE_DIR}"
+
+usage() {
+    cat >&2 <<EOF
+Usage: $(basename "$0") [--cluster-overrides <file>] [--output-dir <dir>]
+
+Options:
+  --cluster-overrides <file>  Helm values for cluster-specific settings
+  --output-dir <dir>          Root directory for all results
+                              (default: results/coefficient-sweep-<timestamp>)
+  -h, --help                  Show this help
+EOF
+    exit 1
+}
+
+CLUSTER_OVERRIDES=""
+OUTPUT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --cluster-overrides) CLUSTER_OVERRIDES="$2"; shift 2 ;;
+        --output-dir)        OUTPUT_DIR="$2";        shift 2 ;;
+        -h|--help)           usage ;;
+        *) echo "Error: unknown argument '$1'" >&2; usage ;;
+    esac
+done
+
+RUN_ID="$(date +%Y%m%d-%H%M%S)"
+OUTPUT_DIR="${OUTPUT_DIR:-results/coefficient-sweep-${RUN_ID}}"
+mkdir -p "${OUTPUT_DIR}"
+
+exec > >(tee "${OUTPUT_DIR}/suite.log") 2>&1
+
+echo "=========================================="
+echo "CPU coefficient sweep — ${RUN_ID}"
+echo "Results: ${OUTPUT_DIR}"
+echo "Cluster overrides: ${CLUSTER_OVERRIDES:-none}"
+echo "Started: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "=========================================="
+echo ""
+
+FAILED_STEPS=()
+
+run_step() {
+    local name="$1"
+    shift
+    local start
+    start="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo ""
+    echo "--- ${name} ---"
+    echo "Started: ${start}"
+    if "$@"; then
+        echo "Completed: $(date -u +%Y-%m-%dT%H:%M:%SZ) — ${name}"
+    else
+        echo "FAILED: $(date -u +%Y-%m-%dT%H:%M:%SZ) — ${name}" >&2
+        FAILED_STEPS+=("${name}")
+    fi
+}
+
+PROXY_MEM="--set kroxylicious.resources.requests.memory=2Gi --set kroxylicious.resources.limits.memory=4Gi"
+PROXY_1CORE="--set kroxylicious.resources.requests.cpu=1000m --set kroxylicious.resources.limits.cpu=1000m ${PROXY_MEM}"
+PROXY_2CORE="--set kroxylicious.resources.requests.cpu=2000m --set kroxylicious.resources.limits.cpu=2000m ${PROXY_MEM}"
+PROXY_4CORE="--set kroxylicious.resources.requests.cpu=4000m --set kroxylicious.resources.limits.cpu=4000m ${PROXY_MEM}"
+
+CLUSTER_OVERRIDES_ARG=()
+[[ -n "${CLUSTER_OVERRIDES}" ]] && CLUSTER_OVERRIDES_ARG=(--cluster-overrides "${CLUSTER_OVERRIDES}")
+
+COMMON=(
+    --scenario encryption
+    --per-producer-rate 10000
+    --steps 1,2,4,8,16,32
+    ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"}
+    --set kafka.replicationFactor=1
+    --set kafka.minInSyncReplicas=1
+)
+
+# ---------------------------------------------------------------------------
+# 1-topic sweeps
+# ---------------------------------------------------------------------------
+run_step "coeff-1core-1topic" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 1topic-1kb \
+        ${PROXY_1CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-1core-1topic-rf1/"
+
+run_step "coeff-2core-1topic" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 1topic-1kb \
+        ${PROXY_2CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-2core-1topic-rf1/"
+
+run_step "coeff-4core-1topic" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 1topic-1kb \
+        ${PROXY_4CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-4core-1topic-rf1/"
+
+# ---------------------------------------------------------------------------
+# 10-topic sweeps
+# ---------------------------------------------------------------------------
+run_step "coeff-1core-10topics" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 10topics-1kb \
+        ${PROXY_1CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-1core-10topics-rf1/"
+
+run_step "coeff-2core-10topics" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 10topics-1kb \
+        ${PROXY_2CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-2core-10topics-rf1/"
+
+run_step "coeff-4core-10topics" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 10topics-1kb \
+        ${PROXY_4CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-4core-10topics-rf1/"
+
+# ---------------------------------------------------------------------------
+# 100-topic sweeps
+# ---------------------------------------------------------------------------
+run_step "coeff-1core-100topics" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 100topics-1kb \
+        ${PROXY_1CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-1core-100topics-rf1/"
+
+run_step "coeff-2core-100topics" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 100topics-1kb \
+        ${PROXY_2CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-2core-100topics-rf1/"
+
+run_step "coeff-4core-100topics" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 100topics-1kb \
+        ${PROXY_4CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-4core-100topics-rf1/"
+
+# ---------------------------------------------------------------------------
+# Cross-configuration comparison
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- CPU coefficient comparison ---"
+
+for topics_dir in 1topic 10topics 100topics; do
+    label="${topics_dir/topic/ topic}"
+    label="${label/topics/ topics}"
+    echo ""
+    echo "=== ${label} ==="
+    compare_args=()
+    for cores in 1 2 4; do
+        dir="${OUTPUT_DIR}/conn-sweep-encryption-${cores}core-${topics_dir}-rf1/encryption"
+        if [[ -d "${dir}" ]]; then
+            compare_args+=("${cores}-core-${topics_dir}:${dir}")
+        fi
+    done
+    if [[ ${#compare_args[@]} -gt 0 ]]; then
+        python3 scripts/analyze-cpu-coefficient.py --compare "${compare_args[@]}"
+    else
+        echo "  (no completed sweeps)"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=========================================="
+echo "Suite complete: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "Results: ${OUTPUT_DIR}"
+echo "=========================================="
+
+if [[ ${#FAILED_STEPS[@]} -gt 0 ]]; then
+    echo ""
+    echo "Failed steps:"
+    for step in ${FAILED_STEPS[@]+"${FAILED_STEPS[@]}"}; do
+        echo "  - ${step}"
+    done
+    exit 1
+fi
+
+echo "All steps succeeded."

--- a/kroxylicious-openmessaging-benchmarks/src/test/java/io/kroxylicious/benchmarks/helm/HelmTemplateRenderingTest.java
+++ b/kroxylicious-openmessaging-benchmarks/src/test/java/io/kroxylicious/benchmarks/helm/HelmTemplateRenderingTest.java
@@ -182,7 +182,7 @@ class HelmTemplateRenderingTest {
     void smokeProfileShouldOverrideDurations() throws IOException {
         String workloadYaml = renderSmokeWorkloadYaml();
         assertThat(workloadYaml)
-                .contains("testDurationMinutes: 1")
+                .contains("testDurationMinutes: 2")
                 .contains("warmupDurationMinutes: 0");
     }
 


### PR DESCRIPTION
> **Stacked on #4023** (`feat/omb-benchmark-sweep-scripts`). The diff currently includes the script changes from that PR because this branch is rebased on top of it. Once #4023 merges, rebase this branch onto `main` and the diff will reduce to just the sizing guide.

### Type of change

- Documentation

### Description

Adds `SIZING-GUIDE.md` to `kroxylicious-openmessaging-benchmarks` documenting the measured performance characteristics of the proxy for operators sizing a deployment with record encryption.

Covers:
- **Passthrough proxy overhead** — latency tables for 10-topic and 100-topic workloads showing sub-millisecond average increase and no throughput impact
- **Record encryption overhead** — latency impact at sub-saturation rates, throughput ceiling (~25% reduction per partition vs direct Kafka), and a CPU flamegraph breakdown
- **CPU sizing coefficient** — derived from connection sweeps at 1/2/4 proxy cores across 1/10/100 topic workloads; formula: `CPU_millicores = coeff × total_proxy_MB_per_s`
- **Sizing recommendations** — formula, example sizing table, KMS overhead note, scaling advice
- **Test environment** — hardware, software versions, and methodology

### Additional Context

Data comes from benchmark runs on an 8-node AMD EPYC-Rome cluster using the coefficient sweep tooling introduced in #4023. The 10-topic coefficient is used as the conservative planning figure; the 100-topic data is cited to show that realistic multi-topic deployments are significantly cheaper (the "proxy doesn't matter to your Kafka sizing" argument).

The coefficient numbers in this guide will be updated once #4023 is reviewed and merged and accurate figures from the full sweep are confirmed.

### Checklist

- [ ] New tests written (where applicable).
- [x] If making a user-facing change, documentation is provided — this PR is the documentation.
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).