### PR TITLE
fix(runtime): registerConnection rejects unless VC is in SERVING state

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterLifecycle.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterLifecycle.java
@@ -144,7 +144,7 @@ public class VirtualClusterLifecycle {
     }
 
     public synchronized boolean registerConnection(ProxyChannelStateMachine pcsm) {
-        if (state instanceof Draining || state instanceof Stopped) {
+        if (!(state instanceof Serving)) {
             return false;
         }
         activeConnections.add(pcsm);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterLifecycleTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterLifecycleTest.java
@@ -40,10 +40,12 @@ class VirtualClusterLifecycleTest {
     private static final String CLUSTER_NAME = "test-cluster";
     private static final Duration DRAIN_TIMEOUT = Duration.ofSeconds(5);
     private VirtualClusterLifecycle manager;
+    private ProxyChannelStateMachine pcsm;
 
     @BeforeEach
     void setUp() {
         manager = new VirtualClusterLifecycle(CLUSTER_NAME, DRAIN_TIMEOUT);
+        pcsm = mock(ProxyChannelStateMachine.class);
     }
 
     @Test
@@ -191,12 +193,75 @@ class VirtualClusterLifecycleTest {
                 .isInstanceOf(IllegalStateException.class);
     }
 
-    // --- Concurrency ---
+    @Test
+    void shouldRejectConnectionRegistrationWhenInitializing() {
+        // given - lifecycle starts in Initializing
+
+        // when
+        var registered = manager.registerConnection(pcsm);
+
+        // then
+        assertThat(registered).isFalse();
+        assertThat(manager.activeConnections()).isEmpty();
+    }
+
+    @Test
+    void shouldAcceptConnectionRegistrationWhenServing() {
+        // given
+        manager.initializationSucceeded();
+
+        // when
+        var registered = manager.registerConnection(pcsm);
+
+        // then
+        assertThat(registered).isTrue();
+        assertThat(manager.activeConnections()).containsExactly(pcsm);
+    }
+
+    @Test
+    void shouldRejectConnectionRegistrationWhenDraining() {
+        // given
+        manager.initializationSucceeded();
+        manager.startDraining();
+
+        // when
+        var registered = manager.registerConnection(pcsm);
+
+        // then
+        assertThat(registered).isFalse();
+    }
+
+    @Test
+    void shouldRejectConnectionRegistrationWhenFailed() {
+        // given
+        manager.initializationFailed(new RuntimeException("oops"));
+
+        // when
+        var registered = manager.registerConnection(pcsm);
+
+        // then
+        assertThat(registered).isFalse();
+        assertThat(manager.activeConnections()).isEmpty();
+    }
+
+    @Test
+    void shouldRejectConnectionRegistrationWhenStopped() {
+        // given
+        manager.initializationFailed(new RuntimeException("oops"));
+        manager.stop();
+
+        // when
+        var registered = manager.registerConnection(pcsm);
+
+        // then
+        assertThat(registered).isFalse();
+    }
 
     @Test
     void concurrentRegisterAndDeregisterDoesNotLoseConnection() throws Exception {
         for (int iter = 0; iter < 200; iter++) {
             var lifecycle = new VirtualClusterLifecycle("c", DRAIN_TIMEOUT);
+            lifecycle.initializationSucceeded();
             var pcsm1 = mock(ProxyChannelStateMachine.class);
             var pcsm2 = mock(ProxyChannelStateMachine.class);
             lifecycle.registerConnection(pcsm1);
@@ -232,6 +297,7 @@ class VirtualClusterLifecycleTest {
         int threads = 8;
         int operationsPerThread = 500;
         var lifecycle = new VirtualClusterLifecycle("c", DRAIN_TIMEOUT);
+        lifecycle.initializationSucceeded();
         var pcsms = new ProxyChannelStateMachine[threads * operationsPerThread];
         for (int i = 0; i < pcsms.length; i++) {
             pcsms[i] = mock(ProxyChannelStateMachine.class);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
@@ -529,6 +529,7 @@ class VirtualClusterRegistryTest {
     @Test
     void shouldTrackRegisteredConnectionForCluster() {
         // given
+        vcc.initializationSucceeded(CLUSTER_A);
         var pcsm = mock(ProxyChannelStateMachine.class);
 
         // when
@@ -541,6 +542,7 @@ class VirtualClusterRegistryTest {
     @Test
     void shouldRemoveConnectionOnDeregister() {
         // given
+        vcc.initializationSucceeded(CLUSTER_A);
         var pcsm = mock(ProxyChannelStateMachine.class);
         vcc.registerConnection(CLUSTER_A, pcsm);
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

`VirtualClusterLifecycle.registerConnection` was using a blocklist guard — rejecting new connections only when the state was `Draining` or `Stopped`. This silently accepted connection registrations while the cluster was in `Initializing` or `Failed` states, where the cluster is not yet (or never will be) ready to serve traffic.

The fix inverts the check to an allowlist: connections are only accepted when the state is `Serving`.

Also fixes the two concurrency tests that were registering connections while the lifecycle was still in `Initializing` state (they now call `initializationSucceeded()` first).

### Additional Context

Addresses review comment on #3977: https://github.com/kroxylicious/kroxylicious/pull/3977#discussion_r3263610085

### Checklist

- [x] New tests written (where applicable).
- [ ] User facing documentation written/updated (where applicable).
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).