### PR TITLE
fix(docs): add Webhook entries to release manifest (#3963)

### DIFF
--- a/kroxylicious-docs/release-manifest.yaml
+++ b/kroxylicious-docs/release-manifest.yaml
@@ -21,6 +21,13 @@ assets:
         path: kroxylicious-operator-$(VERSION).zip
       - format: tar.gz
         path: kroxylicious-operator-$(VERSION).tar.gz
+  - name: Webhook
+    description: The Kubernetes admission webhook.
+    downloads:
+      - format: zip
+        path: kroxylicious-admission-$(VERSION).zip
+      - format: tar.gz
+        path: kroxylicious-admission-$(VERSION).tar.gz
 images:
   - name: Proxy
     url: https://quay.io/repository/kroxylicious/proxy?tab=tags
@@ -30,5 +37,10 @@ images:
   - name: Operator
     url: https://quay.io/repository/kroxylicious/operator?tab=tags
     registry: quay.io/kroxylicious/operator
+    tag: $(VERSION)
+    digest: sha256:REPLACE_WITH_SHA_AFTER_IMAGE_RELEASE
+  - name: Webhook
+    url: https://quay.io/repository/kroxylicious/webhook?tab=tags
+    registry: quay.io/kroxylicious/webhook
     tag: $(VERSION)
     digest: sha256:REPLACE_WITH_SHA_AFTER_IMAGE_RELEASE


### PR DESCRIPTION
### Type of change

Bugfix (release-time documentation metadata).

### Description

Closes #3963.

Adds `Webhook` entries to `kroxylicious-docs/release-manifest.yaml` for both `assets` and `images`, so future releases pick up the admission-webhook download links and image automatically instead of needing the manual post-release patch that was applied to v0.21.0.

The values mirror exactly what was manually added to the v0.21.0 published manifest at [kroxylicious.github.io _data/release/0_21_0.yaml](https://github.com/kroxylicious/kroxylicious.github.io/blob/main/_data/release/0_21_0.yaml):

- **Asset**: `kroxylicious-admission-$(VERSION).zip` / `.tar.gz` — matches the artefact actually produced by [`kroxylicious-admission-dist/src/assembly/asset.xml`](https://github.com/kroxylicious/kroxylicious/blob/main/kroxylicious-kubernetes/kroxylicious-admission-dist/src/assembly/asset.xml) (`finalName: kroxylicious-admission-${project.version}`) and uploaded to the v0.21.0 GitHub release.
- **Image**: `quay.io/kroxylicious/webhook` — matches the registry path used in v0.21.0.

### Additional Context

The issue also notes the page "looks a bit hellacious now with a giant long card for the webhook zips". That's a cosmetic concern with the rendering template, which lives in the docs-site repo (`kroxylicious.github.io`) rather than this source repo, so I've left it out of this PR — happy to file a follow-up there if you'd like.

This change was AI-assisted (Claude Opus 4.7); commit subject is one line per author preference, disclosed here in the PR body. Happy to amend in an `Assisted-by:` trailer if reviewers prefer.

### Checklist

- [ ] New tests written (where applicable). _(N/A — release-time metadata; no runtime/test surface.)_
- [ ] User facing documentation written/updated (where applicable). _(N/A — manifest content is rendered into the docs site, not the asciidoc guides.)_
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed (or suppressed with \`@SuppressWarnings\` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include \`Assisted-by:\` trailer — _omitted from commit subject per author preference; disclosed here instead._
- [ ] For user facing changes, update CHANGELOG.md _(release-engineering metadata only — no behaviour change visible to end users until the next release picks it up.)_