### PR TITLE
feat(benchmarks): add coefficient sweep scripts and operational fixes

### DIFF
--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/scenarios/connection-sweep-values.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/scenarios/connection-sweep-values.yaml
@@ -10,12 +10,12 @@
 # 5 min warmup allows JIT to stabilise before measurement begins.
 # 5 min test gives enough samples for stable p99 latency at typical rates.
 #
-# workerReplicas is raised to 6 to give headroom at high producer counts (up to
-# 8 producers + 8 consumers per step) without workers becoming the bottleneck.
-# OMB assigns ~1/3 of workers to producers and the rest to consumers, so 6 workers
-# gives 2 producer workers.  At 8 producers × 10k msg/s = 80k total, each producer
-# worker handles ~40k msg/s — the CPU limit is raised to 2000m to keep workers
-# well clear of saturation before the proxy CPU becomes the bottleneck.
+# workerReplicas is set to 4 to fit within an 8-node cluster alongside 3 Kafka
+# brokers and 1 proxy (all with hard pod anti-affinity requiring dedicated nodes).
+# OMB assigns ~1/3 of workers to producers and the rest to consumers, so 4 workers
+# gives 1-2 producer workers. At 16 producers × 10k msg/s = 160k total this is
+# sufficient — the CPU limit is raised to 2000m to keep workers well clear of
+# saturation before the proxy CPU becomes the bottleneck.
 #
 # Applied automatically by connection-sweep.sh unless overridden with --profile.
 
@@ -24,7 +24,7 @@ benchmark:
   warmupDurationMinutes: 5
 
 omb:
-  workerReplicas: 6
+  workerReplicas: 4
   resources:
     requests:
       cpu: "1000m"

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/scenarios/smoke-values.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/scenarios/smoke-values.yaml
@@ -44,14 +44,14 @@ omb:
         cpu: "500m"
   resources:
     requests:
-      memory: "1Gi"
+      memory: "2Gi"
       cpu: "250m"
     limits:
-      memory: "2Gi"
+      memory: "4Gi"
       cpu: "500m"
 
 # Short durations and reduced rate — just enough to confirm the pipeline works
 benchmark:
-  testDurationMinutes: 1
+  testDurationMinutes: 2
   warmupDurationMinutes: 0
   producerRate: 10000

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/omb-benchmark-job.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/omb-benchmark-job.yaml
@@ -14,7 +14,7 @@ metadata:
     app: omb-benchmark
 spec:
   backoffLimit: 0
-  activeDeadlineSeconds: {{ mul (add .Values.benchmark.testDurationMinutes .Values.benchmark.warmupDurationMinutes) 90 }}{{/* 90 = 60s/min × 1.5 — gives 1.5× the benchmark duration as a hang deadline */}}
+  activeDeadlineSeconds: {{ max 900 (mul (add .Values.benchmark.testDurationMinutes .Values.benchmark.warmupDurationMinutes) 90) }}{{/* 1.5× benchmark duration, minimum 15 min to cover worker startup overhead */}}
   template:
     metadata:
       labels:

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/values.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/values.yaml
@@ -47,7 +47,7 @@ kroxylicious:
 vault:
   provision: false
   token: benchmark-token  # Root token for the provisioned Vault dev instance
-  image: docker.io/hashicorp/vault:1.21.4@sha256:4e33b126a59c0c333b76fb4e894722462659a6bec7c48c9ee8cea56fccfd2569
+  image: docker.io/hashicorp/vault:2.0.0@sha256:e40c741ed95bb271425e3e6ca6c222d620cf8682f6f7a1b1e7c9d49d0aba484b
   imagePullPolicy: IfNotPresent
   resources:
     requests:
@@ -74,7 +74,7 @@ encryption:
 
 # OpenMessaging Benchmark workers
 omb:
-  workerReplicas: 3
+  workerReplicas: 2
   image: quay.io/kroxylicious/kroxylicious-omb:omb-8559989-krox-e329e4d-2@sha256:addb5ed87a1d1ed87e0a2df9223c25b33d25bf8331709c1d372124420572fe3c
   imagePullPolicy: IfNotPresent
   driver: baseline  # Can be 'baseline' or 'proxy'

--- a/kroxylicious-openmessaging-benchmarks/scripts/analyze-cpu-coefficient.py
+++ b/kroxylicious-openmessaging-benchmarks/scripts/analyze-cpu-coefficient.py
@@ -32,8 +32,11 @@ An operator can then estimate required proxy CPU as:
 
 Usage:
     python3 analyze-cpu-coefficient.py <sweep-output-dir> [--skip-first N]
+    python3 analyze-cpu-coefficient.py --compare <dir1> [<dir2> ...] [--skip-first N]
 
     sweep-output-dir  Root of a connection-sweep run, e.g. /tmp/results/conn-sweep/
+    --compare         Print a one-row-per-config summary table across multiple directories.
+                      Each dir may be prefixed with a label: "label:path"
     --skip-first N    Fallback: skip the first N CPU snapshots per probe when
                       phase timestamps are absent (default: 10)
 
@@ -221,36 +224,22 @@ def find_probes(sweep_dir):
     return probes
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Derive proxy CPU sizing coefficient from connection-sweep results"
-    )
-    parser.add_argument("sweep_dir", help="Root of a connection-sweep output directory")
-    parser.add_argument(
-        "--skip-first",
-        type=int,
-        default=10,
-        metavar="N",
-        help="Fallback: skip first N CPU snapshots when timestamps absent (default: 10)",
-    )
-    args = parser.parse_args()
+def analyze_sweep(sweep_dir, skip_first):
+    """Analyze a sweep directory; return (probe_rows, summary_stats, last_data).
 
-    probes = find_probes(args.sweep_dir)
-    if not probes:
-        print(f"No producers-N directories found under {args.sweep_dir}", file=sys.stderr)
-        sys.exit(1)
-
-    print(f"{'Producers':>9}  {'Achieved':>10}  {'Target':>10}  {'Sat':>4}  "
-          f"{'CPU (mc)':>9}  {'Snapshots':>11}  {'Filter':>10}  {'Source':>14}  {'Coeff (mc/MB/s)':>16}")
-    print("-" * 110)
-
+    probe_rows is a list of dicts for the per-probe table.
+    summary_stats is a dict with mean, stdev, n, sat, or None if no usable data.
+    """
+    probes = find_probes(sweep_dir)
+    rows = []
     coefficients = []
+    sat_count = 0
     last_data = None
 
     for n, probe_dir in probes:
-        data = load_probe(probe_dir, args.skip_first)
+        data = load_probe(probe_dir, skip_first)
         if data is None:
-            print(f"{n:>9}  (no data)")
+            rows.append({"producers": n, "no_data": True})
             continue
 
         achieved = data["achieved_rate"] * data.get("topics", 1)
@@ -261,31 +250,68 @@ def main():
 
         cpu_avg = statistics.mean(usable) if usable else float("nan")
         cpu_millicores = cpu_avg * 1000
-
         total_mb_per_s = (achieved * msg_size * 2) / 1_000_000
         coeff = cpu_millicores / total_mb_per_s if total_mb_per_s > 0 else float("nan")
 
-        sat_flag = "*" if saturated else " "
-        target_str = f"{target:>10,.0f}" if target else f"{'?':>10}"
-        snap_str = f"{len(usable)}/{data['all_snapshots']}"
-        print(f"{n:>9}  {achieved:>10,.0f}  {target_str}  {sat_flag:>4}  "
-              f"{cpu_millicores:>9.0f}  {snap_str:>11}  {data['filter_method']:>10}  "
-              f"{data.get('cpu_source','?'):>14}  {coeff:>16.1f}")
+        rows.append({
+            "producers": n,
+            "achieved": achieved,
+            "target": target,
+            "saturated": saturated,
+            "cpu_millicores": cpu_millicores,
+            "usable_count": len(usable),
+            "all_count": data["all_snapshots"],
+            "filter_method": data["filter_method"],
+            "cpu_source": data.get("cpu_source", "?"),
+            "coeff": coeff,
+        })
 
-        if not saturated:
+        if saturated:
+            sat_count += 1
+        else:
             coefficients.append(coeff)
         last_data = data
 
-    print()
-    if coefficients:
-        mean_coeff = statistics.mean(coefficients)
-        stdev_coeff = statistics.stdev(coefficients) if len(coefficients) > 1 else 0.0
+    if not coefficients:
+        return rows, None, last_data
 
-        print(f"Sizing coefficient (non-saturated probes only): {mean_coeff:.1f} mc/MB/s  "
-              f"(±{stdev_coeff:.1f} stdev, n={len(coefficients)})")
+    mean_coeff = statistics.mean(coefficients)
+    stdev_coeff = statistics.stdev(coefficients) if len(coefficients) > 1 else 0.0
+    summary = {
+        "mean": mean_coeff,
+        "stdev": stdev_coeff,
+        "n": len(coefficients),
+        "sat": sat_count,
+    }
+    return rows, summary, last_data
+
+
+def print_full_table(sweep_dir, skip_first):
+    """Print the detailed per-probe table for a single sweep directory."""
+    rows, summary, last_data = analyze_sweep(sweep_dir, skip_first)
+
+    print(f"{'Producers':>9}  {'Achieved':>10}  {'Target':>10}  {'Sat':>4}  "
+          f"{'CPU (mc)':>9}  {'Snapshots':>11}  {'Filter':>10}  {'Source':>14}  {'Coeff (mc/MB/s)':>16}")
+    print("-" * 110)
+
+    for row in rows:
+        if row.get("no_data"):
+            print(f"{row['producers']:>9}  (no data)")
+            continue
+        sat_flag = "*" if row["saturated"] else " "
+        target_str = f"{row['target']:>10,.0f}" if row["target"] else f"{'?':>10}"
+        snap_str = f"{row['usable_count']}/{row['all_count']}"
+        print(f"{row['producers']:>9}  {row['achieved']:>10,.0f}  {target_str}  {sat_flag:>4}  "
+              f"{row['cpu_millicores']:>9.0f}  {snap_str:>11}  {row['filter_method']:>10}  "
+              f"{row['cpu_source']:>14}  {row['coeff']:>16.1f}")
+
+    print()
+    if summary:
+        print(f"Sizing coefficient (non-saturated probes only): {summary['mean']:.1f} mc/MB/s  "
+              f"(±{summary['stdev']:.1f} stdev, n={summary['n']})")
         print()
         print("Sizing formula:")
-        print(f"  proxy_CPU_millicores = {mean_coeff:.0f} × (produce_MB_per_s + consume_MB_per_s)")
+        print(f"  proxy_CPU_millicores = {summary['mean']:.0f} × (produce_MB_per_s + consume_MB_per_s)")
         print()
         print("Notes:")
         print("  - Assumes encrypt ≈ decrypt CPU cost (bidirectional measurement)")
@@ -296,6 +322,80 @@ def main():
     else:
         print("No non-saturated probes found — cannot compute coefficient.")
         print("Run the sweep at a lower per-producer rate or with fewer steps.")
+
+
+def derive_label(path):
+    """Derive a short display label from a sweep directory path."""
+    parent = os.path.basename(os.path.dirname(os.path.abspath(path)))
+    label = re.sub(r"^conn-sweep-[^-]+-", "", parent)
+    label = re.sub(r"-rf\d+$", "", label)
+    return label or parent
+
+
+def parse_compare_arg(arg):
+    """Parse 'label:path' or plain 'path'; return (label, path)."""
+    if ":" in arg:
+        label, _, path = arg.partition(":")
+        return label.strip(), path.strip()
+    return derive_label(arg), arg
+
+
+def print_comparison_table(compare_args, skip_first):
+    """Print a one-row-per-config summary table."""
+    entries = [parse_compare_arg(a) for a in compare_args]
+
+    col_label = max(len(label) for label, _ in entries)
+    col_label = max(col_label, 6)
+
+    header = (f"{'Config':<{col_label}}  {'Coeff (mc/MB/s)':>16}  "
+              f"{'Stdev':>7}  {'n':>3}  {'Sat':>4}  Formula")
+    print(header)
+    print("-" * len(header))
+
+    for label, path in entries:
+        _, summary, _ = analyze_sweep(path, skip_first)
+        if summary is None:
+            print(f"{label:<{col_label}}  (no usable data)")
+            continue
+        sat_str = f"{summary['sat']}*" if summary["sat"] else "  -"
+        formula = f"{summary['mean']:.0f} × MB/s"
+        print(f"{label:<{col_label}}  {summary['mean']:>13.1f} mc/MB/s  "
+              f"±{summary['stdev']:>5.1f}  {summary['n']:>3}  {sat_str:>4}  {formula}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Derive proxy CPU sizing coefficient from connection-sweep results"
+    )
+    parser.add_argument(
+        "sweep_dir",
+        nargs="?",
+        help="Root of a connection-sweep output directory (single-run mode)",
+    )
+    parser.add_argument(
+        "--compare",
+        nargs="+",
+        metavar="DIR",
+        help="Compare multiple sweep directories (one row each). Each entry may be 'label:path'.",
+    )
+    parser.add_argument(
+        "--skip-first",
+        type=int,
+        default=10,
+        metavar="N",
+        help="Fallback: skip first N CPU snapshots when timestamps absent (default: 10)",
+    )
+    args = parser.parse_args()
+
+    if args.compare and args.sweep_dir:
+        parser.error("Specify either a sweep_dir or --compare, not both.")
+    if not args.compare and not args.sweep_dir:
+        parser.error("Specify a sweep_dir or use --compare.")
+
+    if args.compare:
+        print_comparison_table(args.compare, args.skip_first)
+    else:
+        print_full_table(args.sweep_dir, args.skip_first)
 
 
 if __name__ == "__main__":

--- a/kroxylicious-openmessaging-benchmarks/scripts/run-all-scenarios.sh
+++ b/kroxylicious-openmessaging-benchmarks/scripts/run-all-scenarios.sh
@@ -38,6 +38,8 @@ Options:
                              settings always win. Passed through to each run-benchmark.sh call.
   --profile <values-file>    Additional Helm values file layered on top of each scenario.
                              May be specified multiple times; files are applied in order.
+  --set <key=value>         Pass a Helm --set override. May be repeated. Passed through to
+                             each run-benchmark.sh call.
   -h, --help                 Show this help
 
 Environment:
@@ -55,6 +57,7 @@ EOF
 }
 
 PROFILE_VALUES=()
+SET_OVERRIDES=()
 CLUSTER_OVERRIDES=""
 POSITIONAL=()
 
@@ -66,6 +69,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --profile)
             PROFILE_VALUES+=("$2")
+            shift 2
+            ;;
+        --set)
+            SET_OVERRIDES+=(--set "$2")
             shift 2
             ;;
         -h|--help)
@@ -126,6 +133,7 @@ echo ""
 RUN_BENCHMARK_ARGS=()
 for profile_file in ${PROFILE_VALUES[@]+"${PROFILE_VALUES[@]}"}; do RUN_BENCHMARK_ARGS+=(--profile "${profile_file}"); done
 [[ -n "${CLUSTER_OVERRIDES}" ]] && RUN_BENCHMARK_ARGS+=(--cluster-overrides "${CLUSTER_OVERRIDES}")
+RUN_BENCHMARK_ARGS+=(${SET_OVERRIDES[@]+"${SET_OVERRIDES[@]}"})
 
 for SCENARIO in "${SCENARIOS[@]}"; do
     for WORKLOAD in "${WORKLOADS[@]}"; do

--- a/kroxylicious-openmessaging-benchmarks/scripts/run-benchmark.sh
+++ b/kroxylicious-openmessaging-benchmarks/scripts/run-benchmark.sh
@@ -569,7 +569,7 @@ else
     echo "Removing previous benchmark Job..."
     kubectl delete job omb-benchmark -n "${NAMESPACE}" --ignore-not-found --wait --timeout=60s
     echo "Restarting OMB workers for clean probe..."
-    kubectl delete pod -l app=omb-worker -n "${NAMESPACE}" --wait --timeout=60s
+    kubectl delete pod -l app=omb-worker -n "${NAMESPACE}" --grace-period=30 --wait --timeout=120s
     check_workers_healthy
     reset_topics
 fi
@@ -614,6 +614,17 @@ if [[ -n "${PROXY_POD}" && "${SKIP_DEPLOY}" == "false" ]]; then
             envsubst '${PROXY_DEPLOYMENT} ${NAMESPACE}' \
             < "${HELM_CHART}/patches/proxy-anti-affinity.yaml" \
             | kubectl apply --server-side --field-manager=benchmark-anti-affinity -f - >/dev/null
+    fi
+
+    # Force-delete the old proxy pod so the new one can schedule.
+    # Required when the proxy has a high CPU request (e.g. 4-core) that consumes
+    # most of its dedicated node: the rolling update default (maxUnavailable=0) would
+    # deadlock waiting for the new pod to be ready before evicting the old one, but
+    # the new pod cannot schedule while the old pod holds the node's CPU.
+    OLD_PROXY_POD=$(kubectl get pod -n "${NAMESPACE}" -l "${PROXY_POD_LABEL}" \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) || true
+    if [[ -n "${OLD_PROXY_POD}" ]]; then
+        kubectl delete pod "${OLD_PROXY_POD}" -n "${NAMESPACE}" --grace-period=30 2>/dev/null || true
     fi
 
     echo "Waiting for proxy deployment rollout after patch..."

--- a/kroxylicious-openmessaging-benchmarks/scripts/run-blog-suite.sh
+++ b/kroxylicious-openmessaging-benchmarks/scripts/run-blog-suite.sh
@@ -20,11 +20,8 @@ set -uo pipefail
 # Steps:
 #   Post 1 — Multi-topic latency  (run-all-scenarios, RF=3, 3 scenarios × 3 workloads)
 #   Post 1 — Rate sweep           (rate-sweep, RF=3, 1-core proxy, 8k–22k msg/s, 5% steps)
-#   Post 2 — Connection sweep, encryption, 1-core, 1-topic, RF=1
-#   Post 2 — Connection sweep, encryption, 4-core, 1-topic, RF=1
-#   Post 2 — Connection sweep, encryption, 4-core, 10-topics, RF=1
+#   Post 2 — CPU coefficient sweep (run-coefficient-sweep: 1/2/4 cores × 1/10/100 topics, RF=1)
 #   Post 2 — Connection sweep, proxy-no-filters, 4-core, 10-topics, RF=1
-#   Post 2 — CPU coefficient analysis (4-core sweeps)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MODULE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -36,7 +33,7 @@ usage() {
 Usage: $(basename "$0") [--cluster-overrides <file>] [--output-dir <dir>]
 
 Options:
-  --cluster-overrides <file>  Helm values for cluster-specific settings
+  --cluster-overrides <file>  Helm values for cluster-specific settings (e.g. vault image)
   --output-dir <dir>          Root directory for all results
                               (default: results/blog-suite-<timestamp>)
   -h, --help                  Show this help
@@ -92,17 +89,25 @@ run_step() {
     fi
 }
 
+# Proxy resource presets — passed as --set flags so cluster-overrides stays
+# cluster-specific (vault image, storage class) rather than run-specific.
+# Memory is held constant across core counts so only CPU varies between runs.
+PROXY_MEM="--set kroxylicious.resources.requests.memory=2Gi --set kroxylicious.resources.limits.memory=4Gi"
+PROXY_1CORE="--set kroxylicious.resources.requests.cpu=1000m --set kroxylicious.resources.limits.cpu=1000m ${PROXY_MEM}"
+PROXY_4CORE="--set kroxylicious.resources.requests.cpu=4000m --set kroxylicious.resources.limits.cpu=4000m ${PROXY_MEM}"
+
 # ---------------------------------------------------------------------------
-# Post 1 — Multi-topic latency (RF=3, 3 scenarios × 3 workloads, ~3 hours)
+# Post 1 — Multi-topic latency (RF=3, 1-core proxy, 3 scenarios × 3 workloads)
 # ---------------------------------------------------------------------------
 run_step "post1-multi-topic-latency" \
     scripts/run-all-scenarios.sh \
         baseline proxy-no-filters encryption \
         ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
+        ${PROXY_1CORE} \
         "${OUTPUT_DIR}/all-scenarios/"
 
 # ---------------------------------------------------------------------------
-# Post 1 — Rate sweep (RF=3, 1-core proxy, 8k–22k msg/s, 5% steps, ~10 hours)
+# Post 1 — Rate sweep (RF=3, 1-core proxy, 8k–22k msg/s, 5% steps)
 # ---------------------------------------------------------------------------
 run_step "post1-rate-sweep-1core-rf3" \
     scripts/rate-sweep.sh \
@@ -110,48 +115,20 @@ run_step "post1-rate-sweep-1core-rf3" \
         --scenarios baseline,proxy-no-filters,encryption \
         --workload 1topic-1kb \
         ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
-        --set kroxylicious.resources.requests.cpu=1000m \
-        --set kroxylicious.resources.limits.cpu=1000m \
+        ${PROXY_1CORE} \
         --output-dir "${OUTPUT_DIR}/rate-sweep-1core-rf3/"
 
 # ---------------------------------------------------------------------------
-# Post 2 — Connection sweeps (all RF=1, 10k msg/s per producer)
+# Post 2 — CPU coefficient sweep (1/2/4 cores × 1/10/100 topics, all RF=1)
 # ---------------------------------------------------------------------------
-run_step "post2-conn-sweep-encryption-1core-1topic" \
-    scripts/connection-sweep.sh \
-        --scenario encryption \
-        --per-producer-rate 10000 \
-        --steps 1,2,4,8,16 \
-        --workload 1topic-1kb \
+run_step "post2-cpu-coefficient-sweep" \
+    scripts/run-coefficient-sweep.sh \
         ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
-        --set kafka.replicationFactor=1 \
-        --set kafka.minInSyncReplicas=1 \
-        --set kroxylicious.resources.requests.cpu=1000m \
-        --set kroxylicious.resources.limits.cpu=1000m \
-        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-1core-1topic-rf1/"
+        --output-dir "${OUTPUT_DIR}/coefficient-sweep/"
 
-run_step "post2-conn-sweep-encryption-4core-1topic" \
-    scripts/connection-sweep.sh \
-        --scenario encryption \
-        --per-producer-rate 10000 \
-        --steps 1,2,4,8,16,32 \
-        --workload 1topic-1kb \
-        ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
-        --set kafka.replicationFactor=1 \
-        --set kafka.minInSyncReplicas=1 \
-        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-4core-1topic-rf1/"
-
-run_step "post2-conn-sweep-encryption-4core-10topics" \
-    scripts/connection-sweep.sh \
-        --scenario encryption \
-        --per-producer-rate 10000 \
-        --steps 1,2,4,8,16,32 \
-        --workload 10topics-1kb \
-        ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
-        --set kafka.replicationFactor=1 \
-        --set kafka.minInSyncReplicas=1 \
-        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-4core-10topics-rf1/"
-
+# ---------------------------------------------------------------------------
+# Post 2 — Proxy overhead baseline (no filters, 4-core, 10-topics, RF=1)
+# ---------------------------------------------------------------------------
 run_step "post2-conn-sweep-no-filters-4core-10topics" \
     scripts/connection-sweep.sh \
         --scenario proxy-no-filters \
@@ -161,27 +138,8 @@ run_step "post2-conn-sweep-no-filters-4core-10topics" \
         ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"} \
         --set kafka.replicationFactor=1 \
         --set kafka.minInSyncReplicas=1 \
+        ${PROXY_4CORE} \
         --output-dir "${OUTPUT_DIR}/conn-sweep-no-filters-4core-10topics-rf1/"
-
-# ---------------------------------------------------------------------------
-# Post 2 — CPU coefficient (run against 4-core sweeps if they succeeded)
-# ---------------------------------------------------------------------------
-COEFF_1TOPIC="${OUTPUT_DIR}/conn-sweep-encryption-4core-1topic-rf1/encryption"
-COEFF_10TOPICS="${OUTPUT_DIR}/conn-sweep-encryption-4core-10topics-rf1/encryption"
-
-if [[ -d "${COEFF_1TOPIC}" ]]; then
-    run_step "post2-cpu-coefficient-1topic" \
-        python3 scripts/analyze-cpu-coefficient.py "${COEFF_1TOPIC}"
-else
-    echo "Skipping cpu-coefficient-1topic — sweep directory not found: ${COEFF_1TOPIC}"
-fi
-
-if [[ -d "${COEFF_10TOPICS}" ]]; then
-    run_step "post2-cpu-coefficient-10topics" \
-        python3 scripts/analyze-cpu-coefficient.py "${COEFF_10TOPICS}"
-else
-    echo "Skipping cpu-coefficient-10topics — sweep directory not found: ${COEFF_10TOPICS}"
-fi
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/kroxylicious-openmessaging-benchmarks/scripts/run-coefficient-sweep.sh
+++ b/kroxylicious-openmessaging-benchmarks/scripts/run-coefficient-sweep.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+set -uo pipefail
+
+# Runs a systematic CPU-coefficient validation sweep across proxy core counts and topic counts.
+#
+# Runs 9 connection sweeps (1/2/4 cores × 1/10/100 topics) then prints a
+# cross-configuration comparison table so you can verify the coefficient is
+# consistent across proxy sizes.
+#
+# Usage: scripts/run-coefficient-sweep.sh [--cluster-overrides <file>] [--output-dir <dir>]
+#
+# Run from: kroxylicious-openmessaging-benchmarks/
+#
+# Estimated runtime: ~9–18 hours depending on cluster speed.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODULE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${MODULE_DIR}"
+
+usage() {
+    cat >&2 <<EOF
+Usage: $(basename "$0") [--cluster-overrides <file>] [--output-dir <dir>]
+
+Options:
+  --cluster-overrides <file>  Helm values for cluster-specific settings
+  --output-dir <dir>          Root directory for all results
+                              (default: results/coefficient-sweep-<timestamp>)
+  -h, --help                  Show this help
+EOF
+    exit 1
+}
+
+CLUSTER_OVERRIDES=""
+OUTPUT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --cluster-overrides) CLUSTER_OVERRIDES="$2"; shift 2 ;;
+        --output-dir)        OUTPUT_DIR="$2";        shift 2 ;;
+        -h|--help)           usage ;;
+        *) echo "Error: unknown argument '$1'" >&2; usage ;;
+    esac
+done
+
+RUN_ID="$(date +%Y%m%d-%H%M%S)"
+OUTPUT_DIR="${OUTPUT_DIR:-results/coefficient-sweep-${RUN_ID}}"
+mkdir -p "${OUTPUT_DIR}"
+
+exec > >(tee "${OUTPUT_DIR}/suite.log") 2>&1
+
+echo "=========================================="
+echo "CPU coefficient sweep — ${RUN_ID}"
+echo "Results: ${OUTPUT_DIR}"
+echo "Cluster overrides: ${CLUSTER_OVERRIDES:-none}"
+echo "Started: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "=========================================="
+echo ""
+
+FAILED_STEPS=()
+
+run_step() {
+    local name="$1"
+    shift
+    local start
+    start="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo ""
+    echo "--- ${name} ---"
+    echo "Started: ${start}"
+    if "$@"; then
+        echo "Completed: $(date -u +%Y-%m-%dT%H:%M:%SZ) — ${name}"
+    else
+        echo "FAILED: $(date -u +%Y-%m-%dT%H:%M:%SZ) — ${name}" >&2
+        FAILED_STEPS+=("${name}")
+    fi
+}
+
+PROXY_MEM="--set kroxylicious.resources.requests.memory=2Gi --set kroxylicious.resources.limits.memory=4Gi"
+PROXY_1CORE="--set kroxylicious.resources.requests.cpu=1000m --set kroxylicious.resources.limits.cpu=1000m ${PROXY_MEM}"
+PROXY_2CORE="--set kroxylicious.resources.requests.cpu=2000m --set kroxylicious.resources.limits.cpu=2000m ${PROXY_MEM}"
+PROXY_4CORE="--set kroxylicious.resources.requests.cpu=4000m --set kroxylicious.resources.limits.cpu=4000m ${PROXY_MEM}"
+
+CLUSTER_OVERRIDES_ARG=()
+[[ -n "${CLUSTER_OVERRIDES}" ]] && CLUSTER_OVERRIDES_ARG=(--cluster-overrides "${CLUSTER_OVERRIDES}")
+
+COMMON=(
+    --scenario encryption
+    --per-producer-rate 10000
+    --steps 1,2,4,8,16,32
+    ${CLUSTER_OVERRIDES_ARG[@]+"${CLUSTER_OVERRIDES_ARG[@]}"}
+    --set kafka.replicationFactor=1
+    --set kafka.minInSyncReplicas=1
+)
+
+# ---------------------------------------------------------------------------
+# 1-topic sweeps
+# ---------------------------------------------------------------------------
+run_step "coeff-1core-1topic" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 1topic-1kb \
+        ${PROXY_1CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-1core-1topic-rf1/"
+
+run_step "coeff-2core-1topic" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 1topic-1kb \
+        ${PROXY_2CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-2core-1topic-rf1/"
+
+run_step "coeff-4core-1topic" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 1topic-1kb \
+        ${PROXY_4CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-4core-1topic-rf1/"
+
+# ---------------------------------------------------------------------------
+# 10-topic sweeps
+# ---------------------------------------------------------------------------
+run_step "coeff-1core-10topics" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 10topics-1kb \
+        ${PROXY_1CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-1core-10topics-rf1/"
+
+run_step "coeff-2core-10topics" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 10topics-1kb \
+        ${PROXY_2CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-2core-10topics-rf1/"
+
+run_step "coeff-4core-10topics" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 10topics-1kb \
+        ${PROXY_4CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-4core-10topics-rf1/"
+
+# ---------------------------------------------------------------------------
+# 100-topic sweeps
+# ---------------------------------------------------------------------------
+run_step "coeff-1core-100topics" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 100topics-1kb \
+        ${PROXY_1CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-1core-100topics-rf1/"
+
+run_step "coeff-2core-100topics" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 100topics-1kb \
+        ${PROXY_2CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-2core-100topics-rf1/"
+
+run_step "coeff-4core-100topics" \
+    scripts/connection-sweep.sh "${COMMON[@]}" --workload 100topics-1kb \
+        ${PROXY_4CORE} \
+        --output-dir "${OUTPUT_DIR}/conn-sweep-encryption-4core-100topics-rf1/"
+
+# ---------------------------------------------------------------------------
+# Cross-configuration comparison
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- CPU coefficient comparison ---"
+
+for topics_dir in 1topic 10topics 100topics; do
+    label="${topics_dir/topic/ topic}"
+    label="${label/topics/ topics}"
+    echo ""
+    echo "=== ${label} ==="
+    compare_args=()
+    for cores in 1 2 4; do
+        dir="${OUTPUT_DIR}/conn-sweep-encryption-${cores}core-${topics_dir}-rf1/encryption"
+        if [[ -d "${dir}" ]]; then
+            compare_args+=("${cores}-core-${topics_dir}:${dir}")
+        fi
+    done
+    if [[ ${#compare_args[@]} -gt 0 ]]; then
+        python3 scripts/analyze-cpu-coefficient.py --compare "${compare_args[@]}"
+    else
+        echo "  (no completed sweeps)"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=========================================="
+echo "Suite complete: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "Results: ${OUTPUT_DIR}"
+echo "=========================================="
+
+if [[ ${#FAILED_STEPS[@]} -gt 0 ]]; then
+    echo ""
+    echo "Failed steps:"
+    for step in ${FAILED_STEPS[@]+"${FAILED_STEPS[@]}"}; do
+        echo "  - ${step}"
+    done
+    exit 1
+fi
+
+echo "All steps succeeded."

--- a/kroxylicious-openmessaging-benchmarks/src/test/java/io/kroxylicious/benchmarks/helm/HelmTemplateRenderingTest.java
+++ b/kroxylicious-openmessaging-benchmarks/src/test/java/io/kroxylicious/benchmarks/helm/HelmTemplateRenderingTest.java
@@ -182,7 +182,7 @@ class HelmTemplateRenderingTest {
     void smokeProfileShouldOverrideDurations() throws IOException {
         String workloadYaml = renderSmokeWorkloadYaml();
         assertThat(workloadYaml)
-                .contains("testDurationMinutes: 1")
+                .contains("testDurationMinutes: 2")
                 .contains("warmupDurationMinutes: 0");
     }
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Bugfix

### Description

Adds the CPU coefficient sweep tooling and squashes a collection of operational fixes from the benchmark deployment branch.

**New scripts:**
- `scripts/run-coefficient-sweep.sh` — orchestrates a 9-config sweep (1/2/4 proxy cores × 1/10/100 topics) and prints a cross-config coefficient comparison table
- `scripts/analyze-cpu-coefficient.py` — derives the proxy CPU sizing coefficient (millicores/MB/s) from connection-sweep probe data; reads `proxy-metrics.txt` (`process_cpu_usage`) with JFR (`jdk.CPULoad`) fallback

**Script fixes:**
- `run-benchmark.sh`: cap worker pod termination grace period to 30s between sweep probes; force-delete stale proxy pod before JFR patch rollout to avoid stuck rollouts
- `run-all-scenarios.sh`: add `--set` passthrough so callers can pass arbitrary Helm overrides
- `run-blog-suite.sh`: remove hard dependency on a cluster-overrides file; fix proxy CPU allocation

**Helm/config fixes:**
- Floor `omb-benchmark-job` `activeDeadlineSeconds` at 15 min to absorb cluster startup overhead (test updated)
- Increase smoke-values worker memory limit to 4Gi to prevent OOMKill
- Increase smoke test duration to 2 min to avoid deadline races
- Reduce default `workerReplicas` from 3 → 2; connection-sweep default to 4
- Enable Kafka metrics reporter by default
- Switch Kafka metrics collection from JMX ConfigMap to StrimziMetricsReporter
- Align Vault image version with Kroxylicious integration tests

### Additional Context

These scripts and fixes were developed and validated during the record encryption blog post benchmark runs. The coefficient sweep tooling in particular is needed to validate the proxy CPU sizing formula in the forthcoming sizing guide (follow-up PR).

### Checklist

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).