### PR TITLE
Replace jsr305 annotations with spotbugs Nullable and custom threadin…

### DIFF
--- a/kroxylicious-annotations/src/main/java/io/kroxylicious/proxy/tag/NotThreadSafe.java
+++ b/kroxylicious-annotations/src/main/java/io/kroxylicious/proxy/tag/NotThreadSafe.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.tag;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the annotated class is not thread-safe.
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface NotThreadSafe {
+}

--- a/kroxylicious-annotations/src/main/java/io/kroxylicious/proxy/tag/ThreadSafe.java
+++ b/kroxylicious-annotations/src/main/java/io/kroxylicious/proxy/tag/ThreadSafe.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.tag;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the annotated class is thread-safe.
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface ThreadSafe {
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
@@ -9,8 +9,6 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
-import javax.annotation.Nullable;
-
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
@@ -22,6 +20,8 @@ import io.kroxylicious.proxy.authentication.Subject;
 import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
 import io.kroxylicious.proxy.filter.metadata.TopicNameMappingException;
 import io.kroxylicious.proxy.tls.ClientTlsContext;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A context to allow filters to interact with other filters and the pipeline.

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
@@ -9,7 +9,6 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
@@ -21,6 +20,8 @@ import io.kroxylicious.proxy.authentication.Subject;
 import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
 import io.kroxylicious.proxy.filter.metadata.TopicNameMappingException;
 import io.kroxylicious.proxy.tls.ClientTlsContext;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A context to allow filters to interact with other filters and the pipeline.

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
@@ -21,7 +22,6 @@ import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
 import io.kroxylicious.proxy.filter.metadata.TopicNameMappingException;
 import io.kroxylicious.proxy.tls.ClientTlsContext;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A context to allow filters to interact with other filters and the pipeline.

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
@@ -22,7 +22,6 @@ import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
 import io.kroxylicious.proxy.filter.metadata.TopicNameMappingException;
 import io.kroxylicious.proxy.tls.ClientTlsContext;
 
-
 /**
  * A context to allow filters to interact with other filters and the pipeline.
  */

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterResultBuilder.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterResultBuilder.java
@@ -6,14 +6,14 @@
 
 package io.kroxylicious.proxy.filter;
 
-import javax.annotation.Nullable;
-
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Builder for request filter results.

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterResultBuilder.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterResultBuilder.java
@@ -6,14 +6,14 @@
 
 package io.kroxylicious.proxy.filter;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
-
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Builder for request filter results.

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterResultBuilder.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterResultBuilder.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy.filter;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
@@ -13,7 +15,6 @@ import org.apache.kafka.common.protocol.ApiMessage;
 
 import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Builder for request filter results.

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterResultBuilder.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterResultBuilder.java
@@ -15,7 +15,6 @@ import org.apache.kafka.common.protocol.ApiMessage;
 
 import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
 
-
 /**
  * Builder for request filter results.
  * <br/>

--- a/kroxylicious-authorizer-api/src/main/java/io/kroxylicious/authorizer/service/AuthorizerService.java
+++ b/kroxylicious-authorizer-api/src/main/java/io/kroxylicious/authorizer/service/AuthorizerService.java
@@ -6,7 +6,7 @@
 
 package io.kroxylicious.authorizer.service;
 
-import javax.annotation.concurrent.ThreadSafe;
+import io.kroxylicious.proxy.tag.ThreadSafe;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.UnknownNullness;

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/DeleteTopicsEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/DeleteTopicsEnforcement.java
@@ -14,7 +14,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.DeleteTopicsRequestData;
 import org.apache.kafka.common.message.DeleteTopicsResponseData;
@@ -29,7 +29,7 @@ import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
 import io.kroxylicious.proxy.filter.metadata.TopicNameMappingException;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+
 
 class DeleteTopicsEnforcement extends ApiEnforcement<DeleteTopicsRequestData, DeleteTopicsResponseData> {
 

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/DeleteTopicsEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/DeleteTopicsEnforcement.java
@@ -13,7 +13,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.DeleteTopicsRequestData;

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/DeleteTopicsEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/DeleteTopicsEnforcement.java
@@ -29,8 +29,6 @@ import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
 import io.kroxylicious.proxy.filter.metadata.TopicNameMappingException;
 
-
-
 class DeleteTopicsEnforcement extends ApiEnforcement<DeleteTopicsRequestData, DeleteTopicsResponseData> {
 
     @Override

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/DeleteTopicsEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/DeleteTopicsEnforcement.java
@@ -13,8 +13,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.DeleteTopicsRequestData;
 import org.apache.kafka.common.message.DeleteTopicsResponseData;
@@ -28,6 +26,9 @@ import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
 import io.kroxylicious.proxy.filter.metadata.TopicNameMappingException;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 class DeleteTopicsEnforcement extends ApiEnforcement<DeleteTopicsRequestData, DeleteTopicsResponseData> {
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/Dek.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/Dek.java
@@ -15,13 +15,13 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import javax.annotation.concurrent.NotThreadSafe;
-import javax.annotation.concurrent.ThreadSafe;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.ShortBufferException;
 
 import io.kroxylicious.kms.service.DestroyableRawSecretKey;
+import io.kroxylicious.proxy.tag.NotThreadSafe;
+import io.kroxylicious.proxy.tag.ThreadSafe;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekManager.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekManager.java
@@ -9,12 +9,11 @@ package io.kroxylicious.filter.encryption.dek;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 
-import javax.annotation.concurrent.ThreadSafe;
-
 import io.kroxylicious.filter.encryption.config.EncryptionConfigurationException;
 import io.kroxylicious.kms.service.DestroyableRawSecretKey;
 import io.kroxylicious.kms.service.Kms;
 import io.kroxylicious.kms.service.Serde;
+import io.kroxylicious.proxy.tag.ThreadSafe;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/Wrapping96BitCounter.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/Wrapping96BitCounter.java
@@ -8,9 +8,9 @@ package io.kroxylicious.filter.encryption.dek;
 
 import java.security.SecureRandom;
 
-import javax.annotation.concurrent.NotThreadSafe;
 import javax.security.auth.Destroyable;
 
+import io.kroxylicious.proxy.tag.NotThreadSafe;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/ProduceRequestTransformation.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/ProduceRequestTransformation.java
@@ -21,7 +21,6 @@ import io.kroxylicious.proxy.plugin.PluginImplConfig;
 import io.kroxylicious.proxy.plugin.PluginImplName;
 import io.kroxylicious.proxy.plugin.Plugins;
 
-
 /**
  * A {@link FilterFactory} for {@link ProduceRequestTransformationFilter}.
  *

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/ProduceRequestTransformation.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/ProduceRequestTransformation.java
@@ -6,9 +6,6 @@
 
 package io.kroxylicious.filter.simpletransform;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.kroxylicious.filter.simpletransform.ProduceRequestTransformation.Config;
@@ -20,6 +17,9 @@ import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.plugin.PluginImplConfig;
 import io.kroxylicious.proxy.plugin.PluginImplName;
 import io.kroxylicious.proxy.plugin.Plugins;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A {@link FilterFactory} for {@link ProduceRequestTransformationFilter}.

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/ProduceRequestTransformation.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/ProduceRequestTransformation.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.filter.simpletransform;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -20,7 +21,6 @@ import io.kroxylicious.proxy.plugin.PluginImplConfig;
 import io.kroxylicious.proxy.plugin.PluginImplName;
 import io.kroxylicious.proxy.plugin.Plugins;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * A {@link FilterFactory} for {@link ProduceRequestTransformationFilter}.

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/ProduceRequestTransformation.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/ProduceRequestTransformation.java
@@ -6,7 +6,7 @@
 
 package io.kroxylicious.filter.simpletransform;
 
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/kroxylicious-kafka-message-tools/etc/module-layering.xml
+++ b/kroxylicious-kafka-message-tools/etc/module-layering.xml
@@ -15,5 +15,6 @@
     <allow pkg="javax?\..*" regex="true"/>
     <allow pkg="org.slf4j"/>
     <allow pkg="edu.umd.cs.findbugs"/>
+    <allow pkg="io.kroxylicious.proxy.tag"/>
     <allow pkg="org.apache.kafka"/>
 </import-control>

--- a/kroxylicious-kafka-message-tools/pom.xml
+++ b/kroxylicious-kafka-message-tools/pom.xml
@@ -22,6 +22,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <scope>provided</scope>

--- a/kroxylicious-kafka-message-tools/src/main/java/io/kroxylicious/kafka/transform/ApiVersionsResponseTransformer.java
+++ b/kroxylicious-kafka-message-tools/src/main/java/io/kroxylicious/kafka/transform/ApiVersionsResponseTransformer.java
@@ -8,9 +8,9 @@ package io.kroxylicious.kafka.transform;
 
 import java.util.Objects;
 
-import javax.annotation.concurrent.ThreadSafe;
-
 import org.apache.kafka.common.message.ApiVersionsResponseData;
+
+import io.kroxylicious.proxy.tag.ThreadSafe;
 
 /**
  * synchronously transforms ApiVersionsResponse data.

--- a/kroxylicious-kafka-message-tools/src/main/java/io/kroxylicious/kafka/transform/BatchAwareMemoryRecordsBuilder.java
+++ b/kroxylicious-kafka-message-tools/src/main/java/io/kroxylicious/kafka/transform/BatchAwareMemoryRecordsBuilder.java
@@ -9,8 +9,6 @@ package io.kroxylicious.kafka.transform;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.record.EndTransactionMarker;
@@ -22,6 +20,8 @@ import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
+
+import io.kroxylicious.proxy.tag.NotThreadSafe;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 

--- a/kroxylicious-kafka-message-tools/src/main/java/io/kroxylicious/kafka/transform/RecordTransform.java
+++ b/kroxylicious-kafka-message-tools/src/main/java/io/kroxylicious/kafka/transform/RecordTransform.java
@@ -8,11 +8,11 @@ package io.kroxylicious.kafka.transform;
 
 import java.nio.ByteBuffer;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.record.RecordBatch;
+
+import io.kroxylicious.proxy.tag.NotThreadSafe;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/AzureKeyVaultEdekSerde.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/AzureKeyVaultEdekSerde.java
@@ -11,11 +11,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.HexFormat;
 import java.util.Objects;
 
-import javax.annotation.concurrent.ThreadSafe;
-
 import io.kroxylicious.kms.provider.azure.keyvault.SupportedKeyType;
 import io.kroxylicious.kms.service.KmsException;
 import io.kroxylicious.kms.service.Serde;
+import io.kroxylicious.proxy.tag.ThreadSafe;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/auth/CachingBearerTokenService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/auth/CachingBearerTokenService.java
@@ -12,11 +12,10 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import javax.annotation.concurrent.ThreadSafe;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.kroxylicious.proxy.tag.ThreadSafe;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.Nullable;

--- a/kroxylicious-kms/pom.xml
+++ b/kroxylicious-kms/pom.xml
@@ -28,6 +28,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/DestroyableRawSecretKey.java
+++ b/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/DestroyableRawSecretKey.java
@@ -10,12 +10,13 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.Objects;
 
-import javax.annotation.concurrent.NotThreadSafe;
 import javax.crypto.SecretKey;
 import javax.security.auth.DestroyFailedException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.proxy.tag.NotThreadSafe;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 

--- a/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/KmsService.java
+++ b/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/KmsService.java
@@ -6,7 +6,7 @@
 
 package io.kroxylicious.kms.service;
 
-import javax.annotation.concurrent.ThreadSafe;
+import io.kroxylicious.proxy.tag.ThreadSafe;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/checksum/Crc32ChecksumGenerator.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/checksum/Crc32ChecksumGenerator.java
@@ -12,7 +12,6 @@ import java.util.Base64;
 import java.util.zip.CRC32;
 
 import io.kroxylicious.proxy.tag.NotThreadSafe;
-
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.Nullable;

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/checksum/Crc32ChecksumGenerator.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/checksum/Crc32ChecksumGenerator.java
@@ -11,7 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.zip.CRC32;
 
-import javax.annotation.concurrent.NotThreadSafe;
+import io.kroxylicious.proxy.tag.NotThreadSafe;
 
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceReconcilerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceReconcilerTest.java
@@ -335,7 +335,7 @@ class KafkaServiceReconcilerTest {
             mockGetKafka(context, Optional.of(KAFKA));
             mockGetConfigMap(context, Optional.empty());
             result.add(Arguments.argumentSet("strimziKafkaRef missing listener name",
-                    // @formatter:off
+            // @formatter:off
                     new KafkaServiceBuilder(SERVICE)
                             .withNewSpec()
                                 .withNewStrimziKafkaRef()
@@ -363,7 +363,7 @@ class KafkaServiceReconcilerTest {
             mockGetConfigMap(context, Optional.empty());
             mockGetKafka(context, Optional.of(KAFKA));
             result.add(Arguments.argumentSet("unsupported strimziKafkaRef kind",
-                    // @formatter:off
+            // @formatter:off
                     new KafkaServiceBuilder(SERVICE)
                             .withNewSpec()
                                 .withNewStrimziKafkaRef()
@@ -389,7 +389,7 @@ class KafkaServiceReconcilerTest {
             mockGetConfigMap(context, Optional.empty());
             mockGetKafka(context, Optional.of(UNSUPPORTED_KAFKA));
             result.add(Arguments.argumentSet("listeners not present",
-                    // @formatter:off
+            // @formatter:off
                     new KafkaServiceBuilder(SERVICE)
                             .withNewSpec()
                                 .withNewStrimziKafkaRef()
@@ -485,7 +485,7 @@ class KafkaServiceReconcilerTest {
             mockGetKafka(context, Optional.empty());
             mockGetConfigMap(context, Optional.of(CRT_CONFIG_MAP));
             result.add(Arguments.argumentSet("crt trust bundle of pem store type",
-                    // @formatter:off
+            // @formatter:off
                     new KafkaServiceBuilder(SERVICE)
                             .withNewSpec()
                                 .withNewTls()

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/RoundRobinBootstrapSelectionStrategy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/RoundRobinBootstrapSelectionStrategy.java
@@ -8,11 +8,10 @@ package io.kroxylicious.proxy.bootstrap;
 
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import io.kroxylicious.proxy.service.HostPort;
+import io.kroxylicious.proxy.tag.NotThreadSafe;
 
 /**
  * {@link BootstrapSelectionStrategy} that selects a server from the given list of servers as the bootstrap server in a round-robin fashion.

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/impl/TopicNameCacheFilter.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/impl/TopicNameCacheFilter.java
@@ -13,8 +13,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
-import javax.annotation.concurrent.ThreadSafe;
-
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.message.MetadataRequestData;
@@ -38,6 +36,7 @@ import io.kroxylicious.proxy.filter.MetadataResponseFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
 import io.kroxylicious.proxy.internal.util.RequestHeaderTagger;
+import io.kroxylicious.proxy.tag.ThreadSafe;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import static io.kroxylicious.proxy.internal.util.Metrics.VIRTUAL_CLUSTER_LABEL;


### PR DESCRIPTION
…g annotations

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
X Refactoring
- Documentation

### Description

Replace jsr305 annotations with spotbugs `@Nullable` and custom threading annotations.

- Replaced `javax.annotation.Nullable` with `@edu.umd.cs.findbugs.annotations.Nullable`
- Created `@ThreadSafe` and `@NotThreadSafe` annotations in `io.kroxylicious.proxy.tag`
- Added missing `kroxylicious-annotations` dependency to `kroxylicious-kafka-message-tools` and `kroxylicious-kms`


### Additional Context

Resolves #3960. The jsr305 jar lacks an Automatic-Module-Name, making the module name fragile and causing compiler warnings when used in module-info.java. This change removes the dependency on jsr305 as described in the issue.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] User facing documentation written/updated (where applicable).
- [X] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [X] PR references related GitHub issue(s) so they are closed on merging.
- [X] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
