### PR TITLE
refactor(runtime): collapse SelectingServer and Connecting into Forwarding

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionState.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionState.java
@@ -6,24 +6,13 @@
 
 package io.kroxylicious.proxy.internal;
 
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-
-import org.apache.kafka.common.message.ApiVersionsRequestData;
-
-import io.kroxylicious.proxy.frame.DecodedRequestFrame;
-import io.kroxylicious.proxy.internal.net.HaProxyContext;
-import io.kroxylicious.proxy.service.HostPort;
-
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static io.kroxylicious.proxy.internal.ClientConnectionState.ClientActive;
 import static io.kroxylicious.proxy.internal.ClientConnectionState.Closed;
-import static io.kroxylicious.proxy.internal.ClientConnectionState.Connecting;
 import static io.kroxylicious.proxy.internal.ClientConnectionState.Draining;
 import static io.kroxylicious.proxy.internal.ClientConnectionState.Forwarding;
 import static io.kroxylicious.proxy.internal.ClientConnectionState.HaProxy;
-import static io.kroxylicious.proxy.internal.ClientConnectionState.SelectingServer;
 import static io.kroxylicious.proxy.internal.ClientConnectionState.Startup;
 
 /**
@@ -33,8 +22,6 @@ sealed interface ClientConnectionState permits
         Startup,
         ClientActive,
         HaProxy,
-        SelectingServer,
-        Connecting,
         Forwarding,
         Draining,
         Closed {
@@ -65,132 +52,39 @@ sealed interface ClientConnectionState permits
         }
 
         /**
-         * Transition to {@link SelectingServer}, because some non-ApiVersions request has been received
-         * @return The Connecting state
+         * Transition to {@link Forwarding}, because a client request has been received
+         * and a backend connection is being initiated.
+         * @return The Forwarding state
          */
-        public SelectingServer toSelectingServer(@Nullable DecodedRequestFrame<ApiVersionsRequestData> apiVersionsFrame) {
-            return new SelectingServer(
-                    apiVersionsFrame == null ? null : apiVersionsFrame.body().clientSoftwareName(),
-                    apiVersionsFrame == null ? null : apiVersionsFrame.body().clientSoftwareVersion());
+        public Forwarding toForwarding() {
+            return new Forwarding();
         }
     }
 
     /**
      * A PROXY protocol header has been received on the channel.
      * The connection metadata is captured in the {@link KafkaSession}'s
-     * {@link HaProxyContext}.
+     * {@link io.kroxylicious.proxy.internal.net.HaProxyContext}.
      */
     record HaProxy()
             implements ClientConnectionState {
 
         /**
-         * Transition to {@link SelectingServer}, because some non-ApiVersions request has been received
-         * @return The Connecting state
-         */
-        public SelectingServer toSelectingServer(@Nullable DecodedRequestFrame<ApiVersionsRequestData> apiVersionsFrame) {
-            return new SelectingServer(
-                    apiVersionsFrame == null ? null : apiVersionsFrame.body().clientSoftwareName(),
-                    apiVersionsFrame == null ? null : apiVersionsFrame.body().clientSoftwareVersion());
-        }
-    }
-
-    /**
-     * A channel to the server is now required.
-     * @param clientSoftwareName
-     * @param clientSoftwareVersion
-     */
-    record SelectingServer(@Nullable String clientSoftwareName,
-                           @Nullable String clientSoftwareVersion)
-            implements ClientConnectionState {
-
-        /**
-         * Transition to {@link Connecting}
-         * @return The Connecting state
-         */
-        public Connecting toConnecting(HostPort remote) {
-            return new Connecting(clientSoftwareName,
-                    clientSoftwareVersion, remote);
-        }
-    }
-
-    /**
-     * The connection has started but the channel to it is not yet active.
-     *
-     * @param clientSoftwareName
-     * @param clientSoftwareVersion
-     * @param remote
-     */
-    record Connecting(@Nullable String clientSoftwareName,
-                      @Nullable String clientSoftwareVersion,
-                      HostPort remote)
-            implements ClientConnectionState {
-
-        /**
-         * Transition to {@link Forwarding}
+         * Transition to {@link Forwarding}, because a client request has been received
+         * and a backend connection is being initiated.
          * @return The Forwarding state
          */
         public Forwarding toForwarding() {
-            return new Forwarding(
-                    clientSoftwareName,
-                    clientSoftwareVersion);
+            return new Forwarding();
         }
-
     }
 
     /**
-     * There's a KRPC-capable channel to the server
+     * A backend connection has been initiated. The {@link ClientConnectionStateMachine#progressionLatch}
+     * gates client unblocking until both the transport subject is built and the backend
+     * connection is active.
      */
-    final class Forwarding
-            implements ClientConnectionState {
-
-        @Nullable
-        private final String clientSoftwareName;
-        @Nullable
-        private final String clientSoftwareVersion;
-
-        Forwarding(
-                   @Nullable String clientSoftwareName,
-                   @Nullable String clientSoftwareVersion) {
-            this.clientSoftwareName = clientSoftwareName;
-            this.clientSoftwareVersion = clientSoftwareVersion;
-        }
-
-        @Nullable
-        public String clientSoftwareName() {
-            return clientSoftwareName;
-        }
-
-        @Nullable
-        public String clientSoftwareVersion() {
-            return clientSoftwareVersion;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (obj == this) {
-                return true;
-            }
-            if (obj == null || obj.getClass() != this.getClass()) {
-                return false;
-            }
-            var that = (Forwarding) obj;
-            return Objects.equals(this.clientSoftwareName, that.clientSoftwareName) &&
-                    Objects.equals(this.clientSoftwareVersion, that.clientSoftwareVersion);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(clientSoftwareName, clientSoftwareVersion);
-        }
-
-        @Override
-        public String toString() {
-            return "Forwarding[" +
-                    "clientSoftwareName=" + clientSoftwareName + ", " +
-                    "clientSoftwareVersion=" + clientSoftwareVersion + ']';
-        }
-
-    }
+    record Forwarding() implements ClientConnectionState {}
 
     /**
      * Connections are being drained. autoRead is disabled on the client channel,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
+import java.util.function.Supplier;
 
 import javax.net.ssl.SSLSession;
 
@@ -74,11 +74,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  *  ↓   ↓ frontend.{@link KafkaProxyFrontendHandler#channelRead(ChannelHandlerContext, Object) channelRead} receives a PROXY header
  *  │  {@link ClientConnectionState.HaProxy HaProxy} ╌╌╌╌⤍ <b>error</b> ╌╌╌╌⤍
  *  ╰───┤
- *      ↓ frontend.{@link KafkaProxyFrontendHandler#channelRead(ChannelHandlerContext, Object) channelRead} receives any other KRPC request
- *     {@link ClientConnectionState.SelectingServer SelectingServer} ╌╌╌╌⤍ <b>error</b> ╌╌╌╌⤍
- *     {@link ClientConnectionState.Connecting Connecting} ╌╌╌╌⤍ <b>error</b> ╌╌╌╌⤍
- *      │
- *      ↓
+ *      ↓ frontend.{@link KafkaProxyFrontendHandler#channelRead(ChannelHandlerContext, Object) channelRead} receives any KRPC request
  *     {@link Forwarding Forwarding} ╌╌╌╌⤍ <b>error</b> ╌╌╌╌⤍
  *  ╭───┤
  *  │   ↓ {@link #onDraining(Runnable, CompletableFuture) onDraining}
@@ -110,7 +106,6 @@ import static org.slf4j.LoggerFactory.getLogger;
  */
 @SuppressWarnings("java:S1133")
 public class ClientConnectionStateMachine {
-    private static final String DUPLICATE_INITIATE_CONNECT_ERROR = "onInitiateConnect called more than once";
     private static final Logger LOGGER = getLogger(ClientConnectionStateMachine.class);
 
     /**
@@ -190,12 +185,17 @@ public class ClientConnectionStateMachine {
     private @Nullable KafkaProxyFrontendHandler frontendHandler = null;
 
     /**
-     * The server connection state machine. Non-null if {@link #onInitiateConnect(HostPort)}
-     * has been called.
+     * The server connection state machine. Non-null once the first client request triggers
+     * backend connection setup (transition to {@link Forwarding}).
      */
     @VisibleForTesting
     @Nullable
     private ServerConnectionStateMachine serverConnectionStateMachine;
+
+    @Nullable
+    private String clientSoftwareName;
+    @Nullable
+    private String clientSoftwareVersion;
 
     /** Tracks requests received from the client whose response hasn't been forwarded back yet (client↔proxy). */
     private int clientMessagesInFlightCount;
@@ -295,6 +295,16 @@ public class ClientConnectionStateMachine {
         return endpointBinding.endpointGateway().isUseTls();
     }
 
+    @Nullable
+    String clientSoftwareName() {
+        return clientSoftwareName;
+    }
+
+    @Nullable
+    String clientSoftwareVersion() {
+        return clientSoftwareVersion;
+    }
+
     /**
      * Notify the state machine when the client applies back pressure.
      */
@@ -362,28 +372,15 @@ public class ClientConnectionStateMachine {
     }
 
     /**
-     * Notify the statemachine that the connection to the backend has started.
-     * @param peer the upstream host to connect to.
-     */
-    void onInitiateConnect(
-                           HostPort peer) {
-        if (state instanceof ClientConnectionState.SelectingServer selectingServerState) {
-            toConnecting(selectingServerState.toConnecting(peer));
-        }
-        else {
-            illegalState(DUPLICATE_INITIATE_CONNECT_ERROR);
-        }
-    }
-
-    /**
      * Callback from {@link ServerConnectionStateMachine} when the upstream connection is ready for RPC calls.
      */
     void onServerConnectionActive() {
-        if (state() instanceof ClientConnectionState.Connecting connectedState) {
-            toForwarding(connectedState.toForwarding());
+        if (state() instanceof Forwarding) {
+            kafkaSession.transitionTo(KafkaSessionState.NOT_AUTHENTICATED);
+            maybeUnblock();
         }
         else {
-            illegalState("Server became active while not in the connecting state");
+            illegalState("Server became active while not in the Forwarding state");
         }
     }
 
@@ -472,8 +469,17 @@ public class ClientConnectionStateMachine {
         Objects.requireNonNull(frontendHandler);
         // Count every msg received from the client.
         clientMessagesInFlightCount++;
-        if (state() instanceof Forwarding) { // post-backend connection
-            frontendHandler.admitToFilterChain(msg);
+        if (state() instanceof Forwarding) {
+            if (!(msg instanceof RequestFrame)) {
+                illegalState("Unexpected message received: " + (msg == null ? "null" : "message class=" + msg.getClass()));
+                return;
+            }
+            if (progressionLatch > 0) {
+                frontendHandler.bufferMsg(msg);
+            }
+            else {
+                frontendHandler.admitToFilterChain(msg);
+            }
         }
         else if (state() instanceof ClientConnectionState.Draining draining) {
             // autoRead is disabled the moment we enter Draining, so the only frames that can
@@ -491,27 +497,6 @@ public class ClientConnectionStateMachine {
         }
         else if (!onClientRequestBeforeForwarding(msg)) {
             illegalState("Unexpected message received: " + (msg == null ? "null" : "message class=" + msg.getClass()));
-        }
-    }
-
-    /**
-     * ensure the state machine is in the selecting server state.
-     *
-     * @return the SelectingServer state
-     * @throws IllegalStateException if the state is not {@link ClientConnectionState.SelectingServer}.
-     */
-    ClientConnectionState.SelectingServer enforceInSelectingServer(String errorMessage) {
-        if (state instanceof ClientConnectionState.SelectingServer selectingServerState) {
-            return selectingServerState;
-        }
-        else {
-            illegalState(errorMessage);
-            throw new IllegalStateException("State required to be "
-                    + ClientConnectionState.SelectingServer.class.getSimpleName()
-                    + " but was "
-                    + currentState()
-                    + ":"
-                    + errorMessage);
         }
     }
 
@@ -810,88 +795,63 @@ public class ClientConnectionStateMachine {
     }
 
     @SuppressWarnings("java:S5738")
-    private void toConnecting(
-                              ClientConnectionState.Connecting connecting) {
-        setState(connecting);
+    private void toForwarding(Forwarding forwarding,
+                              HostPort remote) {
+        setState(forwarding);
         boolean upstreamRequiresTls = virtualCluster().getUpstreamSslContext().isPresent();
         serverConnectionStateMachine = new ServerConnectionStateMachine(
-                connecting.remote(),
+                remote,
                 upstreamRequiresTls,
                 this,
                 proxyToServerConnectionCounter,
                 proxyToServerErrorCounter,
                 serverToProxyBackpressureMeter,
                 proxyToServerConnectionToken);
-        Objects.requireNonNull(frontendHandler).inConnecting(
-                connecting.remote(), serverConnectionStateMachine.backendHandler());
-        var frontend = Objects.requireNonNull(this.frontendHandler);
+        var frontend = Objects.requireNonNull(frontendHandler);
+        frontend.initiateBackendConnect(remote, serverConnectionStateMachine.backendHandler());
         log(Level.DEBUG)
-                .addKeyValue("remote", connecting.remote())
+                .addKeyValue("remote", remote)
                 .addKeyValue("clientAddress", () -> HostPort.asString(frontend.remoteHost(), frontend.remotePort()))
-                .log("Upstream connection established for client");
-    }
-
-    @SuppressWarnings("java:S5738")
-    private void toForwarding(Forwarding forwarding) {
-        setState(forwarding);
-        kafkaSession.transitionTo(KafkaSessionState.NOT_AUTHENTICATED);
-        // we must wait for the transport subject to be built before forwarding the buffered messages and then enabling autoread on the client
-        maybeUnblock();
+                .log("Upstream connection initiated for client");
     }
 
     /**
-     * handle a message received from the client prior to connecting to the upstream node
+     * Handle a message received from the client prior to connecting to the upstream node.
+     * Captures client software metadata from ApiVersions requests and triggers
+     * the transition to {@link Forwarding}.
      * @param msg Message received from the downstream client.
-     * @return <code>false</code> for unsupported message types
+     * @return {@code false} for unsupported message types
      */
     private boolean onClientRequestBeforeForwarding(Object msg) {
         Objects.requireNonNull(frontendHandler).bufferMsg(msg);
         if (state() instanceof ClientConnectionState.ClientActive clientActive) {
-            return onClientRequestInClientActiveState(msg, clientActive);
+            return transitionToForwarding(msg, clientActive::toForwarding);
         }
         else if (state() instanceof ClientConnectionState.HaProxy haProxy) {
-            return onClientRequestInHaProxyState(msg, haProxy);
+            return transitionToForwarding(msg, haProxy::toForwarding);
         }
-        else if (state() instanceof ClientConnectionState.SelectingServer) {
-            return msg instanceof RequestFrame;
-        }
-        else {
-            return state() instanceof ClientConnectionState.Connecting && msg instanceof RequestFrame;
-        }
+        return false;
     }
 
-    private boolean onClientRequestInHaProxyState(Object msg, ClientConnectionState.HaProxy haProxy) {
-        return transitionClientRequest(msg, haProxy::toSelectingServer);
-    }
-
-    private boolean transitionClientRequest(
-                                            Object msg,
-                                            Function<DecodedRequestFrame<ApiVersionsRequestData>, ClientConnectionState.SelectingServer> selectingServerFactory) {
+    private boolean transitionToForwarding(
+                                           Object msg,
+                                           Supplier<Forwarding> forwardingFactory) {
         if (isMessageApiVersionsRequest(msg)) {
-            // We know it's an API Versions request even if the compiler doesn't
             @SuppressWarnings("unchecked")
             DecodedRequestFrame<ApiVersionsRequestData> apiVersionsFrame = (DecodedRequestFrame<ApiVersionsRequestData>) msg;
-            toSelectingServer(selectingServerFactory.apply(apiVersionsFrame));
-            return true;
+            this.clientSoftwareName = apiVersionsFrame.body().clientSoftwareName();
+            this.clientSoftwareVersion = apiVersionsFrame.body().clientSoftwareVersion();
         }
-        else if (msg instanceof RequestFrame) {
-            toSelectingServer(selectingServerFactory.apply(null));
+        if (msg instanceof RequestFrame) {
+            var target = Objects.requireNonNull(endpointBinding.upstreamTarget());
+            toForwarding(forwardingFactory.get(), target);
             return true;
         }
         return false;
     }
 
-    private boolean onClientRequestInClientActiveState(Object msg, ClientConnectionState.ClientActive clientActive) {
-        return transitionClientRequest(msg, clientActive::toSelectingServer);
-    }
-
     private void toHaProxy(ClientConnectionState.HaProxy haProxy) {
         setState(haProxy);
-    }
-
-    private void toSelectingServer(ClientConnectionState.SelectingServer selectingServer) {
-        setState(selectingServer);
-        Objects.requireNonNull(frontendHandler).inSelectingServer();
     }
 
     private void toClosed(@Nullable Throwable errorCodeEx) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -85,9 +85,6 @@ import io.kroxylicious.proxy.tls.TlsCredentials;
 import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
-import static io.kroxylicious.proxy.internal.ClientConnectionState.Connecting;
-import static io.kroxylicious.proxy.internal.ClientConnectionState.SelectingServer;
-
 @SuppressWarnings("java:S1192") // ignore dupe string literals is due to logger keys
 public class KafkaProxyFrontendHandler
         extends ChannelInboundHandlerAdapter {
@@ -293,14 +290,6 @@ public class KafkaProxyFrontendHandler
         clientChannel.read();
     }
 
-    /**
-     * Called by the {@link ClientConnectionStateMachine} on entry to the {@link SelectingServer} state.
-     */
-    void inSelectingServer() {
-        var target = Objects.requireNonNull(clientConnectionStateMachine.endpointBinding().upstreamTarget());
-        initiateConnect(target);
-    }
-
     private List<FilterAndInvoker> buildFilters() {
         List<FilterAndInvoker> apiVersionFilters = FilterAndInvoker.build("ApiVersionsIntersect (internal)", apiVersionsIntersectFilter);
         var filterAndInvokers = new ArrayList<>(apiVersionFilters);
@@ -334,26 +323,14 @@ public class KafkaProxyFrontendHandler
 
     /**
      * Initiates the connection to a server.
-     * Changes {@link #clientConnectionStateMachine} from {@link SelectingServer} to {@link Connecting}
-     * Initializes the {@code backendHandler} and configures its pipeline
-     * with the given {@code filters}.
+     * Called by the {@link ClientConnectionStateMachine} to initiate a backend connection.
+     * Configures the backend channel pipeline and starts the TCP connection.
      * @param remote upstream broker target
+     * @param backendHandler the handler for the backend channel
      */
-    void initiateConnect(
-                         HostPort remote) {
-        LOGGER.atDebug()
-                .addKeyValue("sessionId", this.clientConnectionStateMachine.sessionId())
-                .addKeyValue("remote", remote)
-                .log("Connecting to backend broker");
-        this.clientConnectionStateMachine.onInitiateConnect(remote);
-    }
-
-    /**
-     * Called by the {@link ClientConnectionStateMachine} on entry to the {@link Connecting} state.
-     */
-    void inConnecting(
-                      HostPort remote,
-                      KafkaProxyBackendHandler backendHandler) {
+    void initiateBackendConnect(
+                                HostPort remote,
+                                KafkaProxyBackendHandler backendHandler) {
         final Channel inboundChannel = clientCtx().channel();
         // Start the upstream connection attempt.
         final Bootstrap bootstrap = configureBootstrap(backendHandler, inboundChannel);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionState.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionState.java
@@ -11,7 +11,6 @@ import io.kroxylicious.proxy.service.HostPort;
 import static io.kroxylicious.proxy.internal.ServerConnectionState.Active;
 import static io.kroxylicious.proxy.internal.ServerConnectionState.Closed;
 import static io.kroxylicious.proxy.internal.ServerConnectionState.Connecting;
-import static io.kroxylicious.proxy.internal.ServerConnectionState.Draining;
 
 /**
  * States of the {@link ServerConnectionStateMachine}.
@@ -19,7 +18,6 @@ import static io.kroxylicious.proxy.internal.ServerConnectionState.Draining;
 sealed interface ServerConnectionState permits
         Connecting,
         Active,
-        Draining,
         Closed {
 
     /**
@@ -38,20 +36,7 @@ sealed interface ServerConnectionState permits
     /**
      * The connection is established and ready for KRPC.
      */
-    record Active() implements ServerConnectionState {
-
-        public Draining toDraining(Runnable onDrained) {
-            return new Draining(onDrained);
-        }
-    }
-
-    /**
-     * No new requests will be sent. In-flight responses are still completing.
-     * When the in-flight count reaches zero, {@code onDrained} is invoked.
-     *
-     * @param onDrained callback invoked when all in-flight responses have been received
-     */
-    record Draining(Runnable onDrained) implements ServerConnectionState {}
+    record Active() implements ServerConnectionState {}
 
     /**
      * Terminal state. The backend channel is closed.

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachine.java
@@ -31,7 +31,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * server operations here.
  *
  * <pre>
- *     Connecting ──→ Active ──→ [Draining] ──→ Closed
+ *     Connecting ──→ Active ────────────→ Closed
  *         │             │            │
  *         └─────────────┴────────────┴──→ Closed (on error)
  * </pre>

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
@@ -215,7 +215,7 @@ class ClientConnectionStateMachineEndToEndTest {
         assertThat(inboundChannel.config().isAutoRead()).isFalse();
         assertThat(inboundChannel.isWritable()).isTrue();
 
-        assertHandlerInConnectingState(clientConnectionStateMachine, List.of(firstMessage));
+        assertHandlerInForwardingState(clientConnectionStateMachine, List.of(firstMessage));
     }
 
     private ClientConnectionStateMachine buildHandlerInClientActiveState(boolean sni) {
@@ -237,9 +237,7 @@ class ClientConnectionStateMachineEndToEndTest {
                                                   boolean haProxy,
                                                   ApiKeys firstMessage) {
         // Given
-        activateOutboundChannelAutomatically = false;
         var clientConnectionStateMachine = buildHandlerInConnectingState(sni, false, firstMessage);
-        firstRequest(firstMessage);
 
         // When
         outboundChannel.pipeline().fireChannelActive();
@@ -263,9 +261,8 @@ class ClientConnectionStateMachineEndToEndTest {
                                                    ApiKeys firstMessage,
                                                    Throwable serverException) {
         // Given
-        activateOutboundChannelAutomatically = false;
         var clientConnectionStateMachine = buildHandlerInConnectingState(sni, false, firstMessage);
-        final DecodedRequestFrame<ApiMessage> requestFrame = firstRequest(firstMessage);
+        final DecodedRequestFrame<ApiMessage> requestFrame = firstBufferedRequest();
 
         // When
         outboundChannel.pipeline().fireExceptionCaught(serverException);
@@ -291,7 +288,6 @@ class ClientConnectionStateMachineEndToEndTest {
                                                   ApiKeys firstMessage) {
         // Given
         var clientConnectionStateMachine = buildHandlerInConnectingState(sni, false, firstMessage);
-        firstRequest(firstMessage);
 
         // When
         outboundChannel.pipeline().fireChannelInactive();
@@ -310,7 +306,7 @@ class ClientConnectionStateMachineEndToEndTest {
                                                 ApiKeys firstMessage) {
         // Given
         var clientConnectionStateMachine = buildHandlerInConnectingState(sni, true, firstMessage);
-        var firstRequest = firstRequest(firstMessage);
+        var firstRequest = firstBufferedRequest();
 
         // When
         outboundChannel.pipeline().fireChannelActive();
@@ -318,7 +314,7 @@ class ClientConnectionStateMachineEndToEndTest {
         // Then
         inboundChannel.checkException();
 
-        assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Connecting.class);
+        assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Forwarding.class);
 
         assertThat(handler.bufferedMsgs)
                 .asInstanceOf(InstanceOfAssertFactories.list(DecodedRequestFrame.class))
@@ -338,7 +334,7 @@ class ClientConnectionStateMachineEndToEndTest {
                           ApiKeys firstMessage) {
         // Given
         var clientConnectionStateMachine = buildHandlerInConnectingState(sni, true, firstMessage);
-        final DecodedRequestFrame<ApiMessage> requestFrame = firstRequest(firstMessage);
+        final DecodedRequestFrame<ApiMessage> requestFrame = firstBufferedRequest();
         outboundChannel.pipeline().fireChannelActive();
 
         // When
@@ -365,7 +361,6 @@ class ClientConnectionStateMachineEndToEndTest {
                              ApiKeys firstMessage) {
         // Given
         var clientConnectionStateMachine = buildHandlerInConnectingState(sni, true, firstMessage);
-        firstRequest(firstMessage);
         outboundChannel.pipeline().fireChannelActive();
 
         // When
@@ -610,14 +605,13 @@ class ClientConnectionStateMachineEndToEndTest {
                 null);
     }
 
-    private void assertHandlerInConnectingState(
+    private void assertHandlerInForwardingState(
                                                 ClientConnectionStateMachine clientConnectionStateMachine,
                                                 List<ApiKeys> expectedBufferedRequestTypes) {
-        var stateAssert = assertThat(clientConnectionStateMachine.state())
-                .asInstanceOf(InstanceOfAssertFactories.type(ClientConnectionState.Connecting.class));
-        stateAssert.extracting(ClientConnectionState.Connecting::clientSoftwareName)
+        assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Forwarding.class);
+        assertThat(clientConnectionStateMachine.clientSoftwareName())
                 .isEqualTo(expectedBufferedRequestTypes.contains(ApiKeys.API_VERSIONS) ? CLIENT_SOFTWARE_NAME : null);
-        stateAssert.extracting(ClientConnectionState.Connecting::clientSoftwareVersion)
+        assertThat(clientConnectionStateMachine.clientSoftwareVersion())
                 .isEqualTo(expectedBufferedRequestTypes.contains(ApiKeys.API_VERSIONS) ? CLIENT_SOFTWARE_VERSION : null);
         assertThat(handler.bufferedMsgs).asInstanceOf(InstanceOfAssertFactories.list(DecodedRequestFrame.class))
                 .map(DecodedRequestFrame::apiKey).isEqualTo(expectedBufferedRequestTypes);
@@ -695,53 +689,36 @@ class ClientConnectionStateMachineEndToEndTest {
                                                                        boolean sni,
                                                                        boolean tlsConfigured,
                                                                        ApiKeys firstMessage) {
+        activateOutboundChannelAutomatically = false;
         var clientConnectionStateMachine = buildFrontendHandler(tlsConfigured);
 
         hClientConnect(clientConnectionStateMachine, handler);
         if (sni) {
             inboundChannel.pipeline().fireUserEventTriggered(new SniCompletionEvent(SNI_HOSTNAME));
         }
-        // the CCSM unblocks the client after the backend is active and transport subject is asynchronously created
-        // here we force it to wait for a single event before unblocking.
-        int waitingForOneEvent = 1;
-        clientConnectionStateMachine.forceState(
-                new ClientConnectionState.SelectingServer(
-                        firstMessage == ApiKeys.API_VERSIONS ? CLIENT_SOFTWARE_NAME : null,
-                        firstMessage == ApiKeys.API_VERSIONS ? CLIENT_SOFTWARE_VERSION : null),
-                handler,
-                null,
-                TEST_SESSION, waitingForOneEvent);
+        // Complete the transport subject building (decrements progressionLatch from 2 to 1)
+        inboundChannel.runPendingTasks();
 
-        inboundChannel.config().setAutoRead(false);
+        // Write the first client request to trigger the ClientActive → Forwarding transition.
+        // This creates a real SCSM and initiates the backend connection (without activating it).
+        switch (firstMessage) {
+            case API_VERSIONS -> writeInboundApiVersionsRequest();
+            case SASL_HANDSHAKE -> writeSaslPlainHandshake();
+            case SASL_AUTHENTICATE -> writeSaslAuthenticate("pa55word".getBytes(StandardCharsets.UTF_8));
+            case METADATA -> writeInboundMetadataRequest();
+            default -> throw new IllegalArgumentException();
+        }
 
         return clientConnectionStateMachine;
     }
 
+    @SuppressWarnings("unchecked")
     @NonNull
-    private DecodedRequestFrame<ApiMessage> firstRequest(ApiKeys firstMessage) {
-        final DecodedRequestFrame<ApiMessage> firstRequest = apiKeyToMessage(firstMessage);
-        handler.bufferMsg(firstRequest);
-
-        handler.inSelectingServer();
-
-        return firstRequest;
+    private DecodedRequestFrame<ApiMessage> firstBufferedRequest() {
+        return (DecodedRequestFrame<ApiMessage>) handler.bufferedMsgs.get(0);
     }
 
     // TODO backpressure
-
-    private DecodedRequestFrame<ApiMessage> apiKeyToMessage(ApiKeys firstMessage) {
-        return switch (firstMessage) {
-            case API_VERSIONS -> decodedRequestFrame(ApiVersionsRequestData.HIGHEST_SUPPORTED_VERSION, new ApiVersionsRequestData()
-                    .setClientSoftwareName(CLIENT_SOFTWARE_NAME)
-                    .setClientSoftwareVersion(CLIENT_SOFTWARE_VERSION), correlationId++);
-            case SASL_HANDSHAKE -> decodedRequestFrame(SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION, new SaslHandshakeRequestData()
-                    .setMechanism(PLAIN_MECHANISM), correlationId++);
-            case SASL_AUTHENTICATE -> decodedRequestFrame(SaslAuthenticateRequestData.HIGHEST_SUPPORTED_VERSION, new SaslAuthenticateRequestData()
-                    .setAuthBytes("pa55word".getBytes(StandardCharsets.UTF_8)), correlationId++);
-            case METADATA -> decodedRequestFrame(MetadataRequestData.HIGHEST_SUPPORTED_VERSION, new MetadataRequestData(), correlationId++);
-            default -> throw new IllegalArgumentException();
-        };
-    }
 
     private void assertNextClientResponseIsErrorFor(DecodedRequestFrame<ApiMessage> requestFrame) {
         switch (requestFrame.apiKey()) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
@@ -14,7 +14,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
-import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
 
 import org.apache.kafka.common.errors.ApiException;
@@ -27,7 +26,6 @@ import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.Errors;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +40,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.micrometer.core.instrument.Metrics;
@@ -54,14 +51,12 @@ import io.netty.channel.DefaultChannelId;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.util.concurrent.ScheduledFuture;
 
 import io.kroxylicious.proxy.config.CacheConfiguration;
 import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
-import io.kroxylicious.proxy.internal.ClientConnectionState.SelectingServer;
 import io.kroxylicious.proxy.internal.codec.FrameOversizedException;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
@@ -72,7 +67,6 @@ import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -85,7 +79,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -187,10 +180,11 @@ class ClientConnectionStateMachineTest {
     @Test
     void shouldCountProxyToServerConnections() {
         // Given
-        stateMachineInSelectingServer();
+        stateMachineInClientActive();
+        when(endpointBinding.upstreamTarget()).thenReturn(BROKER_ADDRESS);
 
-        // When
-        clientConnectionStateMachine.onInitiateConnect(HostPort.parse("localhost:9090"));
+        // When — first client request triggers SCSM creation which increments the counter
+        clientConnectionStateMachine.onClientRequest(metadataRequest());
 
         // Then
         assertThat(Metrics.globalRegistry.get("kroxylicious_proxy_to_server_connections").counter())
@@ -201,9 +195,9 @@ class ClientConnectionStateMachineTest {
     }
 
     @Test
-    void shouldTransitionToClosedOnServerExceptionInConnecting() {
+    void shouldTransitionToClosedOnServerExceptionInForwardingAwaitingBackend() {
         // Given
-        stateMachineInConnecting();
+        stateMachineInForwardingAwaitingBackend();
 
         // When
         clientConnectionStateMachine.onServerConnectionException(failure);
@@ -344,9 +338,10 @@ class ClientConnectionStateMachineTest {
     }
 
     @Test
-    void inClientActiveShouldBufferWhenOnClientMetadataRequest() {
+    void inClientActiveShouldBufferAndTransitionToForwardingWhenOnClientMetadataRequest() {
         // Given
         stateMachineInClientActive();
+        when(endpointBinding.upstreamTarget()).thenReturn(BROKER_ADDRESS);
         var msg = metadataRequest();
 
         // When
@@ -354,16 +349,16 @@ class ClientConnectionStateMachineTest {
 
         // Then
         assertThat(clientConnectionStateMachine.state())
-                .isInstanceOf(ClientConnectionState.SelectingServer.class);
-        verify(frontendHandler).inSelectingServer();
+                .isInstanceOf(ClientConnectionState.Forwarding.class);
         verify(frontendHandler).bufferMsg(msg);
-        verifyNoMoreInteractions(frontendHandler);
+        verify(frontendHandler).initiateBackendConnect(eq(BROKER_ADDRESS), notNull(KafkaProxyBackendHandler.class));
     }
 
     @Test
-    void inHaProxyShouldBufferWhenOnClientApiVersionsRequest() {
+    void inHaProxyShouldBufferAndTransitionToForwardingWhenOnClientApiVersionsRequest() {
         // Given
         stateMachineInHaProxy();
+        when(endpointBinding.upstreamTarget()).thenReturn(BROKER_ADDRESS);
         var msg = apiVersionsRequest();
 
         // When
@@ -371,10 +366,9 @@ class ClientConnectionStateMachineTest {
 
         // Then
         assertThat(clientConnectionStateMachine.state())
-                .isInstanceOf(ClientConnectionState.SelectingServer.class);
-        verify(frontendHandler).inSelectingServer();
+                .isInstanceOf(ClientConnectionState.Forwarding.class);
         verify(frontendHandler).bufferMsg(msg);
-        verifyNoMoreInteractions(frontendHandler);
+        verify(frontendHandler).initiateBackendConnect(eq(BROKER_ADDRESS), notNull(KafkaProxyBackendHandler.class));
     }
 
     @Test
@@ -392,9 +386,10 @@ class ClientConnectionStateMachineTest {
     }
 
     @Test
-    void inHaProxyShouldBufferWhenOnClientMetadataRequest() {
+    void inHaProxyShouldBufferAndTransitionToForwardingWhenOnClientMetadataRequest() {
         // Given
         stateMachineInHaProxy();
+        when(endpointBinding.upstreamTarget()).thenReturn(BROKER_ADDRESS);
         var msg = metadataRequest();
 
         // When
@@ -402,129 +397,70 @@ class ClientConnectionStateMachineTest {
 
         // Then
         assertThat(clientConnectionStateMachine.state())
-                .isInstanceOf(ClientConnectionState.SelectingServer.class);
-        verify(frontendHandler).inSelectingServer();
+                .isInstanceOf(ClientConnectionState.Forwarding.class);
         verify(frontendHandler).bufferMsg(msg);
-        verifyNoMoreInteractions(frontendHandler);
+        verify(frontendHandler).initiateBackendConnect(eq(BROKER_ADDRESS), notNull(KafkaProxyBackendHandler.class));
     }
 
     @Test
-    void inClientActiveShouldTransitionToApiVersionsOrSelectingServer() {
+    void inClientActiveShouldCaptureClientSoftwareInfoFromApiVersions() {
         // Given
         stateMachineInClientActive();
+        when(endpointBinding.upstreamTarget()).thenReturn(BROKER_ADDRESS);
         var msg = apiVersionsRequest();
 
         // When
-        clientConnectionStateMachine.onClientRequest(
-                msg);
+        clientConnectionStateMachine.onClientRequest(msg);
 
         // Then
-        var stateAssert = assertThat(clientConnectionStateMachine.state())
-                .asInstanceOf(InstanceOfAssertFactories.type(SelectingServer.class));
-        stateAssert
-                .extracting(SelectingServer::clientSoftwareName).isEqualTo("mykafkalib");
-        stateAssert
-                .extracting(SelectingServer::clientSoftwareVersion).isEqualTo("1.0.0");
+        assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Forwarding.class);
+        assertThat(clientConnectionStateMachine.clientSoftwareName()).isEqualTo("mykafkalib");
+        assertThat(clientConnectionStateMachine.clientSoftwareVersion()).isEqualTo("1.0.0");
         verify(frontendHandler).bufferMsg(msg);
     }
 
-    @SuppressWarnings("DataFlowIssue")
-    @ParameterizedTest
-    @ValueSource(booleans = { true, false })
-    void inSelectingServerShouldTransitionToConnectingWhenOnInitiateConnectCalled(boolean configureSsl) throws SSLException {
-        // Given
-        HostPort brokerAddress = new HostPort("localhost", 9092);
-        stateMachineInSelectingServer();
-        var vc = mock(VirtualClusterModel.class);
-        Mockito.lenient().doReturn(configureSsl ? Optional.of(SslContextBuilder.forClient().build()) : Optional.empty()).when(vc).getUpstreamSslContext();
-
-        // When
-        clientConnectionStateMachine.onInitiateConnect(brokerAddress);
-
-        // Then
-        assertThat(clientConnectionStateMachine.state())
-                .isInstanceOf(ClientConnectionState.Connecting.class);
-        verify(frontendHandler).inConnecting(eq(brokerAddress), notNull(KafkaProxyBackendHandler.class));
-        assertThat(clientConnectionStateMachine).extracting("serverConnectionStateMachine").isNotNull();
-    }
-
     @Test
-    void inClientActiveShouldCloseWhenOnInitiateConnectCalled() {
-        // Given
-        HostPort brokerAddress = new HostPort("localhost", 9092);
-        stateMachineInClientActive();
-
-        // When
-        clientConnectionStateMachine.onInitiateConnect(brokerAddress);
-
-        // Then
-        assertThat(clientConnectionStateMachine.state())
-                .isInstanceOf(ClientConnectionState.Closed.class);
-        verify(frontendHandler).inClosed(null);
-        assertThat(clientConnectionStateMachine).extracting("serverConnectionStateMachine").isNull();
-    }
-
-    @Test
-    void inConnectingShouldCloseWhenOnInitiateConnect() {
-        // Given
-        stateMachineInConnecting();
-
-        // When
-        clientConnectionStateMachine.onInitiateConnect(BROKER_ADDRESS);
-
-        // Then
-        assertThat(clientConnectionStateMachine.state())
-                .isInstanceOf(ClientConnectionState.Closed.class);
-        verify(frontendHandler).inClosed(null);
-        verify(serverConnectionStateMachine).close();
-    }
-
-    @Test
-    void inConnectingShouldTransitionWhenOnServerActiveCalled() {
-        // Given
-        int waitingForOneEvent = 1;
+    void inForwardingShouldUnblockClientWhenOnServerActiveCalledAndLatchReachesZero() {
+        // Given — Forwarding state, latch at 1 (waiting only for backend)
         clientConnectionStateMachine.forceState(
-                new ClientConnectionState.Connecting(null, null, new HostPort("localhost", 9089)),
+                new ClientConnectionState.Forwarding(),
                 frontendHandler,
                 serverConnectionStateMachine,
                 TEST_KAFKA_SESSION,
-                waitingForOneEvent);
+                1);
 
         // When
         clientConnectionStateMachine.onServerConnectionActive();
 
         // Then
         assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Forwarding.class);
-
         verify(frontendHandler).unblockClient();
         verifyNoInteractions(serverConnectionStateMachine);
     }
 
     @Test
     void onServerActiveDoesNotUnblockClientIfWaitingForTransportSubject() {
-        // Given
-        int waitingForTwoEvents = 2;
+        // Given — Forwarding state, latch at 2 (waiting for both)
         clientConnectionStateMachine.forceState(
-                new ClientConnectionState.Connecting(null, null, new HostPort("localhost", 9089)),
+                new ClientConnectionState.Forwarding(),
                 frontendHandler,
                 serverConnectionStateMachine,
                 TEST_KAFKA_SESSION,
-                waitingForTwoEvents);
+                2);
 
         // When
         clientConnectionStateMachine.onServerConnectionActive();
 
         // Then
         assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Forwarding.class);
-
         verifyNoInteractions(frontendHandler);
         verifyNoInteractions(serverConnectionStateMachine);
     }
 
     @Test
-    void inConnectingShouldBufferRequests() {
-        // Given
-        stateMachineInConnecting();
+    void inForwardingShouldBufferRequestsWhenLatchNotZero() {
+        // Given — Forwarding state with latch > 0 (backend not yet connected)
+        stateMachineInForwardingAwaitingBackend();
 
         // When
         DecodedRequestFrame<MetadataRequestData> msg = metadataRequest();
@@ -532,7 +468,7 @@ class ClientConnectionStateMachineTest {
 
         // Then
         verify(frontendHandler).bufferMsg(msg);
-        assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Connecting.class);
+        assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Forwarding.class);
     }
 
     @Test
@@ -680,32 +616,6 @@ class ClientConnectionStateMachineTest {
         verify(serverConnectionStateMachine).close();
     }
 
-    @Test
-    void shouldReturnStateWhenInSelectingServer() {
-        // Given
-        stateMachineInSelectingServer();
-
-        // When
-        final SelectingServer actualSelectingServer = clientConnectionStateMachine.enforceInSelectingServer("wibble");
-
-        // Then
-        assertThat(actualSelectingServer).isNotNull();
-    }
-
-    @ParameterizedTest
-    @MethodSource("givenStates")
-    void shouldThrowWhenStateWhenIsNotSelectingServer(Runnable givenState) {
-        // Given
-        givenState.run();
-
-        // When
-        assertThatThrownBy(() -> clientConnectionStateMachine.enforceInSelectingServer("wibble"))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageEndingWith("wibble");
-
-        // Then
-    }
-
     @ParameterizedTest
     @MethodSource("connectedStates")
     void shouldDelegateServerBackpressureToScsmOnClientUnwritable(Runnable givenState) {
@@ -787,10 +697,8 @@ class ClientConnectionStateMachineTest {
                 }, false),
                 argumentSet("Ha Proxy TLS on", (Runnable) this::stateMachineInHaProxy, true),
                 argumentSet("Ha Proxy TLS off ", (Runnable) this::stateMachineInHaProxy, false),
-                argumentSet("Selecting Server TLS on", (Runnable) this::stateMachineInSelectingServer, true),
-                argumentSet("Selecting Server TLS off ", (Runnable) this::stateMachineInSelectingServer, false),
-                argumentSet("Connecting TLS on", (Runnable) this::stateMachineInConnecting, true),
-                argumentSet("Connecting TLS off ", (Runnable) this::stateMachineInConnecting, false),
+                argumentSet("Forwarding awaiting backend TLS on", (Runnable) this::stateMachineInForwardingAwaitingBackend, true),
+                argumentSet("Forwarding awaiting backend TLS off ", (Runnable) this::stateMachineInForwardingAwaitingBackend, false),
                 argumentSet("Client Active TLS on", (Runnable) this::stateMachineInClientActive, true),
                 argumentSet("Client Active TLS off ", (Runnable) this::stateMachineInClientActive, false),
                 argumentSet("Forwarding TLS on", (Runnable) this::stateMachineInForwarding, true),
@@ -802,7 +710,7 @@ class ClientConnectionStateMachineTest {
     public Stream<Arguments> givenStates() {
         return Stream.of(
                 argumentSet("Ha Proxy", (Runnable) this::stateMachineInHaProxy),
-                argumentSet("Connecting", (Runnable) this::stateMachineInConnecting),
+                argumentSet("Forwarding awaiting backend", (Runnable) this::stateMachineInForwardingAwaitingBackend),
                 argumentSet("ClientActive ", (Runnable) this::stateMachineInClientActive),
                 argumentSet("Forwarding", (Runnable) this::stateMachineInForwarding),
                 argumentSet("Closed", (Runnable) this::stateMachineInClosed));
@@ -810,7 +718,7 @@ class ClientConnectionStateMachineTest {
 
     public Stream<Arguments> connectedStates() {
         return Stream.of(
-                argumentSet("Connecting", (Runnable) this::stateMachineInConnecting),
+                argumentSet("Forwarding awaiting backend", (Runnable) this::stateMachineInForwardingAwaitingBackend),
                 argumentSet("Forwarding", (Runnable) this::stateMachineInForwarding),
                 argumentSet("Closed", (Runnable) this::stateMachineInClosed));
     }
@@ -833,26 +741,8 @@ class ClientConnectionStateMachineTest {
                 -1);
     }
 
-    private void stateMachineInSelectingServer() {
-        clientConnectionStateMachine.forceState(
-                new ClientConnectionState.SelectingServer(null, null),
-                frontendHandler,
-                null,
-                TEST_KAFKA_SESSION,
-                -1);
-    }
-
-    private void stateMachineInConnecting() {
-        clientConnectionStateMachine.forceState(
-                new ClientConnectionState.Connecting(null, null, new HostPort("localhost", 9089)),
-                frontendHandler,
-                serverConnectionStateMachine,
-                TEST_KAFKA_SESSION,
-                -1);
-    }
-
     private ClientConnectionState.Forwarding stateMachineInForwarding() {
-        var forwarding = new ClientConnectionState.Forwarding(null, null);
+        var forwarding = new ClientConnectionState.Forwarding();
         clientConnectionStateMachine.forceState(
                 forwarding,
                 frontendHandler,
@@ -860,6 +750,15 @@ class ClientConnectionStateMachineTest {
                 TEST_KAFKA_SESSION,
                 -1);
         return forwarding;
+    }
+
+    private void stateMachineInForwardingAwaitingBackend() {
+        clientConnectionStateMachine.forceState(
+                new ClientConnectionState.Forwarding(),
+                frontendHandler,
+                serverConnectionStateMachine,
+                TEST_KAFKA_SESSION,
+                2);
     }
 
     private void stateMachineInClosed() {
@@ -913,14 +812,14 @@ class ClientConnectionStateMachineTest {
     }
 
     @Test
-    void shouldTransitionToForwardingOnServerConnectionActive() {
+    void shouldRemainInForwardingWhenOnServerConnectionActive() {
         // Given
-        stateMachineInConnecting();
+        stateMachineInForwardingAwaitingBackend();
 
         // When
         clientConnectionStateMachine.onServerConnectionActive();
 
-        // Then
+        // Then — state is still Forwarding (latch decremented but not zero)
         assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Forwarding.class);
     }
 
@@ -928,7 +827,7 @@ class ClientConnectionStateMachineTest {
     void shouldDecrementActiveConnectionsOnClosed() {
         // Given - establish both client and server connections
         clientConnectionStateMachine.onClientActive(frontendHandler);
-        stateMachineInConnecting();
+        stateMachineInForwardingAwaitingBackend();
         clientConnectionStateMachine.onServerConnectionActive();
 
         int initialClientCount = getVirtualNodeClientToProxyActiveConnections();
@@ -946,7 +845,7 @@ class ClientConnectionStateMachineTest {
     void shouldDecrementActiveConnectionsOnServerInactive() {
         // Given - establish both client and server connections
         clientConnectionStateMachine.onClientActive(frontendHandler);
-        stateMachineInConnecting();
+        stateMachineInForwardingAwaitingBackend();
         clientConnectionStateMachine.onServerConnectionActive();
 
         int initialClientCount = getVirtualNodeClientToProxyActiveConnections();
@@ -977,7 +876,7 @@ class ClientConnectionStateMachineTest {
     void shouldDecrementActiveConnectionsOnServerException() {
         // Given - establish both client and server connections
         clientConnectionStateMachine.onClientActive(frontendHandler);
-        stateMachineInConnecting();
+        stateMachineInForwardingAwaitingBackend();
         clientConnectionStateMachine.onServerConnectionActive();
 
         int initialClientCount = getVirtualNodeClientToProxyActiveConnections();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -99,7 +99,7 @@ public abstract class FilterHarness {
 
         var kafkaSession = new KafkaSession(KafkaSessionState.ESTABLISHING);
         clientConnectionStateMachine = new ClientConnectionStateMachine(endpointBinding, new DefaultSubjectBuilder(List.of()), kafkaSession);
-        var forwarding = new ClientConnectionState.Forwarding(null, null);
+        var forwarding = new ClientConnectionState.Forwarding();
         clientConnectionStateMachine.forceState(
                 forwarding,
                 mock(KafkaProxyFrontendHandler.class),

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -489,7 +489,7 @@ class KafkaProxyFrontendHandlerTest {
     }
 
     private void handleConnect(ClientConnectionStateMachine clientConnectionStateMachine) {
-        assertThat(clientConnectionStateMachine.state()).isExactlyInstanceOf(ClientConnectionState.Connecting.class);
+        assertThat(clientConnectionStateMachine.state()).isExactlyInstanceOf(ClientConnectionState.Forwarding.class);
         assertFalse(inboundChannel.config().isAutoRead(),
                 "Expect inbound autoRead=true, since outbound not yet active");
 
@@ -545,7 +545,7 @@ class KafkaProxyFrontendHandlerTest {
                                           String initialClientSoftwareName) {
         initialiseInboundChannel(clientConnectionStateMachine, handler);
         writeInboundApiVersionsRequest(initialClientSoftwareName);
-        assertThat(clientConnectionStateMachine.state()).isExactlyInstanceOf(ClientConnectionState.Connecting.class);
+        assertThat(clientConnectionStateMachine.state()).isExactlyInstanceOf(ClientConnectionState.Forwarding.class);
     }
 
     private static ChannelInboundHandlerAdapter throwOnReadHandler(Exception cause) {


### PR DESCRIPTION
refactor(runtime): collapse SelectingServer and Connecting into Forwarding

With the SCSM extraction, backend connection lifecycle is already managed
by ServerConnectionStateMachine. The SelectingServer and Connecting states
in ClientConnectionState were redundant — they represented backend connection
setup which now belongs entirely in the SCSM.

This collapses the state flow from ClientActive → SelectingServer →
Connecting → Forwarding down to ClientActive → Forwarding. The existing
progressionLatch (count=2) continues to gate client unblocking on both
transport subject completion and backend connection activation, preserving
identical runtime behaviour.

Client software metadata (clientSoftwareName/clientSoftwareVersion) moves
from state record fields to ClientConnectionStateMachine instance fields.

Also removes unused Drain state from the Server side.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

Contributes towards #4015 