### PR TITLE
chore(build): refine checkstyle rules for JSR305 annotation ban

### DIFF
--- a/etc/checkstyle-custom_checks.xml
+++ b/etc/checkstyle-custom_checks.xml
@@ -110,8 +110,19 @@
         </module>
 
         <module name="IllegalImport">
+            <property name="regexp" value="true"/>
             <!-- we shouldn't be relying on class shaded into TC for dependencies -->
-            <property name="illegalPkgs" value="org.testcontainers.shaded"/>
+            <property name="illegalPkgs" value="^org\.testcontainers\.shaded"/>
+            <!-- ban jsr305 annotations - we use spotbugs annotations and custom threading annotations instead -->
+            <!-- Note: javax.annotation.processing is allowed (standard Java annotation processing API) -->
+            <property name="illegalClasses" value="^javax\.annotation\.(?!processing\.).*"/>
+        </module>
+
+        <!-- Ban fully qualified uses of jsr305 annotations (catches cases without imports) -->
+        <!-- Negative lookahead (?!processing\.) allows javax.annotation.processing.* which is standard Java -->
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="javax\.annotation\.(?!processing\.)(concurrent\.)?" />
+            <property name="message" value="Do not use jsr305 annotations (javax.annotation.*). Use spotbugs annotations (e.g. edu.umd.cs.findbugs.annotations.Nullable) or Kroxylicious threading annotations (e.g. io.kroxylicious.proxy.tag.ThreadSafe) instead." />
         </module>
 
         <!--


### PR DESCRIPTION
## Summary

This PR refines the checkstyle rules to make the JSR305 annotation ban more precise, allowing standard Java annotation processing API (`javax.annotation.processing.Generated`) while still blocking JSR305 annotations.

This change follows on from @dahyvuun's work in #3966.

## Background

After merging #3966, which replaced JSR305 annotations with SpotBugs annotations, checkstyle was still failing on generated code because the krpc-plugin code generator uses `@javax.annotation.processing.Generated`, which is part of the standard Java annotation processing API and not a JSR305 annotation.

The original checkstyle rules banned the entire `javax.annotation` package, which was overly broad.

## Changes

Updated `etc/checkstyle-custom_checks.xml`:

1. **IllegalImport**: Use regex mode with negative lookahead pattern `^javax\.annotation\.(?!processing\.).*` to ban all `javax.annotation.*` imports except `javax.annotation.processing.*`

2. **RegexpSinglelineJava**: Updated pattern to allow `javax.annotation.processing.*` for fully qualified usage

## Verification

- ✅ Allows `javax.annotation.processing.Generated` (standard Java)
- ✅ Blocks JSR305 annotations (`javax.annotation.Nullable`, `javax.annotation.concurrent.*`, etc.)
- ✅ Full build passes with `-Pqa`
- ✅ Tested with a violation test class demonstrating both rules catch JSR305 usage

## Related Issues

Follows: #3966