### PR TITLE
(feat) Hot reload Implementation (5/N) - Added addVirtualCluster implementation for hot reload

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
@@ -59,7 +59,11 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private final Optional<KroxyliciousTesterBuilder.TrustStoreConfiguration> trustStoreConfiguration;
 
-    private final Configuration kroxyliciousConfig;
+    // Volatile because reconfigure() updates this from the caller's thread while client-
+    // building helpers (createTopic, producer, etc.) may read it from any thread. The field
+    // is mutated only after a successful KafkaProxy.reconfigure() so the tester's view of
+    // the running configuration mirrors the proxy's currentConfiguration.
+    private volatile Configuration kroxyliciousConfig;
 
     private final Map<GatewayId, KroxyliciousClients> clients;
     private final Map<String, Set<String>> topicsPerVirtualCluster;
@@ -311,7 +315,15 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
             throw new UnsupportedOperationException(
                     "reconfigure() requires a KafkaProxy-backed tester; this tester's proxy is " + proxy.getClass().getName());
         }
-        return kp.reconfigure(newConfig);
+        // On success, advance the tester's view of the running configuration so subsequent
+        // client-building helpers (createTopic, producer(vc), consumer(vc)) can find VCs
+        // that the reconfigure added. Mirror the orchestrator's currentConfiguration update
+        // semantics: advance on any non-exceptional completion, including partial-error
+        // results, because the configuration intent has been committed.
+        return kp.reconfigure(newConfig).thenApply(result -> {
+            this.kroxyliciousConfig = newConfig;
+            return result;
+        });
     }
 
     @Override

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -59,11 +60,11 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private final Optional<KroxyliciousTesterBuilder.TrustStoreConfiguration> trustStoreConfiguration;
 
-    // Volatile because reconfigure() updates this from the caller's thread while client-
-    // building helpers (createTopic, producer, etc.) may read it from any thread. The field
-    // is mutated only after a successful KafkaProxy.reconfigure() so the tester's view of
-    // the running configuration mirrors the proxy's currentConfiguration.
-    private volatile Configuration kroxyliciousConfig;
+    // AtomicReference because reconfigure() updates this from the caller's thread while
+    // client-building helpers (createTopic, producer, etc.) may read it from any thread.
+    // The reference is swapped only after a successful KafkaProxy.reconfigure(), so the
+    // tester's view of the running configuration mirrors the proxy's currentConfiguration.
+    private final AtomicReference<Configuration> kroxyliciousConfig;
 
     private final Map<GatewayId, KroxyliciousClients> clients;
     private final Map<String, Set<String>> topicsPerVirtualCluster;
@@ -75,8 +76,8 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
 
     DefaultKroxyliciousTester(ConfigurationBuilder configurationBuilder, Function<Configuration, AutoCloseable> kroxyliciousFactory, ClientFactory clientFactory,
                               @Nullable KroxyliciousTesterBuilder.TrustStoreConfiguration trustStoreConfiguration) {
-        this.kroxyliciousConfig = configurationBuilder.build();
-        this.proxy = kroxyliciousFactory.apply(kroxyliciousConfig);
+        this.kroxyliciousConfig = new AtomicReference<>(configurationBuilder.build());
+        this.proxy = kroxyliciousFactory.apply(kroxyliciousConfig.get());
         this.trustStoreConfiguration = Optional.ofNullable(trustStoreConfiguration);
         this.clients = new ConcurrentHashMap<>();
         this.clientFactory = clientFactory;
@@ -88,9 +89,10 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     }
 
     private String onlyVirtualCluster() {
-        int numVirtualClusters = kroxyliciousConfig.virtualClusters().size();
+        var config = kroxyliciousConfig.get();
+        int numVirtualClusters = config.virtualClusters().size();
         if (numVirtualClusters == 1) {
-            return kroxyliciousConfig.virtualClusters().stream().map(VirtualCluster::name).findFirst().orElseThrow();
+            return config.virtualClusters().stream().map(VirtualCluster::name).findFirst().orElseThrow();
         }
         else {
             throw new AmbiguousVirtualClusterException(
@@ -127,11 +129,11 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     @Override
     @NonNull
     public String getBootstrapAddress(String virtualCluster, String gateway) {
-        return KroxyliciousConfigUtils.bootstrapServersFor(virtualCluster, kroxyliciousConfig, gateway);
+        return KroxyliciousConfigUtils.bootstrapServersFor(virtualCluster, kroxyliciousConfig.get(), gateway);
     }
 
     private void configureClientTls(String virtualCluster, Map<String, Object> defaultClientConfig, String gateway) {
-        var definedCluster = kroxyliciousConfig.virtualClusters().stream().filter(v -> v.name().equals(virtualCluster)).findFirst();
+        var definedCluster = kroxyliciousConfig.get().virtualClusters().stream().filter(v -> v.name().equals(virtualCluster)).findFirst();
         definedCluster.ifPresent(cluster -> {
 
             var first = cluster.gateways().stream().filter(g -> g.name().equals(gateway)).findFirst();
@@ -302,7 +304,7 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     public void restartProxy() {
         try {
             proxy.close();
-            proxy = spawnProxy(kroxyliciousConfig, Features.defaultFeatures());
+            proxy = spawnProxy(kroxyliciousConfig.get(), Features.defaultFeatures());
         }
         catch (Exception e) {
             throw new IllegalStateException(e);
@@ -321,7 +323,7 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
         // semantics: advance on any non-exceptional completion, including partial-error
         // results, because the configuration intent has been committed.
         return kp.reconfigure(newConfig).thenApply(result -> {
-            this.kroxyliciousConfig = newConfig;
+            this.kroxyliciousConfig.set(newConfig);
             return result;
         });
     }
@@ -413,7 +415,7 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
 
     @Override
     public ManagementClient getManagementClient() {
-        var client = Optional.ofNullable(kroxyliciousConfig.management())
+        var client = Optional.ofNullable(kroxyliciousConfig.get().management())
                 .map(ahc -> URI.create("http://localhost:" + ahc.getEffectivePort()))
                 .map(ManagementClient::new)
                 .orElseThrow(() -> new IllegalStateException("admin http interface not configured"));

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
@@ -62,8 +62,8 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
 
     // AtomicReference because reconfigure() updates this from the caller's thread while
     // client-building helpers (createTopic, producer, etc.) may read it from any thread.
-    // The reference is swapped only after a successful KafkaProxy.reconfigure(), so the
-    // tester's view of the running configuration mirrors the proxy's currentConfiguration.
+    // See reconfigure(Configuration) below for the exact swap semantics (which include
+    // advancing on non-exceptional results that nonetheless carry per-cluster errors).
     private final AtomicReference<Configuration> kroxyliciousConfig;
 
     private final Map<GatewayId, KroxyliciousClients> clients;
@@ -317,11 +317,10 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
             throw new UnsupportedOperationException(
                     "reconfigure() requires a KafkaProxy-backed tester; this tester's proxy is " + proxy.getClass().getName());
         }
-        // On success, advance the tester's view of the running configuration so subsequent
-        // client-building helpers (createTopic, producer(vc), consumer(vc)) can find VCs
-        // that the reconfigure added. Mirror the orchestrator's currentConfiguration update
-        // semantics: advance on any non-exceptional completion, including partial-error
-        // results, because the configuration intent has been committed.
+        // Mirror the orchestrator's commit-on-intent semantics (see
+        // ConfigurationReloadOrchestrator): advance on any non-exceptional completion,
+        // INCLUDING ReconfigureResults with per-cluster errors. Tests that care whether
+        // each VC came up must inspect the ReconfigureResult themselves.
         return kp.reconfigure(newConfig).thenApply(result -> {
             this.kroxyliciousConfig.set(newConfig);
             return result;

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -36,6 +36,8 @@ import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
 import io.kroxylicious.testing.kafka.common.KeystoreManager;
 
+import static io.kroxylicious.it.HotReloadIT.VcSlot.INCOMING;
+import static io.kroxylicious.it.HotReloadIT.VcSlot.OUTGOING;
 import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.defaultSniHostIdentifiesNodeGatewayBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -47,70 +49,189 @@ class HotReloadIT extends BaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HotReloadIT.class);
 
-    private static final String VC_KEEP_NAME = "vc-keep";
-    private static final String VC_REMOVE_NAME = "vc-remove";
+    private static final String VC_BASELINE_NAME = "vc-baseline";
+    private static final String VC_OUTGOING_NAME = "vc-outgoing";
+    private static final String VC_INCOMING_NAME = "vc-incoming";
 
     private static final int SHARED_SNI_PORT = KroxyliciousConfigUtils.DEFAULT_PROXY_BOOTSTRAP.port();
     private static final String SNI_BASE_DOMAIN = IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName(".hotreload");
-    private static final String VC_KEEP_BOOTSTRAP = "bootstrap-keep" + SNI_BASE_DOMAIN + ":" + SHARED_SNI_PORT;
-    private static final String VC_REMOVE_BOOTSTRAP = "bootstrap-remove" + SNI_BASE_DOMAIN + ":" + SHARED_SNI_PORT;
-    private static final String VC_KEEP_BROKER_PATTERN = "broker-$(nodeId)-keep" + SNI_BASE_DOMAIN;
-    private static final String VC_REMOVE_BROKER_PATTERN = "broker-$(nodeId)-remove" + SNI_BASE_DOMAIN;
+    private static final String VC_BASELINE_BOOTSTRAP = "bootstrap-baseline" + SNI_BASE_DOMAIN + ":" + SHARED_SNI_PORT;
+    private static final String VC_OUTGOING_BOOTSTRAP = "bootstrap-outgoing" + SNI_BASE_DOMAIN + ":" + SHARED_SNI_PORT;
+    private static final String VC_INCOMING_BOOTSTRAP = "bootstrap-incoming" + SNI_BASE_DOMAIN + ":" + SHARED_SNI_PORT;
+    private static final String VC_BASELINE_BROKER_PATTERN = "broker-$(nodeId)-baseline" + SNI_BASE_DOMAIN;
+    private static final String VC_OUTGOING_BROKER_PATTERN = "broker-$(nodeId)-outgoing" + SNI_BASE_DOMAIN;
+    private static final String VC_INCOMING_BROKER_PATTERN = "broker-$(nodeId)-incoming" + SNI_BASE_DOMAIN;
 
     private static final Duration RECONFIGURE_TIMEOUT = Duration.ofSeconds(15);
     private static final Duration PRODUCE_CONSUME_TIMEOUT = Duration.ofSeconds(15);
     private static final Duration REJECTION_TIMEOUT = Duration.ofSeconds(5);
 
+    /**
+     * Identifies a non-baseline VC slot used by the tests. {@link #buildConfig} takes a
+     * varargs of these to declare which extras (beyond BASELINE) should appear in the
+     * configuration being built.
+     */
+    enum VcSlot {
+        OUTGOING(VC_OUTGOING_NAME, VC_OUTGOING_BOOTSTRAP, VC_OUTGOING_BROKER_PATTERN),
+        INCOMING(VC_INCOMING_NAME, VC_INCOMING_BOOTSTRAP, VC_INCOMING_BROKER_PATTERN);
+
+        final String name;
+        final String bootstrap;
+        final String brokerPattern;
+
+        VcSlot(String name, String bootstrap, String brokerPattern) {
+            this.name = name;
+            this.bootstrap = bootstrap;
+            this.brokerPattern = brokerPattern;
+        }
+    }
+
     @Test
     void shouldStopRemovedVcButContinueServingOthersEndToEnd(@BrokerCluster KafkaCluster cluster) throws Exception {
         // Wildcard cert covering both VCs' SNI hostnames (both end in SNI_BASE_DOMAIN).
         KeystoreTrustStorePair certs = buildKeystoreTrustStorePair("*" + SNI_BASE_DOMAIN);
-        var twoVcConfig = buildConfig(cluster, certs, true);
-        var oneVcConfig = buildConfig(cluster, certs, false);
+        var startingConfig = buildConfig(cluster, certs, OUTGOING); // baseline + outgoing
+        var afterConfig = buildConfig(cluster, certs); // baseline only
 
         // Tester builder so we can register the truststore — required for the default client
         // configuration to do SSL handshakes against the SNI-addressed VCs.
         var testerBuilder = KroxyliciousConfigUtils.baseConfigurationBuilder()
-                .addToVirtualClusters(twoVcConfig.virtualClusters().toArray(new VirtualCluster[0]));
+                .addToVirtualClusters(startingConfig.virtualClusters().toArray(new VirtualCluster[0]));
         try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(testerBuilder)
                 .setTrustStoreLocation(certs.clientTrustStore())
                 .setTrustStorePassword(certs.password())
                 .createDefaultKroxyliciousTester()) {
 
-            String topic = tester.createTopic(VC_KEEP_NAME);
+            String topic = tester.createTopic(VC_BASELINE_NAME);
 
             // Phase 1: both SNI-addressed VCs serve produce + consume on the shared port.
-            LOGGER.info("Phase 1: producing + consuming through both SNI-addressed VCs");
-            assertProduceConsumeRoundTrip(tester, VC_KEEP_NAME, topic, "phase1-keep");
-            assertProduceConsumeRoundTrip(tester, VC_REMOVE_NAME, topic, "phase1-remove");
+            LOGGER.info("Phase 1: producing + consuming through baseline + outgoing VCs");
+            assertProduceConsumeRoundTrip(tester, VC_BASELINE_NAME, topic, "phase1-baseline");
+            assertProduceConsumeRoundTrip(tester, VC_OUTGOING_NAME, topic, "phase1-outgoing");
 
-            // Phase 2: reconfigure removes vc-remove. The acceptor channel stays alive
-            // (vc-keep still needs it); vc-remove transitions to STOPPED.
-            LOGGER.info("Phase 2: reconfiguring to remove '{}'", VC_REMOVE_NAME);
-            var result = tester.reconfigure(oneVcConfig).get(RECONFIGURE_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+            // Phase 2: reconfigure removes vc-outgoing. The acceptor channel stays alive
+            // (vc-baseline still needs it); vc-outgoing transitions to STOPPED.
+            LOGGER.info("Phase 2: reconfiguring to remove '{}'", VC_OUTGOING_NAME);
+            var result = tester.reconfigure(afterConfig).get(RECONFIGURE_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
             assertThat(result.hasErrors())
                     .as("ReconfigureResult should have no errors for a clean pure-remove")
                     .isFalse();
 
-            // Phase 3: vc-keep continues to serve on the same port + cert. An unaffected
+            // Phase 3: vc-baseline continues to serve on the same port + cert. An unaffected
             // VC is genuinely undisturbed by the reconfigure.
-            LOGGER.info("Phase 3: verifying '{}' still serves produce + consume", VC_KEEP_NAME);
-            assertProduceConsumeRoundTrip(tester, VC_KEEP_NAME, topic, "phase3-keep");
+            LOGGER.info("Phase 3: verifying '{}' still serves produce + consume", VC_BASELINE_NAME);
+            assertProduceConsumeRoundTrip(tester, VC_BASELINE_NAME, topic, "phase3-baseline");
 
-            // Phase 4: new connections with vc-remove's SNI hostname are rejected. TLS
+            // Phase 4: new connections with vc-outgoing's SNI hostname are rejected. TLS
             // handshake succeeds (cert is wildcard, covers both hostnames), but the Kafka
             // session is closed because the VC behind that SNI binding is now STOPPED —
             // the SERVING-state guard rejects registration.
-            LOGGER.info("Phase 4: verifying '{}' no longer accepts traffic on its SNI hostname", VC_REMOVE_NAME);
-            assertProducerFailure(tester, VC_REMOVE_NAME, topic);
+            LOGGER.info("Phase 4: verifying '{}' no longer accepts traffic on its SNI hostname", VC_OUTGOING_NAME);
+            assertProducerFailure(tester, VC_OUTGOING_NAME, topic);
         }
     }
 
-    private static Configuration buildConfig(KafkaCluster cluster, KeystoreTrustStorePair certs, boolean includeRemoveVc) {
+    @Test
+    void shouldStartServingAddedVcEndToEnd(@BrokerCluster KafkaCluster cluster) throws Exception {
+        // Wildcard cert covering both VCs' SNI hostnames; required so the cert is already
+        // valid for the to-be-added VC's hostname when registration runs at reconfigure time.
+        KeystoreTrustStorePair certs = buildKeystoreTrustStorePair("*" + SNI_BASE_DOMAIN);
+        var startingConfig = buildConfig(cluster, certs); // baseline only
+        var afterConfig = buildConfig(cluster, certs, INCOMING); // baseline + incoming
+
+        // Tester is built around the starting (one-VC) config. We pre-register the truststore
+        // so client SSL handshakes against the SNI-addressed VCs succeed in every phase.
+        var testerBuilder = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToVirtualClusters(startingConfig.virtualClusters().toArray(new VirtualCluster[0]));
+        try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(testerBuilder)
+                .setTrustStoreLocation(certs.clientTrustStore())
+                .setTrustStorePassword(certs.password())
+                .createDefaultKroxyliciousTester()) {
+
+            String baselineTopic = tester.createTopic(VC_BASELINE_NAME);
+
+            // Phase 1: only vc-baseline is configured and serving. vc-incoming is not yet known.
+            LOGGER.info("Phase 1: producing + consuming through '{}' (only configured VC)", VC_BASELINE_NAME);
+            assertProduceConsumeRoundTrip(tester, VC_BASELINE_NAME, baselineTopic, "phase1-baseline");
+
+            // Phase 2: reconfigure adds vc-incoming.
+            LOGGER.info("Phase 2: reconfiguring to add '{}'", VC_INCOMING_NAME);
+            var result = tester.reconfigure(afterConfig).get(RECONFIGURE_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+            assertThat(result.hasErrors())
+                    .as("ReconfigureResult should have no errors for a clean pure-add")
+                    .isFalse();
+
+            // Phase 3: the newly-added vc-incoming is reachable end-to-end.
+            LOGGER.info("Phase 3: verifying '{}' serves produce + consume after add", VC_INCOMING_NAME);
+            String incomingTopic = tester.createTopic(VC_INCOMING_NAME);
+            assertProduceConsumeRoundTrip(tester, VC_INCOMING_NAME, incomingTopic, "phase3-incoming");
+
+            // Phase 4: vc-baseline remains undisturbed by the add.
+            LOGGER.info("Phase 4: verifying '{}' still serves produce + consume", VC_BASELINE_NAME);
+            assertProduceConsumeRoundTrip(tester, VC_BASELINE_NAME, baselineTopic, "phase4-baseline");
+        }
+    }
+
+    @Test
+    void shouldHandleMixedAddAndRemoveInSingleReconfigure(@BrokerCluster KafkaCluster cluster) throws Exception {
+        // Wildcard cert covering every VC hostname in this test (baseline, outgoing, incoming).
+        KeystoreTrustStorePair certs = buildKeystoreTrustStorePair("*" + SNI_BASE_DOMAIN);
+        var startingConfig = buildConfig(cluster, certs, OUTGOING); // baseline + outgoing
+        var afterConfig = buildConfig(cluster, certs, INCOMING); // baseline + incoming
+
+        var testerBuilder = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToVirtualClusters(startingConfig.virtualClusters().toArray(new VirtualCluster[0]));
+        try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(testerBuilder)
+                .setTrustStoreLocation(certs.clientTrustStore())
+                .setTrustStorePassword(certs.password())
+                .createDefaultKroxyliciousTester()) {
+
+            String baselineTopic = tester.createTopic(VC_BASELINE_NAME);
+
+            // Phase 1: starting state — baseline + outgoing both serve.
+            LOGGER.info("Phase 1: producing + consuming through baseline + outgoing VCs");
+            assertProduceConsumeRoundTrip(tester, VC_BASELINE_NAME, baselineTopic, "phase1-baseline");
+            assertProduceConsumeRoundTrip(tester, VC_OUTGOING_NAME, baselineTopic, "phase1-outgoing");
+
+            // Phase 2: a single reconfigure both removes vc-outgoing AND adds vc-incoming.
+            LOGGER.info("Phase 2: reconfiguring to remove '{}' and add '{}' in one call", VC_OUTGOING_NAME, VC_INCOMING_NAME);
+            var result = tester.reconfigure(afterConfig).get(RECONFIGURE_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+            assertThat(result.hasErrors())
+                    .as("ReconfigureResult should have no errors for a clean mixed add+remove")
+                    .isFalse();
+
+            // Phase 3: vc-baseline is undisturbed by the mixed reconfigure.
+            LOGGER.info("Phase 3: verifying '{}' still serves produce + consume", VC_BASELINE_NAME);
+            assertProduceConsumeRoundTrip(tester, VC_BASELINE_NAME, baselineTopic, "phase3-baseline");
+
+            // Phase 4: vc-outgoing's SNI hostname no longer accepts traffic — the binding may
+            // still be alive (shared acceptor channel) but the SERVING-state guard rejects
+            // new connections because vc-outgoing is now STOPPED.
+            LOGGER.info("Phase 4: verifying '{}' no longer accepts traffic on its SNI hostname", VC_OUTGOING_NAME);
+            assertProducerFailure(tester, VC_OUTGOING_NAME, baselineTopic);
+
+            // Phase 5: vc-incoming is reachable end-to-end.
+            LOGGER.info("Phase 5: verifying '{}' serves produce + consume after the mixed reconfigure", VC_INCOMING_NAME);
+            String incomingTopic = tester.createTopic(VC_INCOMING_NAME);
+            assertProduceConsumeRoundTrip(tester, VC_INCOMING_NAME, incomingTopic, "phase5-incoming");
+        }
+    }
+
+    /**
+     * Build a {@link Configuration} containing {@code VC_BASELINE} plus the additional VCs
+     * named by {@code extras}. Call sites read like declarations of intent:
+     * <pre>{@code
+     *   buildConfig(cluster, certs)                    // baseline only
+     *   buildConfig(cluster, certs, OUTGOING)          // baseline + outgoing
+     *   buildConfig(cluster, certs, INCOMING)          // baseline + incoming
+     *   buildConfig(cluster, certs, OUTGOING, INCOMING) // baseline + both
+     * }</pre>
+     */
+    private static Configuration buildConfig(KafkaCluster cluster, KeystoreTrustStorePair certs, VcSlot... extras) {
         var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
-                .addToVirtualClusters(buildSniVirtualCluster(cluster, certs, VC_KEEP_NAME, VC_KEEP_BOOTSTRAP, VC_KEEP_BROKER_PATTERN));
-        if (includeRemoveVc) {
-            builder.addToVirtualClusters(buildSniVirtualCluster(cluster, certs, VC_REMOVE_NAME, VC_REMOVE_BOOTSTRAP, VC_REMOVE_BROKER_PATTERN));
+                .addToVirtualClusters(buildSniVirtualCluster(cluster, certs, VC_BASELINE_NAME, VC_BASELINE_BOOTSTRAP, VC_BASELINE_BROKER_PATTERN));
+        for (var slot : extras) {
+            builder.addToVirtualClusters(buildSniVirtualCluster(cluster, certs, slot.name, slot.bootstrap, slot.brokerPattern));
         }
         return builder.build();
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -268,7 +268,7 @@ public final class KafkaProxy implements AutoCloseable {
             ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl(overrideMap);
             this.filterChainFactory = new FilterChainFactory(pfr, config.filterDefinitions());
             this.reconfigureOrchestrator = new ConfigurationReloadOrchestrator(
-                    config, virtualClusterRegistry, pfr,
+                    config, virtualClusterRegistry, endpointRegistry, pfr,
                     ConfigurationReloadOrchestrator.defaultDetectors());
 
             Optional<NettySettings> proxyNettySettings = getNettySettings(config, NetworkDefinition::proxy);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
@@ -248,21 +248,29 @@ public class VirtualClusterRegistry {
     }
 
     /**
-     * Brings a new virtual cluster up: creates a {@link VirtualClusterLifecycle} in
-     * {@code INITIALIZING}, registers its gateways, and transitions it to {@code SERVING}.
-     * Invoked by {@code ConfigurationReloadOrchestrator} for clusters absent in the running
-     * configuration but present in the submitted one.
+     * Creates a {@link VirtualClusterLifecycle} in {@code INITIALIZING} for
+     * the given model. Endpoint binding and the transition to {@code SERVING} are the
+     * orchestrator's responsibility — once gateway registration succeeds it calls
+     * {@link #initializationSucceeded(String)}; on failure it calls
+     * {@link #initializationFailed(String, Throwable)} and rolls back the gateway bindings.
      *
-     * @param newModel the model for the new cluster
-     * @return a future that completes when the cluster is in {@code SERVING}
+     * @param newModel the model for the new cluster; must not name a cluster already present
+     * @return an already-completed future (the operation is synchronous; the
+     *         {@link CompletableFuture} shape is preserved for caller symmetry with
+     *         {@link #removeVirtualCluster})
+     * @throws IllegalArgumentException if a cluster with this name already exists
      */
     public CompletableFuture<Void> addVirtualCluster(VirtualClusterModel newModel) {
-        // TODO: implement [create lifecycle in INITIALIZING] -> [register gateways] -> SERVING
-        // in the follow-up PR. See removeVirtualCluster Javadoc.
-        LOGGER.atWarn()
-                .addKeyValue("virtualCluster", newModel.getClusterName())
+        Objects.requireNonNull(newModel, "newModel must not be null");
+        String name = newModel.getClusterName();
+        if (lifecyclesByCluster.containsKey(name)) {
+            throw new IllegalArgumentException("Cluster already exists: " + name);
+        }
+        LOGGER.atInfo()
+                .addKeyValue("virtualCluster", name)
                 .addKeyValue("operation", "addVirtualCluster")
-                .log("reconfigure: per-VC lifecycle transitions not yet implemented; no-op stub invoked");
+                .log("reconfigure: created lifecycle in INITIALIZING; gateway registration is the orchestrator's responsibility");
+        lifecyclesByCluster.put(name, new VirtualClusterLifecycle(name, newModel.drainTimeout()));
         return CompletableFuture.completedFuture(null);
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
@@ -7,10 +7,12 @@ package io.kroxylicious.proxy.internal.reload;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,6 +20,9 @@ import org.slf4j.LoggerFactory;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.internal.VirtualClusterRegistry;
+import io.kroxylicious.proxy.internal.net.EndpointGateway;
+import io.kroxylicious.proxy.internal.net.EndpointRegistry;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.reload.ConcurrentReconfigureException;
 import io.kroxylicious.proxy.reload.ReconfigureError;
 import io.kroxylicious.proxy.reload.ReconfigureResult;
@@ -56,6 +61,7 @@ public class ConfigurationReloadOrchestrator {
     private final List<ChangeDetector> detectors;
     private final StaticSectionDiffer staticSectionDiffer;
     private final VirtualClusterRegistry virtualClusterRegistry;
+    private final EndpointRegistry endpointRegistry;
     private final PluginFactoryRegistry pfr;
 
     /**
@@ -75,6 +81,9 @@ public class ConfigurationReloadOrchestrator {
      *                               drives its {@code removeVirtualCluster} /
      *                               {@code replaceVirtualCluster} / {@code addVirtualCluster}
      *                               methods (currently no-ops; see class-level Javadoc)
+     * @param endpointRegistry       the proxy's endpoint registry; the orchestrator calls
+     *                               {@code registerVirtualCluster} / {@code deregisterVirtualCluster}
+     *                               on it when applying per-VC add/remove operations
      * @param pfr                    plugin factory registry, used by change detectors and
      *                               by filter-chain reconciliation
      * @param detectors              the change-detector pipeline to drive; production wiring
@@ -84,10 +93,12 @@ public class ConfigurationReloadOrchestrator {
      */
     public ConfigurationReloadOrchestrator(Configuration initialConfiguration,
                                            VirtualClusterRegistry virtualClusterRegistry,
+                                           EndpointRegistry endpointRegistry,
                                            PluginFactoryRegistry pfr,
                                            List<ChangeDetector> detectors) {
         this.currentConfiguration = Objects.requireNonNull(initialConfiguration, "initialConfiguration");
         this.virtualClusterRegistry = Objects.requireNonNull(virtualClusterRegistry, "virtualClusterRegistry");
+        this.endpointRegistry = Objects.requireNonNull(endpointRegistry, "endpointRegistry");
         this.pfr = Objects.requireNonNull(pfr, "pfr");
         this.staticSectionDiffer = new StaticSectionDiffer();
         this.detectors = List.copyOf(Objects.requireNonNull(detectors, "detectors"));
@@ -112,17 +123,16 @@ public class ConfigurationReloadOrchestrator {
      *               submitted configuration produces no changes (a no-op reconfigure);
      *               {@code currentConfiguration} is updated to the submitted value</li>
      *           <li>successfully with a {@link ReconfigureResult} (possibly with per-cluster
-     *               errors) when the submitted configuration removes one or more virtual
-     *               clusters and does not add or modify any; {@code currentConfiguration}
-     *               is updated to the submitted value</li>
+     *               errors) when the submitted configuration only removes and/or adds
+     *               virtual clusters (no modifies); {@code currentConfiguration} is updated
+     *               to the submitted value</li>
      *           <li>exceptionally with {@link StaticConfigurationChangedException} when the
      *               submitted configuration differs from the current one in any static
      *               section</li>
      *           <li>exceptionally with {@link ConcurrentReconfigureException} when another
      *               reconfigure is already in progress</li>
      *           <li>exceptionally with {@link UnsupportedOperationException} when the
-     *               submitted configuration would add or modify any virtual cluster
-     *               (placeholder for follow-up staircase steps)</li>
+     *               submitted configuration would modify any virtual cluster </li>
      *         </ul>
      */
     public CompletableFuture<ReconfigureResult> reconfigure(Configuration newConfig) {
@@ -157,28 +167,37 @@ public class ConfigurationReloadOrchestrator {
                 return CompletableFuture.completedFuture(ReconfigureResult.of(List.of()));
             }
 
-            // 5. Mixed-reconfigure guard. Submissions that ADD or MODIFY any virtual cluster
-            // would land at the per-VC modify/add placeholders below, which are still no-op
-            // stubs. Rather than partially apply the removes and leave the proxy in a half-
-            // reconciled state, reject the whole submission upfront.
-            if (!changeResult.clustersToModify().isEmpty() || !changeResult.clustersToAdd().isEmpty()) {
+            // 5. Mixed-reconfigure guard. Modify operations would land at the per-VC modify
+            // placeholder below, which is still a no-op stub. Reject submissions that require
+            // any modify rather than partially-applying the adds/removes around it.
+            if (!changeResult.clustersToModify().isEmpty()) {
                 throw new UnsupportedOperationException(
-                        "KafkaProxy.reconfigure() does not yet support add/replace operations. "
+                        "KafkaProxy.reconfigure() does not yet support modify operations. "
                                 + "Pre-flight, concurrency, validation, and change detection have completed; "
                                 + "this reconfigure was rejected because it would have required "
-                                + changeResult.clustersToAdd().size() + " cluster add(s) and "
                                 + changeResult.clustersToModify().size() + " cluster modify operation(s).");
             }
 
-            // 6. Per-VC remove. SEQUENTIAL. Errors are accumulated into
-            // a per-cluster list and surfaced via the ReconfigureResult; a failed cluster
-            // does not prevent subsequent removes from being attempted.
+            // 6. Per-VC remove. SEQUENTIAL. Errors are accumulated into a per-cluster list
+            // and surfaced via the ReconfigureResult; a failed cluster does not prevent
+            // subsequent removes from being attempted.
             var errors = new ArrayList<ReconfigureError>();
             for (String name : changeResult.clustersToRemove()) {
                 removeCluster(name, errors);
             }
 
-            // 7. Commit. currentConfiguration advances to the submitted value
+            // 7. Per-VC add. SEQUENTIAL, after removes. Same error-accumulation contract:
+            // a failed add does not prevent subsequent adds from being attempted. Adds run
+            // after removes so that endpoint conflicts produced by swap-style edits resolve
+            // in the right order.
+            if (!changeResult.clustersToAdd().isEmpty()) {
+                var newModelsByName = resolveModelsByName(newConfig);
+                for (String name : changeResult.clustersToAdd()) {
+                    addCluster(name, newModelsByName.get(name), errors);
+                }
+            }
+
+            // 8. Commit. currentConfiguration advances to the submitted value
             this.currentConfiguration = newConfig;
             return CompletableFuture.completedFuture(ReconfigureResult.of(errors));
         }
@@ -209,9 +228,7 @@ public class ConfigurationReloadOrchestrator {
             virtualClusterRegistry.removeVirtualCluster(clusterName).join();
         }
         catch (RuntimeException e) {
-            Throwable cause = e instanceof CompletionException ce && ce.getCause() != null
-                    ? ce.getCause()
-                    : e;
+            Throwable cause = unwrap(e);
             LOGGER.atWarn()
                     .setCause(cause)
                     .addKeyValue("virtualCluster", clusterName)
@@ -219,5 +236,78 @@ public class ConfigurationReloadOrchestrator {
                     .log("reconfigure: failed to remove virtual cluster");
             errors.add(new ReconfigureError(clusterName, cause));
         }
+    }
+
+    /**
+     * Attempt to add a single virtual cluster. Mirrors {@code KafkaProxy.start()}'s wiring:
+     * <ol>
+     *   <li>Ask the registry to create the lifecycle in {@code INITIALIZING}.</li>
+     *   <li>Bind each gateway via {@link EndpointRegistry#registerVirtualCluster}.</li>
+     *   <li>On success, transition the lifecycle to {@code SERVING} via
+     *       {@link VirtualClusterRegistry#initializationSucceeded}.</li>
+     *   <li>On bind failure, transition to {@code STOPPED} via
+     *       {@link VirtualClusterRegistry#initializationFailed} and best-effort deregister each
+     *       gateway to roll back any partial registration.</li>
+     * </ol>
+     * Mirrors {@link #removeCluster}'s error-accumulation contract: failures are recorded
+     * but do not stop subsequent adds.
+     */
+    private void addCluster(String clusterName, VirtualClusterModel newModel, List<ReconfigureError> errors) {
+        try {
+            // Step 1: pure bookkeeping — creates the lifecycle in INITIALIZING.
+            virtualClusterRegistry.addVirtualCluster(newModel).join();
+            // Step 2 (+ rollback on failure): bind gateways and transition the lifecycle.
+            bindGatewaysAndTransitionToServing(clusterName, newModel, errors);
+        }
+        catch (RuntimeException e) {
+            Throwable cause = unwrap(e);
+            LOGGER.atWarn()
+                    .setCause(cause)
+                    .addKeyValue("virtualCluster", clusterName)
+                    .addKeyValue("error", cause.getMessage())
+                    .log("reconfigure: failed to create lifecycle for virtual cluster");
+            errors.add(new ReconfigureError(clusterName, cause));
+        }
+    }
+
+    /**
+     * Register every gateway for {@code newModel}. On success, transitions the cluster's
+     * lifecycle to {@code SERVING}. On failure, drives the lifecycle to {@code STOPPED}
+     * via {@code FAILED}, issues best-effort deregister for every gateway (some may not
+     * have been registered yet — that's fine, {@code deregisterVirtualCluster} is idempotent),
+     * and adds a {@link ReconfigureError} to {@code errors}.
+     */
+    private void bindGatewaysAndTransitionToServing(String clusterName, VirtualClusterModel newModel, List<ReconfigureError> errors) {
+        List<EndpointGateway> gateways = List.copyOf(newModel.gateways().values());
+        var bindFutures = gateways.stream()
+                .map(g -> endpointRegistry.registerVirtualCluster(g).toCompletableFuture())
+                .toArray(CompletableFuture[]::new);
+        try {
+            CompletableFuture.allOf(bindFutures).join();
+        }
+        catch (RuntimeException bindError) {
+            Throwable cause = unwrap(bindError);
+            LOGGER.atWarn()
+                    .setCause(cause)
+                    .addKeyValue("virtualCluster", clusterName)
+                    .addKeyValue("error", cause.getMessage())
+                    .log("reconfigure: gateway registration failed; rolling back");
+            virtualClusterRegistry.initializationFailed(clusterName, cause);
+            for (var g : gateways) {
+                endpointRegistry.deregisterVirtualCluster(g);
+            }
+            errors.add(new ReconfigureError(clusterName, cause));
+            return;
+        }
+        virtualClusterRegistry.initializationSucceeded(clusterName);
+    }
+
+    private static Throwable unwrap(Throwable t) {
+        return t instanceof CompletionException ce && ce.getCause() != null ? ce.getCause() : t;
+    }
+
+    private Map<String, VirtualClusterModel> resolveModelsByName(Configuration newConfig) {
+        return newConfig.virtualClusterModel(pfr).stream()
+                .collect(Collectors.toUnmodifiableMap(VirtualClusterModel::getClusterName, m -> m));
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
@@ -192,7 +192,8 @@ public class ConfigurationReloadOrchestrator {
             // 7. Per-VC add. SEQUENTIAL, after removes. Same error-accumulation contract:
             // a failed add does not prevent subsequent adds from being attempted. Adds run
             // after removes so that endpoint conflicts produced by swap-style edits resolve
-            // in the right order.
+            // in the right order. addCluster() asserts model non-null with a clear diagnostic
+            // for the most likely contract violation (a buggy ChangeDetector).
             if (!changeResult.clustersToAdd().isEmpty()) {
                 var newModelsByName = resolveModelsByName(newConfig);
                 for (String name : changeResult.clustersToAdd()) {
@@ -244,6 +245,9 @@ public class ConfigurationReloadOrchestrator {
     /**
      * Attempt to add a single virtual cluster:
      * <ol>
+     *   <li>Validate {@code newModel} is non-null — this is the canonical place to surface
+     *       a {@link io.kroxylicious.proxy.internal.reload.ChangeDetector} contract violation
+     *       (a name reported as "to add" with no matching model in the submitted config).</li>
      *   <li>Ask the registry to create the lifecycle in {@code INITIALIZING}.</li>
      *   <li>Bind each gateway via {@link EndpointRegistry#registerVirtualCluster}.</li>
      *   <li>On success, transition the lifecycle to {@code SERVING} via
@@ -254,6 +258,12 @@ public class ConfigurationReloadOrchestrator {
      * </ol>
      */
     private void addCluster(String clusterName, VirtualClusterModel newModel, List<ReconfigureError> errors) {
+        if (newModel == null) {
+            throw new IllegalStateException(
+                    "addCluster called with null model for cluster '" + clusterName
+                            + "'; this indicates a ChangeDetector contract violation"
+                            + " (cluster reported as added but absent from the submitted configuration)");
+        }
         try {
             // Step 1: pure bookkeeping — creates the lifecycle in INITIALIZING.
             virtualClusterRegistry.addVirtualCluster(newModel).join();
@@ -294,8 +304,20 @@ public class ConfigurationReloadOrchestrator {
                     .addKeyValue(LOG_KEY_ERROR, cause.getMessage())
                     .log("reconfigure: gateway registration failed; rolling back");
             virtualClusterRegistry.initializationFailed(clusterName, cause);
+
+            // Best-effort rollback. Fire-and-forget per gateway, but attach an exceptionally
+            // handler so a deregister failure surfaces in operator-visible logs — without
+            // logging silently, a stuck port binding after a failed add would be invisible.
             for (var g : gateways) {
-                endpointRegistry.deregisterVirtualCluster(g);
+                endpointRegistry.deregisterVirtualCluster(g)
+                        .exceptionally(ex -> {
+                            LOGGER.atWarn()
+                                    .setCause(LOGGER.isDebugEnabled() ? ex : null)
+                                    .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, clusterName)
+                                    .addKeyValue(LOG_KEY_ERROR, ex.getMessage())
+                                    .log("reconfigure: rollback deregister failed; gateway binding may remain active");
+                            return null;
+                        });
             }
             errors.add(new ReconfigureError(clusterName, cause));
             return;

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
@@ -57,6 +57,9 @@ public class ConfigurationReloadOrchestrator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationReloadOrchestrator.class);
 
+    private static final String LOG_KEY_VIRTUAL_CLUSTER = "virtualCluster";
+    private static final String LOG_KEY_ERROR = "error";
+
     private final ReentrantLock reconfigureLock = new ReentrantLock();
     private final List<ChangeDetector> detectors;
     private final StaticSectionDiffer staticSectionDiffer;
@@ -204,7 +207,7 @@ public class ConfigurationReloadOrchestrator {
         catch (RuntimeException e) {
             LOGGER.atError()
                     .setCause(e)
-                    .addKeyValue("error", e.getMessage())
+                    .addKeyValue(LOG_KEY_ERROR, e.getMessage())
                     .log("reconfigure failed");
             return CompletableFuture.failedFuture(e);
         }
@@ -231,8 +234,8 @@ public class ConfigurationReloadOrchestrator {
             Throwable cause = unwrap(e);
             LOGGER.atWarn()
                     .setCause(cause)
-                    .addKeyValue("virtualCluster", clusterName)
-                    .addKeyValue("error", cause.getMessage())
+                    .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, clusterName)
+                    .addKeyValue(LOG_KEY_ERROR, cause.getMessage())
                     .log("reconfigure: failed to remove virtual cluster");
             errors.add(new ReconfigureError(clusterName, cause));
         }
@@ -261,8 +264,8 @@ public class ConfigurationReloadOrchestrator {
             Throwable cause = unwrap(e);
             LOGGER.atWarn()
                     .setCause(cause)
-                    .addKeyValue("virtualCluster", clusterName)
-                    .addKeyValue("error", cause.getMessage())
+                    .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, clusterName)
+                    .addKeyValue(LOG_KEY_ERROR, cause.getMessage())
                     .log("reconfigure: failed to create lifecycle for virtual cluster");
             errors.add(new ReconfigureError(clusterName, cause));
         }
@@ -287,8 +290,8 @@ public class ConfigurationReloadOrchestrator {
             Throwable cause = unwrap(bindError);
             LOGGER.atWarn()
                     .setCause(cause)
-                    .addKeyValue("virtualCluster", clusterName)
-                    .addKeyValue("error", cause.getMessage())
+                    .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, clusterName)
+                    .addKeyValue(LOG_KEY_ERROR, cause.getMessage())
                     .log("reconfigure: gateway registration failed; rolling back");
             virtualClusterRegistry.initializationFailed(clusterName, cause);
             for (var g : gateways) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
@@ -239,7 +239,7 @@ public class ConfigurationReloadOrchestrator {
     }
 
     /**
-     * Attempt to add a single virtual cluster. Mirrors {@code KafkaProxy.start()}'s wiring:
+     * Attempt to add a single virtual cluster:
      * <ol>
      *   <li>Ask the registry to create the lifecycle in {@code INITIALIZING}.</li>
      *   <li>Bind each gateway via {@link EndpointRegistry#registerVirtualCluster}.</li>
@@ -249,8 +249,6 @@ public class ConfigurationReloadOrchestrator {
      *       {@link VirtualClusterRegistry#initializationFailed} and best-effort deregister each
      *       gateway to roll back any partial registration.</li>
      * </ol>
-     * Mirrors {@link #removeCluster}'s error-accumulation contract: failures are recorded
-     * but do not stop subsequent adds.
      */
     private void addCluster(String clusterName, VirtualClusterModel newModel, List<ReconfigureError> errors) {
         try {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
@@ -718,7 +718,7 @@ class VirtualClusterRegistryTest {
     }
 
     @Test
-    void addVirtualClusterStubReturnsCompletedFutureWithoutCreatingLifecycle() {
+    void addVirtualClusterCreatesLifecycleInInitializing() {
         // given
         var newModel = mockModel(CLUSTER_B);
         assertThat(vcc.lifecycleFor(CLUSTER_B)).isNull();
@@ -726,10 +726,28 @@ class VirtualClusterRegistryTest {
         // when
         var future = vcc.addVirtualCluster(newModel);
 
-        // then
+        // then — future already completed; lifecycle exists in INITIALIZING (orchestrator will
+        // call initializationSucceeded once gateways are bound).
         assertThat(future).isCompleted();
-        // the stub doesn't actually create a lifecycle for the new cluster
-        assertThat(vcc.lifecycleFor(CLUSTER_B)).isNull();
+        assertThat(vcc.lifecycleFor(CLUSTER_B)).isNotNull()
+                .extracting(VirtualClusterLifecycle::state)
+                .isInstanceOf(VirtualClusterLifecycleState.Initializing.class);
+    }
+
+    @Test
+    void addVirtualClusterRejectsDuplicateName() {
+        // CLUSTER_A is already present from setUp
+        var duplicate = mockModel(CLUSTER_A);
+        assertThatThrownBy(() -> vcc.addVirtualCluster(duplicate))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(CLUSTER_A);
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void addVirtualClusterRejectsNullModel() {
+        assertThatThrownBy(() -> vcc.addVirtualCluster(null))
+                .isInstanceOf(NullPointerException.class);
     }
 
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
@@ -371,11 +371,11 @@ class ConfigurationReloadOrchestratorTest {
     @Test
     void perClusterAddFailureSurfacesAsReconfigureErrorAndOthersStillRun() {
         // Two clusters are being added. The registry's addVirtualCluster (bookkeeping) for
-        // one of them returns a failed future; the other returns a completed future. The
-        // orchestrator must:
-        // (a) still attempt the second add (failure of one does not abort the loop);
-        // (b) surface the failure as a per-cluster ReconfigureError in the result;
-        // (c) return a successful future overall (ReconfigureResult conveys partial failure).
+        // one of them returns a failed future; the other returns a completed future.
+        // Required orchestrator behaviour:
+        // - still attempt the second add (failure of one does not abort the loop);
+        // - surface the failure as a per-cluster ReconfigureError in the result;
+        // - return a successful future overall (ReconfigureResult conveys partial failure).
         var oldConfig = configWith(vc("cluster-a"));
         var newConfig = configWith(vc("cluster-a"), vc("cluster-b"), vc("cluster-c"));
 
@@ -404,10 +404,11 @@ class ConfigurationReloadOrchestratorTest {
     @Test
     void perClusterRemoveFailureSurfacesAsReconfigureErrorAndOthersStillRun() {
         // Two clusters are being removed. The registry's removeVirtualCluster for one of them
-        // returns a failed future; the other returns a completed future. The orchestrator must:
-        // (a) still attempt the second removal (failure of one does not abort the loop);
-        // (b) surface the failure as a per-cluster ReconfigureError in the result;
-        // (c) return a successful future overall (ReconfigureResult conveys partial failure).
+        // returns a failed future; the other returns a completed future.
+        // Required orchestrator behaviour:
+        // - still attempt the second removal (failure of one does not abort the loop);
+        // - surface the failure as a per-cluster ReconfigureError in the result;
+        // - return a successful future overall (ReconfigureResult conveys partial failure).
         var oldConfig = configWith(vc("cluster-a"), vc("cluster-b"), vc("cluster-c"));
         var newConfig = configWith(vc("cluster-a")); // removes cluster-b AND cluster-c
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
@@ -25,6 +25,9 @@ import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.config.VirtualCluster;
 import io.kroxylicious.proxy.config.VirtualClusterGateway;
 import io.kroxylicious.proxy.internal.VirtualClusterRegistry;
+import io.kroxylicious.proxy.internal.net.EndpointGateway;
+import io.kroxylicious.proxy.internal.net.EndpointRegistry;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.reload.ConcurrentReconfigureException;
 import io.kroxylicious.proxy.reload.StaticConfigurationChangedException;
 import io.kroxylicious.proxy.service.HostPort;
@@ -33,6 +36,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -82,8 +87,12 @@ class ConfigurationReloadOrchestratorTest {
     }
 
     @Test
-    void clusterAdditionInvokesAddNoOpThenThrows() {
-        // given — old has cluster-a, new has cluster-a + cluster-b → addVirtualCluster is called
+    void pureAddCompletesSuccessfullyAndDrivesBookkeepingAndBindingAndServingTransition() {
+        // given — old has cluster-a, new has cluster-a + cluster-b. With step 2 of the
+        // staircase, a pure-add reconfigure is supported end-to-end. The orchestrator drives:
+        // 1. vcr.addVirtualCluster(newModel) — bookkeeping (lifecycle in INITIALIZING)
+        // 2. endpointRegistry.registerVirtualCluster — bind every gateway
+        // 3. vcr.initializationSucceeded(name) — transition to SERVING
         var oldConfig = configWith(vc("cluster-a"));
         var newConfig = configWith(vc("cluster-a"), vc("cluster-b"));
         var registry = stubbedRegistry();
@@ -92,13 +101,63 @@ class ConfigurationReloadOrchestratorTest {
         // when
         var future = orchestrator.reconfigure(newConfig);
 
-        // then
-        assertThat(future).isCompletedExceptionally();
-        assertThatThrownBy(future::join).cause().isInstanceOf(UnsupportedOperationException.class);
+        // then — successful with no errors.
+        assertThat(future).isCompletedWithValueMatching(r -> !r.hasErrors());
 
-        verify(registry, never()).addVirtualCluster(any());
+        // Step 1: addVirtualCluster invoked for the new cluster only.
+        var captor = ArgumentCaptor.forClass(VirtualClusterModel.class);
+        verify(registry).addVirtualCluster(captor.capture());
+        assertThat(captor.getValue().getClusterName()).isEqualTo("cluster-b");
+
+        // Step 2: at least one gateway was registered. (cluster-b's vc() helper builds a
+        // single "default" gateway, so we expect exactly one register call for this test.)
+        verify(endpointRegistry).registerVirtualCluster(any(EndpointGateway.class));
+
+        // Step 3: lifecycle transitioned to SERVING.
+        verify(registry).initializationSucceeded("cluster-b");
+
+        // Negative assertions: no remove/replace happened, no rollback deregister fired.
         verify(registry, never()).removeVirtualCluster(anyString());
         verify(registry, never()).replaceVirtualCluster(anyString(), any());
+        verify(registry, never()).initializationFailed(anyString(), any());
+        verify(endpointRegistry, never()).deregisterVirtualCluster(any(EndpointGateway.class));
+    }
+
+    @Test
+    void addClusterBindFailureRollsBackAndSurfacesError() {
+        // given — pure-add reconfigure where endpointRegistry.registerVirtualCluster fails.
+        // The orchestrator must:
+        // - call vcr.addVirtualCluster (bookkeeping always runs first)
+        // - observe the bind failure
+        // - call vcr.initializationFailed to drive the lifecycle Stopped via Failed
+        // - issue a best-effort deregisterVirtualCluster for each gateway (rollback)
+        // - surface a per-cluster ReconfigureError in the result (not an exceptional future)
+        var oldConfig = configWith(vc("cluster-a"));
+        var newConfig = configWith(vc("cluster-a"), vc("cluster-b"));
+        var registry = stubbedRegistry();
+
+        // Override the shared endpointRegistry to fail every register call.
+        var bindFailure = new IllegalStateException("simulated bind failure");
+        when(endpointRegistry.registerVirtualCluster(any(EndpointGateway.class)))
+                .thenReturn(CompletableFuture.failedStage(bindFailure));
+
+        var orchestrator = newOrchestrator(oldConfig, registry);
+
+        // when
+        var future = orchestrator.reconfigure(newConfig);
+
+        // then — completes successfully with one error for cluster-b.
+        assertThat(future).isCompletedWithValueMatching(r -> r.hasErrors()
+                && r.errors().size() == 1
+                && r.errors().iterator().next().humanReadableIdentifier().equals("cluster-b")
+                && r.errors().iterator().next().cause() == bindFailure);
+
+        // Verify the orchestrator drove the full rollback sequence.
+        verify(registry).addVirtualCluster(argThat(m -> m != null && "cluster-b".equals(m.getClusterName())));
+        verify(registry).initializationFailed("cluster-b", bindFailure);
+        verify(endpointRegistry).deregisterVirtualCluster(any(EndpointGateway.class));
+        // Critically: initializationSucceeded must NOT have fired.
+        verify(registry, never()).initializationSucceeded("cluster-b");
     }
 
     @Test
@@ -126,19 +185,21 @@ class ConfigurationReloadOrchestratorTest {
     void lockIsReleasedOnExceptionSoSubsequentCallsCanProceed() {
         // After the first reconfigure throws UnsupportedOperationException, a second call
         // must not be rejected with ConcurrentReconfigureException — the lock should be
-        // released even on exception via the finally block. Use a config with a real
-        // cluster change so the orchestrator reaches the placeholder UOE rather than
-        // the no-op early-return.
-        var oldConfig = configWith(vc("cluster-a"));
-        var newConfig = configWith(vc("cluster-a"), vc("cluster-b"));
-        var registry = stubbedRegistry();
-        var orchestrator = newOrchestrator(oldConfig, registry);
+        // released even on exception via the finally block. Inject a detector that produces
+        // a modify (the only operation still unsupported under step 2) so the orchestrator
+        // reaches the placeholder UOE rather than the no-op early-return.
+        var config = configWith(vc("cluster-a"));
+        var modifyDetector = mock(ChangeDetector.class);
+        when(modifyDetector.detect(any())).thenReturn(new ChangeResult(
+                Set.of(), Set.of(), Set.of("cluster-a")));
+        var orchestrator = new ConfigurationReloadOrchestrator(
+                config, stubbedRegistry(), endpointRegistry, mock(PluginFactoryRegistry.class), List.of(modifyDetector));
 
-        var first = orchestrator.reconfigure(newConfig);
+        var first = orchestrator.reconfigure(config);
         assertThat(first).isCompletedExceptionally();
         assertThatThrownBy(first::join).cause().isInstanceOf(UnsupportedOperationException.class);
 
-        var second = orchestrator.reconfigure(newConfig);
+        var second = orchestrator.reconfigure(config);
         assertThat(second).isCompletedExceptionally();
         // Second call should also throw UOE (not ConcurrentReconfigureException).
         assertThatThrownBy(second::join).cause().isInstanceOf(UnsupportedOperationException.class);
@@ -219,7 +280,7 @@ class ConfigurationReloadOrchestratorTest {
         when(capturingDetector.detect(any())).thenReturn(ChangeResult.EMPTY);
 
         var orchestrator = new ConfigurationReloadOrchestrator(
-                initialConfig, mock(VirtualClusterRegistry.class),
+                initialConfig, mock(VirtualClusterRegistry.class), endpointRegistry,
                 mock(PluginFactoryRegistry.class), List.of(capturingDetector));
 
         orchestrator.reconfigure(firstSubmittedConfig).join();
@@ -247,7 +308,7 @@ class ConfigurationReloadOrchestratorTest {
 
         var registry = stubbedRegistry();
         var orchestrator = new ConfigurationReloadOrchestrator(
-                config, registry, mock(PluginFactoryRegistry.class), List.of(customDetector));
+                config, registry, endpointRegistry, mock(PluginFactoryRegistry.class), List.of(customDetector));
 
         // when
         var future = orchestrator.reconfigure(config);
@@ -263,10 +324,10 @@ class ConfigurationReloadOrchestratorTest {
     }
 
     @Test
-    void mixedReconfigureWithRemoveAndAddIsRejectedUpfront() {
-        // A reconfigure that BOTH removes and adds clusters is a mixed result. Step 1 of the
-        // staircase rejects this upfront with UOE rather than processing the removes and then
-        // throwing for the adds (which would leave the proxy in a partial-state outcome).
+    void mixedAddAndRemoveCompletesSuccessfullyAndExecutesRemovesBeforeAdds() {
+        // A reconfigure that BOTH removes and adds clusters is supported under step 2. Removes
+        // are executed BEFORE adds so swap-style edits (e.g. moving an endpoint between VCs)
+        // resolve cleanly without overlapping binding conflicts.
         var oldConfig = configWith(vc("cluster-a"), vc("cluster-b"));
         var newConfig = configWith(vc("cluster-a"), vc("cluster-c")); // removes cluster-b, adds cluster-c
         var registry = stubbedRegistry();
@@ -274,12 +335,70 @@ class ConfigurationReloadOrchestratorTest {
 
         var future = orchestrator.reconfigure(newConfig);
 
+        assertThat(future).isCompletedWithValueMatching(r -> !r.hasErrors());
+        var inOrder = inOrder(registry);
+        inOrder.verify(registry).removeVirtualCluster("cluster-b");
+        inOrder.verify(registry).addVirtualCluster(argThat(m -> m.getClusterName().equals("cluster-c")));
+        verify(registry, never()).replaceVirtualCluster(anyString(), any());
+    }
+
+    @Test
+    void modifyOnlyReconfigureIsRejectedUpfront() {
+        // A modify-only reconfigure is still unsupported and rejected upfront with UOE
+        // before any per-VC work runs. We inject a detector that produces a clustersToModify
+        // entry because the production detectors require an actual filter/cluster change to
+        // surface a modify; this lets the test focus on the orchestrator's guard behaviour.
+        var config = configWith(vc("cluster-a"));
+        var customDetector = mock(ChangeDetector.class);
+        when(customDetector.detect(any())).thenReturn(new ChangeResult(
+                Set.of(),
+                Set.of(),
+                Set.of("cluster-a")));
+
+        var registry = stubbedRegistry();
+        var orchestrator = new ConfigurationReloadOrchestrator(
+                config, registry, endpointRegistry, mock(PluginFactoryRegistry.class), List.of(customDetector));
+
+        var future = orchestrator.reconfigure(config);
+
         assertThat(future).isCompletedExceptionally();
         assertThatThrownBy(future::join).cause().isInstanceOf(UnsupportedOperationException.class);
-        // No registry methods invoked — rejection happens before the per-VC loop.
         verify(registry, never()).removeVirtualCluster(anyString());
         verify(registry, never()).addVirtualCluster(any());
         verify(registry, never()).replaceVirtualCluster(anyString(), any());
+    }
+
+    @Test
+    void perClusterAddFailureSurfacesAsReconfigureErrorAndOthersStillRun() {
+        // Two clusters are being added. The registry's addVirtualCluster (bookkeeping) for
+        // one of them returns a failed future; the other returns a completed future. The
+        // orchestrator must:
+        // (a) still attempt the second add (failure of one does not abort the loop);
+        // (b) surface the failure as a per-cluster ReconfigureError in the result;
+        // (c) return a successful future overall (ReconfigureResult conveys partial failure).
+        var oldConfig = configWith(vc("cluster-a"));
+        var newConfig = configWith(vc("cluster-a"), vc("cluster-b"), vc("cluster-c"));
+
+        var registry = mock(VirtualClusterRegistry.class);
+        var bSpecificFailure = new IllegalStateException("simulated bookkeeping failure on cluster-b");
+        when(registry.addVirtualCluster(argThat(m -> m != null && "cluster-b".equals(m.getClusterName()))))
+                .thenReturn(CompletableFuture.failedFuture(bSpecificFailure));
+        when(registry.addVirtualCluster(argThat(m -> m != null && "cluster-c".equals(m.getClusterName()))))
+                .thenReturn(CompletableFuture.completedFuture(null));
+
+        var orchestrator = newOrchestrator(oldConfig, registry);
+
+        var future = orchestrator.reconfigure(newConfig);
+
+        // Both adds attempted.
+        verify(registry).addVirtualCluster(argThat(m -> m != null && "cluster-b".equals(m.getClusterName())));
+        verify(registry).addVirtualCluster(argThat(m -> m != null && "cluster-c".equals(m.getClusterName())));
+
+        // Future succeeds (with errors inside the result), not exceptional.
+        assertThat(future).isCompletedWithValueMatching(r -> r.hasErrors()
+                && r.errors().size() == 1
+                && r.errors().iterator().next().humanReadableIdentifier().equals("cluster-b")
+                && r.errors().iterator().next().cause() == bSpecificFailure);
     }
 
     @Test
@@ -329,7 +448,7 @@ class ConfigurationReloadOrchestratorTest {
                 ChangeResult.EMPTY);
 
         var orchestrator = new ConfigurationReloadOrchestrator(
-                initialConfig, stubbedRegistry(), mock(PluginFactoryRegistry.class), List.of(capturingDetector));
+                initialConfig, stubbedRegistry(), endpointRegistry, mock(PluginFactoryRegistry.class), List.of(capturingDetector));
 
         orchestrator.reconfigure(afterRemove).join();
         orchestrator.reconfigure(afterRemove).join();
@@ -346,21 +465,37 @@ class ConfigurationReloadOrchestratorTest {
 
     // -------- fixture helpers --------
 
+    /**
+     * A single shared {@link EndpointRegistry} mock per test, stubbed to succeed for every
+     * {@code registerVirtualCluster} call. Tests that need bind failure override this
+     * per-test (see {@link #addClusterBindFailureRollsBackAndSurfacesError()}).
+     */
+    private final EndpointRegistry endpointRegistry = stubbedEndpointRegistry();
+
     private ConfigurationReloadOrchestrator newOrchestrator(Configuration initial, VirtualClusterRegistry registry) {
-        return new ConfigurationReloadOrchestrator(initial, registry, mock(PluginFactoryRegistry.class),
+        return new ConfigurationReloadOrchestrator(initial, registry, endpointRegistry, mock(PluginFactoryRegistry.class),
                 ConfigurationReloadOrchestrator.defaultDetectors());
     }
 
     /**
-     * A {@link VirtualClusterRegistry} mock where the three reconfigure operations are all
-     * stubbed to return a completed future, mirroring the production stub behaviour. Used in
-     * tests that don't need per-call observation of the registry.
+     * A {@link VirtualClusterRegistry} mock where the reconfigure operations are stubbed to
+     * return a completed future, mirroring the production stub behaviour. Used in tests that
+     * don't need per-call observation of the registry.
      */
     private static VirtualClusterRegistry stubbedRegistry() {
         var registry = mock(VirtualClusterRegistry.class);
         when(registry.removeVirtualCluster(anyString())).thenReturn(CompletableFuture.completedFuture(null));
         when(registry.replaceVirtualCluster(anyString(), any())).thenReturn(CompletableFuture.completedFuture(null));
         when(registry.addVirtualCluster(any())).thenReturn(CompletableFuture.completedFuture(null));
+        return registry;
+    }
+
+    private static EndpointRegistry stubbedEndpointRegistry() {
+        var registry = mock(EndpointRegistry.class);
+        when(registry.registerVirtualCluster(any(EndpointGateway.class)))
+                .thenReturn(CompletableFuture.completedStage(null));
+        when(registry.deregisterVirtualCluster(any(EndpointGateway.class)))
+                .thenReturn(CompletableFuture.completedStage(null));
         return registry;
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
@@ -87,7 +87,7 @@ class ConfigurationReloadOrchestratorTest {
     }
 
     @Test
-    void pureAddCompletesSuccessfullyAndDrivesBookkeepingAndBindingAndServingTransition() {
+    void shouldTransitionAddedClusterToServing() {
         // given — old has cluster-a, new has cluster-a + cluster-b. With step 2 of the
         // staircase, a pure-add reconfigure is supported end-to-end. The orchestrator drives:
         // 1. vcr.addVirtualCluster(newModel) — bookkeeping (lifecycle in INITIALIZING)
@@ -124,7 +124,7 @@ class ConfigurationReloadOrchestratorTest {
     }
 
     @Test
-    void addClusterBindFailureRollsBackAndSurfacesError() {
+    void shouldSurfaceErrorAndRollbackWhenGatewayBindFails() {
         // given — pure-add reconfigure where endpointRegistry.registerVirtualCluster fails.
         // The orchestrator must:
         // - call vcr.addVirtualCluster (bookkeeping always runs first)
@@ -158,6 +158,39 @@ class ConfigurationReloadOrchestratorTest {
         verify(endpointRegistry).deregisterVirtualCluster(any(EndpointGateway.class));
         // Critically: initializationSucceeded must NOT have fired.
         verify(registry, never()).initializationSucceeded("cluster-b");
+    }
+
+    @Test
+    void shouldNotPropagateRollbackDeregisterFailureWhenBindAlsoFailed() {
+        // The bind failed (primary reason the add is being rolled back). The subsequent
+        // deregister rollback ALSO fails. The orchestrator must:
+        // - log the deregister failure (operator-visible) but not propagate it;
+        // - keep the per-cluster ReconfigureError carrying the original bind cause,
+        // not the deregister cause — the deregister is a side-effect, not the trigger.
+        var oldConfig = configWith(vc("cluster-a"));
+        var newConfig = configWith(vc("cluster-a"), vc("cluster-b"));
+        var registry = stubbedRegistry();
+
+        var bindFailure = new IllegalStateException("simulated bind failure");
+        var rollbackFailure = new IllegalStateException("simulated deregister failure during rollback");
+        when(endpointRegistry.registerVirtualCluster(any(EndpointGateway.class)))
+                .thenReturn(CompletableFuture.failedStage(bindFailure));
+        when(endpointRegistry.deregisterVirtualCluster(any(EndpointGateway.class)))
+                .thenReturn(CompletableFuture.failedStage(rollbackFailure));
+
+        var orchestrator = newOrchestrator(oldConfig, registry);
+
+        var future = orchestrator.reconfigure(newConfig);
+
+        // The reconfigure future is still non-exceptional; the ReconfigureError carries the
+        // BIND cause, not the deregister cause.
+        assertThat(future).isCompletedWithValueMatching(r -> r.hasErrors()
+                && r.errors().size() == 1
+                && r.errors().iterator().next().humanReadableIdentifier().equals("cluster-b")
+                && r.errors().iterator().next().cause() == bindFailure);
+
+        // Deregister was attempted.
+        verify(endpointRegistry).deregisterVirtualCluster(any(EndpointGateway.class));
     }
 
     @Test
@@ -324,7 +357,7 @@ class ConfigurationReloadOrchestratorTest {
     }
 
     @Test
-    void mixedAddAndRemoveCompletesSuccessfullyAndExecutesRemovesBeforeAdds() {
+    void shouldExecuteRemovesBeforeAddsInMixedReconfigure() {
         // A reconfigure that BOTH removes and adds clusters is supported under step 2. Removes
         // are executed BEFORE adds so swap-style edits (e.g. moving an endpoint between VCs)
         // resolve cleanly without overlapping binding conflicts.
@@ -369,7 +402,42 @@ class ConfigurationReloadOrchestratorTest {
     }
 
     @Test
-    void perClusterAddFailureSurfacesAsReconfigureErrorAndOthersStillRun() {
+    void shouldFailFastWhenChangeDetectorReportsAddForClusterMissingFromNewConfig() {
+        // Programming-error guard: if a ChangeDetector lies and reports a cluster as added
+        // when that cluster isn't present in the submitted newConfig's models, the orchestrator
+        // must fail loud (IllegalStateException via addCluster's null-model guard) rather than
+        // NPE deep inside VCR or surface it as a per-cluster ReconfigureError (the cluster
+        // isn't the cause of the failure; the detector contract is). We inject a custom
+        // detector that reports a phantom add.
+        var config = configWith(vc("cluster-a"));
+        var phantomDetector = mock(ChangeDetector.class);
+        when(phantomDetector.detect(any())).thenReturn(new ChangeResult(
+                Set.of("phantom-cluster"), // detector lies: this cluster is not in any config
+                Set.of(),
+                Set.of()));
+
+        var registry = stubbedRegistry();
+        var orchestrator = new ConfigurationReloadOrchestrator(
+                config, registry, endpointRegistry, mock(PluginFactoryRegistry.class), List.of(phantomDetector));
+
+        var future = orchestrator.reconfigure(config);
+
+        // Future fails with IllegalStateException naming the phantom cluster and pointing
+        // at the ChangeDetector contract as the diagnostic origin.
+        assertThat(future).isCompletedExceptionally();
+        assertThatThrownBy(future::join)
+                .cause()
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("phantom-cluster")
+                .hasMessageContaining("ChangeDetector contract violation");
+
+        // addCluster's guard fires BEFORE the VCR bookkeeping call, so the registry's
+        // addVirtualCluster method must not have been invoked.
+        verify(registry, never()).addVirtualCluster(any());
+    }
+
+    @Test
+    void shouldContinueAddingClustersAfterPerClusterFailure() {
         // Two clusters are being added. The registry's addVirtualCluster (bookkeeping) for
         // one of them returns a failed future; the other returns a completed future.
         // Required orchestrator behaviour:
@@ -402,7 +470,7 @@ class ConfigurationReloadOrchestratorTest {
     }
 
     @Test
-    void perClusterRemoveFailureSurfacesAsReconfigureErrorAndOthersStillRun() {
+    void shouldContinueRemovingClustersAfterPerClusterFailure() {
         // Two clusters are being removed. The registry's removeVirtualCluster for one of them
         // returns a failed future; the other returns a completed future.
         // Required orchestrator behaviour:
@@ -469,7 +537,7 @@ class ConfigurationReloadOrchestratorTest {
     /**
      * A single shared {@link EndpointRegistry} mock per test, stubbed to succeed for every
      * {@code registerVirtualCluster} call. Tests that need bind failure override this
-     * per-test (see {@link #addClusterBindFailureRollsBackAndSurfacesError()}).
+     * per-test (see {@link #shouldSurfaceErrorAndRollbackWhenGatewayBindFails()}).
      */
     private final EndpointRegistry endpointRegistry = stubbedEndpointRegistry();
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As per the [discussed sequence](https://github.com/kroxylicious/kroxylicious/pull/3977#discussion_r3270313081), I have added the actual implementation to the `addVirtualCluster()` method.
With this hot-reload will now support addition of VC's.

### Additional Context

https://github.com/kroxylicious/kroxylicious/issues/3998

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
