### PR TITLE
fix(test): complete queued requests on channel close in KafkaClientHandler

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/client/ChannelClosedException.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/client/ChannelClosedException.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.integration.client;
+
+/**
+ * Exception thrown when a channel closes before queued requests can be sent.
+ */
+public class ChannelClosedException extends RuntimeException {
+
+    public ChannelClosedException(String message) {
+        super(message);
+    }
+}

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/client/KafkaClientHandler.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/client/KafkaClientHandler.java
@@ -48,9 +48,23 @@ public class KafkaClientHandler extends ChannelInboundHandlerAdapter {
     }
 
     @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        failQueuedRequests(new ChannelClosedException("Channel closed before request could be sent"));
+        ctx.fireChannelInactive();
+    }
+
+    @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         LOGGER.warn("Kafka test client received unexpected exception, closing connection.", cause);
+        failQueuedRequests(cause);
         ctx.close();
+    }
+
+    private void failQueuedRequests(Throwable cause) {
+        RequestFrame pending;
+        while ((pending = queue.pollFirst()) != null) {
+            pending.getResponseFuture().completeExceptionally(cause);
+        }
     }
 
     /**

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/client/KafkaClientHandlerTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/client/KafkaClientHandlerTest.java
@@ -6,10 +6,10 @@
 package io.kroxylicious.testing.integration.client;
 
 import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
 
 import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -24,40 +24,44 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class KafkaClientHandlerTest {
 
+    private final KafkaClientHandler handler = new KafkaClientHandler();
+    private final EmbeddedChannel channel = new EmbeddedChannel(handler);
+
+    @AfterEach
+    void tearDown() {
+        channel.close();
+    }
+
     @Test
     void channelInactive_completesQueuedRequestsExceptionally() {
         // given
-        var handler = new KafkaClientHandler();
-        var channel = new EmbeddedChannel(handler);
         var requestFrame = createRequestFrame();
-        CompletableFuture<SequencedResponse> future = handler.sendRequest(requestFrame);
+        var responseFuture = handler.sendRequest(requestFrame);
 
         // when
         channel.pipeline().fireChannelInactive();
 
         // then
-        assertThat(future)
+        assertThat(responseFuture)
                 .isCompletedExceptionally();
-        assertThatThrownBy(future::join)
+        assertThatThrownBy(responseFuture::join)
                 .hasCauseInstanceOf(ChannelClosedException.class);
     }
 
     @Test
     void exceptionCaught_failsQueuedRequestsWithCause() {
         // given
-        var handler = new KafkaClientHandler();
-        var channel = new EmbeddedChannel(handler);
         var requestFrame = createRequestFrame();
-        CompletableFuture<SequencedResponse> future = handler.sendRequest(requestFrame);
+        var responseFuture = handler.sendRequest(requestFrame);
+        var testException = new IOException("test error");
 
         // when
-        var testException = new IOException("test error");
         channel.pipeline().fireExceptionCaught(testException);
 
         // then
-        assertThat(future)
+        assertThat(responseFuture)
                 .isCompletedExceptionally();
-        assertThatThrownBy(future::join)
+        assertThatThrownBy(responseFuture::join)
                 .hasCauseExactlyInstanceOf(IOException.class)
                 .hasMessageContaining("test error");
     }
@@ -65,22 +69,21 @@ class KafkaClientHandlerTest {
     @Test
     void channelActive_sendsQueuedRequests() {
         // given
-        var handler = new KafkaClientHandler();
-        var channel = new EmbeddedChannel(handler);
         var requestFrame = createRequestFrame();
-        CompletableFuture<SequencedResponse> future = handler.sendRequest(requestFrame);
+        var responseFuture = handler.sendRequest(requestFrame);
 
         // when
+
+        // fireChannelActive activates the channel, with processes pending writes, async, on the Netty thread.
+        // the runPendingTasks is present to ensure that the async work has actually happened.
         channel.pipeline().fireChannelActive();
         channel.runPendingTasks();
 
         // then
         assertThat(channel.outboundMessages())
                 .hasSize(1);
-        assertThat(future)
+        assertThat(responseFuture)
                 .isNotCompleted();
-
-        channel.close();
     }
 
     private DecodedRequestFrame<ApiVersionsRequestData> createRequestFrame() {

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/client/KafkaClientHandlerTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/client/KafkaClientHandlerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.integration.client;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.junit.jupiter.api.Test;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+import io.kroxylicious.testing.integration.codec.DecodedRequestFrame;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link KafkaClientHandler} lifecycle behavior.
+ */
+class KafkaClientHandlerTest {
+
+    @Test
+    void channelInactive_completesQueuedRequestsExceptionally() {
+        // given
+        var handler = new KafkaClientHandler();
+        var channel = new EmbeddedChannel(handler);
+        var requestFrame = createRequestFrame();
+        CompletableFuture<SequencedResponse> future = handler.sendRequest(requestFrame);
+
+        // when
+        channel.pipeline().fireChannelInactive();
+
+        // then
+        assertThat(future)
+                .isCompletedExceptionally();
+        assertThatThrownBy(future::join)
+                .hasCauseInstanceOf(ChannelClosedException.class);
+    }
+
+    @Test
+    void exceptionCaught_failsQueuedRequestsWithCause() {
+        // given
+        var handler = new KafkaClientHandler();
+        var channel = new EmbeddedChannel(handler);
+        var requestFrame = createRequestFrame();
+        CompletableFuture<SequencedResponse> future = handler.sendRequest(requestFrame);
+
+        // when
+        var testException = new IOException("test error");
+        channel.pipeline().fireExceptionCaught(testException);
+
+        // then
+        assertThat(future)
+                .isCompletedExceptionally();
+        assertThatThrownBy(future::join)
+                .hasCauseExactlyInstanceOf(IOException.class)
+                .hasMessageContaining("test error");
+    }
+
+    @Test
+    void channelActive_sendsQueuedRequests() {
+        // given
+        var handler = new KafkaClientHandler();
+        var channel = new EmbeddedChannel(handler);
+        var requestFrame = createRequestFrame();
+        CompletableFuture<SequencedResponse> future = handler.sendRequest(requestFrame);
+
+        // when
+        channel.pipeline().fireChannelActive();
+        channel.runPendingTasks();
+
+        // then
+        assertThat(channel.outboundMessages())
+                .hasSize(1);
+        assertThat(future)
+                .isNotCompleted();
+
+        channel.close();
+    }
+
+    private DecodedRequestFrame<ApiVersionsRequestData> createRequestFrame() {
+        var header = new org.apache.kafka.common.message.RequestHeaderData()
+                .setRequestApiKey(ApiKeys.API_VERSIONS.id)
+                .setRequestApiVersion(ApiVersionsRequestData.HIGHEST_SUPPORTED_VERSION)
+                .setClientId("test-client")
+                .setCorrelationId(0);
+        return new DecodedRequestFrame<>(
+                header.requestApiVersion(),
+                header.correlationId(),
+                header,
+                new ApiVersionsRequestData(),
+                ApiVersionsRequestData.HIGHEST_SUPPORTED_VERSION);
+    }
+}


### PR DESCRIPTION
### Type of change
Bugfix

### Description

Improve KafkaClientHandler defensive behavior to properly complete queued request futures when the channel closes or encounters errors. This prevents futures from hanging indefinitely if the peer drops the connection before requests are sent.

Add `channelInactive()` to drain the queue with `ChannelClosedException` (a new custom exception), and update `exceptionCaught()` to fail queued requests with the real cause rather than letting them hang or fail later with a follow-up exception.

Add `KafkaClientHandlerTest` to verify the lifecycle behavior.

### Additional Context

This PR extracts useful improvements from #3762. The original test flake has been fixed by other work, but these improvements are still valuable for defensive programming.

Relates to #3757

### Checklist

- [x] PR raised from a fork of this repository and made from a branch rather than main
- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored
- [ ] If applicable to the change, make sure system tests pass
- [ ] If applicable to the change, trigger the performance test suite
- [x] Ensure the PR references relevant issue(s) so they are closed on merging
- [ ] For user facing changes, update CHANGELOG.md