### PR TITLE
ci: enable KT execution in integration test workflow

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -218,22 +218,16 @@ jobs:
 
           # Extract operator dist ZIP if this is an operator test
           if [ "${{ steps.parse.outputs.module }}" = "kroxylicious-kubernetes/kroxylicious-operator" ]; then
-            mkdir -p kroxylicious-kubernetes/kroxylicious-operator/target
+            mkdir -p kroxylicious-kubernetes/kroxylicious-operator/target/packaged
             unzip -q "$HOME/.m2/repository/io/kroxylicious/kroxylicious-operator-dist/${KROXYLICIOUS_VERSION}/kroxylicious-operator-dist-${KROXYLICIOUS_VERSION}.zip" \
-              -d kroxylicious-kubernetes/kroxylicious-operator/target/
-            # Rename extracted dir to 'packaged' (ZIP contains kroxylicious-operator-VERSION/)
-            mv kroxylicious-kubernetes/kroxylicious-operator/target/kroxylicious-operator-${KROXYLICIOUS_VERSION} \
-               kroxylicious-kubernetes/kroxylicious-operator/target/packaged
+              -d kroxylicious-kubernetes/kroxylicious-operator/target/packaged/
           fi
 
           # Extract admission dist ZIP if this is an admission test
           if [ "${{ steps.parse.outputs.module }}" = "kroxylicious-kubernetes/kroxylicious-admission" ]; then
-            mkdir -p kroxylicious-kubernetes/kroxylicious-admission/target
+            mkdir -p kroxylicious-kubernetes/kroxylicious-admission/target/packaged
             unzip -q "$HOME/.m2/repository/io/kroxylicious/kroxylicious-admission-dist/${KROXYLICIOUS_VERSION}/kroxylicious-admission-dist-${KROXYLICIOUS_VERSION}.zip" \
-              -d kroxylicious-kubernetes/kroxylicious-admission/target/
-            # Rename extracted dir to 'packaged' (ZIP contains kroxylicious-admission-VERSION/)
-            mv kroxylicious-kubernetes/kroxylicious-admission/target/kroxylicious-admission-${KROXYLICIOUS_VERSION} \
-               kroxylicious-kubernetes/kroxylicious-admission/target/packaged
+              -d kroxylicious-kubernetes/kroxylicious-admission/target/packaged/
           fi
       - name: 'Run integration tests'
         env:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -57,7 +57,8 @@ jobs:
           # Always include BOM as it's required for dependency management
           # Also include filter-archetype as it has special IT requirements
           # Also include kroxylicious-app to build operand container image for operator ITs
-          MODULES=":kroxylicious-bom,:kroxylicious-filter-archetype,:kroxylicious-app,${DISCOVERED_MODULES}"
+          # Also include dist modules for operator and admission webhook KT tests
+          MODULES=":kroxylicious-bom,:kroxylicious-filter-archetype,:kroxylicious-app,:kroxylicious-operator-dist,:kroxylicious-admission-dist,${DISCOVERED_MODULES}"
 
           echo "test_chunks=$TEST_CHUNKS" >> $GITHUB_OUTPUT
           echo "modules=$MODULES" >> $GITHUB_OUTPUT
@@ -162,34 +163,43 @@ jobs:
           mkdir -p "$HOME/.m2/repository"
           cd "$HOME/.m2/repository"
           tar xzf /tmp/kroxylicious-artifacts/maven-repo.tar.gz
-      - name: Check if operator tests in chunk
-        id: check_operator
+      - name: Check if Kubernetes tests in chunk
+        id: check_k8s
         env:
           CHUNK: ${{ matrix.tests }}
         run: |
-          if echo "$CHUNK" | grep -q "kroxylicious-kubernetes/kroxylicious-operator:"; then
-            echo "has_operator_tests=true" >> "$GITHUB_OUTPUT"
-            echo "This chunk contains operator tests - Minikube will be started"
+          # Check if chunk contains tests from any Kubernetes module
+          if echo "$CHUNK" | grep -q "kroxylicious-kubernetes/"; then
+            echo "needs_minikube=true" >> "$GITHUB_OUTPUT"
+            echo "This chunk contains Kubernetes tests - Minikube will be started"
           else
-            echo "has_operator_tests=false" >> "$GITHUB_OUTPUT"
-            echo "This chunk has no operator tests - Minikube will be skipped"
+            echo "needs_minikube=false" >> "$GITHUB_OUTPUT"
+            echo "This chunk has no Kubernetes tests - Minikube will be skipped"
+          fi
+
+          # Check if chunk contains KT (Kubernetes Test) files
+          if echo "$CHUNK" | grep -q "KT,\|KT$"; then
+            echo "has_kt_tests=true" >> "$GITHUB_OUTPUT"
+            echo "This chunk contains KT tests - dist profile will be activated"
+          else
+            echo "has_kt_tests=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Set up Docker Buildx
-        if: steps.check_operator.outputs.has_operator_tests == 'true'
+        if: steps.check_k8s.outputs.needs_minikube == 'true'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
       - name: Setup Minikube
-        if: steps.check_operator.outputs.has_operator_tests == 'true'
+        if: steps.check_k8s.outputs.needs_minikube == 'true'
         uses: ./.github/actions/common/setup-minikube
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
       - name: Download Operand Image Artifact
-        if: steps.check_operator.outputs.has_operator_tests == 'true'
+        if: steps.check_k8s.outputs.needs_minikube == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: kroxylicious-operand-image
           path: /tmp/kroxylicious-operand
       - name: Load Operand Image in Minikube
-        if: steps.check_operator.outputs.has_operator_tests == 'true'
+        if: steps.check_k8s.outputs.needs_minikube == 'true'
         env:
           KROXYLICIOUS_IMAGE: ${{ needs.build_artifacts.outputs.kroxylicious_image }}
         run: |
@@ -201,6 +211,30 @@ jobs:
 
           # Set environment variable for tests
           echo "KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE}" >> "${GITHUB_ENV}"
+      - name: 'Extract dist artifacts for KT tests'
+        if: steps.check_k8s.outputs.needs_minikube == 'true'
+        run: |
+          KROXYLICIOUS_VERSION="$(mvn org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=project.version -q -DforceStdout)"
+
+          # Extract operator dist ZIP if this is an operator test
+          if [ "${{ steps.parse.outputs.module }}" = "kroxylicious-kubernetes/kroxylicious-operator" ]; then
+            mkdir -p kroxylicious-kubernetes/kroxylicious-operator/target
+            unzip -q "$HOME/.m2/repository/io/kroxylicious/kroxylicious-operator-dist/${KROXYLICIOUS_VERSION}/kroxylicious-operator-dist-${KROXYLICIOUS_VERSION}.zip" \
+              -d kroxylicious-kubernetes/kroxylicious-operator/target/
+            # Rename extracted dir to 'packaged' (ZIP contains kroxylicious-operator-VERSION/)
+            mv kroxylicious-kubernetes/kroxylicious-operator/target/kroxylicious-operator-${KROXYLICIOUS_VERSION} \
+               kroxylicious-kubernetes/kroxylicious-operator/target/packaged
+          fi
+
+          # Extract admission dist ZIP if this is an admission test
+          if [ "${{ steps.parse.outputs.module }}" = "kroxylicious-kubernetes/kroxylicious-admission" ]; then
+            mkdir -p kroxylicious-kubernetes/kroxylicious-admission/target
+            unzip -q "$HOME/.m2/repository/io/kroxylicious/kroxylicious-admission-dist/${KROXYLICIOUS_VERSION}/kroxylicious-admission-dist-${KROXYLICIOUS_VERSION}.zip" \
+              -d kroxylicious-kubernetes/kroxylicious-admission/target/
+            # Rename extracted dir to 'packaged' (ZIP contains kroxylicious-admission-VERSION/)
+            mv kroxylicious-kubernetes/kroxylicious-admission/target/kroxylicious-admission-${KROXYLICIOUS_VERSION} \
+               kroxylicious-kubernetes/kroxylicious-admission/target/packaged
+          fi
       - name: 'Run integration tests'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -211,11 +245,21 @@ jobs:
           KROXYLICIOUS_KMS_FORTANIX_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_API_KEY }}
         working-directory: ${{ steps.parse.outputs.module }}
         run: |
+          # Activate dist profile for KT tests
+          if [ "${{ steps.check_k8s.outputs.has_kt_tests }}" = "true" ]; then
+            PROFILES="dist,!qa"
+            EXTRA_PROPS="-DskipKTs=false"
+          else
+            PROFILES="!qa"
+            EXTRA_PROPS=""
+          fi
+
           mvn --batch-mode \
-            --activate-profiles '!qa' \
+            --activate-profiles "${PROFILES}" \
             -DskipUTs \
             -Derrorprone.skip=true \
             -Dit.test="${{ steps.parse.outputs.tests }}" \
+            ${EXTRA_PROPS} \
             verify
   integration_test_filter_archetype:
     needs: build_artifacts

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -239,10 +239,11 @@ jobs:
           KROXYLICIOUS_KMS_FORTANIX_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_API_KEY }}
         working-directory: ${{ steps.parse.outputs.module }}
         run: |
-          # Activate dist profile for KT tests
+          # Activate dist profile and skip flags for KT tests
           if [ "${{ steps.check_k8s.outputs.has_kt_tests }}" = "true" ]; then
             PROFILES="dist,!qa"
-            EXTRA_PROPS="-DskipKTs=false"
+            # Skip default integration-test execution, enable kube-integration-test execution
+            EXTRA_PROPS="-DskipITs=true -DskipKTs=false"
           else
             PROFILES="!qa"
             EXTRA_PROPS=""

--- a/scripts/discover-integration-tests.sh
+++ b/scripts/discover-integration-tests.sh
@@ -18,64 +18,93 @@ fi
 # Default chunk size
 TESTS_PER_CHUNK=${1:-15}
 
-# Discover ITs and KTs from all modules, format as "module:TestClass"
-# Exclude target dirs and archetype template resources
-TEST_LIST=$(find . -type f \( -name "*IT.java" -o -name "*KT.java" \) \
-  -not -path "*/target/*" \
-  -not -path "*/archetype-resources/*" \
-  | while read -r file; do
-      testname=$(basename "$file" .java)
-      # Extract module path: ./kroxylicious-operator/src/... -> kroxylicious-operator
-      module=$(echo "$file" | ${SED} 's|^\./||' | ${SED} 's|/src/.*||')
-      echo "${module}:${testname}"
-    done | sort)
+# Function to discover and chunk tests by pattern
+# $1 = file name pattern (e.g., "*IT.java" or "*KT.java")
+discover_and_chunk() {
+  local pattern="$1"
+  local chunks=()
 
-# Group tests by module, shuffle within each module, then chunk
-# Compatible with bash 3.2+ (no associative arrays)
-CHUNKS=()
-current_module=""
-module_tests=""
+  # Discover tests matching the pattern, format as "module:TestClass"
+  # Exclude target dirs and archetype template resources
+  local test_list=$(find . -type f -name "$pattern" \
+    -not -path "*/target/*" \
+    -not -path "*/archetype-resources/*" \
+    | while read -r file; do
+        testname=$(basename "$file" .java)
+        # Extract module path: ./kroxylicious-operator/src/... -> kroxylicious-operator
+        module=$(echo "$file" | ${SED} 's|^\./||' | ${SED} 's|/src/.*||')
+        echo "${module}:${testname}"
+      done | sort)
 
-while IFS= read -r spec; do
-    if [ -z "$spec" ]; then
-        continue
-    fi
+  # Group tests by module, shuffle within each module, then chunk
+  # Compatible with bash 3.2+ (no associative arrays)
+  local current_module=""
+  local module_tests=""
 
-    module=$(echo "$spec" | cut -d: -f1)
-    test=$(echo "$spec" | cut -d: -f2)
+  while IFS= read -r spec; do
+      if [ -z "$spec" ]; then
+          continue
+      fi
 
-    # If we hit a new module, process the previous module's tests
-    if [ -n "$current_module" ] && [ "$module" != "$current_module" ]; then
-        # Shuffle and chunk the accumulated tests
-        shuffled=$(echo "$module_tests" | tr ' ' '\n' | grep -v '^$' | shuf)
-        while IFS= read -r chunk; do
-            if [ -n "$chunk" ]; then
-                # Prefix each test with module: and convert spaces to commas
-                prefixed=$(echo "$chunk" | ${SED} "s|\([^ ]*\)|${current_module}:\1|g" | tr ' ' ',')
-                CHUNKS+=("\"$prefixed\"")
-            fi
-        done <<< "$(echo "$shuffled" | xargs -L ${TESTS_PER_CHUNK})"
+      local module=$(echo "$spec" | cut -d: -f1)
+      local test=$(echo "$spec" | cut -d: -f2)
 
-        # Reset for new module
-        module_tests=""
-    fi
+      # If we hit a new module, process the previous module's tests
+      if [ -n "$current_module" ] && [ "$module" != "$current_module" ]; then
+          # Shuffle and chunk the accumulated tests
+          local shuffled=$(echo "$module_tests" | tr ' ' '\n' | grep -v '^$' | shuf)
+          while IFS= read -r chunk; do
+              if [ -n "$chunk" ]; then
+                  # Prefix each test with module: and convert spaces to commas
+                  local prefixed=$(echo "$chunk" | ${SED} "s|\([^ ]*\)|${current_module}:\1|g" | tr ' ' ',')
+                  chunks+=("\"$prefixed\"")
+              fi
+          done <<< "$(echo "$shuffled" | xargs -L ${TESTS_PER_CHUNK})"
 
-    current_module="$module"
-    module_tests="${module_tests}${test} "
-done <<< "$TEST_LIST"
+          # Reset for new module
+          module_tests=""
+      fi
 
-# Process the last module
-if [ -n "$current_module" ] && [ -n "$module_tests" ]; then
-    shuffled=$(echo "$module_tests" | tr ' ' '\n' | grep -v '^$' | shuf)
-    while IFS= read -r chunk; do
-        if [ -n "$chunk" ]; then
-            # Prefix each test with module: and convert spaces to commas
-            prefixed=$(echo "$chunk" | ${SED} "s|\([^ ]*\)|${current_module}:\1|g" | tr ' ' ',')
-            CHUNKS+=("\"$prefixed\"")
-        fi
-    done <<< "$(echo "$shuffled" | xargs -L ${TESTS_PER_CHUNK})"
-fi
+      current_module="$module"
+      module_tests="${module_tests}${test} "
+  done <<< "$test_list"
+
+  # Process the last module
+  if [ -n "$current_module" ] && [ -n "$module_tests" ]; then
+      local shuffled=$(echo "$module_tests" | tr ' ' '\n' | grep -v '^$' | shuf)
+      while IFS= read -r chunk; do
+          if [ -n "$chunk" ]; then
+              # Prefix each test with module: and convert spaces to commas
+              local prefixed=$(echo "$chunk" | ${SED} "s|\([^ ]*\)|${current_module}:\1|g" | tr ' ' ',')
+              chunks+=("\"$prefixed\"")
+          fi
+      done <<< "$(echo "$shuffled" | xargs -L ${TESTS_PER_CHUNK})"
+  fi
+
+  # Return chunks as array elements
+  printf '%s\n' "${chunks[@]}"
+}
+
+# Discover IT tests (exclude KT patterns to avoid overlap)
+IT_CHUNKS=$(discover_and_chunk "*IT.java" | grep -v "KT.java\"$" || true)
+
+# Discover KT tests
+KT_CHUNKS=$(discover_and_chunk "*KT.java")
+
+# Combine chunks (IT first, then KT to preserve test ordering)
+ALL_CHUNKS=()
+while IFS= read -r chunk; do
+  if [ -n "$chunk" ]; then
+    ALL_CHUNKS+=("$chunk")
+  fi
+done <<< "$IT_CHUNKS"
+
+while IFS= read -r chunk; do
+  if [ -n "$chunk" ]; then
+    ALL_CHUNKS+=("$chunk")
+  fi
+done <<< "$KT_CHUNKS"
 
 # Output JSON array
-TEST_CHUNKS="[$(IFS=,; echo "${CHUNKS[*]}")]"
+TEST_CHUNKS="[$(IFS=,; echo "${ALL_CHUNKS[*]}")]"
 echo "$TEST_CHUNKS"

--- a/scripts/discover-integration-tests.sh
+++ b/scripts/discover-integration-tests.sh
@@ -18,9 +18,9 @@ fi
 # Default chunk size
 TESTS_PER_CHUNK=${1:-15}
 
-# Discover ITs from all modules, format as "module:TestClass"
+# Discover ITs and KTs from all modules, format as "module:TestClass"
 # Exclude target dirs and archetype template resources
-TEST_LIST=$(find . -type f -name "*IT.java" \
+TEST_LIST=$(find . -type f \( -name "*IT.java" -o -name "*KT.java" \) \
   -not -path "*/target/*" \
   -not -path "*/archetype-resources/*" \
   | while read -r file; do


### PR DESCRIPTION
## Summary
Fixes #3892 

Enables Kubernetes Tests (KT files) to run in the integration test workflow. Previously, these tests were never executed in CI despite being configured in the `dist` Maven profile.

## Changes

**1. Discovery Script (`scripts/discover-integration-tests.sh`)**
- Modified to discover `*KT.java` files in addition to `*IT.java` files
- Discovers 10 KT test files:
  - 4 from kroxylicious-operator
  - 6 from kroxylicious-admission

**2. Workflow (`.github/workflows/integration-tests.yaml`)**
- Added `kroxylicious-operator-dist` and `kroxylicious-admission-dist` to build modules
  - These modules package installation artifacts as ZIPs and install to `~/.m2/repository`
- Renamed check step from `check_operator` to `check_k8s` for clarity
- Minikube now triggers for ANY test from `kroxylicious-kubernetes/*` modules (not just operator)
- Added step to extract dist ZIPs from `~/.m2/repository` to `target/packaged` before running KT tests
  - Reuses artifacts built in build_artifacts job, avoids rebuilding
- Detects KT tests in chunks and activates `dist` profile with `-DskipKTs=false`
- Maintains backward compatibility for non-KT chunks

## Architecture

The solution reuses artifacts built in the `build_artifacts` job:
1. `build_artifacts` builds with `-Pdist`, creating operator-dist and admission-dist ZIPs
2. ZIPs are installed to `~/.m2/repository` which is uploaded/downloaded
3. Test job extracts ZIPs to `target/packaged` before running KT tests
4. No rebuild needed - KT tests use the pre-built installation artifacts

## Testing Strategy

The workflow logic has been validated locally:
- ✅ K8s chunk with KT → triggers Minikube + activates dist profile
- ✅ K8s chunk with IT only → triggers Minikube, no dist profile  
- ✅ Non-K8s chunk → no Minikube, no dist profile

This PR will validate that KT tests can actually run in CI. If they fail due to bitrot (untested code), we can address those issues in follow-up PRs.

## Risk Assessment

**Medium risk:**
- KT tests haven't run in CI before, they may fail
- CI time will increase (KT tests require Kubernetes cluster setup)

**Mitigation:**
- Changes are additive (adds KT tests without removing IT tests)
- Existing IT tests continue to run as before
- Can adjust chunking/parallelization if resource issues occur