### PR TITLE
feat(filter-archetype): demonstrate topicId lookups and MockFilterContext (#3349)

### DIFF
--- a/kroxylicious-filter-archetype/pom.xml
+++ b/kroxylicious-filter-archetype/pom.xml
@@ -54,6 +54,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-filter-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.kroxylicious.testing</groupId>
             <artifactId>testing-api</artifactId>
             <scope>test</scope>
@@ -148,6 +153,9 @@
                                         </ignoredUnusedDeclaredDependency>
                                         <ignoredUnusedDeclaredDependency>
                                             io.kroxylicious:kroxylicious-integration-test-support
+                                        </ignoredUnusedDeclaredDependency>
+                                        <ignoredUnusedDeclaredDependency>
+                                            io.kroxylicious:kroxylicious-filter-test-support
                                         </ignoredUnusedDeclaredDependency>
                                         <ignoredUnusedDeclaredDependency>io.kroxylicious:kroxylicious-api
                                         </ignoredUnusedDeclaredDependency>

--- a/kroxylicious-filter-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kroxylicious-filter-archetype/src/main/resources/archetype-resources/pom.xml
@@ -26,6 +26,7 @@
         <maven.compiler.testRelease>${java.version}</maven.compiler.testRelease>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.failsafe.version>@maven.failsafe.version@</maven.failsafe.version>
+        <maven.surefire.version>@maven.surefire.version@</maven.surefire.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -87,6 +88,12 @@
         <dependency>
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-integration-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Provides MockFilterContext, the Kroxylicious-supplied emulation of FilterContext used by the unit tests -->
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-filter-test-support</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- SampleFilterIT uses the config classes from runtime -->
@@ -161,8 +168,13 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.4</version>
+                <version>${maven.failsafe.version}</version>
                 <configuration>
                     <skipTests>${skipITs}</skipTests>
                     <environmentVariables>

--- a/kroxylicious-filter-archetype/src/main/resources/archetype-resources/src/main/java/SampleFetchResponseFilter.java
+++ b/kroxylicious-filter-archetype/src/main/resources/archetype-resources/src/main/java/SampleFetchResponseFilter.java
@@ -1,8 +1,9 @@
 package ${package};
 
-import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.concurrent.CompletionStage;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.record.MemoryRecords;
@@ -11,6 +12,7 @@ import io.kroxylicious.kafka.transform.RecordStream;
 import io.kroxylicious.proxy.filter.FetchResponseFilter;
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
 import ${package}.config.SampleFilterConfig;
 import ${package}.util.SampleFilterTransformer;
 
@@ -18,15 +20,15 @@ import ${package}.util.SampleFilterTransformer;
  * A sample FetchResponseFilter implementation, intended to demonstrate how custom filters work with
  * Kroxylicious.<br />
  * <br/>
- * This filter transforms the topic data sent by a Kafka broker in response to a fetch request sent by a
- * Kafka consumer, by replacing all occurrences of the String "bar" with the String "baz". These strings are
- * configurable in the config file, so you could substitute this with any text you want.<br/>
+ * This filter transforms the topic data sent by a Kafka broker in response to a fetch request by
+ * replacing all occurrences of the String "bar" with the String "baz" (configurable), and by prefixing
+ * the value with the name of the topic the record belongs to.<br />
  * <br/>
- * An example of a use case where this might be applicable is when producers are sending data to Kafka
- * using different formats from what consumers are expecting. You could configure this filter to transform
- * the data sent by Kafka to the consumers into the format they expect. In this example use case, the filter
- * could be further modified to apply different transformations to different topics, or when sending to
- * particular consumers.
+ * Newer Apache Kafka Fetch RPCs carry topic ids rather than topic names. This filter demonstrates the
+ * preferred Kroxylicious pattern for resolving topic ids to topic names using
+ * {@link FilterContext#topicNames}: collect all non-zero topic ids in the response and ask the framework
+ * to resolve them in a single call. The resolved {@link TopicNameMapping} short-circuits when the input
+ * set is empty, so the same code path works for older response versions that carry topic names directly.
  */
 class SampleFetchResponseFilter implements FetchResponseFilter {
 
@@ -47,25 +49,41 @@ class SampleFetchResponseFilter implements FetchResponseFilter {
      */
     @Override
     public CompletionStage<ResponseFilterResult> onFetchResponse(short apiVersion, ResponseHeaderData header, FetchResponseData response, FilterContext context) {
-        applyTransformation(response, context);
-        return context.forwardResponse(header, response);
+        List<Uuid> topicIds = response.responses().stream()
+                .map(FetchResponseData.FetchableTopicResponse::topicId)
+                .filter(uuid -> !Uuid.ZERO_UUID.equals(uuid))
+                .toList();
+        // Even when topicIds is empty, calling topicNames keeps the code path uniform; the framework
+        // has a fast path for the empty case.
+        return context.topicNames(topicIds).thenCompose(topicNameMapping -> {
+            applyTransformation(response, context, topicNameMapping);
+            return context.forwardResponse(header, response);
+        });
     }
 
     /**
-     * Applies the transformation to the response data.
-     * @param response the response to be transformed
-     * @param context the context
+     * Applies the transformation to each partition's records, prefixing each value with the topic name
+     * resolved either from the response itself or from the topic-id lookup.
      */
-    private void applyTransformation(FetchResponseData response, FilterContext context) {
+    private void applyTransformation(FetchResponseData response, FilterContext context, TopicNameMapping topicNameMapping) {
         response.responses().forEach(responseData -> {
+            String topicName = resolveTopicName(responseData, topicNameMapping);
             for (FetchResponseData.PartitionData partitionDatum : responseData.partitions()) {
                 MemoryRecords records = (MemoryRecords) partitionDatum.records();
                 partitionDatum.setRecords(RecordStream.ofRecords(records)
                         .toMemoryRecords(
                                 context.createByteBufferOutputStream(records.sizeInBytes()),
-                                new SampleFilterTransformer(config.getFindValue(), config.getReplacementValue()){}));
+                                new SampleFilterTransformer(topicName, config.getFindValue(), config.getReplacementValue()){}));
             }
         });
+    }
+
+    private static String resolveTopicName(FetchResponseData.FetchableTopicResponse responseData, TopicNameMapping topicNameMapping) {
+        if (responseData.topic() != null && !responseData.topic().isEmpty()) {
+            return responseData.topic();
+        }
+        String resolved = topicNameMapping.topicNames().get(responseData.topicId());
+        return resolved != null ? resolved : "unknown";
     }
 
 }

--- a/kroxylicious-filter-archetype/src/main/resources/archetype-resources/src/main/java/SampleProduceRequestFilter.java
+++ b/kroxylicious-filter-archetype/src/main/resources/archetype-resources/src/main/java/SampleProduceRequestFilter.java
@@ -1,7 +1,9 @@
 package ${package};
 
+import java.util.List;
 import java.util.concurrent.CompletionStage;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.record.MemoryRecords;
@@ -10,6 +12,7 @@ import io.kroxylicious.kafka.transform.RecordStream;
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
 import ${package}.config.SampleFilterConfig;
 import ${package}.util.SampleFilterTransformer;
 
@@ -18,14 +21,14 @@ import ${package}.util.SampleFilterTransformer;
  * Kroxylicious.<br />
  * <br />
  * This filter transforms the partition data sent by a Kafka producer in a produce request by replacing all
- * occurrences of the String "foo" with the String "bar". These strings are configurable in the config file,
- * so you could substitute this with any text you want.<br />
+ * occurrences of the String "foo" with the String "bar" (configurable), and by prefixing the value with
+ * the name of the topic the record belongs to.<br />
  * <br />
- * An example of a use case where this might be applicable is when producers are sending data to Kafka
- * using different formats from what consumers are expecting. You could configure this filter to transform
- * the data sent by producers to Kafka into the format consumers expect. In this example use case, the filter
- * could be further modified to apply different transformations to different topics, or when sent by
- * particular producers.
+ * Newer Apache Kafka Produce RPCs carry topic ids rather than topic names. This filter demonstrates the
+ * preferred Kroxylicious pattern for resolving topic ids to topic names using
+ * {@link FilterContext#topicNames}: collect all non-zero topic ids in the request and ask the framework
+ * to resolve them in a single call. The resolved {@link TopicNameMapping} short-circuits when the input
+ * set is empty, so the same code path works for older request versions that carry topic names directly.
  */
 class SampleProduceRequestFilter implements ProduceRequestFilter {
 
@@ -47,25 +50,44 @@ class SampleProduceRequestFilter implements ProduceRequestFilter {
      */
     @Override
     public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, FilterContext context) {
-        applyTransformation(request, context);
-        return context.forwardRequest(header, request);
+        List<Uuid> topicIds = request.topicData().stream()
+                .map(ProduceRequestData.TopicProduceData::topicId)
+                .filter(uuid -> !Uuid.ZERO_UUID.equals(uuid))
+                .toList();
+        // Even when topicIds is empty (older API versions that already carry topic names), calling
+        // topicNames keeps the code path uniform; the framework has a fast path for the empty case.
+        return context.topicNames(topicIds).thenCompose(topicNameMapping -> {
+            applyTransformation(request, context, topicNameMapping);
+            return context.forwardRequest(header, request);
+        });
     }
 
     /**
-     * Applies the transformation to the request data.
-     * @param request the request to be transformed
-     * @param context the context
+     * Applies the transformation to each partition's records, prefixing each value with the topic name
+     * resolved either from the request itself or from the topic-id lookup.
      */
-    private void applyTransformation(ProduceRequestData request, FilterContext context) {
+    private void applyTransformation(ProduceRequestData request, FilterContext context, TopicNameMapping topicNameMapping) {
         request.topicData().forEach(topicData -> {
+            String topicName = resolveTopicName(topicData, topicNameMapping);
             for (ProduceRequestData.PartitionProduceData partitionDatum : topicData.partitionData()) {
                 MemoryRecords records = (MemoryRecords) partitionDatum.records();
                 partitionDatum.setRecords(RecordStream.ofRecords(records)
                         .toMemoryRecords(
                                 context.createByteBufferOutputStream(records.sizeInBytes()),
-                                new SampleFilterTransformer(config.getFindValue(), config.getReplacementValue()){}));
+                                new SampleFilterTransformer(topicName, config.getFindValue(), config.getReplacementValue()){}));
             }
         });
+    }
+
+    private static String resolveTopicName(ProduceRequestData.TopicProduceData topicData, TopicNameMapping topicNameMapping) {
+        if (topicData.name() != null && !topicData.name().isEmpty()) {
+            return topicData.name();
+        }
+        String resolved = topicNameMapping.topicNames().get(topicData.topicId());
+        // Falling back to a placeholder keeps this archetype simple. A production filter should log
+        // the failure and either short-circuit with an error response or drop the request; see
+        // io.kroxylicious.filter.simpletransform.ProduceRequestTransformationFilter for that pattern.
+        return resolved != null ? resolved : "unknown";
     }
 
 }

--- a/kroxylicious-filter-archetype/src/main/resources/archetype-resources/src/main/java/util/SampleFilterTransformer.java
+++ b/kroxylicious-filter-archetype/src/main/resources/archetype-resources/src/main/java/util/SampleFilterTransformer.java
@@ -12,13 +12,17 @@ import ${package}.config.SampleFilterConfig;
 
 /**
  * A {@link RecordTransform} implementation used by the sample filters to perform find-and-replace
- * on the UTF-8 encoded value of each Kafka {@link Record}.
+ * on the UTF-8 encoded value of each Kafka {@link Record}. The transformed value is also prefixed
+ * with the name of the topic the record belongs to, demonstrating how a filter can incorporate
+ * topic-name-derived context into the record. Filters using a {@code SampleFilterTransformer}
+ * therefore need to resolve topic names from the topic ids carried in newer Kafka RPCs (see
+ * {@code FilterContext#topicNames}).
  *
  * <p>Instances are stateful and follow the {@link RecordTransform} lifecycle:
  * <ol>
  * <li>
  *     {@link SampleFilterTransformer#init} is called first to pre-compute the transformed value.
- *     This is where the find-and-replace occurs.
+ *     This is where the find-and-replace occurs and where the topic-name prefix is applied.
  * </li>
  * <li>
  *     {@code SampleFilterTransformer#transform*()} methods are then called to supply the fields
@@ -35,18 +39,23 @@ import ${package}.config.SampleFilterConfig;
  */
 public class SampleFilterTransformer implements RecordTransform<Void> {
 
+    private final String topicName;
     private final String findValue;
     private final String replacementValue;
     private ByteBuffer transformedValue;
 
     /**
      * Creates a transformer that replaces all occurrences of {@code findValue} with
-     * {@code replacementValue} in the UTF-8 encoded value of each Kafka {@link Record}.
+     * {@code replacementValue} in the UTF-8 encoded value of each Kafka {@link Record}, and
+     * prefixes the result with the topic name in square brackets, for example
+     * {@code "[my-topic] hello"}.
      *
+     * @param topicName the name of the topic the records belong to; prepended to the transformed value
      * @param findValue the regex pattern to search for in the record value
      * @param replacementValue the string to substitute for each match
      */
-    public SampleFilterTransformer(String findValue, String replacementValue) {
+    public SampleFilterTransformer(String topicName, String findValue, String replacementValue) {
+        this.topicName = topicName;
         this.findValue = findValue;
         this.replacementValue = replacementValue;
     }
@@ -60,9 +69,10 @@ public class SampleFilterTransformer implements RecordTransform<Void> {
 
     /**
      * Called once per record before any {@code transform*()} methods are invoked.
-     * Applies the find-and-replace to the record's value and caches the result so
-     * that {@link #transformValue(Record)} can be called repeatedly without repeating the work.
-     * Records with a {@code null} value are handled gracefully by storing {@code null}.
+     * Applies the find-and-replace to the record's value, prepends the topic name in
+     * square brackets, and caches the result so that {@link #transformValue(Record)}
+     * can be called repeatedly without repeating the work. Records with a {@code null}
+     * value are handled gracefully by storing {@code null}.
      *
      * @param state unused — this transformer requires no external state
      * @param record the record about to be transformed
@@ -72,7 +82,9 @@ public class SampleFilterTransformer implements RecordTransform<Void> {
         ByteBuffer value = record.value();
         if (value != null) {
             String original = StandardCharsets.UTF_8.decode(value.duplicate()).toString();
-            transformedValue = ByteBuffer.wrap(original.replaceAll(findValue, replacementValue).getBytes(StandardCharsets.UTF_8));
+            String replaced = original.replaceAll(findValue, replacementValue);
+            String prefixed = "[" + topicName + "] " + replaced;
+            transformedValue = ByteBuffer.wrap(prefixed.getBytes(StandardCharsets.UTF_8));
         }
         else {
             transformedValue = null;

--- a/kroxylicious-filter-archetype/src/main/resources/archetype-resources/src/test/java/SampleFetchResponseFilterTest.java
+++ b/kroxylicious-filter-archetype/src/main/resources/archetype-resources/src/test/java/SampleFetchResponseFilterTest.java
@@ -2,17 +2,17 @@ package ${package};
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.message.ApiMessageType;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.ResponseHeaderData;
-import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.record.RecordBatch;
@@ -21,125 +21,126 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
 
-import io.kroxylicious.proxy.filter.FilterContext;
-import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.testing.filter.assertj.MockFilterContextAssert;
+import io.kroxylicious.testing.filter.context.MockFilterContext;
 import ${package}.config.SampleFilterConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
+/**
+ * Unit tests for {@link SampleFetchResponseFilter}.
+ *
+ * <p>These tests use {@link MockFilterContext} — Kroxylicious's tested emulation of
+ * {@link io.kroxylicious.proxy.filter.FilterContext} — instead of building a Mockito mock by hand.
+ * That avoids reimplementing the {@code FilterContext} contract in every test and keeps the
+ * test code focused on filter behaviour.</p>
+ */
 class SampleFetchResponseFilterTest {
 
     private static final short API_VERSION = ApiMessageType.FETCH.highestSupportedVersion(true); // this is arbitrary for our filter
+    private static final String TOPIC_NAME = "my-topic";
+    private static final Uuid TOPIC_ID = new Uuid(7L, 7L);
     private static final String PRE_TRANSFORM_VALUE = "this is what the value will be transformed from";
     private static final String NO_TRANSFORM_VALUE = "this value will not be transformed";
-    private static final String POST_TRANSFORM_VALUE = "this is what the value will be transformed to";
+    private static final String EXPECTED_TRANSFORMED_RECORD_VALUE = "[" + TOPIC_NAME + "] this is what the value will be transformed to";
+    private static final String EXPECTED_NO_TRANSFORM_RECORD_VALUE = "[" + TOPIC_NAME + "] " + NO_TRANSFORM_VALUE;
     private static final String CONFIG_FIND_VALUE = "from";
     private static final String CONFIG_REPLACE_VALUE = "to";
-    @Mock
-    private FilterContext context;
 
-    @Mock(strictness = Mock.Strictness.LENIENT)
-    private ResponseFilterResult responseFilterResult;
-    @Captor
-    private ArgumentCaptor<Integer> bufferInitialCapacity;
-
-    @Captor
-    private ArgumentCaptor<ResponseHeaderData> responseHeaderDataCaptor;
-
-    @Captor
-    private ArgumentCaptor<ApiMessage> apiMessageCaptor;
     private SampleFetchResponseFilter filter;
     private ResponseHeaderData headerData;
 
     @BeforeEach
     public void beforeEach() {
-        setupContextMock();
         SampleFilterConfig config = new SampleFilterConfig(CONFIG_FIND_VALUE, CONFIG_REPLACE_VALUE);
         this.filter = new SampleFetchResponseFilter(config);
         this.headerData = new ResponseHeaderData();
     }
 
     /**
-     * Unit Test: Checks that transformation is applied when response data contains configured value.
+     * Unit Test: Checks that the transformation is applied (find/replace + topic-name prefix) when the
+     * response carries the topic name directly.
      */
     @Test
-    void willTransformFetchResponseTest() throws Exception {
-        var responseData = buildFetchResponseData(PRE_TRANSFORM_VALUE);
+    void willTransformFetchResponseUsingTopicNameTest() {
+        var responseData = buildFetchResponseData(PRE_TRANSFORM_VALUE, topic -> topic.setTopic(TOPIC_NAME));
+        MockFilterContext context = MockFilterContext.builder(headerData, responseData).build();
+
         var stage = filter.onFetchResponse(API_VERSION, headerData, responseData, context);
-        assertThat(stage).isCompleted();
-        var response = stage.toCompletableFuture().get().message();
-        var unpackedResponse = unpackFetchResponseData(((FetchResponseData) response));
-        // We only put 1 record in, we should only get 1 record back, and
-        // We should see that the unpacked response value has changed from the input value, and
-        // We should see that the unpacked response value has been transformed to the correct value
-        assertThat(unpackedResponse)
-                .doesNotContain(PRE_TRANSFORM_VALUE)
-                .containsExactly(POST_TRANSFORM_VALUE);
+
+        assertThat(stage).succeedsWithin(Duration.ZERO).satisfies(result -> {
+            MockFilterContextAssert.assertThat(result).isForwardResponse()
+                    .hasMessageInstanceOfSatisfying(FetchResponseData.class, forwarded -> {
+                        var unpackedResponse = unpackFetchResponseData(forwarded);
+                        assertThat(unpackedResponse)
+                                .doesNotContain(PRE_TRANSFORM_VALUE)
+                                .containsExactly(EXPECTED_TRANSFORMED_RECORD_VALUE);
+                    });
+        });
     }
 
     /**
-     * Unit Test: Checks that transformation is not applied when response data does not contain configured
-     * value.
+     * Unit Test: Checks that the topic-name prefix is applied even when no find/replace match occurs.
      */
     @Test
-    void wontTransformFetchResponseTest() throws Exception {
-        var responseData = buildFetchResponseData(NO_TRANSFORM_VALUE);
+    void wontTransformFetchResponseTest() {
+        var responseData = buildFetchResponseData(NO_TRANSFORM_VALUE, topic -> topic.setTopic(TOPIC_NAME));
+        MockFilterContext context = MockFilterContext.builder(headerData, responseData).build();
+
         var stage = filter.onFetchResponse(API_VERSION, headerData, responseData, context);
-        assertThat(stage).isCompleted();
-        var response = stage.toCompletableFuture().get().message();
-        var unpackedResponse = unpackFetchResponseData((FetchResponseData) response);
-        // We only put 1 record in, we should only get 1 record back, and
-        // We should see that the unpacked response value has not changed from the input value
-        assertThat(unpackedResponse).containsExactly(NO_TRANSFORM_VALUE);
+
+        assertThat(stage).succeedsWithin(Duration.ZERO).satisfies(result -> {
+            MockFilterContextAssert.assertThat(result).isForwardResponse()
+                    .hasMessageInstanceOfSatisfying(FetchResponseData.class, forwarded -> {
+                        var unpackedResponse = unpackFetchResponseData(forwarded);
+                        assertThat(unpackedResponse).containsExactly(EXPECTED_NO_TRANSFORM_RECORD_VALUE);
+                    });
+        });
     }
 
     /**
-     * Unit Test: Checks that when a transformation is applied that the response record(s) metadata matches what was sent.
+     * Unit Test: Checks that when a transformation is applied, the response record(s) metadata
+     * (offset, timestamp, key, headers) is preserved.
      */
     @Test
-    void onTransformMetadataRetainedFetchResponseTest() throws Exception {
-        var responseData = buildFetchResponseData(PRE_TRANSFORM_VALUE);
+    void onTransformMetadataRetainedFetchResponseTest() {
+        var responseData = buildFetchResponseData(PRE_TRANSFORM_VALUE, topic -> topic.setTopic(TOPIC_NAME));
         var sent = responseData.duplicate(); // due to pass-by-reference issues we need a safe copy to compare with
+        MockFilterContext context = MockFilterContext.builder(headerData, responseData).build();
+
         var stage = filter.onFetchResponse(API_VERSION, headerData, responseData, context);
-        assertThat(stage).isCompleted();
-        var received = (FetchResponseData) stage.toCompletableFuture().get().message();
-        compareRecords(received, sent);
+
+        assertThat(stage).succeedsWithin(Duration.ZERO).satisfies(result -> {
+            MockFilterContextAssert.assertThat(result).isForwardResponse()
+                    .hasMessageInstanceOfSatisfying(FetchResponseData.class, forwarded -> compareRecords(forwarded, sent));
+        });
     }
 
     /**
-     * Unit Test: Checks that when a transformation is not applied that the response record(s) metadata matches what was sent.
+     * Unit Test: Demonstrates the topic-id lookup pattern. The response carries only a {@code topicId}
+     * (the latest Fetch RPC behaviour) and the filter is expected to resolve the topic name via
+     * {@link io.kroxylicious.proxy.filter.FilterContext#topicNames} before applying its transformation.
      */
     @Test
-    void onNoTransformMetadataRetainedFetchResponseTest() throws Exception {
-        var responseData = buildFetchResponseData(NO_TRANSFORM_VALUE);
-        var sent = responseData.duplicate(); // due to pass-by-reference issues we need a safe copy to compare with
+    void willResolveTopicNameFromTopicIdTest() {
+        var responseData = buildFetchResponseData(PRE_TRANSFORM_VALUE, topic -> topic.setTopicId(TOPIC_ID));
+        MockFilterContext context = MockFilterContext.builder(headerData, responseData)
+                .withTopicName(TOPIC_ID, TOPIC_NAME)
+                .build();
+
         var stage = filter.onFetchResponse(API_VERSION, headerData, responseData, context);
-        assertThat(stage).isCompleted();
-        var received = (FetchResponseData) stage.toCompletableFuture().get().message();
-        compareRecords(received, sent);
-    }
 
-    private void setupContextMock() {
-        when(context.forwardResponse(responseHeaderDataCaptor.capture(), apiMessageCaptor.capture())).thenAnswer(
-                invocation -> CompletableFuture.completedStage(responseFilterResult));
-        when(responseFilterResult.message()).thenAnswer(invocation -> apiMessageCaptor.getValue());
-        when(responseFilterResult.header()).thenAnswer(invocation -> responseHeaderDataCaptor.getValue());
-
-        when(context.createByteBufferOutputStream(bufferInitialCapacity.capture())).thenAnswer(
-                (Answer<ByteBufferOutputStream>) invocation -> {
-                    Object[] args = invocation.getArguments();
-                    Integer size = (Integer) args[0];
-                    return new ByteBufferOutputStream(size);
-                });
+        assertThat(stage).succeedsWithin(Duration.ZERO).satisfies(result -> {
+            MockFilterContextAssert.assertThat(result).isForwardResponse()
+                    .hasMessageInstanceOfSatisfying(FetchResponseData.class, forwarded -> {
+                        var unpackedResponse = unpackFetchResponseData(forwarded);
+                        // Value is both transformed (from→to) AND prefixed with the topic name resolved from the id
+                        assertThat(unpackedResponse)
+                                .doesNotContain(PRE_TRANSFORM_VALUE)
+                                .containsExactly(EXPECTED_TRANSFORMED_RECORD_VALUE);
+                    });
+        });
     }
 
     /**
@@ -147,9 +148,11 @@ class SampleFetchResponseFilterTest {
      * the SampleFetchResponseFilter during the test, after which it will attempt to perform a
      * transformation on that string based on the provided configuration.
      * @param transformValue  the content to be embedded in the response and transformed (or not) in the test
+     * @param topicConfigurer applied to the synthesized topic response to set either {@code topic} or {@code topicId}
      * @return the FetchResponseData object to be passed to the SampleFetchResponseFilter during the test
      */
-    private static FetchResponseData buildFetchResponseData(String transformValue) {
+    private static FetchResponseData buildFetchResponseData(String transformValue,
+                                                            java.util.function.Consumer<FetchResponseData.FetchableTopicResponse> topicConfigurer) {
         var responseData = new FetchResponseData();
         // Build stream
         var stream = new ByteBufferOutputStream(ByteBuffer.wrap(transformValue.getBytes(StandardCharsets.UTF_8)));
@@ -171,6 +174,7 @@ class SampleFetchResponseFilterTest {
         var responses = new ArrayList<FetchResponseData.FetchableTopicResponse>();
         var response = new FetchResponseData.FetchableTopicResponse();
         response.setPartitions(partitions);
+        topicConfigurer.accept(response);
         responses.add(response);
         // Add built responses to FetchResponseData object so that we can return it
         responseData.setResponses(responses);

--- a/kroxylicious-filter-archetype/src/main/resources/archetype-resources/src/test/java/SampleFilterIT.java
+++ b/kroxylicious-filter-archetype/src/main/resources/archetype-resources/src/test/java/SampleFilterIT.java
@@ -69,11 +69,13 @@ class SampleFilterIT {
                     new ProducerRecord<>(topic.name(), "This is foo!");
             assertThat(producer.send(producerRecord)).succeedsWithin(TIMEOUT);
             consumer.subscribe(List.of(topic.name()));
+            // The filter also prefixes the value with the topic name (e.g. "[<topic-name>] This is bar!"),
+            // demonstrating the topic-id-to-name lookup pattern.
             assertThat(consumer.poll(TIMEOUT).records(topic.name()))
                     .singleElement()
                     .extracting(ConsumerRecord::value)
                     .extracting(String::new)
-                    .isEqualTo("This is bar!");
+                    .isEqualTo("[" + topic.name() + "] This is bar!");
         }
     }
 
@@ -94,11 +96,13 @@ class SampleFilterIT {
                     new ProducerRecord<>(topic.name(), "This is foo!");
             assertThat(producer.send(producerRecord)).succeedsWithin(TIMEOUT);
             consumer.subscribe(List.of(topic.name()));
+            // The filter also prefixes the value with the topic name (e.g. "[<topic-name>] This is bar!"),
+            // demonstrating the topic-id-to-name lookup pattern.
             assertThat(consumer.poll(TIMEOUT).records(topic.name()))
                     .singleElement()
                     .extracting(ConsumerRecord::value)
                     .extracting(String::new)
-                    .isEqualTo("This is bar!");
+                    .isEqualTo("[" + topic.name() + "] This is bar!");
         }
     }
 }

--- a/kroxylicious-filter-archetype/src/main/resources/archetype-resources/src/test/java/SampleProduceRequestFilterTest.java
+++ b/kroxylicious-filter-archetype/src/main/resources/archetype-resources/src/test/java/SampleProduceRequestFilterTest.java
@@ -2,17 +2,17 @@ package ${package};
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.message.ApiMessageType;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
-import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.record.RecordBatch;
@@ -21,128 +21,130 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
 
-import io.kroxylicious.proxy.filter.FilterContext;
-import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.testing.filter.assertj.MockFilterContextAssert;
+import io.kroxylicious.testing.filter.context.MockFilterContext;
 import ${package}.config.SampleFilterConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
+/**
+ * Unit tests for {@link SampleProduceRequestFilter}.
+ *
+ * <p>These tests use {@link MockFilterContext} — Kroxylicious's tested emulation of
+ * {@link io.kroxylicious.proxy.filter.FilterContext} — instead of building a Mockito mock by hand.
+ * That avoids reimplementing the {@code FilterContext} contract in every test and keeps the
+ * test code focused on filter behaviour.</p>
+ */
 class SampleProduceRequestFilterTest {
 
     private static final short API_VERSION = ApiMessageType.PRODUCE.highestSupportedVersion(true); // this is arbitrary for our filter
+    private static final String TOPIC_NAME = "my-topic";
+    private static final Uuid TOPIC_ID = new Uuid(5L, 5L);
     private static final String PRE_TRANSFORM_VALUE = "this is what the value will be transformed from";
     private static final String NO_TRANSFORM_VALUE = "this value will not be transformed";
-    private static final String POST_TRANSFORM_VALUE = "this is what the value will be transformed to";
+    private static final String EXPECTED_TRANSFORMED_RECORD_VALUE = "[" + TOPIC_NAME + "] this is what the value will be transformed to";
+    private static final String EXPECTED_NO_TRANSFORM_RECORD_VALUE = "[" + TOPIC_NAME + "] " + NO_TRANSFORM_VALUE;
     private static final String CONFIG_FIND_VALUE = "from";
     private static final String CONFIG_REPLACE_VALUE = "to";
-
-    @Mock
-    private FilterContext context;
-
-    @Mock(strictness = Mock.Strictness.LENIENT)
-    private RequestFilterResult requestFilterResult;
-    @Captor
-    private ArgumentCaptor<Integer> bufferInitialCapacity;
-
-    @Captor
-    private ArgumentCaptor<ApiMessage> apiMessageCaptor;
-    @Captor
-    private ArgumentCaptor<RequestHeaderData> requestHeaderDataCaptor;
 
     private SampleProduceRequestFilter filter;
     private RequestHeaderData headerData;
 
     @BeforeEach
     public void beforeEach() {
-        setupContextMock();
         SampleFilterConfig config = new SampleFilterConfig(CONFIG_FIND_VALUE, CONFIG_REPLACE_VALUE);
         this.filter = new SampleProduceRequestFilter(config);
         this.headerData = new RequestHeaderData();
     }
 
     /**
-     * Unit Test: Checks that transformation is applied when request data contains configured value.
+     * Unit Test: Checks that the transformation is applied (find/replace + topic-name prefix) when the
+     * request carries the topic name directly.
      */
     @Test
-    void willTransformProduceRequestTest() throws Exception {
-        var requestData = buildProduceRequestData(PRE_TRANSFORM_VALUE);
+    void willTransformProduceRequestUsingTopicNameTest() {
+        var requestData = buildProduceRequestData(PRE_TRANSFORM_VALUE, topic -> topic.setName(TOPIC_NAME));
+        MockFilterContext context = MockFilterContext.builder(headerData, requestData).build();
+
         var stage = filter.onProduceRequest(API_VERSION, headerData, requestData, context);
-        assertThat(stage).isCompleted();
-        var forwardedRequest = stage.toCompletableFuture().get().message();
-        var unpackedRequest = unpackProduceRequestData((ProduceRequestData) forwardedRequest);
-        // We should see that the unpacked request value has changed from the input value, and
-        // We should see that the unpacked request value has been transformed to the correct value
-        assertThat(unpackedRequest)
-                .doesNotContain(PRE_TRANSFORM_VALUE)
-                .containsExactly(POST_TRANSFORM_VALUE);
+
+        assertThat(stage).succeedsWithin(Duration.ZERO).satisfies(result -> {
+            MockFilterContextAssert.assertThat(result).isForwardRequest()
+                    .hasMessageInstanceOfSatisfying(ProduceRequestData.class, forwarded -> {
+                        var unpackedRequest = unpackProduceRequestData(forwarded);
+                        assertThat(unpackedRequest)
+                                .doesNotContain(PRE_TRANSFORM_VALUE)
+                                .containsExactly(EXPECTED_TRANSFORMED_RECORD_VALUE);
+                    });
+        });
     }
 
     /**
-     * Unit Test: Checks that transformation is not applied when request data does not contain configured
-     * value.
+     * Unit Test: Checks that the topic-name prefix is applied even when no find/replace match occurs.
      */
     @Test
-    void wontTransformProduceRequestTest() throws Exception {
-        var requestData = buildProduceRequestData(NO_TRANSFORM_VALUE);
+    void wontTransformProduceRequestTest() {
+        var requestData = buildProduceRequestData(NO_TRANSFORM_VALUE, topic -> topic.setName(TOPIC_NAME));
+        MockFilterContext context = MockFilterContext.builder(headerData, requestData).build();
+
         var stage = filter.onProduceRequest(API_VERSION, headerData, requestData, context);
-        assertThat(stage).isCompleted();
-        var forwardedRequest = stage.toCompletableFuture().get().message();
-        var unpackedRequest = unpackProduceRequestData((ProduceRequestData) forwardedRequest);
-        // We should see that the unpacked request value has not changed from the input value
-        assertThat(unpackedRequest)
-                .containsExactly(NO_TRANSFORM_VALUE);
+
+        assertThat(stage).succeedsWithin(Duration.ZERO).satisfies(result -> {
+            MockFilterContextAssert.assertThat(result).isForwardRequest()
+                    .hasMessageInstanceOfSatisfying(ProduceRequestData.class, forwarded -> {
+                        var unpackedRequest = unpackProduceRequestData(forwarded);
+                        assertThat(unpackedRequest).containsExactly(EXPECTED_NO_TRANSFORM_RECORD_VALUE);
+                    });
+        });
     }
 
     /**
-     * Unit Test: Checks that when a transformation is applied that the request record(s) metadata matches what was sent.
+     * Unit Test: Checks that when a transformation is applied, the request record(s) metadata
+     * (offset, timestamp, key, headers) is preserved.
      */
     @Test
-    void onTransformMetadataRetainedProduceRequestTest() throws Exception {
-        var requestData = buildProduceRequestData(PRE_TRANSFORM_VALUE);
+    void onTransformMetadataRetainedProduceRequestTest() {
+        var requestData = buildProduceRequestData(PRE_TRANSFORM_VALUE, topic -> topic.setName(TOPIC_NAME));
         var sent = requestData.duplicate(); // due to pass-by-reference issues we need a safe copy to compare with
+        MockFilterContext context = MockFilterContext.builder(headerData, requestData).build();
+
         var stage = filter.onProduceRequest(API_VERSION, headerData, requestData, context);
-        assertThat(stage).isCompleted();
-        var received = (ProduceRequestData) stage.toCompletableFuture().get().message();
-        compareRecords(received, sent);
+
+        assertThat(stage).succeedsWithin(Duration.ZERO).satisfies(result -> {
+            MockFilterContextAssert.assertThat(result).isForwardRequest()
+                    .hasMessageInstanceOfSatisfying(ProduceRequestData.class, forwarded -> compareRecords(forwarded, sent));
+        });
     }
 
     /**
-     * Unit Test: Checks that when a transformation is not applied that the request record(s) metadata matches what was sent.
+     * Unit Test: Demonstrates the topic-id lookup pattern. The request carries only a {@code topicId}
+     * (the latest Produce RPC behaviour) and the filter is expected to resolve the topic name via
+     * {@link io.kroxylicious.proxy.filter.FilterContext#topicNames} before applying its transformation.
      */
     @Test
-    void onNoTransformMetadataRetainedProduceRequestTest() throws Exception {
-        var requestData = buildProduceRequestData(NO_TRANSFORM_VALUE);
-        var sent = requestData.duplicate(); // due to pass-by-reference issues we need a safe copy to compare with
+    void willResolveTopicNameFromTopicIdTest() {
+        var requestData = buildProduceRequestData(PRE_TRANSFORM_VALUE, topic -> topic.setTopicId(TOPIC_ID));
+        MockFilterContext context = MockFilterContext.builder(headerData, requestData)
+                .withTopicName(TOPIC_ID, TOPIC_NAME)
+                .build();
+
         var stage = filter.onProduceRequest(API_VERSION, headerData, requestData, context);
-        assertThat(stage).isCompleted();
-        var received = (ProduceRequestData) stage.toCompletableFuture().get().message();
-        compareRecords(received, sent);
+
+        assertThat(stage).succeedsWithin(Duration.ZERO).satisfies(result -> {
+            MockFilterContextAssert.assertThat(result).isForwardRequest()
+                    .hasMessageInstanceOfSatisfying(ProduceRequestData.class, forwarded -> {
+                        var unpackedRequest = unpackProduceRequestData(forwarded);
+                        // Value is both transformed (foo→bar) AND prefixed with the topic name resolved from the id
+                        assertThat(unpackedRequest)
+                                .doesNotContain(PRE_TRANSFORM_VALUE)
+                                .containsExactly(EXPECTED_TRANSFORMED_RECORD_VALUE);
+                    });
+        });
     }
 
-    private void setupContextMock() {
-        when(context.forwardRequest(requestHeaderDataCaptor.capture(), apiMessageCaptor.capture())).thenAnswer(
-                invocation -> CompletableFuture.completedStage(requestFilterResult));
-        when(requestFilterResult.message()).thenAnswer(invocation -> apiMessageCaptor.getValue());
-        when(requestFilterResult.header()).thenAnswer(invocation -> requestHeaderDataCaptor.getValue());
-
-        when(context.createByteBufferOutputStream(bufferInitialCapacity.capture())).thenAnswer(
-                (Answer<ByteBufferOutputStream>) invocation -> {
-                    Object[] args = invocation.getArguments();
-                    Integer size = (Integer) args[0];
-                    return new ByteBufferOutputStream(size);
-                });
-    }
-
-    private static ProduceRequestData buildProduceRequestData(String transformValue) {
+    private static ProduceRequestData buildProduceRequestData(String transformValue,
+                                                              java.util.function.Consumer<ProduceRequestData.TopicProduceData> topicConfigurer) {
         var requestData = new ProduceRequestData();
         // Build stream
         var stream = new ByteBufferOutputStream(ByteBuffer.wrap(transformValue.getBytes(StandardCharsets.UTF_8)));
@@ -164,6 +166,7 @@ class SampleProduceRequestFilterTest {
         var topics = new ProduceRequestData.TopicProduceDataCollection();
         var topicData = new ProduceRequestData.TopicProduceData();
         topicData.setPartitionData(partitions);
+        topicConfigurer.accept(topicData);
         topics.add(topicData);
         // Add built topics to ProduceRequestData object so that we can return it
         requestData.setTopicData(topics);

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <maven.exec.version>3.1.0</maven.exec.version>
         <maven.compiler.version>3.15.0</maven.compiler.version>
         <maven.failsafe.version>3.5.5</maven.failsafe.version>
+        <maven.surefire.version>3.5.5</maven.surefire.version>
         <maven-dependency-plugin.version>3.10.0</maven-dependency-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.release>${java.version}</maven.compiler.release>
@@ -847,7 +848,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.5</version>
+                    <version>${maven.surefire.version}</version>
                     <configuration>
                         <skipTests>${skipUTs}</skipTests>
                         <failIfNoTests>false</failIfNoTests>


### PR DESCRIPTION
### Type of change

Enhancement / new feature (filter archetype refresh).

### Description

Closes #3349.

Refreshes the `kroxylicious-filter-archetype` so it demonstrates two patterns that filter authors should reach for in real code:

1. **Topic id → topic name resolution.** Both `SampleProduceRequestFilter` and `SampleFetchResponseFilter` now collect non-zero topic ids from the request/response and call `FilterContext.topicNames(...)` (with the empty-set fast path keeping a single code path for both newer topic-id-bearing RPCs and older topic-name RPCs). The resolved name is threaded into `SampleFilterTransformer`, which prefixes every transformed record value with `[<topicName>]` so the topic name is visible end-to-end.

2. **Unit testing with `MockFilterContext`.** Both filter unit tests are rewritten to build a `MockFilterContext` per test (including a new test that exercises the topic-id-only path via `withTopicName`) and use `MockFilterContextAssert` for the result assertions. This replaces the hand-rolled Mockito setup of the prior tests, matching the pattern used elsewhere in the codebase (e.g. `ProduceRequestTransformationFilterTest`).

The shared `SampleFilterIT` assertion is updated to match the new value format (`[<topic-name>] This is bar!`).

### Additional Context

While verifying the changes I noticed the generated project's `mvn verify` was using Maven's default Surefire 2.17 — a pre-JUnit-Platform version that silently skipped every JUnit 5 test in the archetype (Surefire reported `Tests run: 0` for each class). Without fixing this, the archetype's stated goal of "demonstrate how to unit test filters effectively" was not being exercised. So the change also bumps the generated project's `maven-surefire-plugin` to 3.5.5 (matching the existing failsafe pin), via a new `maven.surefire.version` property in the root pom. After the bump, the archetype IT reports 10/10 unit tests and 2/2 integration tests passing on `clean verify` of the generated project.


### Checklist

- [x] New tests written (where applicable).
- [ ] User facing documentation written/updated (where applicable). _(no user-facing docs affected; the archetype README is unchanged.)_
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed (or suppressed with \`@SuppressWarnings\` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include \`Assisted-by:\` trailer — _omitted from commit subject per author preference; disclosed here instead. Happy to amend if preferred._
- [ ] For user facing changes, update CHANGELOG.md _(no end-user-visible change; archetype users see the new pattern by re-generating.)_