### PR TITLE
refactor: decouple client state machine from backend connection active

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -177,7 +177,7 @@ public class ClientConnectionStateMachine {
     boolean clientReadsBlocked;
     private final TransportSubjectBuilder transportSubjectBuilder;
     private final ClientSubjectManager clientSubjectManager = new ClientSubjectManager();
-    private int progressionLatch = -1;
+    private boolean transportSubjectReady;
     /**
      * The frontend handler. Non-null if we got as far as ClientActive.
      */
@@ -240,7 +240,7 @@ public class ClientConnectionStateMachine {
                     KafkaProxyFrontendHandler frontendHandler,
                     @Nullable ServerConnectionStateMachine serverConnectionStateMachine,
                     KafkaSession kafkaSession,
-                    int transportAndBackendLatch) {
+                    boolean transportSubjectReady) {
         LOGGER.atInfo()
                 .addKeyValue("sessionId", kafkaSession.sessionId())
                 .addKeyValue("virtualCluster", clusterName())
@@ -252,7 +252,7 @@ public class ClientConnectionStateMachine {
         this.kafkaSession = kafkaSession;
         this.frontendHandler = frontendHandler;
         this.serverConnectionStateMachine = serverConnectionStateMachine;
-        this.progressionLatch = transportAndBackendLatch;
+        this.transportSubjectReady = transportSubjectReady;
     }
 
     @Override
@@ -473,7 +473,7 @@ public class ClientConnectionStateMachine {
                 illegalState("Unexpected message received: " + (msg == null ? "null" : "message class=" + msg.getClass()));
                 return;
             }
-            if (progressionLatch > 0) {
+            if (!transportSubjectReady) {
                 frontendHandler.bufferMsg(msg);
             }
             else {
@@ -759,11 +759,7 @@ public class ClientConnectionStateMachine {
                                 ClientConnectionState.ClientActive clientActive,
                                 KafkaProxyFrontendHandler frontendHandler) {
         setState(clientActive);
-        // we require two events before unblocking (making reads from) the client:
-        // 1. the completion of the building of the transport subject
-        // 2. the transition to Forwarding state (triggered by the first client request)
-        // these can happen in either order
-        this.progressionLatch = 2;
+        this.transportSubjectReady = false;
         if (!this.isTlsListener()) {
             this.clientSubjectManager.subjectFromTransport(null, this.transportSubjectBuilder,
                     frontendHandler.eventLoopExecutor(), this::onTransportSubjectBuilt);
@@ -779,15 +775,16 @@ public class ClientConnectionStateMachine {
         if (!authenticatedSubject().isAnonymous()) {
             onSessionTransportAuthenticated();
         }
-        maybeUnblock();
+        this.transportSubjectReady = true;
+        tryUnblockClient();
     }
 
     Subject authenticatedSubject() {
         return Objects.requireNonNull(clientSubjectManager).authenticatedSubject();
     }
 
-    private void maybeUnblock() {
-        if (--this.progressionLatch == 0) {
+    private void tryUnblockClient() {
+        if (transportSubjectReady && state instanceof Forwarding) {
             Objects.requireNonNull(frontendHandler).unblockClient();
         }
     }
@@ -843,7 +840,7 @@ public class ClientConnectionStateMachine {
         if (msg instanceof RequestFrame) {
             var target = Objects.requireNonNull(endpointBinding.upstreamTarget());
             toForwarding(forwardingFactory.get(), target);
-            maybeUnblock();
+            tryUnblockClient();
             return true;
         }
         return false;

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -377,7 +377,6 @@ public class ClientConnectionStateMachine {
     void onServerConnectionActive() {
         if (state() instanceof Forwarding) {
             kafkaSession.transitionTo(KafkaSessionState.NOT_AUTHENTICATED);
-            maybeUnblock();
         }
         else {
             illegalState("Server became active while not in the Forwarding state");
@@ -762,8 +761,7 @@ public class ClientConnectionStateMachine {
         setState(clientActive);
         // we require two events before unblocking (making reads from) the client:
         // 1. the completion of the building of the transport subject
-        // 2. the progression of the state machine to forwarding state
-        // (completion of the connection to the backend)
+        // 2. the transition to Forwarding state (triggered by the first client request)
         // these can happen in either order
         this.progressionLatch = 2;
         if (!this.isTlsListener()) {
@@ -845,6 +843,7 @@ public class ClientConnectionStateMachine {
         if (msg instanceof RequestFrame) {
             var target = Objects.requireNonNull(endpointBinding.upstreamTarget());
             toForwarding(forwardingFactory.get(), target);
+            maybeUnblock();
             return true;
         }
         return false;

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -111,6 +111,9 @@ public class KafkaProxyFrontendHandler
     @VisibleForTesting
     @Nullable
     List<Object> bufferedMsgs;
+    @VisibleForTesting
+    @Nullable
+    DecodedRequestFrame<?> initialRequestForError;
     private boolean pendingClientFlushes;
     private @Nullable String sniHostname;
 
@@ -591,6 +594,9 @@ public class KafkaProxyFrontendHandler
     void bufferMsg(Object msg) {
         if (bufferedMsgs == null) {
             bufferedMsgs = new ArrayList<>();
+            if (msg instanceof DecodedRequestFrame<?> frame) {
+                initialRequestForError = frame;
+            }
         }
         bufferedMsgs.add(msg);
     }
@@ -667,15 +673,17 @@ public class KafkaProxyFrontendHandler
      */
     private @Nullable ResponseFrame errorResponse(
                                                   @Nullable Throwable errorCodeEx) {
-        ResponseFrame errorResponse;
-        final Object triggerMsg = bufferedMsgs != null && !bufferedMsgs.isEmpty() ? bufferedMsgs.get(0) : null;
-        if (errorCodeEx != null && triggerMsg instanceof final DecodedRequestFrame<?> triggerFrame) {
-            errorResponse = buildErrorResponseFrame(triggerFrame, errorCodeEx);
+        final Object triggerMsg;
+        if (bufferedMsgs != null && !bufferedMsgs.isEmpty()) {
+            triggerMsg = bufferedMsgs.get(0);
         }
         else {
-            errorResponse = null;
+            triggerMsg = initialRequestForError;
         }
-        return errorResponse;
+        if (errorCodeEx != null && triggerMsg instanceof final DecodedRequestFrame<?> triggerFrame) {
+            return buildErrorResponseFrame(triggerFrame, errorCodeEx);
+        }
+        return null;
     }
 
     /**

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachine.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy.internal;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import org.slf4j.Logger;
@@ -14,6 +16,7 @@ import org.slf4j.spi.LoggingEventBuilder;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
+import io.netty.util.ReferenceCountUtil;
 
 import io.kroxylicious.proxy.internal.util.ActivationToken;
 import io.kroxylicious.proxy.service.HostPort;
@@ -53,6 +56,9 @@ class ServerConnectionStateMachine {
     @Nullable
     @VisibleForTesting
     Timer.Sample serverBackpressureTimer;
+
+    @Nullable
+    private List<Object> pendingRequests;
 
     private final Counter proxyToServerErrorCounter;
     private final Timer serverToProxyBackpressureMeter;
@@ -94,6 +100,7 @@ class ServerConnectionStateMachine {
         if (state instanceof ServerConnectionState.Connecting connecting) {
             setState(connecting.toActive());
             proxyToServerConnectionToken.acquire();
+            flushPendingRequests();
             ccsm.onServerConnectionActive();
         }
         else {
@@ -143,9 +150,27 @@ class ServerConnectionStateMachine {
     // === Called by ClientConnectionStateMachine ===
 
     void sendRequest(Object msg) {
+        if (state instanceof ServerConnectionState.Connecting) {
+            if (pendingRequests == null) {
+                pendingRequests = new ArrayList<>();
+            }
+            pendingRequests.add(msg);
+            return;
+        }
         serverMessagesInFlightCount++;
         backendHandler.forwardToServer(msg);
         backendHandler.flushToServer();
+    }
+
+    private void flushPendingRequests() {
+        if (pendingRequests != null) {
+            for (Object msg : pendingRequests) {
+                serverMessagesInFlightCount++;
+                backendHandler.forwardToServer(msg);
+            }
+            pendingRequests = null;
+            backendHandler.flushToServer();
+        }
     }
 
     void applyBackpressure() {
@@ -174,9 +199,19 @@ class ServerConnectionStateMachine {
     }
 
     private void toClosed() {
+        releasePendingRequests();
         setState(new ServerConnectionState.Closed());
         backendHandler.inClosed();
         proxyToServerConnectionToken.release();
+    }
+
+    private void releasePendingRequests() {
+        if (pendingRequests != null) {
+            for (Object msg : pendingRequests) {
+                ReferenceCountUtil.release(msg);
+            }
+            pendingRequests = null;
+        }
     }
 
     private void setState(ServerConnectionState newState) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
@@ -195,7 +195,7 @@ class ClientConnectionStateMachineEndToEndTest {
                     new ClientConnectionState.HaProxy(),
                     handler,
                     null,
-                    TEST_SESSION, -1);
+                    TEST_SESSION, false);
         }
 
         // When
@@ -220,7 +220,7 @@ class ClientConnectionStateMachineEndToEndTest {
                 .isEqualTo(firstMessage == ApiKeys.API_VERSIONS ? CLIENT_SOFTWARE_VERSION : null);
 
         if (haProxy) {
-            // forceState with latch=-1 means unblock never fires
+            // forceState with transportSubjectReady=false prevents unblockClient from firing
             assertThat(inboundChannel.config().isAutoRead()).isFalse();
             assertThat(handler.bufferedMsgs)
                     .asInstanceOf(InstanceOfAssertFactories.list(DecodedRequestFrame.class))
@@ -690,13 +690,14 @@ class ClientConnectionStateMachineEndToEndTest {
         if (sni) {
             inboundChannel.pipeline().fireUserEventTriggered(new SniCompletionEvent(SNI_HOSTNAME));
         }
-        // Complete the transport subject building (decrements progressionLatch from 2 to 1)
+        // Complete the transport subject building (sets transportSubjectReady = true)
         inboundChannel.runPendingTasks();
 
         // Write the first client request to trigger the ClientActive → Forwarding transition.
-        // This creates a real SCSM, initiates the backend connection, and decrements the
-        // progressionLatch from 1 to 0 — triggering unblockClient(). The first request is
-        // forwarded through the filter chain to the SCSM, which buffers it (Connecting state).
+        // This creates a real SCSM and initiates the backend connection. Since
+        // transportSubjectReady is already true, tryUnblockClient() fires, enabling autoRead
+        // and forwarding the buffered request through the filter chain to the SCSM (which
+        // buffers it in Connecting state).
         switch (firstMessage) {
             case API_VERSIONS -> writeInboundApiVersionsRequest();
             case SASL_HANDSHAKE -> writeSaslPlainHandshake();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -211,11 +212,26 @@ class ClientConnectionStateMachineEndToEndTest {
         assertThat(inboundChannel.<Object> readOutbound())
                 .describedAs("No response deferred until upstream connected")
                 .isNull();
-
-        assertThat(inboundChannel.config().isAutoRead()).isFalse();
         assertThat(inboundChannel.isWritable()).isTrue();
+        assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Forwarding.class);
+        assertThat(clientConnectionStateMachine.clientSoftwareName())
+                .isEqualTo(firstMessage == ApiKeys.API_VERSIONS ? CLIENT_SOFTWARE_NAME : null);
+        assertThat(clientConnectionStateMachine.clientSoftwareVersion())
+                .isEqualTo(firstMessage == ApiKeys.API_VERSIONS ? CLIENT_SOFTWARE_VERSION : null);
 
-        assertHandlerInForwardingState(clientConnectionStateMachine, List.of(firstMessage));
+        if (haProxy) {
+            // forceState with latch=-1 means unblock never fires
+            assertThat(inboundChannel.config().isAutoRead()).isFalse();
+            assertThat(handler.bufferedMsgs)
+                    .asInstanceOf(InstanceOfAssertFactories.list(DecodedRequestFrame.class))
+                    .map(DecodedRequestFrame::apiKey).isEqualTo(List.of(firstMessage));
+        }
+        else {
+            // Both latch events fire (entering Forwarding + transport subject via runPendingTasks)
+            // so the client is unblocked and the request is forwarded to the SCSM
+            assertThat(inboundChannel.config().isAutoRead()).isTrue();
+            assertThat(handler.bufferedMsgs).isNull();
+        }
     }
 
     private ClientConnectionStateMachine buildHandlerInClientActiveState(boolean sni) {
@@ -262,7 +278,7 @@ class ClientConnectionStateMachineEndToEndTest {
                                                    Throwable serverException) {
         // Given
         var clientConnectionStateMachine = buildHandlerInConnectingState(sni, false, firstMessage);
-        final DecodedRequestFrame<ApiMessage> requestFrame = firstBufferedRequest();
+        final DecodedRequestFrame<ApiMessage> requestFrame = firstInitialRequest();
 
         // When
         outboundChannel.pipeline().fireExceptionCaught(serverException);
@@ -306,7 +322,6 @@ class ClientConnectionStateMachineEndToEndTest {
                                                 ApiKeys firstMessage) {
         // Given
         var clientConnectionStateMachine = buildHandlerInConnectingState(sni, true, firstMessage);
-        var firstRequest = firstBufferedRequest();
 
         // When
         outboundChannel.pipeline().fireChannelActive();
@@ -316,14 +331,9 @@ class ClientConnectionStateMachineEndToEndTest {
 
         assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Forwarding.class);
 
-        assertThat(handler.bufferedMsgs)
-                .asInstanceOf(InstanceOfAssertFactories.list(DecodedRequestFrame.class))
-                .singleElement()
-                .isEqualTo(firstRequest);
-
         assertThat(inboundChannel.config().isAutoRead())
-                .describedAs("Client autoread should be off while connecting to server")
-                .isFalse();
+                .describedAs("Client is already unblocked; SCSM buffers until TLS handshake completes")
+                .isTrue();
     }
 
     @ParameterizedTest
@@ -334,7 +344,7 @@ class ClientConnectionStateMachineEndToEndTest {
                           ApiKeys firstMessage) {
         // Given
         var clientConnectionStateMachine = buildHandlerInConnectingState(sni, true, firstMessage);
-        final DecodedRequestFrame<ApiMessage> requestFrame = firstBufferedRequest();
+        final DecodedRequestFrame<ApiMessage> requestFrame = firstInitialRequest();
         outboundChannel.pipeline().fireChannelActive();
 
         // When
@@ -345,10 +355,6 @@ class ClientConnectionStateMachineEndToEndTest {
         outboundChannel.checkException();
 
         assertNextClientResponseIsErrorFor(requestFrame);
-
-        assertThat(inboundChannel.config().isAutoRead())
-                .describedAs("Client autoread should be off while connecting to server")
-                .isFalse();
 
         assertEverythingClosed(clientConnectionStateMachine);
     }
@@ -605,18 +611,6 @@ class ClientConnectionStateMachineEndToEndTest {
                 null);
     }
 
-    private void assertHandlerInForwardingState(
-                                                ClientConnectionStateMachine clientConnectionStateMachine,
-                                                List<ApiKeys> expectedBufferedRequestTypes) {
-        assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Forwarding.class);
-        assertThat(clientConnectionStateMachine.clientSoftwareName())
-                .isEqualTo(expectedBufferedRequestTypes.contains(ApiKeys.API_VERSIONS) ? CLIENT_SOFTWARE_NAME : null);
-        assertThat(clientConnectionStateMachine.clientSoftwareVersion())
-                .isEqualTo(expectedBufferedRequestTypes.contains(ApiKeys.API_VERSIONS) ? CLIENT_SOFTWARE_VERSION : null);
-        assertThat(handler.bufferedMsgs).asInstanceOf(InstanceOfAssertFactories.list(DecodedRequestFrame.class))
-                .map(DecodedRequestFrame::apiKey).isEqualTo(expectedBufferedRequestTypes);
-    }
-
     @SafeVarargs
     static List<Arguments> crossProduct(List<Arguments>... list) {
         if (list.length == 0) {
@@ -700,7 +694,9 @@ class ClientConnectionStateMachineEndToEndTest {
         inboundChannel.runPendingTasks();
 
         // Write the first client request to trigger the ClientActive → Forwarding transition.
-        // This creates a real SCSM and initiates the backend connection (without activating it).
+        // This creates a real SCSM, initiates the backend connection, and decrements the
+        // progressionLatch from 1 to 0 — triggering unblockClient(). The first request is
+        // forwarded through the filter chain to the SCSM, which buffers it (Connecting state).
         switch (firstMessage) {
             case API_VERSIONS -> writeInboundApiVersionsRequest();
             case SASL_HANDSHAKE -> writeSaslPlainHandshake();
@@ -714,8 +710,8 @@ class ClientConnectionStateMachineEndToEndTest {
 
     @SuppressWarnings("unchecked")
     @NonNull
-    private DecodedRequestFrame<ApiMessage> firstBufferedRequest() {
-        return (DecodedRequestFrame<ApiMessage>) handler.bufferedMsgs.get(0);
+    private DecodedRequestFrame<ApiMessage> firstInitialRequest() {
+        return (DecodedRequestFrame<ApiMessage>) Objects.requireNonNull(handler.initialRequestForError);
     }
 
     // TODO backpressure

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
@@ -421,13 +421,13 @@ class ClientConnectionStateMachineTest {
 
     @Test
     void onServerActiveShouldNotUnblockClient() {
-        // Given — Forwarding state, latch at 1
+        // Given — Forwarding state, transport subject not yet ready
         clientConnectionStateMachine.forceState(
                 new ClientConnectionState.Forwarding(),
                 frontendHandler,
                 serverConnectionStateMachine,
                 TEST_KAFKA_SESSION,
-                1);
+                false);
 
         // When
         clientConnectionStateMachine.onServerConnectionActive();
@@ -438,7 +438,7 @@ class ClientConnectionStateMachineTest {
     }
 
     @Test
-    void inForwardingShouldBufferRequestsWhenLatchNotZero() {
+    void inForwardingShouldBufferRequestsWhenTransportSubjectNotReady() {
         // Given — Forwarding state with latch > 0 (backend not yet connected)
         stateMachineInForwardingAwaitingTransportSubject();
 
@@ -709,7 +709,7 @@ class ClientConnectionStateMachineTest {
                 frontendHandler,
                 null,
                 TEST_KAFKA_SESSION,
-                -1);
+                true);
     }
 
     private void stateMachineInHaProxy() {
@@ -718,7 +718,7 @@ class ClientConnectionStateMachineTest {
                 frontendHandler,
                 null,
                 TEST_KAFKA_SESSION,
-                -1);
+                true);
     }
 
     private ClientConnectionState.Forwarding stateMachineInForwarding() {
@@ -728,7 +728,7 @@ class ClientConnectionStateMachineTest {
                 frontendHandler,
                 serverConnectionStateMachine,
                 TEST_KAFKA_SESSION,
-                -1);
+                true);
         return forwarding;
     }
 
@@ -738,7 +738,7 @@ class ClientConnectionStateMachineTest {
                 frontendHandler,
                 serverConnectionStateMachine,
                 TEST_KAFKA_SESSION,
-                1);
+                false);
     }
 
     private void stateMachineInClosed() {
@@ -747,7 +747,7 @@ class ClientConnectionStateMachineTest {
                 frontendHandler,
                 serverConnectionStateMachine,
                 TEST_KAFKA_SESSION,
-                -1);
+                true);
     }
 
     private static DecodedRequestFrame<ApiVersionsRequestData> apiVersionsRequest() {
@@ -1131,7 +1131,7 @@ class ClientConnectionStateMachineTest {
         @Test
         void drainWhenStateIsNotForwardingStillCompletesFuture() {
             // Given — CCSM stuck in HaProxy state (not Forwarding)
-            clientConnectionStateMachine.forceState(new ClientConnectionState.HaProxy(), frontendHandler, null, TEST_KAFKA_SESSION, -1);
+            clientConnectionStateMachine.forceState(new ClientConnectionState.HaProxy(), frontendHandler, null, TEST_KAFKA_SESSION, true);
 
             // When
             CompletableFuture<Void> closedFuture = clientConnectionStateMachine.drain(DRAIN_TIMEOUT);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
@@ -197,7 +197,7 @@ class ClientConnectionStateMachineTest {
     @Test
     void shouldTransitionToClosedOnServerExceptionInForwardingAwaitingBackend() {
         // Given
-        stateMachineInForwardingAwaitingBackend();
+        stateMachineInForwardingAwaitingTransportSubject();
 
         // When
         clientConnectionStateMachine.onServerConnectionException(failure);
@@ -420,8 +420,8 @@ class ClientConnectionStateMachineTest {
     }
 
     @Test
-    void inForwardingShouldUnblockClientWhenOnServerActiveCalledAndLatchReachesZero() {
-        // Given — Forwarding state, latch at 1 (waiting only for backend)
+    void onServerActiveShouldNotUnblockClient() {
+        // Given — Forwarding state, latch at 1
         clientConnectionStateMachine.forceState(
                 new ClientConnectionState.Forwarding(),
                 frontendHandler,
@@ -432,35 +432,15 @@ class ClientConnectionStateMachineTest {
         // When
         clientConnectionStateMachine.onServerConnectionActive();
 
-        // Then
+        // Then — backend activation no longer participates in unblocking
         assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Forwarding.class);
-        verify(frontendHandler).unblockClient();
-        verifyNoInteractions(serverConnectionStateMachine);
-    }
-
-    @Test
-    void onServerActiveDoesNotUnblockClientIfWaitingForTransportSubject() {
-        // Given — Forwarding state, latch at 2 (waiting for both)
-        clientConnectionStateMachine.forceState(
-                new ClientConnectionState.Forwarding(),
-                frontendHandler,
-                serverConnectionStateMachine,
-                TEST_KAFKA_SESSION,
-                2);
-
-        // When
-        clientConnectionStateMachine.onServerConnectionActive();
-
-        // Then
-        assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Forwarding.class);
-        verifyNoInteractions(frontendHandler);
-        verifyNoInteractions(serverConnectionStateMachine);
+        verify(frontendHandler, never()).unblockClient();
     }
 
     @Test
     void inForwardingShouldBufferRequestsWhenLatchNotZero() {
         // Given — Forwarding state with latch > 0 (backend not yet connected)
-        stateMachineInForwardingAwaitingBackend();
+        stateMachineInForwardingAwaitingTransportSubject();
 
         // When
         DecodedRequestFrame<MetadataRequestData> msg = metadataRequest();
@@ -697,8 +677,8 @@ class ClientConnectionStateMachineTest {
                 }, false),
                 argumentSet("Ha Proxy TLS on", (Runnable) this::stateMachineInHaProxy, true),
                 argumentSet("Ha Proxy TLS off ", (Runnable) this::stateMachineInHaProxy, false),
-                argumentSet("Forwarding awaiting backend TLS on", (Runnable) this::stateMachineInForwardingAwaitingBackend, true),
-                argumentSet("Forwarding awaiting backend TLS off ", (Runnable) this::stateMachineInForwardingAwaitingBackend, false),
+                argumentSet("Forwarding awaiting backend TLS on", (Runnable) this::stateMachineInForwardingAwaitingTransportSubject, true),
+                argumentSet("Forwarding awaiting backend TLS off ", (Runnable) this::stateMachineInForwardingAwaitingTransportSubject, false),
                 argumentSet("Client Active TLS on", (Runnable) this::stateMachineInClientActive, true),
                 argumentSet("Client Active TLS off ", (Runnable) this::stateMachineInClientActive, false),
                 argumentSet("Forwarding TLS on", (Runnable) this::stateMachineInForwarding, true),
@@ -710,7 +690,7 @@ class ClientConnectionStateMachineTest {
     public Stream<Arguments> givenStates() {
         return Stream.of(
                 argumentSet("Ha Proxy", (Runnable) this::stateMachineInHaProxy),
-                argumentSet("Forwarding awaiting backend", (Runnable) this::stateMachineInForwardingAwaitingBackend),
+                argumentSet("Forwarding awaiting backend", (Runnable) this::stateMachineInForwardingAwaitingTransportSubject),
                 argumentSet("ClientActive ", (Runnable) this::stateMachineInClientActive),
                 argumentSet("Forwarding", (Runnable) this::stateMachineInForwarding),
                 argumentSet("Closed", (Runnable) this::stateMachineInClosed));
@@ -718,7 +698,7 @@ class ClientConnectionStateMachineTest {
 
     public Stream<Arguments> connectedStates() {
         return Stream.of(
-                argumentSet("Forwarding awaiting backend", (Runnable) this::stateMachineInForwardingAwaitingBackend),
+                argumentSet("Forwarding awaiting backend", (Runnable) this::stateMachineInForwardingAwaitingTransportSubject),
                 argumentSet("Forwarding", (Runnable) this::stateMachineInForwarding),
                 argumentSet("Closed", (Runnable) this::stateMachineInClosed));
     }
@@ -752,13 +732,13 @@ class ClientConnectionStateMachineTest {
         return forwarding;
     }
 
-    private void stateMachineInForwardingAwaitingBackend() {
+    private void stateMachineInForwardingAwaitingTransportSubject() {
         clientConnectionStateMachine.forceState(
                 new ClientConnectionState.Forwarding(),
                 frontendHandler,
                 serverConnectionStateMachine,
                 TEST_KAFKA_SESSION,
-                2);
+                1);
     }
 
     private void stateMachineInClosed() {
@@ -814,7 +794,7 @@ class ClientConnectionStateMachineTest {
     @Test
     void shouldRemainInForwardingWhenOnServerConnectionActive() {
         // Given
-        stateMachineInForwardingAwaitingBackend();
+        stateMachineInForwardingAwaitingTransportSubject();
 
         // When
         clientConnectionStateMachine.onServerConnectionActive();
@@ -827,7 +807,7 @@ class ClientConnectionStateMachineTest {
     void shouldDecrementActiveConnectionsOnClosed() {
         // Given - establish both client and server connections
         clientConnectionStateMachine.onClientActive(frontendHandler);
-        stateMachineInForwardingAwaitingBackend();
+        stateMachineInForwardingAwaitingTransportSubject();
         clientConnectionStateMachine.onServerConnectionActive();
 
         int initialClientCount = getVirtualNodeClientToProxyActiveConnections();
@@ -845,7 +825,7 @@ class ClientConnectionStateMachineTest {
     void shouldDecrementActiveConnectionsOnServerInactive() {
         // Given - establish both client and server connections
         clientConnectionStateMachine.onClientActive(frontendHandler);
-        stateMachineInForwardingAwaitingBackend();
+        stateMachineInForwardingAwaitingTransportSubject();
         clientConnectionStateMachine.onServerConnectionActive();
 
         int initialClientCount = getVirtualNodeClientToProxyActiveConnections();
@@ -876,7 +856,7 @@ class ClientConnectionStateMachineTest {
     void shouldDecrementActiveConnectionsOnServerException() {
         // Given - establish both client and server connections
         clientConnectionStateMachine.onClientActive(frontendHandler);
-        stateMachineInForwardingAwaitingBackend();
+        stateMachineInForwardingAwaitingTransportSubject();
         clientConnectionStateMachine.onServerConnectionActive();
 
         int initialClientCount = getVirtualNodeClientToProxyActiveConnections();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -105,7 +105,7 @@ public abstract class FilterHarness {
                 mock(KafkaProxyFrontendHandler.class),
                 mock(ServerConnectionStateMachine.class),
                 kafkaSession,
-                -1);
+                true);
         var filterHandlers = Arrays.stream(filters)
                 .collect(Collector.of(ArrayDeque<Filter>::new, ArrayDeque::addLast, (d1, d2) -> {
                     d2.addAll(d1);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -62,7 +62,6 @@ import io.kroxylicious.testing.filter.RequestFactory;
 
 import static io.kroxylicious.proxy.model.VirtualClusterModel.DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -490,8 +489,8 @@ class KafkaProxyFrontendHandlerTest {
 
     private void handleConnect(ClientConnectionStateMachine clientConnectionStateMachine) {
         assertThat(clientConnectionStateMachine.state()).isExactlyInstanceOf(ClientConnectionState.Forwarding.class);
-        assertFalse(inboundChannel.config().isAutoRead(),
-                "Expect inbound autoRead=true, since outbound not yet active");
+        assertTrue(inboundChannel.config().isAutoRead(),
+                "Expect inbound autoRead=true, client already unblocked on entering Forwarding");
 
         // Simulate the backend handler receiving channel active and telling the frontend handler
         outboundChannelBecomesActive(clientConnectionStateMachine);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachineTest.java
@@ -20,6 +20,9 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
 
 import io.kroxylicious.proxy.internal.util.ActivationToken;
 import io.kroxylicious.proxy.service.HostPort;
@@ -29,6 +32,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class ServerConnectionStateMachineTest {
@@ -76,6 +80,116 @@ class ServerConnectionStateMachineTest {
             meterRegistry.getMeters().forEach(Metrics.globalRegistry::remove);
             Metrics.globalRegistry.remove(meterRegistry);
         }
+    }
+
+    @Test
+    void sendRequestWhileConnectingShouldBuffer() {
+        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Connecting.class);
+
+        Object msg = new Object();
+        serverStateMachine.sendRequest(msg);
+
+        assertThat(serverStateMachine.serverMessagesInFlightCount).isZero();
+    }
+
+    @Test
+    void sendRequestWhileActiveShouldForwardImmediately() {
+        var channel = new EmbeddedChannel(serverStateMachine.backendHandler());
+        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Active.class);
+
+        Object msg = "test-request";
+        serverStateMachine.sendRequest(msg);
+
+        assertThat(serverStateMachine.serverMessagesInFlightCount).isEqualTo(1);
+        assertThat(channel.<Object> readOutbound()).isEqualTo(msg);
+    }
+
+    @Test
+    void onServerActiveShouldFlushPendingRequests() {
+
+        serverStateMachine.sendRequest("req-1");
+        serverStateMachine.sendRequest("req-2");
+        assertThat(serverStateMachine.serverMessagesInFlightCount).isZero();
+
+        // Registering the handler triggers channelActive → onServerActive → flush
+        var channel = new EmbeddedChannel(serverStateMachine.backendHandler());
+        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Active.class);
+        assertThat(serverStateMachine.serverMessagesInFlightCount).isEqualTo(2);
+
+        assertThat(channel.<Object> readOutbound()).isEqualTo("req-1");
+        assertThat(channel.<Object> readOutbound()).isEqualTo("req-2");
+        assertThat(channel.<Object> readOutbound()).isNull();
+    }
+
+    @Test
+    void onServerActiveShouldFlushBeforePcsmCallback() {
+        serverStateMachine.sendRequest("req-1");
+        verifyNoInteractions(ccsm);
+
+        // channelActive → onServerActive → flush pending → pcsm callback
+        new EmbeddedChannel(serverStateMachine.backendHandler());
+
+        // At the point pcsm.onServerConnectionActive() was called,
+        // the pending requests had already been flushed
+        assertThat(serverStateMachine.serverMessagesInFlightCount).isEqualTo(1);
+        verify(ccsm).onServerConnectionActive();
+    }
+
+    @Test
+    void closedShouldReleasePendingRequests() {
+        ByteBuf buf = Unpooled.buffer(4).writeInt(42);
+        assertThat(buf.refCnt()).isEqualTo(1);
+        serverStateMachine.sendRequest(buf);
+
+        serverStateMachine.close();
+
+        assertThat(buf.refCnt()).isZero();
+    }
+
+    @Test
+    void closedWithNoPendingRequestsShouldNotFail() {
+        serverStateMachine.close();
+
+        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Closed.class);
+    }
+
+    @Test
+    void exceptionWhileConnectingShouldReleasePendingRequests() {
+        ByteBuf buf = Unpooled.buffer(4).writeInt(99);
+        serverStateMachine.sendRequest(buf);
+        assertThat(buf.refCnt()).isEqualTo(1);
+
+        serverStateMachine.onServerException(new RuntimeException("connection failed"));
+
+        assertThat(buf.refCnt()).isZero();
+        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Closed.class);
+    }
+
+    @Test
+    void onServerActiveWithNoPendingRequestsShouldNotFail() {
+        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Connecting.class);
+
+        // channelActive triggers onServerActive — no pending requests to flush
+        new EmbeddedChannel(serverStateMachine.backendHandler());
+
+        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Active.class);
+        assertThat(serverStateMachine.serverMessagesInFlightCount).isZero();
+    }
+
+    @Test
+    void pendingRequestsPreserveOrder() {
+
+        for (int i = 0; i < 5; i++) {
+            serverStateMachine.sendRequest("req-" + i);
+        }
+
+        var channel = new EmbeddedChannel(serverStateMachine.backendHandler());
+
+        for (int i = 0; i < 5; i++) {
+            assertThat(channel.<Object> readOutbound()).isEqualTo("req-" + i);
+        }
+        assertThat(channel.<Object> readOutbound()).isNull();
+        assertThat(serverStateMachine.serverMessagesInFlightCount).isEqualTo(5);
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

refactor(runtime): add request buffering to ServerConnectionStateMachine
refactor(runtime): decouple progressionLatch from backend connection
refactor(runtime): collapse progressionLatch to a boolean

This moves to a cleaner separation of concerns where the Client state machine only concerns itself with waiting for the transport subject to be ready, then it can forward messages to the backend, without having to know if the backend is connected.

The backend state machine buffers messages until it becomes active, then forwards them on.

The client state maching is simplified and we do not have to co-ordinate feedback from a SCSM.

Contributes towards #4015 
### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
