### PR TITLE
refactor(test): improve ProxyProtocolIT test infrastructure

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ProxyProtocolIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ProxyProtocolIT.java
@@ -21,6 +21,7 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.SocketChannel;
@@ -93,21 +94,7 @@ class ProxyProtocolIT {
             var correlationManager = new CorrelationManager();
             var kafkaHandler = new KafkaClientHandler();
             try (var group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory())) {
-                var bootstrap = new Bootstrap()
-                        .group(group)
-                        .channel(NioSocketChannel.class)
-                        .option(ChannelOption.TCP_NODELAY, true)
-                        .handler(new ChannelInitializer<SocketChannel>() {
-                            @Override
-                            protected void initChannel(SocketChannel ch) {
-                                ch.pipeline().addLast(HAProxyMessageEncoder.INSTANCE);
-                                ch.pipeline().addLast(new KafkaRequestEncoder(correlationManager));
-                                ch.pipeline().addLast(new KafkaResponseDecoder(correlationManager));
-                                ch.pipeline().addLast(kafkaHandler);
-                            }
-                        });
-
-                Channel channel = bootstrap.connect(host, port).sync().channel();
+                Channel channel = connectClient(group, host, port, correlationManager, kafkaHandler);
 
                 // Send PROXY header first
                 channel.writeAndFlush(new HAProxyMessage(
@@ -184,21 +171,7 @@ class ProxyProtocolIT {
                     .build();
 
             try (var group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory())) {
-                var bootstrap = new Bootstrap()
-                        .group(group)
-                        .channel(NioSocketChannel.class)
-                        .option(ChannelOption.TCP_NODELAY, true)
-                        .handler(new ChannelInitializer<SocketChannel>() {
-                            @Override
-                            protected void initChannel(SocketChannel ch) {
-                                ch.pipeline().addLast(HAProxyMessageEncoder.INSTANCE);
-                                ch.pipeline().addLast(new KafkaRequestEncoder(correlationManager));
-                                ch.pipeline().addLast(new KafkaResponseDecoder(correlationManager));
-                                ch.pipeline().addLast(kafkaHandler);
-                            }
-                        });
-
-                Channel channel = bootstrap.connect(host, port).sync().channel();
+                Channel channel = connectClient(group, host, port, correlationManager, kafkaHandler);
 
                 // Send PROXY header first (before TLS handshake)
                 channel.writeAndFlush(new HAProxyMessage(
@@ -289,21 +262,7 @@ class ProxyProtocolIT {
                     .build();
 
             try (var group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory())) {
-                var bootstrap = new Bootstrap()
-                        .group(group)
-                        .channel(NioSocketChannel.class)
-                        .option(ChannelOption.TCP_NODELAY, true)
-                        .handler(new ChannelInitializer<SocketChannel>() {
-                            @Override
-                            protected void initChannel(SocketChannel ch) {
-                                ch.pipeline().addLast(HAProxyMessageEncoder.INSTANCE);
-                                ch.pipeline().addLast(new KafkaRequestEncoder(correlationManager));
-                                ch.pipeline().addLast(new KafkaResponseDecoder(correlationManager));
-                                ch.pipeline().addLast(kafkaHandler);
-                            }
-                        });
-
-                Channel channel = bootstrap.connect(host, port).sync().channel();
+                Channel channel = connectClient(group, host, port, correlationManager, kafkaHandler);
 
                 // Send PROXY header first (before TLS handshake)
                 channel.writeAndFlush(new HAProxyMessage(
@@ -349,21 +308,7 @@ class ProxyProtocolIT {
             var correlationManager = new CorrelationManager();
             var kafkaHandler = new KafkaClientHandler();
             try (var group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory())) {
-                var bootstrap = new Bootstrap()
-                        .group(group)
-                        .channel(NioSocketChannel.class)
-                        .option(ChannelOption.TCP_NODELAY, true)
-                        .handler(new ChannelInitializer<SocketChannel>() {
-                            @Override
-                            protected void initChannel(SocketChannel ch) {
-                                ch.pipeline().addLast(HAProxyMessageEncoder.INSTANCE);
-                                ch.pipeline().addLast(new KafkaRequestEncoder(correlationManager));
-                                ch.pipeline().addLast(new KafkaResponseDecoder(correlationManager));
-                                ch.pipeline().addLast(kafkaHandler);
-                            }
-                        });
-
-                Channel channel = bootstrap.connect(host, port).sync().channel();
+                Channel channel = connectClient(group, host, port, correlationManager, kafkaHandler);
 
                 // Send PROXY header — in DISABLED mode, proxy treats this as Kafka data
                 channel.writeAndFlush(new HAProxyMessage(
@@ -392,6 +337,33 @@ class ProxyProtocolIT {
     }
 
     // ---- Helpers ----
+
+    /**
+     * Build a {@link Bootstrap} with the standard test-client pipeline
+     * (PROXY encoder, Kafka codec, {@code kafkaHandler}) and wire channel-close
+     * to {@link CorrelationManager#onChannelClose()} so in-flight request futures
+     * are completed when the peer drops the connection.
+     */
+    private static Channel connectClient(EventLoopGroup group, String host, int port,
+                                         CorrelationManager correlationManager, KafkaClientHandler kafkaHandler)
+            throws InterruptedException {
+        var bootstrap = new Bootstrap()
+                .group(group)
+                .channel(NioSocketChannel.class)
+                .option(ChannelOption.TCP_NODELAY, true)
+                .handler(new ChannelInitializer<SocketChannel>() {
+                    @Override
+                    protected void initChannel(SocketChannel ch) {
+                        ch.pipeline().addLast(HAProxyMessageEncoder.INSTANCE);
+                        ch.pipeline().addLast(new KafkaRequestEncoder(correlationManager));
+                        ch.pipeline().addLast(new KafkaResponseDecoder(correlationManager));
+                        ch.pipeline().addLast(kafkaHandler);
+                    }
+                });
+        var channel = bootstrap.connect(host, port).sync().channel();
+        channel.closeFuture().addListener(f -> correlationManager.onChannelClose());
+        return channel;
+    }
 
     private static ConfigurationBuilder buildTlsProxyProtocolConfig(String mockBootstrap, CertificateGenerator.KeyStore keystore,
                                                                     ProxyProtocolMode mode) {


### PR DESCRIPTION
### Type of change
Refactoring

### Description

Refactor ProxyProtocolIT to reduce code duplication and improve defensive request handling.

Extract a `connectClient()` helper to eliminate duplicated Bootstrap/pipeline wiring across the four test methods. Wire `CorrelationManager.onChannelClose()` via `channel.closeFuture()` listener (mirroring how `KafkaClient` already does it) to defensively ensure in-flight requests complete if the peer closes the connection.

### Additional Context

This PR extracts useful improvements from #3762. The original test flake has been fixed by other work, but these improvements are still valuable for:
1. **Code quality**: Reducing duplication via `connectClient()` helper
2. **Defensive programming**: Adding `onChannelClose()` wiring to prevent similar issues in the future

Relates to #3757

### Checklist

- [x] PR raised from a fork of this repository and made from a branch rather than main
- [x] Write tests (existing tests verify behavior)
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored
- [ ] If applicable to the change, make sure system tests pass
- [ ] If applicable to the change, trigger the performance test suite
- [x] Ensure the PR references relevant issue(s) so they are closed on merging
- [ ] For user facing changes, update CHANGELOG.md