### PR TITLE
feat(benchmarks): enforce hard pod anti-affinity for clean benchmark placement

### DIFF
--- a/kroxylicious-openmessaging-benchmarks/README.md
+++ b/kroxylicious-openmessaging-benchmarks/README.md
@@ -12,11 +12,66 @@ For information on modifying or extending the benchmark infrastructure, see [DEV
 
 - Kubernetes cluster with `kubectl` configured
   - Smoke / local validation: 4 CPU, 8 GB RAM (single-node minikube/kind is fine)
-  - Full benchmark run: 8 CPU, 16 GB RAM across the cluster (3 brokers + 3 OMB workers)
+  - Full benchmark run: see [Cluster topology](#cluster-topology) below
 - `helm` 3.0+
 - `gh` (GitHub CLI) — for downloading the Kroxylicious operator release
 - `jbang` — for result comparison scripts ([install](https://www.jbang.dev/download/))
 - `mvn` — for generating JBang source filters
+
+## Cluster topology
+
+These benchmarks model a **centralised proxy tier** — a dedicated set of proxy nodes
+sitting between clients and Kafka brokers. The topology is intentionally strict to produce
+repeatable, comparable numbers: if pods share nodes, the measured overhead changes depending
+on what the scheduler happened to co-locate, making results non-reproducible across runs or
+clusters.
+
+> **Note on other deployment patterns.** Co-locating the proxy with brokers or clients
+> (e.g. a sidecar deployed alongside each broker as a reverse proxy) is a valid and
+> potentially more efficient architecture. In that pattern, pod-to-pod traffic never
+> crosses the physical network, which is a feature not a flaw. These benchmarks do not
+> measure that pattern — they measure the cost of a dedicated proxy hop.
+
+### Recommended node layout
+
+Each process class should be isolated to its own node(s). Mixing classes onto shared
+nodes changes the measured network path and introduces CPU and memory contention that
+varies unpredictably between runs.
+
+| Role | Nodes | Notes |
+|---|---|---|
+| Kafka brokers | 3 | One per node; required for RF=3 |
+| OMB workers | 2–3 | One per node; dedicated nodes separate from brokers and proxy |
+| Proxy | 1 | Dedicated node; separate from brokers and workers |
+
+**Total: 6 nodes** for a fully isolated run matching the recommended layout.
+
+A 4-node cluster (brokers on 3 nodes, proxy + workers sharing 1) is the practical minimum
+but workers will share a node and may interfere with each other under load.
+
+The proxy node must have enough allocatable CPU to satisfy the largest proxy CPU request
+in your sweep. For the blog coefficient sweep (`run-coefficient-sweep.sh`) that is 4000m,
+so size the proxy node to match whatever core count your deployment is targeting.
+
+### Enforcement
+
+The benchmark scripts enforce this topology automatically via pod anti-affinity rules:
+
+- **Kafka brokers** — hard anti-affinity against each other (one per node, enforced by Strimzi)
+- **OMB workers** — hard anti-affinity against broker and proxy nodes; soft anti-affinity
+  against each other (spread across worker nodes where possible)
+- **Proxy** — hard anti-affinity against broker and worker nodes, applied as a strategic-merge
+  patch to the proxy Deployment by `run-benchmark.sh` on every run
+
+If the cluster lacks a node that satisfies the proxy's anti-affinity rules, the proxy pod
+goes **Pending** rather than silently producing results on a co-located node. This is
+intentional — Pending is a visible signal to add capacity.
+
+Use `--skip-proxy-isolation` on `run-benchmark.sh` to bypass the proxy patch if you
+deliberately want to measure co-located behaviour.
+
+Single-node clusters (minikube, kind) are fine for smoke testing and verifying deployment
+but will not produce representative numbers.
 
 ## Quick Start
 
@@ -203,17 +258,6 @@ METRICS_INTERVAL=10 ./scripts/run-benchmark.sh proxy-no-filters 1topic-1kb ./res
 ```
 
 ## Troubleshooting
-
-### Leaving infrastructure running for post-failure inspection
-
-Pass `--skip-teardown` to `run-benchmark.sh` to prevent the script from tearing down
-infrastructure on exit, whether it succeeds or fails:
-
-```bash
-./scripts/run-benchmark.sh --skip-teardown baseline 1topic-1kb ./results/baseline/
-```
-
-The script will print the teardown commands to run manually when you are done inspecting.
 
 ### Leaving infrastructure running for post-failure inspection
 

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/patches/proxy-anti-affinity.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/patches/proxy-anti-affinity.yaml
@@ -4,17 +4,19 @@
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
-# Patches the proxy Deployment to add hard pod anti-affinity against Kafka broker pods.
+# Patches the proxy Deployment to add hard pod anti-affinity against Kafka broker
+# pods and OMB worker pods.
 #
-# This ensures the proxy is never co-located with a Kafka broker. Without isolation,
-# the proxy and a broker share CPU on the same node, which causes enough contention
-# to push the encryption ceiling below its true value — making the proxy appear
-# slower than it is on a properly provisioned cluster.
+# Ensures the proxy is never co-located with a Kafka broker or an OMB worker.
+# Co-location with either causes pod-to-pod traffic to bypass the real network
+# (OVS in-kernel path on OpenShift), artificially lowering measured latency and
+# inflating throughput ceilings.
 #
-# Requires at least one worker node that has no Kafka pod scheduled on it.
-# On a 3-worker cluster where Strimzi fills each worker with one broker, this
-# patch will prevent the proxy from scheduling at all — use --no-isolate-proxy
-# in that case and treat results as indicative only.
+# With 3 Kafka brokers on 3 nodes and OMB workers on the remaining nodes, the
+# proxy is forced onto a broker node when fewer than (brokers + workers + 1) nodes
+# are available — the proxy will go Pending if no node is free of both brokers and
+# workers. This is intentional: Pending is a visible signal to add capacity rather
+# than silently producing corrupted results.
 #
 # The PROXY_DEPLOYMENT and NAMESPACE placeholders are substituted by the script
 # using envsubst before applying.
@@ -32,4 +34,8 @@ spec:
           - labelSelector:
               matchLabels:
                 strimzi.io/cluster: kafka
+            topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchLabels:
+                app: omb-worker
             topologyKey: kubernetes.io/hostname

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/patches/proxy-anti-affinity.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/patches/proxy-anti-affinity.yaml
@@ -33,7 +33,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
-                strimzi.io/cluster: kafka
+                strimzi.io/pool-name: kafka-pool
             topologyKey: kubernetes.io/hostname
           - labelSelector:
               matchLabels:

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/kafka-nodepool.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/kafka-nodepool.yaml
@@ -28,3 +28,12 @@ spec:
       deleteClaim: false
   resources:
 {{ toYaml .Values.kafka.resources | nindent 4 }}
+  template:
+    pod:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                strimzi.io/cluster: kafka
+            topologyKey: kubernetes.io/hostname

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/kafka-nodepool.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/kafka-nodepool.yaml
@@ -35,5 +35,5 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
-                strimzi.io/cluster: kafka
+                strimzi.io/pool-name: kafka-pool
             topologyKey: kubernetes.io/hostname

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/omb-workers-statefulset.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/omb-workers-statefulset.yaml
@@ -50,6 +50,10 @@ spec:
                 operator: In
                 values: ["proxy"]
             topologyKey: kubernetes.io/hostname
+          # Soft rather than hard: worker-to-worker co-location does not affect the measured
+          # proxy path (only broker and proxy co-location does), so packing workers onto
+          # shared nodes is harmless to measurement quality. A hard rule would make workers
+          # unschedulable on smaller clusters without improving result accuracy.
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/omb-workers-statefulset.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/omb-workers-statefulset.yaml
@@ -37,6 +37,26 @@ spec:
       labels:
         app: omb-worker
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                strimzi.io/cluster: kafka
+            topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values: ["proxy"]
+            topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: omb-worker
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: omb-worker
         image: {{ .Values.omb.image }}

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/omb-workers-statefulset.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/omb-workers-statefulset.yaml
@@ -42,7 +42,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
-                strimzi.io/cluster: kafka
+                strimzi.io/pool-name: kafka-pool
             topologyKey: kubernetes.io/hostname
           - labelSelector:
               matchExpressions:

--- a/kroxylicious-openmessaging-benchmarks/scripts/run-blog-suite.sh
+++ b/kroxylicious-openmessaging-benchmarks/scripts/run-blog-suite.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+set -uo pipefail
+
+# Runs the full benchmark suite for the Kroxylicious blog posts.
+#
+# Executes all steps sequentially and continues on failure, reporting a summary
+# at the end. Designed to be kicked off in a tmux session and left running
+# (~14 hours total).
+#
+# Usage: scripts/run-blog-suite.sh [--cluster-overrides <file>] [--output-dir <dir>]
+#
+# Run from: kroxylicious-openmessaging-benchmarks/
+#
+# Steps:
+#   Post 1 — Multi-topic latency  (run-all-scenarios, RF=3, 3 scenarios × 3 workloads)
+#   Post 1 — Rate sweep           (rate-sweep, RF=3, 1-core proxy, 8k–22k msg/s, 5% steps)
+#   Post 2 — Connection sweep, encryption, 1-core, 1-topic, RF=1
+#   Post 2 — Connection sweep, encryption, 4-core, 1-topic, RF=1
+#   Post 2 — Connection sweep, encryption, 4-core, 10-topics, RF=1
+#   Post 2 — Connection sweep, proxy-no-filters, 4-core, 10-topics, RF=1
+#   Post 2 — CPU coefficient analysis (4-core sweeps)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODULE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${MODULE_DIR}"
+
+usage() {
+    cat >&2 <<EOF
+Usage: $(basename "$0") [--cluster-overrides <file>] [--output-dir <dir>]
+
+Options:
+  --cluster-overrides <file>  Helm values for cluster-specific settings
+                              (default: fyre-cluster.yaml)
+  --output-dir <dir>          Root directory for all results
+                              (default: results/blog-suite-<timestamp>)
+  -h, --help                  Show this help
+EOF
+    exit 1
+}
+
+CLUSTER_OVERRIDES="fyre-cluster.yaml"
+OUTPUT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --cluster-overrides) CLUSTER_OVERRIDES="$2"; shift 2 ;;
+        --output-dir)        OUTPUT_DIR="$2";        shift 2 ;;
+        -h|--help)           usage ;;
+        *) echo "Error: unknown argument '$1'" >&2; usage ;;
+    esac
+done
+
+RUN_ID="$(date +%Y%m%d-%H%M%S)"
+OUTPUT_DIR="${OUTPUT_DIR:-results/blog-suite-${RUN_ID}}"
+mkdir -p "${OUTPUT_DIR}"
+
+# Tee all output to a log file — tail -f results/blog-suite-<id>/suite.log to monitor
+exec > >(tee "${OUTPUT_DIR}/suite.log") 2>&1
+
+echo "=========================================="
+echo "Blog benchmark suite — ${RUN_ID}"
+echo "Results: ${OUTPUT_DIR}"
+echo "Cluster overrides: ${CLUSTER_OVERRIDES}"
+echo "Started: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "=========================================="
+echo ""
+
+FAILED_STEPS=()
+
+run_step() {
+    local name="$1"
+    shift
+    local start
+    start="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo ""
+    echo "--- ${name} ---"
+    echo "Started: ${start}"
+    if "$@"; then
+        echo "Completed: $(date -u +%Y-%m-%dT%H:%M:%SZ) — ${name}"
+    else
+        echo "FAILED: $(date -u +%Y-%m-%dT%H:%M:%SZ) — ${name}" >&2
+        FAILED_STEPS+=("${name}")
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Post 1 — Multi-topic latency (RF=3, 3 scenarios × 3 workloads, ~3 hours)
+# ---------------------------------------------------------------------------
+run_step "post1-multi-topic-latency" \
+    scripts/run-all-scenarios.sh \
+        baseline proxy-no-filters encryption \
+        --cluster-overrides "${CLUSTER_OVERRIDES}" \
+        "${OUTPUT_DIR}/all-scenarios/"
+
+# ---------------------------------------------------------------------------
+# Post 1 — Rate sweep (RF=3, 1-core proxy, 8k–22k msg/s, 5% steps, ~10 hours)
+# ---------------------------------------------------------------------------
+run_step "post1-rate-sweep-1core-rf3" \
+    scripts/rate-sweep.sh \
+        --min-rate 8000 --max-rate 22000 --step-percent 5 \
+        --scenarios baseline,proxy-no-filters,encryption \
+        --workload 1topic-1kb \
+        --cluster-overrides "${CLUSTER_OVERRIDES}" \
+        --set kroxylicious.resources.requests.cpu=1000m \
+        --set kroxylicious.resources.limits.cpu=1000m \
+        --output-dir "${OUTPUT_DIR}/rate-sweep-1core-rf3/"
+
+# ---------------------------------------------------------------------------
+# Post 2 — Connection sweeps (all RF=1, 10k msg/s per producer)
+# ---------------------------------------------------------------------------
+run_step "post2-conn-sweep-encryption-1core-1topic" \
+    scripts/connection-sweep.sh \
+        --scenario encryption \
+        --per-producer-rate 10000 \
+        --steps 1,2,4,8,16 \
+        --workload 1topic-1kb \
+        --cluster-overrides "${CLUSTER_OVERRIDES}" \
+        --set kafka.replicationFactor=1 \
+        --set kafka.minInSyncReplicas=1 \
+        --set kroxylicious.resources.requests.cpu=1000m \
+        --set kroxylicious.resources.limits.cpu=1000m \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-1core-1topic-rf1/"
+
+run_step "post2-conn-sweep-encryption-4core-1topic" \
+    scripts/connection-sweep.sh \
+        --scenario encryption \
+        --per-producer-rate 10000 \
+        --steps 1,2,4,8,16,32 \
+        --workload 1topic-1kb \
+        --cluster-overrides "${CLUSTER_OVERRIDES}" \
+        --set kafka.replicationFactor=1 \
+        --set kafka.minInSyncReplicas=1 \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-4core-1topic-rf1/"
+
+run_step "post2-conn-sweep-encryption-4core-10topics" \
+    scripts/connection-sweep.sh \
+        --scenario encryption \
+        --per-producer-rate 10000 \
+        --steps 1,2,4,8,16,32 \
+        --workload 10topics-1kb \
+        --cluster-overrides "${CLUSTER_OVERRIDES}" \
+        --set kafka.replicationFactor=1 \
+        --set kafka.minInSyncReplicas=1 \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-4core-10topics-rf1/"
+
+run_step "post2-conn-sweep-no-filters-4core-10topics" \
+    scripts/connection-sweep.sh \
+        --scenario proxy-no-filters \
+        --per-producer-rate 10000 \
+        --steps 1,2,4,8,16,32 \
+        --workload 10topics-1kb \
+        --cluster-overrides "${CLUSTER_OVERRIDES}" \
+        --set kafka.replicationFactor=1 \
+        --set kafka.minInSyncReplicas=1 \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-no-filters-4core-10topics-rf1/"
+
+# ---------------------------------------------------------------------------
+# Post 2 — CPU coefficient (run against 4-core sweeps if they succeeded)
+# ---------------------------------------------------------------------------
+COEFF_1TOPIC="${OUTPUT_DIR}/conn-sweep-encryption-4core-1topic-rf1/encryption"
+COEFF_10TOPICS="${OUTPUT_DIR}/conn-sweep-encryption-4core-10topics-rf1/encryption"
+
+if [[ -d "${COEFF_1TOPIC}" ]]; then
+    run_step "post2-cpu-coefficient-1topic" \
+        python3 scripts/analyze-cpu-coefficient.py "${COEFF_1TOPIC}"
+else
+    echo "Skipping cpu-coefficient-1topic — sweep directory not found: ${COEFF_1TOPIC}"
+fi
+
+if [[ -d "${COEFF_10TOPICS}" ]]; then
+    run_step "post2-cpu-coefficient-10topics" \
+        python3 scripts/analyze-cpu-coefficient.py "${COEFF_10TOPICS}"
+else
+    echo "Skipping cpu-coefficient-10topics — sweep directory not found: ${COEFF_10TOPICS}"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=========================================="
+echo "Suite complete: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "Results: ${OUTPUT_DIR}"
+echo "=========================================="
+
+if [[ ${#FAILED_STEPS[@]} -gt 0 ]]; then
+    echo ""
+    echo "Failed steps:"
+    for step in ${FAILED_STEPS[@]+"${FAILED_STEPS[@]}"}; do
+        echo "  - ${step}"
+    done
+    exit 1
+fi
+
+echo "All steps succeeded."

--- a/kroxylicious-openmessaging-benchmarks/scripts/run-blog-suite.sh
+++ b/kroxylicious-openmessaging-benchmarks/scripts/run-blog-suite.sh
@@ -37,7 +37,6 @@ Usage: $(basename "$0") [--cluster-overrides <file>] [--output-dir <dir>]
 
 Options:
   --cluster-overrides <file>  Helm values for cluster-specific settings
-                              (default: fyre-cluster.yaml)
   --output-dir <dir>          Root directory for all results
                               (default: results/blog-suite-<timestamp>)
   -h, --help                  Show this help
@@ -45,7 +44,7 @@ EOF
     exit 1
 }
 
-CLUSTER_OVERRIDES="fyre-cluster.yaml"
+CLUSTER_OVERRIDES=""
 OUTPUT_DIR=""
 
 while [[ $# -gt 0 ]]; do
@@ -67,10 +66,13 @@ exec > >(tee "${OUTPUT_DIR}/suite.log") 2>&1
 echo "=========================================="
 echo "Blog benchmark suite — ${RUN_ID}"
 echo "Results: ${OUTPUT_DIR}"
-echo "Cluster overrides: ${CLUSTER_OVERRIDES}"
+echo "Cluster overrides: ${CLUSTER_OVERRIDES:-none}"
 echo "Started: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 echo "=========================================="
 echo ""
+
+CLUSTER_OVERRIDES_ARG=()
+[[ -n "${CLUSTER_OVERRIDES}" ]] && CLUSTER_OVERRIDES_ARG=(--cluster-overrides "${CLUSTER_OVERRIDES}")
 
 FAILED_STEPS=()
 
@@ -96,7 +98,7 @@ run_step() {
 run_step "post1-multi-topic-latency" \
     scripts/run-all-scenarios.sh \
         baseline proxy-no-filters encryption \
-        --cluster-overrides "${CLUSTER_OVERRIDES}" \
+        ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
         "${OUTPUT_DIR}/all-scenarios/"
 
 # ---------------------------------------------------------------------------
@@ -107,7 +109,7 @@ run_step "post1-rate-sweep-1core-rf3" \
         --min-rate 8000 --max-rate 22000 --step-percent 5 \
         --scenarios baseline,proxy-no-filters,encryption \
         --workload 1topic-1kb \
-        --cluster-overrides "${CLUSTER_OVERRIDES}" \
+        ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
         --set kroxylicious.resources.requests.cpu=1000m \
         --set kroxylicious.resources.limits.cpu=1000m \
         --output-dir "${OUTPUT_DIR}/rate-sweep-1core-rf3/"
@@ -121,7 +123,7 @@ run_step "post2-conn-sweep-encryption-1core-1topic" \
         --per-producer-rate 10000 \
         --steps 1,2,4,8,16 \
         --workload 1topic-1kb \
-        --cluster-overrides "${CLUSTER_OVERRIDES}" \
+        ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
         --set kafka.replicationFactor=1 \
         --set kafka.minInSyncReplicas=1 \
         --set kroxylicious.resources.requests.cpu=1000m \
@@ -134,7 +136,7 @@ run_step "post2-conn-sweep-encryption-4core-1topic" \
         --per-producer-rate 10000 \
         --steps 1,2,4,8,16,32 \
         --workload 1topic-1kb \
-        --cluster-overrides "${CLUSTER_OVERRIDES}" \
+        ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
         --set kafka.replicationFactor=1 \
         --set kafka.minInSyncReplicas=1 \
         --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-4core-1topic-rf1/"
@@ -145,7 +147,7 @@ run_step "post2-conn-sweep-encryption-4core-10topics" \
         --per-producer-rate 10000 \
         --steps 1,2,4,8,16,32 \
         --workload 10topics-1kb \
-        --cluster-overrides "${CLUSTER_OVERRIDES}" \
+        ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
         --set kafka.replicationFactor=1 \
         --set kafka.minInSyncReplicas=1 \
         --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-4core-10topics-rf1/"
@@ -156,7 +158,7 @@ run_step "post2-conn-sweep-no-filters-4core-10topics" \
         --per-producer-rate 10000 \
         --steps 1,2,4,8,16,32 \
         --workload 10topics-1kb \
-        --cluster-overrides "${CLUSTER_OVERRIDES}" \
+        ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
         --set kafka.replicationFactor=1 \
         --set kafka.minInSyncReplicas=1 \
         --output-dir "${OUTPUT_DIR}/conn-sweep-no-filters-4core-10topics-rf1/"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds hard `podAntiAffinity` rules to prevent co-location between Kafka brokers, OMB workers, and the proxy pod. Co-location allows pod-to-pod traffic to bypass the real network via the OVS in-kernel path on OpenShift, which artificially lowers measured latency and inflates throughput ceilings.

**Placement rules:**
- Kafka brokers: hard away from each other (via Strimzi `KafkaNodePool` template — Strimzi does not add this automatically)
- OMB workers: hard away from brokers and proxy; soft away from each other (spread when possible, pack when necessary)
- Proxy: hard away from brokers and OMB workers (existing patch extended)

**Scaling behaviour:** with 6+ worker nodes the proxy gets its own dedicated node. With fewer nodes the proxy goes `Pending` rather than silently co-locating and producing corrupted results — a visible failure signal.

Also adds `scripts/run-blog-suite.sh` to orchestrate the full benchmark suite (latency, rate sweep, connection sweeps, CPU coefficient) as a single tmux-friendly command.

### Additional Context

Without these rules, Kubernetes may schedule the proxy or OMB workers onto the same node as Kafka brokers. On OpenShift, same-node pod-to-pod traffic goes through OVS `br-int` (in-kernel, sub-millisecond, no physical NIC), bypassing the real network entirely. This makes the proxy appear faster than it is and inflates throughput ceilings.

### Checklist

- [ ] New tests written (where applicable).
- [ ] User facing documentation written/updated (where applicable).
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).