### PR TITLE
(feat) Hot reload Implementation (4/N) - Added removeVirtualCluster method for hot reload

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -43,6 +44,7 @@ import io.kroxylicious.proxy.config.ServiceBasedPluginFactoryRegistry;
 import io.kroxylicious.proxy.config.VirtualCluster;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.internal.config.Features;
+import io.kroxylicious.proxy.reload.ReconfigureResult;
 import io.kroxylicious.testing.integration.client.KafkaClient;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -301,6 +303,15 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
         catch (Exception e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    @Override
+    public CompletableFuture<ReconfigureResult> reconfigure(Configuration newConfig) {
+        if (!(proxy instanceof KafkaProxy kp)) {
+            throw new UnsupportedOperationException(
+                    "reconfigure() requires a KafkaProxy-backed tester; this tester's proxy is " + proxy.getClass().getName());
+        }
+        return kp.reconfigure(newConfig);
     }
 
     @Override

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousTester.java
@@ -9,6 +9,7 @@ package io.kroxylicious.testing.integration.tester;
 import java.io.Closeable;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -16,6 +17,8 @@ import org.apache.kafka.clients.consumer.ShareConsumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.serialization.Serde;
 
+import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.reload.ReconfigureResult;
 import io.kroxylicious.testing.integration.client.KafkaClient;
 
 /**
@@ -339,6 +342,17 @@ public interface KroxyliciousTester extends Closeable {
      * Restarts the Kroxylicious server under test without closing any other resources.
      */
     void restartProxy();
+
+    /**
+     * Submits {@code newConfig} to the underlying Kroxylicious server's
+     * {@code reconfigure(Configuration)} entry point. The future completes with the
+     * outcome reported by the server.
+     *
+     * @param newConfig the desired end-state configuration
+     * @return the proxy's reconfigure outcome
+     * @throws UnsupportedOperationException if the underlying proxy is not a {@link io.kroxylicious.proxy.KafkaProxy}
+     */
+    CompletableFuture<ReconfigureResult> reconfigure(Configuration newConfig);
 
     /**
      * Close the Kroxylicious server under test and any other resources that need cleaning.

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -161,6 +161,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-pkitesting</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-kafka-message-tools</artifactId>
             <scope>test</scope>

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -6,133 +6,160 @@
 
 package io.kroxylicious.it;
 
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.kroxylicious.it.net.IntegrationTestInetAddressResolverProvider;
 import io.kroxylicious.proxy.KafkaProxy;
 import io.kroxylicious.proxy.config.Configuration;
-import io.kroxylicious.proxy.config.ServiceBasedPluginFactoryRegistry;
-import io.kroxylicious.proxy.internal.config.Features;
+import io.kroxylicious.proxy.config.VirtualCluster;
+import io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils;
+import io.kroxylicious.testing.integration.tester.KroxyliciousTester;
+import io.kroxylicious.testing.integration.tester.KroxyliciousTesters;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
-import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
 
-import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.proxy;
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.defaultSniHostIdentifiesNodeGatewayBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * End-to-end integration tests for {@link KafkaProxy#reconfigure(Configuration)}
  */
-@ExtendWith(KafkaClusterExtension.class)
-class HotReloadIT {
+class HotReloadIT extends BaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HotReloadIT.class);
 
     private static final String VC_KEEP_NAME = "vc-keep";
     private static final String VC_REMOVE_NAME = "vc-remove";
 
-    // KroxyliciousConfigUtils.proxy(srvs, "vc1", "vc2") spaces VCs at the default bootstrap
-    // port + i*10 — i.e. vc[0]=9192, vc[1]=9202. Hardcoding these here so the test asserts
-    // against the same addresses the proxy listens on.
-    private static final String VC_KEEP_BOOTSTRAP = "localhost:9192";
-    private static final String VC_REMOVE_BOOTSTRAP = "localhost:9202";
+    private static final int SHARED_SNI_PORT = KroxyliciousConfigUtils.DEFAULT_PROXY_BOOTSTRAP.port();
+    private static final String SNI_BASE_DOMAIN = IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName(".hotreload");
+    private static final String VC_KEEP_BOOTSTRAP = "bootstrap-keep" + SNI_BASE_DOMAIN + ":" + SHARED_SNI_PORT;
+    private static final String VC_REMOVE_BOOTSTRAP = "bootstrap-remove" + SNI_BASE_DOMAIN + ":" + SHARED_SNI_PORT;
+    private static final String VC_KEEP_BROKER_PATTERN = "broker-$(nodeId)-keep" + SNI_BASE_DOMAIN;
+    private static final String VC_REMOVE_BROKER_PATTERN = "broker-$(nodeId)-remove" + SNI_BASE_DOMAIN;
 
     private static final Duration RECONFIGURE_TIMEOUT = Duration.ofSeconds(15);
     private static final Duration PRODUCE_CONSUME_TIMEOUT = Duration.ofSeconds(15);
-    private static final Duration REJECTION_TIMEOUT = Duration.ofSeconds(8);
+    private static final Duration REJECTION_TIMEOUT = Duration.ofSeconds(5);
+
+    @TempDir
+    private static Path certsDirectory;
 
     @Test
     void shouldStopRemovedVcButContinueServingOthersEndToEnd(@BrokerCluster KafkaCluster cluster) throws Exception {
-        String topic = "hotreload-remove-it-" + System.currentTimeMillis();
-        createTopicOnUpstream(cluster, topic);
+        // Wildcard cert covering both VCs' SNI hostnames (both end in SNI_BASE_DOMAIN).
+        KeystoreTrustStorePair certs = buildKeystoreTrustStorePair("*" + SNI_BASE_DOMAIN);
+        var twoVcConfig = buildConfig(cluster, certs, true);
+        var oneVcConfig = buildConfig(cluster, certs, false);
 
-        Configuration twoVcConfig = proxy(cluster.getBootstrapServers(), VC_KEEP_NAME, VC_REMOVE_NAME).build();
-        Configuration oneVcConfig = proxy(cluster.getBootstrapServers(), VC_KEEP_NAME).build();
+        // Tester builder so we can register the truststore — required for the default client
+        // configuration to do SSL handshakes against the SNI-addressed VCs.
+        var testerBuilder = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToVirtualClusters(twoVcConfig.virtualClusters().toArray(new VirtualCluster[0]));
+        try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(testerBuilder)
+                .setTrustStoreLocation(certs.clientTrustStore())
+                .setTrustStorePassword(certs.password())
+                .createDefaultKroxyliciousTester()) {
 
-        try (KafkaProxy proxy = new KafkaProxy(new ServiceBasedPluginFactoryRegistry(), twoVcConfig, Features.defaultFeatures())) {
-            proxy.startup();
+            String topic = tester.createTopic(VC_KEEP_NAME);
 
-            // Phase 1: both VCs serve produce + consume.
-            LOGGER.info("Phase 1: producing + consuming through both VCs");
-            assertProduceConsumeRoundTrip(VC_KEEP_BOOTSTRAP, topic, "phase1-keep");
-            assertProduceConsumeRoundTrip(VC_REMOVE_BOOTSTRAP, topic, "phase1-remove");
+            // Phase 1: both SNI-addressed VCs serve produce + consume on the shared port.
+            LOGGER.info("Phase 1: producing + consuming through both SNI-addressed VCs");
+            assertProduceConsumeRoundTrip(tester, VC_KEEP_NAME, topic, "phase1-keep");
+            assertProduceConsumeRoundTrip(tester, VC_REMOVE_NAME, topic, "phase1-remove");
 
-            // Phase 2: reconfigure removes vc-remove. The orchestrator's pure-remove path
-            // drains vc-remove (no live connections at this point since we closed them in
-            // phase 1) and transitions it to STOPPED.
+            // Phase 2: reconfigure removes vc-remove. The acceptor channel stays alive
+            // (vc-keep still needs it); vc-remove transitions to STOPPED.
             LOGGER.info("Phase 2: reconfiguring to remove '{}'", VC_REMOVE_NAME);
-            var result = proxy.reconfigure(oneVcConfig).get(RECONFIGURE_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+            var result = tester.reconfigure(oneVcConfig).get(RECONFIGURE_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
             assertThat(result.hasErrors())
                     .as("ReconfigureResult should have no errors for a clean pure-remove")
                     .isFalse();
 
-            // Phase 3: vc-keep continues to serve traffic — verifies unaffected VCs are
-            // genuinely undisturbed by the reconfigure.
+            // Phase 3: vc-keep continues to serve on the same port + cert. An unaffected
+            // VC is genuinely undisturbed by the reconfigure.
             LOGGER.info("Phase 3: verifying '{}' still serves produce + consume", VC_KEEP_NAME);
-            assertProduceConsumeRoundTrip(VC_KEEP_BOOTSTRAP, topic, "phase3-keep");
+            assertProduceConsumeRoundTrip(tester, VC_KEEP_NAME, topic, "phase3-keep");
 
-            // Phase 4: new connections to vc-remove are rejected. The acceptor channel is
-            // still bound (a documented limitation until step 3 of the staircase introduces
-            // proper port unbinding), but the SERVING-state guard closes connections at the
-            // Kafka protocol layer, so the producer's send() future fails.
-            LOGGER.info("Phase 4: verifying '{}' no longer accepts traffic", VC_REMOVE_NAME);
-            assertProducerFailsAgainstRemovedVc(VC_REMOVE_BOOTSTRAP, topic);
+            // Phase 4: new connections with vc-remove's SNI hostname are rejected. TLS
+            // handshake succeeds (cert is wildcard, covers both hostnames), but the Kafka
+            // session is closed because the VC behind that SNI binding is now STOPPED —
+            // the SERVING-state guard rejects registration.
+            LOGGER.info("Phase 4: verifying '{}' no longer accepts traffic on its SNI hostname", VC_REMOVE_NAME);
+            assertProducerFailure(tester, VC_REMOVE_NAME, topic);
         }
     }
 
+    private static Configuration buildConfig(KafkaCluster cluster, KeystoreTrustStorePair certs, boolean includeRemoveVc) {
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToVirtualClusters(buildSniVirtualCluster(cluster, certs, VC_KEEP_NAME, VC_KEEP_BOOTSTRAP, VC_KEEP_BROKER_PATTERN));
+        if (includeRemoveVc) {
+            builder.addToVirtualClusters(buildSniVirtualCluster(cluster, certs, VC_REMOVE_NAME, VC_REMOVE_BOOTSTRAP, VC_REMOVE_BROKER_PATTERN));
+        }
+        return builder.build();
+    }
+
+    private static VirtualCluster buildSniVirtualCluster(KafkaCluster cluster,
+                                                         KeystoreTrustStorePair certs,
+                                                         String name,
+                                                         String bootstrap,
+                                                         String brokerPattern) {
+        return KroxyliciousConfigUtils.baseVirtualClusterBuilder(cluster, name)
+                .addToGateways(defaultSniHostIdentifiesNodeGatewayBuilder(bootstrap, brokerPattern)
+                        .withNewTls()
+                        .withNewKeyStoreKey()
+                        .withStoreFile(certs.brokerKeyStore())
+                        .withNewInlinePasswordStoreProvider(certs.password())
+                        .endKeyStoreKey()
+                        .endTls()
+                        .build())
+                .build();
+    }
+
     /**
-     * Produce a random batch of records (50-100) through the proxy at {@code proxyBootstrap},
-     * then consume them back through the same proxy. Records are keyed {@code marker-0},
-     * {@code marker-1}, ... so the consumer can isolate this round-trip's records from
-     * earlier phases' records that share the same topic.
-     *
-     * <p>Asserts that the consumer observes exactly {@code N} unique keys carrying this
-     * call's {@code marker} — proving the full proxy I/O round-trip is working *and* that
-     * no records are dropped mid-stream.
+     * Produce a random batch of records (50-100) via {@code tester.producer(vc)}, then
+     * consume them back via {@code tester.consumer(vc)}. Records are keyed
+     * {@code marker-0}..{@code marker-N-1} so the consumer can isolate this round-trip's
+     * records from earlier phases' records that share the same topic.
      */
-    private static void assertProduceConsumeRoundTrip(String proxyBootstrap, String topic, String marker) throws Exception {
+    private static void assertProduceConsumeRoundTrip(KroxyliciousTester tester, String vc, String topic, String marker) throws Exception {
         int messageCount = ThreadLocalRandom.current().nextInt(50, 101);
-        LOGGER.info("Producing {} records via {} (marker='{}')", messageCount, proxyBootstrap, marker);
+        LOGGER.info("Producing {} records via VC '{}' (marker='{}')", messageCount, vc, marker);
 
         var sendFutures = new ArrayList<Future<RecordMetadata>>(messageCount);
-        try (Producer<String, String> producer = newProducer(proxyBootstrap, false)) {
+        try (var producer = tester.producer(vc)) {
             for (int i = 0; i < messageCount; i++) {
                 sendFutures.add(producer.send(new ProducerRecord<>(topic, marker + "-" + i, marker + "-value-" + i)));
             }
-            // Wait for each ack — fails fast if any individual send didn't make it through
-            // the proxy + broker round-trip within the timeout budget.
             for (Future<RecordMetadata> f : sendFutures) {
                 f.get(PRODUCE_CONSUME_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
             }
         }
 
-        try (Consumer<String, String> consumer = newConsumer(proxyBootstrap, "hotreload-it-consumer-" + marker)) {
+        try (var consumer = tester.consumer(vc, Map.of(
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
+                ConsumerConfig.GROUP_ID_CONFIG, "hotreload-it-consumer-" + marker))) {
             consumer.subscribe(List.of(topic));
             var seenKeys = new HashSet<String>();
             String keyPrefix = marker + "-";
@@ -146,60 +173,49 @@ class HotReloadIT {
                 }
             }
             assertThat(seenKeys)
-                    .as("consumer should have read all %d records (marker='%s') via proxy %s within %s",
-                            messageCount, marker, proxyBootstrap, PRODUCE_CONSUME_TIMEOUT)
+                    .as("consumer should have read all %d records (marker='%s') via VC '%s' within %s",
+                            messageCount, marker, vc, PRODUCE_CONSUME_TIMEOUT)
                     .hasSize(messageCount);
         }
     }
 
     /**
      * Open a fresh producer against the removed VC and verify it cannot deliver a record.
-     * The exact exception depends on how the Kafka client interprets the connection rejection
-     * (NetworkException, TimeoutException, etc.); we accept any failure from {@code send().get()}.
+     * Uses aggressively short timeouts so the failure surfaces within
+     * {@link #REJECTION_TIMEOUT} rather than the default Kafka client delivery timeout.
      */
-    private static void assertProducerFailsAgainstRemovedVc(String proxyBootstrap, String topic) {
-        try (Producer<String, String> producer = newProducer(proxyBootstrap, true)) {
+    private static void assertProducerFailure(KroxyliciousTester tester, String vc, String topic) {
+        try (var producer = tester.producer(vc, shortTimeoutProducerConfig())) {
             assertThatThrownBy(() -> producer.send(new ProducerRecord<>(topic, "should-fail", "should-fail-value"))
                     .get(REJECTION_TIMEOUT.toSeconds(), TimeUnit.SECONDS))
-                    .as("producer should fail to deliver to the removed VC at %s", proxyBootstrap)
+                    .as("producer should fail to deliver to the removed VC '%s'", vc)
                     .isInstanceOf(ExecutionException.class);
         }
     }
 
-    private static void createTopicOnUpstream(KafkaCluster cluster, String topic) throws Exception {
-        try (Admin admin = Admin.create(Map.of("bootstrap.servers", cluster.getBootstrapServers()))) {
-            admin.createTopics(List.of(new NewTopic(topic, 1, (short) 1))).all().get(10, TimeUnit.SECONDS);
-        }
+    private static Map<String, Object> shortTimeoutProducerConfig() {
+        return Map.of(
+                ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 3_000,
+                ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 5_000,
+                ProducerConfig.MAX_BLOCK_MS_CONFIG, 5_000,
+                ProducerConfig.RETRIES_CONFIG, 1,
+                ProducerConfig.RECONNECT_BACKOFF_MS_CONFIG, 100,
+                ProducerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG, 500);
     }
 
-    /**
-     * @param shortTimeouts when {@code true}, configures aggressively short timeouts so the
-     *                      "expected to fail" path completes within {@link #REJECTION_TIMEOUT}
-     *                      rather than the default Kafka client delivery-timeout (2 minutes).
-     */
-    private static Producer<String, String> newProducer(String bootstrap, boolean shortTimeouts) {
-        var cfg = new HashMap<String, Object>();
-        cfg.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrap);
-        cfg.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-        cfg.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-        cfg.put(ProducerConfig.ACKS_CONFIG, "all");
-        if (shortTimeouts) {
-            cfg.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 3_000);
-            cfg.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 5_000);
-            cfg.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 5_000);
-            cfg.put(ProducerConfig.RETRIES_CONFIG, 1);
-            cfg.put(ProducerConfig.RECONNECT_BACKOFF_MS_CONFIG, 100);
-            cfg.put(ProducerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG, 500);
-        }
-        return new KafkaProducer<>(cfg);
-    }
+    private record KeystoreTrustStorePair(String brokerKeyStore, String clientTrustStore, String password) {}
 
-    private static Consumer<String, String> newConsumer(String bootstrap, String groupId) {
-        return new KafkaConsumer<>(Map.of(
-                ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrap,
-                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName(),
-                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName(),
-                ConsumerConfig.GROUP_ID_CONFIG, groupId,
-                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
+    private static KeystoreTrustStorePair buildKeystoreTrustStorePair(String domain) throws Exception {
+        var brokerCertificateGenerator = new KeytoolCertificateGenerator();
+        brokerCertificateGenerator.generateSelfSignedCertificateEntry("test@kroxylicious.io", domain, "KI", "kroxylicious.io", null, null, "US");
+        Path resolve = certsDirectory.resolve(UUID.randomUUID().toString());
+        if (!resolve.toFile().mkdirs()) {
+            throw new RuntimeException("Could not create directory " + resolve);
+        }
+        var clientTrustStore = resolve.resolve("kafka.truststore.jks");
+        brokerCertificateGenerator.generateTrustStore(brokerCertificateGenerator.getCertFilePath(), "client",
+                clientTrustStore.toAbsolutePath().toString());
+        return new KeystoreTrustStorePair(brokerCertificateGenerator.getKeyStoreLocation(), clientTrustStore.toAbsolutePath().toString(),
+                brokerCertificateGenerator.getPassword());
     }
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -137,18 +137,34 @@ class HotReloadIT extends BaseIT {
                 .build();
     }
 
+    // Per-record produce: batch.size=1 + linger.ms=0 forces the producer to issue one
+    // ProduceRequest per record rather than coalescing records into a single batched
+    // request. Without this, sending 50-100 small records in a tight loop yields just
+    // 1-3 batched requests — which exercises far less of the proxy's request-handling
+    // path than the variable name "messageCount" would imply.
+    private static final Map<String, Object> PER_RECORD_PRODUCER_CONFIG = Map.of(
+            ProducerConfig.BATCH_SIZE_CONFIG, 1,
+            ProducerConfig.LINGER_MS_CONFIG, 0,
+            ProducerConfig.ACKS_CONFIG, "all");
+
     /**
-     * Produce a random batch of records (50-100) via {@code tester.producer(vc)}, then
-     * consume them back via {@code tester.consumer(vc)}. Records are keyed
+     * Produce a random number of records (50-100) via {@code tester.producer(vc)}
+     * configured with {@code batch.size=1, linger.ms=0} so each record results in its
+     * own {@code ProduceRequest} — the proxy sees N round-trips rather than one batched
+     * request. Then consume them back via {@code tester.consumer(vc)}. Records are keyed
      * {@code marker-0}..{@code marker-N-1} so the consumer can isolate this round-trip's
      * records from earlier phases' records that share the same topic.
+     *
+     * <p>Asserts the consumer observes exactly {@code N} unique keys carrying this call's
+     * {@code marker} — proving the full proxy I/O round-trip is working and that no
+     * records are dropped mid-stream across many independent produce requests.
      */
     private static void assertProduceConsumeRoundTrip(KroxyliciousTester tester, String vc, String topic, String marker) throws Exception {
         int messageCount = ThreadLocalRandom.current().nextInt(50, 101);
-        LOGGER.info("Producing {} records via VC '{}' (marker='{}')", messageCount, vc, marker);
+        LOGGER.info("Producing {} records via VC '{}' (marker='{}') with per-record requests", messageCount, vc, marker);
 
         var sendFutures = new ArrayList<Future<RecordMetadata>>(messageCount);
-        try (var producer = tester.producer(vc)) {
+        try (var producer = tester.producer(vc, PER_RECORD_PRODUCER_CONFIG)) {
             for (int i = 0; i < messageCount; i++) {
                 sendFutures.add(producer.send(new ProducerRecord<>(topic, marker + "-" + i, marker + "-value-" + i)));
             }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -139,9 +139,7 @@ class HotReloadIT extends BaseIT {
 
     // Per-record produce: batch.size=1 + linger.ms=0 forces the producer to issue one
     // ProduceRequest per record rather than coalescing records into a single batched
-    // request. Without this, sending 50-100 small records in a tight loop yields just
-    // 1-3 batched requests — which exercises far less of the proxy's request-handling
-    // path than the variable name "messageCount" would imply.
+    // request.
     private static final Map<String, Object> PER_RECORD_PRODUCER_CONFIG = Map.of(
             ProducerConfig.BATCH_SIZE_CONFIG, 1,
             ProducerConfig.LINGER_MS_CONFIG, 0,

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
@@ -23,7 +22,6 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +34,7 @@ import io.kroxylicious.testing.integration.tester.KroxyliciousTester;
 import io.kroxylicious.testing.integration.tester.KroxyliciousTesters;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
-import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
+import io.kroxylicious.testing.kafka.common.KeystoreManager;
 
 import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.defaultSniHostIdentifiesNodeGatewayBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,9 +60,6 @@ class HotReloadIT extends BaseIT {
     private static final Duration RECONFIGURE_TIMEOUT = Duration.ofSeconds(15);
     private static final Duration PRODUCE_CONSUME_TIMEOUT = Duration.ofSeconds(15);
     private static final Duration REJECTION_TIMEOUT = Duration.ofSeconds(5);
-
-    @TempDir
-    private static Path certsDirectory;
 
     @Test
     void shouldStopRemovedVcButContinueServingOthersEndToEnd(@BrokerCluster KafkaCluster cluster) throws Exception {
@@ -220,16 +215,15 @@ class HotReloadIT extends BaseIT {
     private record KeystoreTrustStorePair(String brokerKeyStore, String clientTrustStore, String password) {}
 
     private static KeystoreTrustStorePair buildKeystoreTrustStorePair(String domain) throws Exception {
-        var brokerCertificateGenerator = new KeytoolCertificateGenerator();
-        brokerCertificateGenerator.generateSelfSignedCertificateEntry("test@kroxylicious.io", domain, "KI", "kroxylicious.io", null, null, "US");
-        Path resolve = certsDirectory.resolve(UUID.randomUUID().toString());
-        if (!resolve.toFile().mkdirs()) {
-            throw new RuntimeException("Could not create directory " + resolve);
-        }
-        var clientTrustStore = resolve.resolve("kafka.truststore.jks");
-        brokerCertificateGenerator.generateTrustStore(brokerCertificateGenerator.getCertFilePath(), "client",
-                clientTrustStore.toAbsolutePath().toString());
-        return new KeystoreTrustStorePair(brokerCertificateGenerator.getKeyStoreLocation(), clientTrustStore.toAbsolutePath().toString(),
-                brokerCertificateGenerator.getPassword());
+        var keystoreManager = new KeystoreManager();
+        String dn = keystoreManager.buildDistinguishedName("test@kroxylicious.io", domain, "KI", "kroxylicious.io", null, null, "US");
+        var bundle = keystoreManager.createSelfSignedCertificate(
+                keystoreManager.newCertificateBuilder(dn));
+        Path keystorePath = keystoreManager.generateCertificateFile(bundle);
+        String password = keystoreManager.getPassword(keystorePath);
+        // The generated JKS contains both the private key entry and the CA cert,
+        // so the same file serves as both the proxy keystore and the client truststore.
+        String keystore = keystorePath.toAbsolutePath().toString();
+        return new KeystoreTrustStorePair(keystore, keystore, password);
     }
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.it;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.proxy.KafkaProxy;
+import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.ServiceBasedPluginFactoryRegistry;
+import io.kroxylicious.proxy.internal.config.Features;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.BrokerCluster;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.proxy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * End-to-end integration tests for {@link KafkaProxy#reconfigure(Configuration)}
+ */
+@ExtendWith(KafkaClusterExtension.class)
+class HotReloadIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HotReloadIT.class);
+
+    private static final String VC_KEEP_NAME = "vc-keep";
+    private static final String VC_REMOVE_NAME = "vc-remove";
+
+    // KroxyliciousConfigUtils.proxy(srvs, "vc1", "vc2") spaces VCs at the default bootstrap
+    // port + i*10 — i.e. vc[0]=9192, vc[1]=9202. Hardcoding these here so the test asserts
+    // against the same addresses the proxy listens on.
+    private static final String VC_KEEP_BOOTSTRAP = "localhost:9192";
+    private static final String VC_REMOVE_BOOTSTRAP = "localhost:9202";
+
+    private static final Duration RECONFIGURE_TIMEOUT = Duration.ofSeconds(15);
+    private static final Duration PRODUCE_CONSUME_TIMEOUT = Duration.ofSeconds(15);
+    private static final Duration REJECTION_TIMEOUT = Duration.ofSeconds(8);
+
+    @Test
+    void shouldStopRemovedVcButContinueServingOthersEndToEnd(@BrokerCluster KafkaCluster cluster) throws Exception {
+        String topic = "hotreload-remove-it-" + System.currentTimeMillis();
+        createTopicOnUpstream(cluster, topic);
+
+        Configuration twoVcConfig = proxy(cluster.getBootstrapServers(), VC_KEEP_NAME, VC_REMOVE_NAME).build();
+        Configuration oneVcConfig = proxy(cluster.getBootstrapServers(), VC_KEEP_NAME).build();
+
+        try (KafkaProxy proxy = new KafkaProxy(new ServiceBasedPluginFactoryRegistry(), twoVcConfig, Features.defaultFeatures())) {
+            proxy.startup();
+
+            // Phase 1: both VCs serve produce + consume.
+            LOGGER.info("Phase 1: producing + consuming through both VCs");
+            assertProduceConsumeRoundTrip(VC_KEEP_BOOTSTRAP, topic, "phase1-keep");
+            assertProduceConsumeRoundTrip(VC_REMOVE_BOOTSTRAP, topic, "phase1-remove");
+
+            // Phase 2: reconfigure removes vc-remove. The orchestrator's pure-remove path
+            // drains vc-remove (no live connections at this point since we closed them in
+            // phase 1) and transitions it to STOPPED.
+            LOGGER.info("Phase 2: reconfiguring to remove '{}'", VC_REMOVE_NAME);
+            var result = proxy.reconfigure(oneVcConfig).get(RECONFIGURE_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+            assertThat(result.hasErrors())
+                    .as("ReconfigureResult should have no errors for a clean pure-remove")
+                    .isFalse();
+
+            // Phase 3: vc-keep continues to serve traffic — verifies unaffected VCs are
+            // genuinely undisturbed by the reconfigure.
+            LOGGER.info("Phase 3: verifying '{}' still serves produce + consume", VC_KEEP_NAME);
+            assertProduceConsumeRoundTrip(VC_KEEP_BOOTSTRAP, topic, "phase3-keep");
+
+            // Phase 4: new connections to vc-remove are rejected. The acceptor channel is
+            // still bound (a documented limitation until step 3 of the staircase introduces
+            // proper port unbinding), but the SERVING-state guard closes connections at the
+            // Kafka protocol layer, so the producer's send() future fails.
+            LOGGER.info("Phase 4: verifying '{}' no longer accepts traffic", VC_REMOVE_NAME);
+            assertProducerFailsAgainstRemovedVc(VC_REMOVE_BOOTSTRAP, topic);
+        }
+    }
+
+    /**
+     * Produce a random batch of records (50-100) through the proxy at {@code proxyBootstrap},
+     * then consume them back through the same proxy. Records are keyed {@code marker-0},
+     * {@code marker-1}, ... so the consumer can isolate this round-trip's records from
+     * earlier phases' records that share the same topic.
+     *
+     * <p>Asserts that the consumer observes exactly {@code N} unique keys carrying this
+     * call's {@code marker} — proving the full proxy I/O round-trip is working *and* that
+     * no records are dropped mid-stream.
+     */
+    private static void assertProduceConsumeRoundTrip(String proxyBootstrap, String topic, String marker) throws Exception {
+        int messageCount = ThreadLocalRandom.current().nextInt(50, 101);
+        LOGGER.info("Producing {} records via {} (marker='{}')", messageCount, proxyBootstrap, marker);
+
+        var sendFutures = new ArrayList<Future<RecordMetadata>>(messageCount);
+        try (Producer<String, String> producer = newProducer(proxyBootstrap, false)) {
+            for (int i = 0; i < messageCount; i++) {
+                sendFutures.add(producer.send(new ProducerRecord<>(topic, marker + "-" + i, marker + "-value-" + i)));
+            }
+            // Wait for each ack — fails fast if any individual send didn't make it through
+            // the proxy + broker round-trip within the timeout budget.
+            for (Future<RecordMetadata> f : sendFutures) {
+                f.get(PRODUCE_CONSUME_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+            }
+        }
+
+        try (Consumer<String, String> consumer = newConsumer(proxyBootstrap, "hotreload-it-consumer-" + marker)) {
+            consumer.subscribe(List.of(topic));
+            var seenKeys = new HashSet<String>();
+            String keyPrefix = marker + "-";
+            long deadline = System.currentTimeMillis() + PRODUCE_CONSUME_TIMEOUT.toMillis();
+            while (System.currentTimeMillis() < deadline && seenKeys.size() < messageCount) {
+                var batch = consumer.poll(Duration.ofMillis(500));
+                for (var record : batch) {
+                    if (record.key() != null && record.key().startsWith(keyPrefix)) {
+                        seenKeys.add(record.key());
+                    }
+                }
+            }
+            assertThat(seenKeys)
+                    .as("consumer should have read all %d records (marker='%s') via proxy %s within %s",
+                            messageCount, marker, proxyBootstrap, PRODUCE_CONSUME_TIMEOUT)
+                    .hasSize(messageCount);
+        }
+    }
+
+    /**
+     * Open a fresh producer against the removed VC and verify it cannot deliver a record.
+     * The exact exception depends on how the Kafka client interprets the connection rejection
+     * (NetworkException, TimeoutException, etc.); we accept any failure from {@code send().get()}.
+     */
+    private static void assertProducerFailsAgainstRemovedVc(String proxyBootstrap, String topic) {
+        try (Producer<String, String> producer = newProducer(proxyBootstrap, true)) {
+            assertThatThrownBy(() -> producer.send(new ProducerRecord<>(topic, "should-fail", "should-fail-value"))
+                    .get(REJECTION_TIMEOUT.toSeconds(), TimeUnit.SECONDS))
+                    .as("producer should fail to deliver to the removed VC at %s", proxyBootstrap)
+                    .isInstanceOf(ExecutionException.class);
+        }
+    }
+
+    private static void createTopicOnUpstream(KafkaCluster cluster, String topic) throws Exception {
+        try (Admin admin = Admin.create(Map.of("bootstrap.servers", cluster.getBootstrapServers()))) {
+            admin.createTopics(List.of(new NewTopic(topic, 1, (short) 1))).all().get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * @param shortTimeouts when {@code true}, configures aggressively short timeouts so the
+     *                      "expected to fail" path completes within {@link #REJECTION_TIMEOUT}
+     *                      rather than the default Kafka client delivery-timeout (2 minutes).
+     */
+    private static Producer<String, String> newProducer(String bootstrap, boolean shortTimeouts) {
+        var cfg = new HashMap<String, Object>();
+        cfg.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrap);
+        cfg.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        cfg.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        cfg.put(ProducerConfig.ACKS_CONFIG, "all");
+        if (shortTimeouts) {
+            cfg.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 3_000);
+            cfg.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 5_000);
+            cfg.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 5_000);
+            cfg.put(ProducerConfig.RETRIES_CONFIG, 1);
+            cfg.put(ProducerConfig.RECONNECT_BACKOFF_MS_CONFIG, 100);
+            cfg.put(ProducerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG, 500);
+        }
+        return new KafkaProducer<>(cfg);
+    }
+
+    private static Consumer<String, String> newConsumer(String bootstrap, String groupId) {
+        return new KafkaConsumer<>(Map.of(
+                ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrap,
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName(),
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName(),
+                ConsumerConfig.GROUP_ID_CONFIG, groupId,
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.proxy.internal;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -122,37 +121,65 @@ public class VirtualClusterRegistry {
      * </ul>
      */
     public void shutdownAllClusters() {
-        var drainFutures = new ArrayList<CompletableFuture<Void>>();
-        lifecyclesByCluster.forEach((name, lifecycle) -> {
-            var state = lifecycle.state();
-            if (state instanceof VirtualClusterLifecycleState.Serving) {
-                drainFutures.add(lifecycle.startDraining()
-                        .thenRun(() -> {
-                            lifecycle.drainComplete();
-                            onVirtualClusterStopped.accept(name, Optional.empty());
-                        }));
-            }
-            else if (state instanceof VirtualClusterLifecycleState.Draining) {
-                // Pre-existing drain (e.g. hot-reload) — join it rather than starting a new one.
-                drainFutures.add(lifecycle.drainFuture()
-                        .thenRun(() -> {
-                            lifecycle.drainComplete();
-                            onVirtualClusterStopped.accept(name, Optional.empty());
-                        }));
-            }
-            else if (state instanceof VirtualClusterLifecycleState.Failed failed) {
-                lifecycle.stop();
-                onVirtualClusterStopped.accept(name, Optional.of(failed.cause()));
-            }
-            else if (state instanceof VirtualClusterLifecycleState.Stopped) {
-                // it's already dead, let sleeping dogs lie
-            }
-            else {
-                lifecycle.stop();
-                onVirtualClusterStopped.accept(name, Optional.empty());
-            }
-        });
-        CompletableFuture.allOf(drainFutures.toArray(CompletableFuture[]::new)).join();
+        var drainFutures = lifecyclesByCluster.entrySet().stream()
+                .map(e -> shutdownCluster(e.getKey(), e.getValue()))
+                .toArray(CompletableFuture[]::new);
+        CompletableFuture.allOf(drainFutures).join();
+    }
+
+    /**
+     * Drives a single virtual cluster to its terminal {@code Stopped} state, regardless of
+     * which non-terminal state it is currently in. Shared by {@link #shutdownAllClusters()}
+     * (which drives every cluster) and {@link #removeVirtualCluster(String)} (which drives one).
+     *
+     * <p>State handling matches the proxy-wide shutdown semantics:
+     * <ul>
+     *   <li>{@code Serving} → start draining, then transition to {@code Stopped} once
+     *       connections have drained; fires {@link #onVirtualClusterStopped} with empty cause</li>
+     *   <li>{@code Draining} (e.g. concurrent shutdown / reconfigure) → join the existing
+     *       drain future, then transition to {@code Stopped}; fires callback with empty cause</li>
+     *   <li>{@code Failed} → transition to {@code Stopped} synchronously; fires callback with
+     *       the prior failure cause</li>
+     *   <li>{@code Stopped} → no-op (cluster is already terminal)</li>
+     *   <li>{@code Initializing} → transition to {@code Stopped} synchronously; fires callback
+     *       with empty cause</li>
+     * </ul>
+     *
+     * @return a future that completes when the cluster has reached {@code Stopped}
+     */
+    private CompletableFuture<Void> shutdownCluster(String clusterName, VirtualClusterLifecycle lifecycle) {
+        var state = lifecycle.state();
+        if (state instanceof VirtualClusterLifecycleState.Serving) {
+            return lifecycle.startDraining()
+                    .thenRun(() -> {
+                        lifecycle.drainComplete();
+                        onVirtualClusterStopped.accept(clusterName, Optional.empty());
+                    });
+        }
+        else if (state instanceof VirtualClusterLifecycleState.Draining) {
+            // Pre-existing drain (e.g. concurrent shutdown or hot-reload) — join it rather
+            // than starting a new one.
+            return lifecycle.drainFuture()
+                    .thenRun(() -> {
+                        lifecycle.drainComplete();
+                        onVirtualClusterStopped.accept(clusterName, Optional.empty());
+                    });
+        }
+        else if (state instanceof VirtualClusterLifecycleState.Failed failed) {
+            lifecycle.stop();
+            onVirtualClusterStopped.accept(clusterName, Optional.of(failed.cause()));
+            return CompletableFuture.completedFuture(null);
+        }
+        else if (state instanceof VirtualClusterLifecycleState.Stopped) {
+            // Already dead, let sleeping dogs lie.
+            return CompletableFuture.completedFuture(null);
+        }
+        else {
+            // Initializing — transition to Stopped via the dedicated stop() method.
+            lifecycle.stop();
+            onVirtualClusterStopped.accept(clusterName, Optional.empty());
+            return CompletableFuture.completedFuture(null);
+        }
     }
 
     /**
@@ -179,23 +206,21 @@ public class VirtualClusterRegistry {
     }
 
     /**
-     * Drives an existing virtual cluster through {@code SERVING → DRAINING → STOPPED} and
-     * deregisters its gateways. Invoked by {@code ConfigurationReloadOrchestrator} for clusters
-     * present in the running configuration but absent in the submitted one.
+     * Drives an existing virtual cluster through {@code SERVING → DRAINING → STOPPED}.
+     * Invoked by {@code ConfigurationReloadOrchestrator} for clusters present in the running
+     * configuration but absent in the submitted one.
      *
      * @param clusterName the virtual cluster to remove; must name an existing cluster
-     * @return a future that completes when the removal is finished (currently completes
-     *         immediately because no work is done)
+     * @return a future that completes when the cluster has reached {@code Stopped}
+     * @throws IllegalArgumentException if {@code clusterName} does not name a registered cluster
      */
     public CompletableFuture<Void> removeVirtualCluster(String clusterName) {
-        // TODO: implement SERVING -> DRAINING -> STOPPED transition + gateway deregistration
-        // in the follow-up PR. This no-op exists so the orchestrator can be reviewed and
-        // tested for its pipeline structure ahead of the lifecycle work.
-        LOGGER.atWarn()
+        var lifecycle = requireKnownCluster(clusterName);
+        LOGGER.atInfo()
                 .addKeyValue("virtualCluster", clusterName)
                 .addKeyValue("operation", "removeVirtualCluster")
-                .log("reconfigure: per-VC lifecycle transitions not yet implemented; no-op stub invoked");
-        return CompletableFuture.completedFuture(null);
+                .log("reconfigure: removing virtual cluster");
+        return shutdownCluster(clusterName, lifecycle);
     }
 
     /**

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
@@ -5,12 +5,12 @@
  */
 package io.kroxylicious.proxy.internal.reload;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,8 +18,8 @@ import org.slf4j.LoggerFactory;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.internal.VirtualClusterRegistry;
-import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.reload.ConcurrentReconfigureException;
+import io.kroxylicious.proxy.reload.ReconfigureError;
 import io.kroxylicious.proxy.reload.ReconfigureResult;
 import io.kroxylicious.proxy.reload.StaticConfigurationChangedException;
 
@@ -111,12 +111,19 @@ public class ConfigurationReloadOrchestrator {
      *           <li>successfully with an empty-errors {@link ReconfigureResult} when the
      *               submitted configuration produces no changes (a no-op reconfigure);
      *               {@code currentConfiguration} is updated to the submitted value</li>
+     *           <li>successfully with a {@link ReconfigureResult} (possibly with per-cluster
+     *               errors) when the submitted configuration removes one or more virtual
+     *               clusters and does not add or modify any; {@code currentConfiguration}
+     *               is updated to the submitted value</li>
      *           <li>exceptionally with {@link StaticConfigurationChangedException} when the
      *               submitted configuration differs from the current one in any static
      *               section</li>
      *           <li>exceptionally with {@link ConcurrentReconfigureException} when another
      *               reconfigure is already in progress</li>
-     *          </ul>
+     *           <li>exceptionally with {@link UnsupportedOperationException} when the
+     *               submitted configuration would add or modify any virtual cluster
+     *               (placeholder for follow-up staircase steps)</li>
+     *         </ul>
      */
     public CompletableFuture<ReconfigureResult> reconfigure(Configuration newConfig) {
         Objects.requireNonNull(newConfig, "newConfig");
@@ -150,47 +157,43 @@ public class ConfigurationReloadOrchestrator {
                 return CompletableFuture.completedFuture(ReconfigureResult.of(List.of()));
             }
 
-            // 5. Per-VC operations in order: remove -> replace -> add. These are no-ops in
-            // this PR — see VirtualClusterRegistry's stub methods and class-level Javadoc.
-            var newModelsByName = newConfig.virtualClusterModel(pfr).stream()
-                    .collect(Collectors.toMap(VirtualClusterModel::getClusterName, m -> m));
+            // 5. Mixed-reconfigure guard. Submissions that ADD or MODIFY any virtual cluster
+            // would land at the per-VC modify/add placeholders below, which are still no-op
+            // stubs. Rather than partially apply the removes and leave the proxy in a half-
+            // reconciled state, reject the whole submission upfront.
+            if (!changeResult.clustersToModify().isEmpty() || !changeResult.clustersToAdd().isEmpty()) {
+                throw new UnsupportedOperationException(
+                        "KafkaProxy.reconfigure() does not yet support add/replace operations. "
+                                + "Pre-flight, concurrency, validation, and change detection have completed; "
+                                + "this reconfigure was rejected because it would have required "
+                                + changeResult.clustersToAdd().size() + " cluster add(s) and "
+                                + changeResult.clustersToModify().size() + " cluster modify operation(s).");
+            }
 
-            // TODO (follow-up PR): when the registry methods become real:
-            // 1. wrap each .join() in try/catch to accumulate ReconfigureError into a list
-            // rather than aborting on the first failure — a failed cluster shouldn't
-            // prevent the others from being attempted.
-            // 2. keep per-VC operations SEQUENTIAL within a phase — VCs that share a
-            // NamedFilterDefinition (directly via filters: or transitively via
-            // defaultFilters) are coupled through shared filter-wrapper state, so
-            // concurrent reconciles would race on that shared state.
-            // 3. introduce per-wrapper replacement inside FilterChainFactory so filter
-            // definitions used by unchanged VCs are not torn down.
+            // 6. Per-VC remove. SEQUENTIAL. Errors are accumulated into
+            // a per-cluster list and surfaced via the ReconfigureResult; a failed cluster
+            // does not prevent subsequent removes from being attempted.
+            var errors = new ArrayList<ReconfigureError>();
             for (String name : changeResult.clustersToRemove()) {
-                virtualClusterRegistry.removeVirtualCluster(name).join();
-            }
-            for (String name : changeResult.clustersToModify()) {
-                VirtualClusterModel newModel = requireModel(newModelsByName, name);
-                virtualClusterRegistry.replaceVirtualCluster(name, newModel).join();
-            }
-            for (String name : changeResult.clustersToAdd()) {
-                VirtualClusterModel newModel = requireModel(newModelsByName, name);
-                virtualClusterRegistry.addVirtualCluster(newModel).join();
+                try {
+                    virtualClusterRegistry.removeVirtualCluster(name).join();
+                }
+                catch (RuntimeException e) {
+                    Throwable cause = e instanceof CompletionException ce && ce.getCause() != null
+                            ? ce.getCause()
+                            : e;
+                    LOGGER.atWarn()
+                            .setCause(cause)
+                            .addKeyValue("virtualCluster", name)
+                            .addKeyValue("error", cause.getMessage())
+                            .log("reconfigure: failed to remove virtual cluster");
+                    errors.add(new ReconfigureError(name, cause));
+                }
             }
 
-            // 6. PLACEHOLDER: throw until the follow-up PR implements per-VC mechanics +
-            // filter-chain reconciliation + result construction. The throw lands here
-            // intentionally — every phase above is real and will run on a real call to
-            // reconfigure(), but the proxy's state has not been mutated (per-VC ops are
-            // no-ops). Embedders calling reconfigure() therefore see a clear "feature not
-            // done" signal rather than a misleading "successful no-op" outcome.
-            throw new UnsupportedOperationException(
-                    "KafkaProxy.reconfigure() per-VC mechanics not yet implemented; coming in follow-up PR. "
-                            + "Pre-flight, concurrency, validation, and change detection have completed.");
-
-            // 7. (Follow-up PR) On success:
-            // reconcile filter chain (per-wrapper replacement inside FilterChainFactory);
-            // update currentConfiguration;
-            // return CompletableFuture.completedFuture(ReconfigureResult.of(errors));
+            // 7. Commit. currentConfiguration advances to the submitted value
+            this.currentConfiguration = newConfig;
+            return CompletableFuture.completedFuture(ReconfigureResult.of(errors));
         }
         catch (RuntimeException e) {
             LOGGER.atError()
@@ -209,14 +212,5 @@ public class ConfigurationReloadOrchestrator {
         return detectors.stream()
                 .map(d -> d.detect(context))
                 .reduce(ChangeResult.EMPTY, ChangeResult::merge);
-    }
-
-    private static VirtualClusterModel requireModel(Map<String, VirtualClusterModel> modelsByName, String name) {
-        VirtualClusterModel model = modelsByName.get(name);
-        if (model == null) {
-            throw new IllegalStateException("ChangeResult referenced cluster '" + name
-                    + "' but no matching model was built from the submitted configuration");
-        }
-        return model;
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
@@ -175,20 +175,7 @@ public class ConfigurationReloadOrchestrator {
             // does not prevent subsequent removes from being attempted.
             var errors = new ArrayList<ReconfigureError>();
             for (String name : changeResult.clustersToRemove()) {
-                try {
-                    virtualClusterRegistry.removeVirtualCluster(name).join();
-                }
-                catch (RuntimeException e) {
-                    Throwable cause = e instanceof CompletionException ce && ce.getCause() != null
-                            ? ce.getCause()
-                            : e;
-                    LOGGER.atWarn()
-                            .setCause(cause)
-                            .addKeyValue("virtualCluster", name)
-                            .addKeyValue("error", cause.getMessage())
-                            .log("reconfigure: failed to remove virtual cluster");
-                    errors.add(new ReconfigureError(name, cause));
-                }
+                removeCluster(name, errors);
             }
 
             // 7. Commit. currentConfiguration advances to the submitted value
@@ -212,5 +199,25 @@ public class ConfigurationReloadOrchestrator {
         return detectors.stream()
                 .map(d -> d.detect(context))
                 .reduce(ChangeResult.EMPTY, ChangeResult::merge);
+    }
+
+    /**
+     * Attempt to remove a single virtual cluster.
+     */
+    private void removeCluster(String clusterName, List<ReconfigureError> errors) {
+        try {
+            virtualClusterRegistry.removeVirtualCluster(clusterName).join();
+        }
+        catch (RuntimeException e) {
+            Throwable cause = e instanceof CompletionException ce && ce.getCause() != null
+                    ? ce.getCause()
+                    : e;
+            LOGGER.atWarn()
+                    .setCause(cause)
+                    .addKeyValue("virtualCluster", clusterName)
+                    .addKeyValue("error", cause.getMessage())
+                    .log("reconfigure: failed to remove virtual cluster");
+            errors.add(new ReconfigureError(clusterName, cause));
+        }
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -32,7 +32,6 @@ import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.IllegalConfigurationException;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
-import io.kroxylicious.proxy.internal.VirtualClusterLifecycleState;
 import io.kroxylicious.proxy.internal.config.Features;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 
@@ -50,26 +49,6 @@ class KafkaProxyTest {
                    - name: default
                      portIdentifiesNode:
                        bootstrapAddress: localhost:9192
-            """;
-    // Two port-addressed VCs. Each portIdentifiesNode strategy reserves a range of broker
-    // ports starting just after its bootstrap port, so the two bootstrap ports must be
-    // spaced far enough apart that their reserved broker-port ranges do not collide.
-    private static final String TWO_VC_CONFIG_YAML = """
-               virtualClusters:
-                 - name: demo1
-                   targetCluster:
-                     bootstrapServers: kafka.example:1234
-                   gateways:
-                   - name: default
-                     portIdentifiesNode:
-                       bootstrapAddress: localhost:9192
-                 - name: demo2
-                   targetCluster:
-                     bootstrapServers: kafka.example:1234
-                   gateways:
-                   - name: default
-                     portIdentifiesNode:
-                       bootstrapAddress: localhost:9292
             """;
     private ConfigParser configParser;
 
@@ -447,29 +426,6 @@ class KafkaProxyTest {
             var newConfig = configParser.parseConfiguration(MINIMUM_VIABLE_CONFIG_YAML);
             var result = proxy.reconfigure(newConfig).get(5, TimeUnit.SECONDS);
             assertThat(result.hasErrors()).isFalse();
-        }
-    }
-
-    @Test
-    void shouldRemoveOneVirtualClusterEndToEnd() throws Exception {
-        // End-to-end integration test for step 1 of the hot-reload staircase:
-        // start a proxy with two virtual clusters, reconfigure to drop one, and assert:
-        // (a) the future completes successfully with no errors
-        // (b) the removed cluster's lifecycle is in Stopped state
-        // (c) the remaining cluster's lifecycle is still in Serving state (unaffected)
-        try (var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(TWO_VC_CONFIG_YAML), Features.defaultFeatures())) {
-            proxy.startup();
-            assertThat(proxy.lifecycleFor("demo1").state()).isInstanceOf(VirtualClusterLifecycleState.Serving.class);
-            assertThat(proxy.lifecycleFor("demo2").state()).isInstanceOf(VirtualClusterLifecycleState.Serving.class);
-
-            // when — reconfigure to drop demo2
-            var newConfig = configParser.parseConfiguration(MINIMUM_VIABLE_CONFIG_YAML);
-            var result = proxy.reconfigure(newConfig).get(10, TimeUnit.SECONDS);
-
-            // then
-            assertThat(result.hasErrors()).isFalse();
-            assertThat(proxy.lifecycleFor("demo2").state()).isInstanceOf(VirtualClusterLifecycleState.Stopped.class);
-            assertThat(proxy.lifecycleFor("demo1").state()).isInstanceOf(VirtualClusterLifecycleState.Serving.class);
         }
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -32,6 +32,7 @@ import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.IllegalConfigurationException;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
+import io.kroxylicious.proxy.internal.VirtualClusterLifecycleState;
 import io.kroxylicious.proxy.internal.config.Features;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 
@@ -49,6 +50,26 @@ class KafkaProxyTest {
                    - name: default
                      portIdentifiesNode:
                        bootstrapAddress: localhost:9192
+            """;
+    // Two port-addressed VCs. Each portIdentifiesNode strategy reserves a range of broker
+    // ports starting just after its bootstrap port, so the two bootstrap ports must be
+    // spaced far enough apart that their reserved broker-port ranges do not collide.
+    private static final String TWO_VC_CONFIG_YAML = """
+               virtualClusters:
+                 - name: demo1
+                   targetCluster:
+                     bootstrapServers: kafka.example:1234
+                   gateways:
+                   - name: default
+                     portIdentifiesNode:
+                       bootstrapAddress: localhost:9192
+                 - name: demo2
+                   targetCluster:
+                     bootstrapServers: kafka.example:1234
+                   gateways:
+                   - name: default
+                     portIdentifiesNode:
+                       bootstrapAddress: localhost:9292
             """;
     private ConfigParser configParser;
 
@@ -426,6 +447,29 @@ class KafkaProxyTest {
             var newConfig = configParser.parseConfiguration(MINIMUM_VIABLE_CONFIG_YAML);
             var result = proxy.reconfigure(newConfig).get(5, TimeUnit.SECONDS);
             assertThat(result.hasErrors()).isFalse();
+        }
+    }
+
+    @Test
+    void shouldRemoveOneVirtualClusterEndToEnd() throws Exception {
+        // End-to-end integration test for step 1 of the hot-reload staircase:
+        // start a proxy with two virtual clusters, reconfigure to drop one, and assert:
+        // (a) the future completes successfully with no errors
+        // (b) the removed cluster's lifecycle is in Stopped state
+        // (c) the remaining cluster's lifecycle is still in Serving state (unaffected)
+        try (var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(TWO_VC_CONFIG_YAML), Features.defaultFeatures())) {
+            proxy.startup();
+            assertThat(proxy.lifecycleFor("demo1").state()).isInstanceOf(VirtualClusterLifecycleState.Serving.class);
+            assertThat(proxy.lifecycleFor("demo2").state()).isInstanceOf(VirtualClusterLifecycleState.Serving.class);
+
+            // when — reconfigure to drop demo2
+            var newConfig = configParser.parseConfiguration(MINIMUM_VIABLE_CONFIG_YAML);
+            var result = proxy.reconfigure(newConfig).get(10, TimeUnit.SECONDS);
+
+            // then
+            assertThat(result.hasErrors()).isFalse();
+            assertThat(proxy.lifecycleFor("demo2").state()).isInstanceOf(VirtualClusterLifecycleState.Stopped.class);
+            assertThat(proxy.lifecycleFor("demo1").state()).isInstanceOf(VirtualClusterLifecycleState.Serving.class);
         }
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
@@ -627,25 +627,61 @@ class VirtualClusterRegistryTest {
     }
 
     // -----------------------------------------------------------------------------------------
-    // Stub reconfigure operations — currently no-op. The follow-up PR will replace these stubs
-    // with the real lifecycle transitions; until then we pin the contract: each stub completes
-    // its future immediately without mutating registry state, so the orchestrator can drive
-    // the full pipeline against this class even before per-VC mechanics land.
+    // Reconfigure operations. removeVirtualCluster is the first to be made real (step 1 of
+    // the hot-reload staircase); replaceVirtualCluster and addVirtualCluster remain no-op
+    // stubs until later steps land them. The stub tests below pin the contract: each stub
+    // completes its future immediately without mutating registry state, so the orchestrator
+    // can drive the full pipeline against this class while only some operations are real.
     // -----------------------------------------------------------------------------------------
 
     @Test
-    void removeVirtualClusterStubReturnsCompletedFutureWithoutMutatingState() {
+    void removeVirtualClusterDrivesServingClusterToStopped() {
         // given
         vcc.initializationSucceeded(CLUSTER_A);
-        var lifecycleBefore = vcc.lifecycleFor(CLUSTER_A);
+        assertThat(requireLifecycle(CLUSTER_A).state()).isInstanceOf(VirtualClusterLifecycleState.Serving.class);
 
         // when
         var future = vcc.removeVirtualCluster(CLUSTER_A);
 
         // then
-        assertThat(future).isCompleted();
-        // the stub doesn't actually remove the lifecycle — that's the follow-up PR's job
-        assertThat(vcc.lifecycleFor(CLUSTER_A)).isSameAs(lifecycleBefore);
+        assertThat(future).succeedsWithin(5, TimeUnit.SECONDS);
+        assertThat(requireLifecycle(CLUSTER_A).state()).isInstanceOf(VirtualClusterLifecycleState.Stopped.class);
+    }
+
+    @Test
+    void removeVirtualClusterFiresOnStoppedCallback() {
+        // given
+        vcc.initializationSucceeded(CLUSTER_A);
+
+        // when
+        vcc.removeVirtualCluster(CLUSTER_A).join();
+
+        // then — callback invoked with (clusterName, Optional.empty()) per the no-failure case
+        verify(noOpCallback).accept(CLUSTER_A, Optional.empty());
+    }
+
+    @Test
+    void removeVirtualClusterIsNoOpWhenAlreadyStopped() {
+        // given — drive the cluster to Stopped via the normal remove path
+        vcc.initializationSucceeded(CLUSTER_A);
+        vcc.removeVirtualCluster(CLUSTER_A).join();
+        assertThat(requireLifecycle(CLUSTER_A).state()).isInstanceOf(VirtualClusterLifecycleState.Stopped.class);
+
+        // when — call remove again on an already-Stopped cluster
+        var future = vcc.removeVirtualCluster(CLUSTER_A);
+
+        // then — completes immediately, no exception
+        assertThat(future).succeedsWithin(1, TimeUnit.SECONDS);
+        assertThat(requireLifecycle(CLUSTER_A).state()).isInstanceOf(VirtualClusterLifecycleState.Stopped.class);
+    }
+
+    @Test
+    void removeVirtualClusterThrowsForUnknownClusterName() {
+        // The real removeVirtualCluster validates via requireKnownCluster, unlike the previous
+        // stub which silently accepted unknown names.
+        assertThatThrownBy(() -> vcc.removeVirtualCluster("never-existed"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown cluster");
     }
 
     @Test
@@ -678,11 +714,4 @@ class VirtualClusterRegistryTest {
         assertThat(vcc.lifecycleFor(CLUSTER_B)).isNull();
     }
 
-    @Test
-    void removeVirtualClusterStubAcceptsUnknownClusterName() {
-        // Unlike runtime-state methods, the stub does not validate the cluster name — when the
-        // real implementation lands, validation will be part of the lifecycle transition.
-        var future = vcc.removeVirtualCluster("never-existed");
-        assertThat(future).isCompleted();
-    }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
@@ -649,6 +649,24 @@ class VirtualClusterRegistryTest {
     }
 
     @Test
+    void removeVirtualClusterLeavesOtherClustersUnaffected() {
+        // given — two serving clusters in one registry
+        var registry = new VirtualClusterRegistry(
+                List.of(mockModel(CLUSTER_A), mockModel(CLUSTER_B)), noOpCallback);
+        registry.initializationSucceeded(CLUSTER_A);
+        registry.initializationSucceeded(CLUSTER_B);
+
+        // when — remove only CLUSTER_B
+        registry.removeVirtualCluster(CLUSTER_B).join();
+
+        // then — CLUSTER_B reaches Stopped, CLUSTER_A stays in Serving
+        assertThat(registry.lifecycleFor(CLUSTER_B).state())
+                .isInstanceOf(VirtualClusterLifecycleState.Stopped.class);
+        assertThat(registry.lifecycleFor(CLUSTER_A).state())
+                .isInstanceOf(VirtualClusterLifecycleState.Serving.class);
+    }
+
+    @Test
     void removeVirtualClusterFiresOnStoppedCallback() {
         // given
         vcc.initializationSucceeded(CLUSTER_A);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
@@ -33,7 +33,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -96,16 +95,18 @@ class ConfigurationReloadOrchestratorTest {
         // then
         assertThat(future).isCompletedExceptionally();
         assertThatThrownBy(future::join).cause().isInstanceOf(UnsupportedOperationException.class);
-        // The orchestrator invoked the addVirtualCluster stub for the new cluster before the
-        // swap-point throw. The other two ops are not called when there's only an addition.
-        verify(registry).addVirtualCluster(any());
+
+        verify(registry, never()).addVirtualCluster(any());
         verify(registry, never()).removeVirtualCluster(anyString());
         verify(registry, never()).replaceVirtualCluster(anyString(), any());
     }
 
     @Test
-    void clusterRemovalInvokesRemoveNoOpThenThrows() {
-        // given — old has cluster-a + cluster-b, new has only cluster-a → cluster-b removed
+    void pureRemoveCompletesSuccessfully() {
+        // given — old has cluster-a + cluster-b, new has only cluster-a → cluster-b removed.
+        // This is a pure-remove reconfigure: step 1 of the hot-reload staircase supports it
+        // end-to-end and the orchestrator returns a clean ReconfigureResult rather than
+        // throwing the placeholder UOE.
         var oldConfig = configWith(vc("cluster-a"), vc("cluster-b"));
         var newConfig = configWith(vc("cluster-a"));
         var registry = stubbedRegistry();
@@ -115,8 +116,7 @@ class ConfigurationReloadOrchestratorTest {
         var future = orchestrator.reconfigure(newConfig);
 
         // then
-        assertThat(future).isCompletedExceptionally();
-        assertThatThrownBy(future::join).cause().isInstanceOf(UnsupportedOperationException.class);
+        assertThat(future).isCompletedWithValueMatching(r -> !r.hasErrors());
         verify(registry).removeVirtualCluster("cluster-b");
         verify(registry, never()).addVirtualCluster(any());
         verify(registry, never()).replaceVirtualCluster(anyString(), any());
@@ -149,19 +149,18 @@ class ConfigurationReloadOrchestratorTest {
         // Hold the reconfigure lock by blocking inside a registry no-op invocation. While the
         // first reconfigure is parked there, a second call from another thread must fail fast
         // with ConcurrentReconfigureException.
-        var oldConfig = configWith(vc("cluster-a"));
+        var oldConfig = configWith(vc("cluster-a"), vc("cluster-b"));
         var newConfig = configWith(vc("cluster-b"));
         var registry = mock(VirtualClusterRegistry.class);
 
         var entered = new CountDownLatch(1);
         var release = new CountDownLatch(1);
-        // removeVirtualCluster will be called for cluster-a — block there.
+        // removeVirtualCluster will be called for cluster-b — block there.
         when(registry.removeVirtualCluster(anyString())).thenAnswer(inv -> {
             entered.countDown();
             release.await();
             return CompletableFuture.completedFuture(null);
         });
-        when(registry.addVirtualCluster(any())).thenReturn(CompletableFuture.completedFuture(null));
 
         var orchestrator = newOrchestrator(oldConfig, registry);
 
@@ -243,8 +242,8 @@ class ConfigurationReloadOrchestratorTest {
         var customDetector = mock(ChangeDetector.class);
         when(customDetector.detect(any())).thenReturn(new ChangeResult(
                 Set.of(), // clustersToAdd
-                Set.of(), // clustersToRemove
-                Set.of("cluster-a"))); // clustersToModify
+                Set.of("cluster-a"), // clustersToRemove
+                Set.of())); // clustersToModify
 
         var registry = stubbedRegistry();
         var orchestrator = new ConfigurationReloadOrchestrator(
@@ -255,13 +254,94 @@ class ConfigurationReloadOrchestratorTest {
 
         // then — the orchestrator consulted the injected detector and acted on its verdict.
         verify(customDetector).detect(any());
-        verify(registry).replaceVirtualCluster(eq("cluster-a"), any());
-        verify(registry, never()).removeVirtualCluster(anyString());
+        verify(registry).removeVirtualCluster("cluster-a");
+        verify(registry, never()).replaceVirtualCluster(anyString(), any());
         verify(registry, never()).addVirtualCluster(any());
 
-        // The pipeline still reaches the swap-point placeholder.
+        // Pure-remove reconfigure: orchestrator completes successfully.
+        assertThat(future).isCompletedWithValueMatching(r -> !r.hasErrors());
+    }
+
+    @Test
+    void mixedReconfigureWithRemoveAndAddIsRejectedUpfront() {
+        // A reconfigure that BOTH removes and adds clusters is a mixed result. Step 1 of the
+        // staircase rejects this upfront with UOE rather than processing the removes and then
+        // throwing for the adds (which would leave the proxy in a partial-state outcome).
+        var oldConfig = configWith(vc("cluster-a"), vc("cluster-b"));
+        var newConfig = configWith(vc("cluster-a"), vc("cluster-c")); // removes cluster-b, adds cluster-c
+        var registry = stubbedRegistry();
+        var orchestrator = newOrchestrator(oldConfig, registry);
+
+        var future = orchestrator.reconfigure(newConfig);
+
         assertThat(future).isCompletedExceptionally();
         assertThatThrownBy(future::join).cause().isInstanceOf(UnsupportedOperationException.class);
+        // No registry methods invoked — rejection happens before the per-VC loop.
+        verify(registry, never()).removeVirtualCluster(anyString());
+        verify(registry, never()).addVirtualCluster(any());
+        verify(registry, never()).replaceVirtualCluster(anyString(), any());
+    }
+
+    @Test
+    void perClusterRemoveFailureSurfacesAsReconfigureErrorAndOthersStillRun() {
+        // Two clusters are being removed. The registry's removeVirtualCluster for one of them
+        // returns a failed future; the other returns a completed future. The orchestrator must:
+        // (a) still attempt the second removal (failure of one does not abort the loop);
+        // (b) surface the failure as a per-cluster ReconfigureError in the result;
+        // (c) return a successful future overall (ReconfigureResult conveys partial failure).
+        var oldConfig = configWith(vc("cluster-a"), vc("cluster-b"), vc("cluster-c"));
+        var newConfig = configWith(vc("cluster-a")); // removes cluster-b AND cluster-c
+
+        var registry = mock(VirtualClusterRegistry.class);
+        var bSpecificFailure = new IllegalStateException("simulated drain failure on cluster-b");
+        when(registry.removeVirtualCluster("cluster-b"))
+                .thenReturn(CompletableFuture.failedFuture(bSpecificFailure));
+        when(registry.removeVirtualCluster("cluster-c"))
+                .thenReturn(CompletableFuture.completedFuture(null));
+
+        var orchestrator = newOrchestrator(oldConfig, registry);
+
+        var future = orchestrator.reconfigure(newConfig);
+
+        // Both removals attempted.
+        verify(registry).removeVirtualCluster("cluster-b");
+        verify(registry).removeVirtualCluster("cluster-c");
+
+        // Future succeeds (with errors inside the result), not exceptional.
+        assertThat(future).isCompletedWithValueMatching(r -> r.hasErrors()
+                && r.errors().size() == 1
+                && r.errors().iterator().next().humanReadableIdentifier().equals("cluster-b")
+                && r.errors().iterator().next().cause() == bSpecificFailure);
+    }
+
+    @Test
+    void pureRemoveAdvancesCurrentConfigurationOnSuccess() {
+        // After a successful pure-remove, currentConfiguration should advance to the submitted
+        // value so subsequent reconfigures use the new baseline. Verified via the captured
+        // ConfigurationChangeContext on the detector's subsequent invocation.
+        var initialConfig = configWith(vc("cluster-a"), vc("cluster-b"));
+        var afterRemove = configWith(vc("cluster-a")); // removes cluster-b
+        var capturingDetector = mock(ChangeDetector.class);
+        // First call: report cluster-b as removed.
+        // Second call: report no changes (we're submitting afterRemove again).
+        when(capturingDetector.detect(any())).thenReturn(
+                new ChangeResult(Set.of(), Set.of("cluster-b"), Set.of()),
+                ChangeResult.EMPTY);
+
+        var orchestrator = new ConfigurationReloadOrchestrator(
+                initialConfig, stubbedRegistry(), mock(PluginFactoryRegistry.class), List.of(capturingDetector));
+
+        orchestrator.reconfigure(afterRemove).join();
+        orchestrator.reconfigure(afterRemove).join();
+
+        var captor = ArgumentCaptor.forClass(ConfigurationChangeContext.class);
+        verify(capturingDetector, times(2)).detect(captor.capture());
+        var contexts = captor.getAllValues();
+        // First call's oldConfig is the constructor-supplied one.
+        assertThat(contexts.get(0).oldConfig()).isSameAs(initialConfig);
+        // Second call's oldConfig must be the previously-submitted config, proving the
+        // baseline advanced through the pure-remove path (not just the no-op early return).
+        assertThat(contexts.get(1).oldConfig()).isSameAs(afterRemove);
     }
 
     // -------- fixture helpers --------


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As per the [discussed sequence](https://github.com/kroxylicious/kroxylicious/pull/3977#discussion_r3270313081), I have added the actual implementation to the `removeVirtualCluster()` method.
With this hot-reload will now support removal of SNI based VC's.

### Additional Context

https://github.com/kroxylicious/kroxylicious/issues/3997

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [x] New tests written (where applicable).
- [ ] User facing documentation written/updated (where applicable).
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
