### PR TITLE
fix(runtime): log virtual cluster stop at INFO for clean shutdown, WARN for failure

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -182,7 +182,7 @@ public final class KafkaProxy implements AutoCloseable {
                         .log("Virtual cluster reached terminal stopped state due to failure, proxy shutdown required");
             }
             else {
-                STARTUP_SHUTDOWN_LOGGER.atDebug()
+                STARTUP_SHUTDOWN_LOGGER.atInfo()
                         .addKeyValue("virtualCluster", clusterName)
                         .log("Virtual cluster stopped");
             }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -174,10 +174,19 @@ public final class KafkaProxy implements AutoCloseable {
 
     private static VirtualClusterRegistry defaultRegistry(Configuration config, PluginFactoryRegistry pfr) {
         var models = config.virtualClusterModel(pfr);
-        return new VirtualClusterRegistry(models, (clusterName, cause) -> STARTUP_SHUTDOWN_LOGGER.atWarn()
-                .addKeyValue("virtualCluster", clusterName)
-                .addKeyValue("error", cause.map(Throwable::getMessage).orElse(null))
-                .log("Virtual cluster reached terminal stopped state, proxy shutdown required"));
+        return new VirtualClusterRegistry(models, (clusterName, cause) -> {
+            if (cause.isPresent()) {
+                STARTUP_SHUTDOWN_LOGGER.atWarn()
+                        .addKeyValue("virtualCluster", clusterName)
+                        .addKeyValue("error", cause.get().getMessage())
+                        .log("Virtual cluster reached terminal stopped state due to failure, proxy shutdown required");
+            }
+            else {
+                STARTUP_SHUTDOWN_LOGGER.atDebug()
+                        .addKeyValue("virtualCluster", clusterName)
+                        .log("Virtual cluster stopped");
+            }
+        });
     }
 
     @VisibleForTesting


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `onVirtualClusterStopped` callback in `KafkaProxy` logged at `WARN` for every virtual cluster stop, including clean stops during normal proxy shutdown. This produced spurious warnings in system test logs on every test teardown:

```
WARN  <main> i.k.p.StartupShutdownLogger - Virtual cluster reached terminal stopped state, proxy shutdown required
```

The `Optional<Throwable>` parameter passed to the callback already carries the distinction between the two cases:

- **cause absent** — clean stop (drain completed, normal shutdown)
- **cause present** — failure-driven stop (initialization failed, unexpected state)

The fix uses that signal: log at `INFO` for clean stops, `WARN` for failure-driven stops. The WARN message is also clarified to say "due to failure" so it is unambiguous.

### Additional Context

Spotted because the warning was appearing repeatedly during system test execution, making it harder to identify real failures in logs. The callback was already edge-triggered (only fires on the transition to `Stopped`, not on every poll), so no structural change was needed — only the log level conditional.

### Checklist

- [ ] New tests written (where applicable).
- [x] User facing documentation written/updated (where applicable). N/A — log output only.
- [x] Existing unit/integration/system tests passing. `KafkaProxyTest` (59 tests) and `VirtualClusterRegistryTest` (39 tests) pass.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [ ] For user facing changes, update CHANGELOG.md.