### PR TITLE
feat(test): dynamic port allocation for KroxyliciousTester

### DIFF
--- a/kroxylicious-api/src/test/resources/log4j2-test.properties
+++ b/kroxylicious-api/src/test/resources/log4j2-test.properties
@@ -12,7 +12,7 @@ appender.null.name = NullAppender
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} <%t> %-5p %c:%L - %m%replace{ %K{ctx}}{' $'}{}%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} <%t> %-5p %c:%L - %m%replace{ %mdc}{' $'}{}%n
 
 rootLogger.level = TRACE
 rootLogger.appenderRefs = null,console

--- a/kroxylicious-app/src/test/resources/log4j2-test.properties
+++ b/kroxylicious-app/src/test/resources/log4j2-test.properties
@@ -12,7 +12,7 @@ appender.null.name = NullAppender
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} <%t> %-5p %c:%L - %m%replace{ %K{ctx}}{' $'}{}%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} <%t> %-5p %c:%L - %m%replace{ %mdc}{' $'}{}%n
 
 rootLogger.level = TRACE
 rootLogger.appenderRefs = null,console

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
@@ -45,9 +45,7 @@ import io.kroxylicious.proxy.config.ServiceBasedPluginFactoryRegistry;
 import io.kroxylicious.proxy.config.VirtualCluster;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.internal.config.Features;
-import io.kroxylicious.proxy.internal.net.EndpointRegistry;
 import io.kroxylicious.proxy.reload.ReconfigureResult;
-import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.integration.client.KafkaClient;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -131,23 +129,14 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     @Override
     @NonNull
     public String getBootstrapAddress(String virtualCluster, String gateway) {
-        var config = kroxyliciousConfig.get();
-        var vc = config.virtualClusters().stream()
-                .filter(v -> v.name().equals(virtualCluster))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("virtualCluster " + virtualCluster + " not found in config"));
-        var strategy = vc.gateways().stream()
-                .filter(g -> g.name().equals(gateway))
-                .map(g -> g.buildNodeIdentificationStrategy(virtualCluster))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException(virtualCluster + " does not have gateway named " + gateway));
-        var bootstrapAddress = strategy.getClusterBootstrapAddress();
-        if (bootstrapAddress.port() == EndpointRegistry.OS_ASSIGNED_PORT && proxy instanceof KafkaProxy kp) {
-            var bindAddress = strategy.getBindAddress().orElse(null);
-            int actualPort = kp.listeningPort(bindAddress, EndpointRegistry.OS_ASSIGNED_PORT);
-            return new HostPort(bootstrapAddress.host(), actualPort).toString();
-        }
-        return bootstrapAddress.toString();
+        return KroxyliciousConfigUtils.bootstrapAddressFor(
+                virtualCluster,
+                kroxyliciousConfig.get(),
+                gateway,
+                proxy instanceof KafkaProxy kp
+                        ? (bind, port) -> kp.listeningPort(bind.orElse(null), port)
+                        : (bind, port) -> port)
+                .toString();
     }
 
     private void configureClientTls(String virtualCluster, Map<String, Object> defaultClientConfig, String gateway) {
@@ -364,15 +353,6 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
                             .formatted(exceptions.size()),
                     exceptions.get(0));
         }
-    }
-
-    @Override
-    public int listeningPort(@Nullable String bindAddress, int port) {
-        if (!(proxy instanceof KafkaProxy kp)) {
-            throw new UnsupportedOperationException(
-                    "listeningPort() requires a KafkaProxy-backed tester; this tester's proxy is " + proxy.getClass().getName());
-        }
-        return kp.listeningPort(bindAddress, port);
     }
 
     @Override

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
@@ -41,15 +41,11 @@ import org.slf4j.LoggerFactory;
 import io.kroxylicious.proxy.KafkaProxy;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
-import io.kroxylicious.proxy.config.PortIdentifiesNodeIdentificationStrategy;
 import io.kroxylicious.proxy.config.ServiceBasedPluginFactoryRegistry;
-import io.kroxylicious.proxy.config.SniHostIdentifiesNodeIdentificationStrategy;
 import io.kroxylicious.proxy.config.VirtualCluster;
-import io.kroxylicious.proxy.config.VirtualClusterGateway;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.internal.config.Features;
 import io.kroxylicious.proxy.reload.ReconfigureResult;
-import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.integration.client.KafkaClient;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -314,71 +310,41 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     @Override
     public void restartProxy() {
         try {
-            // Capture resolved ports before closing the proxy. Port 0 (OS-assigned) gets a new
-            // ephemeral port on each bind; existing clients hold the first resolved port and cannot
-            // reconnect if the restarted proxy lands on a different one. Capturing while the proxy
-            // is still running avoids the TOCTOU that would arise from finding a free port and then
-            // releasing it before the proxy starts.
-            Configuration configForRestart = currentConfig();
+            // Existing clients hold the originally resolved port. With OS-assigned (port 0) gateways
+            // the restarted proxy binds to a different ephemeral port, leaving those clients unable to
+            // reconnect. There is no safe transparent fix: the caller must use fixed ports when both
+            // restart and client reuse are required.
+            boolean hasOsAssignedPort = kroxyliciousConfig.get().virtualClusters().stream()
+                    .flatMap(vc -> vc.gateways().stream().map(g -> g.buildNodeIdentificationStrategy(vc.name())))
+                    .anyMatch(s -> s.getClusterBootstrapAddress().port() == 0);
+            if (hasOsAssignedPort) {
+                throw new IllegalStateException(
+                        "Cannot restart a proxy that uses OS-assigned (port 0) bootstrap ports: the restarted " +
+                        "proxy will bind to a different ephemeral port and existing clients will be unable to " +
+                        "reconnect. Use fixed ports in the gateway configuration when restartProxy() is needed.");
+            }
             proxy.close();
-            proxy = spawnProxy(configForRestart, Features.defaultFeatures());
-            kroxyliciousConfig.set(configForRestart);
+            proxy = spawnProxy(kroxyliciousConfig.get(), Features.defaultFeatures());
+        }
+        catch (IllegalStateException e) {
+            throw e;
         }
         catch (Exception e) {
             throw new IllegalStateException(e);
         }
     }
 
-    private Configuration currentConfig() {
-        return proxy instanceof KafkaProxy kp
-                ? replaceOsAssignedWithCurrentlyBoundPort(kroxyliciousConfig.get(), kp)
-                : kroxyliciousConfig.get();
-    }
-
-    private static Configuration replaceOsAssignedWithCurrentlyBoundPort(Configuration config, KafkaProxy kp) {
-        var updatedClusters = config.virtualClusters().stream()
-                .map(vc -> replaceOsAssignedWithCurrentlyBoundPort(vc, kp))
-                .toList();
-        if (updatedClusters.equals(config.virtualClusters())) {
-            return config;
+    @Override
+    public void restartProxy(ConfigurationBuilder configForRestart) {
+        try {
+            var config = configForRestart.build();
+            proxy.close();
+            proxy = spawnProxy(config, Features.defaultFeatures());
+            kroxyliciousConfig.set(config);
         }
-        return new Configuration(config.management(), config.filterDefinitions(), config.defaultFilters(),
-                updatedClusters, config.micrometer(), config.useIoUring(), config.development(),
-                config.network(), config.proxyProtocol());
-    }
-
-    private static VirtualCluster replaceOsAssignedWithCurrentlyBoundPort(VirtualCluster vc, KafkaProxy kp) {
-        var updatedGateways = vc.gateways().stream()
-                .map(gateway -> withOsAssignedPortResolved(gateway, kp))
-                .toList();
-        if (updatedGateways.equals(vc.gateways())) {
-            return vc;
+        catch (Exception e) {
+            throw new IllegalStateException(e);
         }
-        return new VirtualCluster(vc.name(), vc.targetCluster(), updatedGateways,
-                vc.logNetwork(), vc.logFrames(), vc.filters(), vc.subjectBuilder(),
-                vc.topicNameCache(), vc.drainTimeout());
-    }
-
-    private static VirtualClusterGateway withOsAssignedPortResolved(VirtualClusterGateway gateway, KafkaProxy kp) {
-        if (gateway.portIdentifiesNode() != null) {
-            var pin = gateway.portIdentifiesNode();
-            var configured = pin.getBootstrapAddress();
-            int resolved = kp.listeningPort(null, configured.port());
-            return new VirtualClusterGateway(gateway.name(),
-                    new PortIdentifiesNodeIdentificationStrategy(new HostPort(configured.host(), resolved),
-                            pin.getAdvertisedBrokerAddressPattern(), pin.getNodeStartPort(), pin.getNodeIdRanges()),
-                    null, gateway.tls());
-        }
-        if (gateway.sniHostIdentifiesNode() != null) {
-            var sni = gateway.sniHostIdentifiesNode();
-            var configured = HostPort.parse(sni.getBootstrapAddress());
-            int resolved = kp.listeningPort(null, configured.port());
-            return new VirtualClusterGateway(gateway.name(), null,
-                    new SniHostIdentifiesNodeIdentificationStrategy(configured.host() + ":" + resolved,
-                            sni.getAdvertisedBrokerAddressPattern()),
-                    gateway.tls());
-        }
-        return gateway;
     }
 
     @Override

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
@@ -349,6 +349,15 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     }
 
     @Override
+    public int listeningPort(@Nullable String bindAddress, int port) {
+        if (!(proxy instanceof KafkaProxy kp)) {
+            throw new UnsupportedOperationException(
+                    "listeningPort() requires a KafkaProxy-backed tester; this tester's proxy is " + proxy.getClass().getName());
+        }
+        return kp.listeningPort(bindAddress, port);
+    }
+
+    @Override
     public void close() {
         try {
             List<Exception> exceptions = new ArrayList<>();

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
@@ -41,11 +41,15 @@ import org.slf4j.LoggerFactory;
 import io.kroxylicious.proxy.KafkaProxy;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
+import io.kroxylicious.proxy.config.PortIdentifiesNodeIdentificationStrategy;
 import io.kroxylicious.proxy.config.ServiceBasedPluginFactoryRegistry;
+import io.kroxylicious.proxy.config.SniHostIdentifiesNodeIdentificationStrategy;
 import io.kroxylicious.proxy.config.VirtualCluster;
+import io.kroxylicious.proxy.config.VirtualClusterGateway;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.internal.config.Features;
 import io.kroxylicious.proxy.reload.ReconfigureResult;
+import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.integration.client.KafkaClient;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -310,12 +314,71 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     @Override
     public void restartProxy() {
         try {
+            // Capture resolved ports before closing the proxy. Port 0 (OS-assigned) gets a new
+            // ephemeral port on each bind; existing clients hold the first resolved port and cannot
+            // reconnect if the restarted proxy lands on a different one. Capturing while the proxy
+            // is still running avoids the TOCTOU that would arise from finding a free port and then
+            // releasing it before the proxy starts.
+            Configuration configForRestart = currentConfig();
             proxy.close();
-            proxy = spawnProxy(kroxyliciousConfig.get(), Features.defaultFeatures());
+            proxy = spawnProxy(configForRestart, Features.defaultFeatures());
+            kroxyliciousConfig.set(configForRestart);
         }
         catch (Exception e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    private Configuration currentConfig() {
+        return proxy instanceof KafkaProxy kp
+                ? replaceOsAssignedWithCurrentlyBoundPort(kroxyliciousConfig.get(), kp)
+                : kroxyliciousConfig.get();
+    }
+
+    private static Configuration replaceOsAssignedWithCurrentlyBoundPort(Configuration config, KafkaProxy kp) {
+        var updatedClusters = config.virtualClusters().stream()
+                .map(vc -> replaceOsAssignedWithCurrentlyBoundPort(vc, kp))
+                .toList();
+        if (updatedClusters.equals(config.virtualClusters())) {
+            return config;
+        }
+        return new Configuration(config.management(), config.filterDefinitions(), config.defaultFilters(),
+                updatedClusters, config.micrometer(), config.useIoUring(), config.development(),
+                config.network(), config.proxyProtocol());
+    }
+
+    private static VirtualCluster replaceOsAssignedWithCurrentlyBoundPort(VirtualCluster vc, KafkaProxy kp) {
+        var updatedGateways = vc.gateways().stream()
+                .map(gateway -> withOsAssignedPortResolved(gateway, kp))
+                .toList();
+        if (updatedGateways.equals(vc.gateways())) {
+            return vc;
+        }
+        return new VirtualCluster(vc.name(), vc.targetCluster(), updatedGateways,
+                vc.logNetwork(), vc.logFrames(), vc.filters(), vc.subjectBuilder(),
+                vc.topicNameCache(), vc.drainTimeout());
+    }
+
+    private static VirtualClusterGateway withOsAssignedPortResolved(VirtualClusterGateway gateway, KafkaProxy kp) {
+        if (gateway.portIdentifiesNode() != null) {
+            var pin = gateway.portIdentifiesNode();
+            var configured = pin.getBootstrapAddress();
+            int resolved = kp.listeningPort(null, configured.port());
+            return new VirtualClusterGateway(gateway.name(),
+                    new PortIdentifiesNodeIdentificationStrategy(new HostPort(configured.host(), resolved),
+                            pin.getAdvertisedBrokerAddressPattern(), pin.getNodeStartPort(), pin.getNodeIdRanges()),
+                    null, gateway.tls());
+        }
+        if (gateway.sniHostIdentifiesNode() != null) {
+            var sni = gateway.sniHostIdentifiesNode();
+            var configured = HostPort.parse(sni.getBootstrapAddress());
+            int resolved = kp.listeningPort(null, configured.port());
+            return new VirtualClusterGateway(gateway.name(), null,
+                    new SniHostIdentifiesNodeIdentificationStrategy(configured.host() + ":" + resolved,
+                            sni.getAdvertisedBrokerAddressPattern()),
+                    gateway.tls());
+        }
+        return gateway;
     }
 
     @Override

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
@@ -45,7 +45,9 @@ import io.kroxylicious.proxy.config.ServiceBasedPluginFactoryRegistry;
 import io.kroxylicious.proxy.config.VirtualCluster;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.internal.config.Features;
+import io.kroxylicious.proxy.internal.net.EndpointRegistry;
 import io.kroxylicious.proxy.reload.ReconfigureResult;
+import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.integration.client.KafkaClient;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -129,7 +131,23 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     @Override
     @NonNull
     public String getBootstrapAddress(String virtualCluster, String gateway) {
-        return KroxyliciousConfigUtils.bootstrapServersFor(virtualCluster, kroxyliciousConfig.get(), gateway);
+        var config = kroxyliciousConfig.get();
+        var vc = config.virtualClusters().stream()
+                .filter(v -> v.name().equals(virtualCluster))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("virtualCluster " + virtualCluster + " not found in config"));
+        var strategy = vc.gateways().stream()
+                .filter(g -> g.name().equals(gateway))
+                .map(g -> g.buildNodeIdentificationStrategy(virtualCluster))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(virtualCluster + " does not have gateway named " + gateway));
+        var bootstrapAddress = strategy.getClusterBootstrapAddress();
+        if (bootstrapAddress.port() == EndpointRegistry.OS_ASSIGNED_PORT && proxy instanceof KafkaProxy kp) {
+            var bindAddress = strategy.getBindAddress().orElse(null);
+            int actualPort = kp.listeningPort(bindAddress, EndpointRegistry.OS_ASSIGNED_PORT);
+            return new HostPort(bootstrapAddress.host(), actualPort).toString();
+        }
+        return bootstrapAddress.toString();
     }
 
     private void configureClientTls(String virtualCluster, Map<String, Object> defaultClientConfig, String gateway) {

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
@@ -320,8 +320,8 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
             if (hasOsAssignedPort) {
                 throw new IllegalStateException(
                         "Cannot restart a proxy that uses OS-assigned (port 0) bootstrap ports: the restarted " +
-                        "proxy will bind to a different ephemeral port and existing clients will be unable to " +
-                        "reconnect. Use fixed ports in the gateway configuration when restartProxy() is needed.");
+                                "proxy will bind to a different ephemeral port and existing clients will be unable to " +
+                                "reconnect. Use fixed ports in the gateway configuration when restartProxy() is needed.");
             }
             proxy.close();
             proxy = spawnProxy(kroxyliciousConfig.get(), Features.defaultFeatures());

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousConfigUtils.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousConfigUtils.java
@@ -7,7 +7,10 @@
 package io.kroxylicious.testing.integration.tester;
 
 import java.time.Duration;
+import java.util.Optional;
+import java.util.function.BiFunction;
 
+import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterGatewayBuilder;
@@ -73,6 +76,31 @@ public class KroxyliciousConfigUtils {
      */
     public static ConfigurationBuilder proxy(KafkaCluster cluster) {
         return proxy(cluster.getBootstrapServers());
+    }
+
+    /**
+     * Resolves the bootstrap address for a named virtual cluster and gateway, using a caller-supplied
+     * port resolver to obtain the actual listening port.
+     *
+     * @param virtualCluster the virtual cluster name
+     * @param config the proxy configuration
+     * @param gateway the gateway name
+     * @param portResolver maps (bindAddress, configuredPort) to the actual port; for fixed ports, returns the port unchanged
+     * @return the bootstrap address with the resolved port
+     */
+    public static HostPort bootstrapAddressFor(String virtualCluster, Configuration config, String gateway,
+                                               BiFunction<Optional<String>, Integer, Integer> portResolver) {
+        var vc = config.virtualClusters().stream()
+                .filter(v -> v.name().equals(virtualCluster))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("virtualCluster " + virtualCluster + " not found in config"));
+        var strategy = vc.gateways().stream()
+                .filter(g -> g.name().equals(gateway))
+                .map(g -> g.buildNodeIdentificationStrategy(virtualCluster))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(virtualCluster + " does not have gateway named " + gateway));
+        var bootstrapAddress = strategy.getClusterBootstrapAddress();
+        return new HostPort(bootstrapAddress.host(), portResolver.apply(strategy.getBindAddress(), bootstrapAddress.port()));
     }
 
     public static VirtualClusterGatewayBuilder defaultGatewayBuilder() {

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousConfigUtils.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousConfigUtils.java
@@ -8,7 +8,6 @@ package io.kroxylicious.testing.integration.tester;
 
 import java.time.Duration;
 
-import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterGatewayBuilder;
@@ -74,29 +73,6 @@ public class KroxyliciousConfigUtils {
      */
     public static ConfigurationBuilder proxy(KafkaCluster cluster) {
         return proxy(cluster.getBootstrapServers());
-    }
-
-    /**
-     * Locate the bootstrap servers for a virtual cluster
-     * @param virtualCluster virtual cluster
-     * @param config config to retrieve the bootstrap from
-     * @param gateway gateway of the virtual cluster
-     * @return bootstrap address
-     * @throws IllegalStateException if we encounter an unknown endpoint config provider type for the virtualcluster
-     * @throws IllegalArgumentException if the virtualCluster is not in the kroxylicious config
-     */
-    static String bootstrapServersFor(String virtualCluster, Configuration config, String gateway) {
-        var cluster = config.virtualClusters().stream().filter(v -> v.name().equals(virtualCluster)).findFirst();
-        if (cluster.isEmpty()) {
-            throw new IllegalArgumentException("virtualCluster " + virtualCluster + " not found in config: " + config);
-        }
-        var first = cluster.get().gateways().stream().filter(l -> l.name().equals(gateway)).map(
-                virtualClusterGateway -> virtualClusterGateway.buildNodeIdentificationStrategy(virtualCluster)).findFirst();
-        var nodeIdentificationStrategy = first.orElseThrow(() -> new IllegalArgumentException(virtualCluster + " does not have gateway named " + gateway));
-        // Need proper way to do this for embedded use-cases. We should have a way to query kroxy for the virtual cluster's
-        // actual bootstrap after the proxy is started. The provider might support dynamic ports (port 0), so querying the
-        // config might not work.
-        return nodeIdentificationStrategy.getClusterBootstrapAddress().toString();
     }
 
     public static VirtualClusterGatewayBuilder defaultGatewayBuilder() {

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousConfigUtils.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousConfigUtils.java
@@ -12,6 +12,7 @@ import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterGatewayBuilder;
+import io.kroxylicious.proxy.internal.net.EndpointRegistry;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 
@@ -28,7 +29,7 @@ public class KroxyliciousConfigUtils {
     public static final String DEFAULT_VIRTUAL_CLUSTER = "demo";
     public static final String DEFAULT_GATEWAY_NAME = "default";
 
-    public static final HostPort DEFAULT_PROXY_BOOTSTRAP = new HostPort("localhost", 9192);
+    public static final HostPort DEFAULT_PROXY_BOOTSTRAP = new HostPort("localhost", EndpointRegistry.OS_ASSIGNED_PORT);
 
     /**
      * Create a KroxyliciousConfigBuilder with a single virtual cluster configured to

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousConfigUtils.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousConfigUtils.java
@@ -60,7 +60,7 @@ public class KroxyliciousConfigUtils {
                     .withNewTargetCluster()
                     .withBootstrapServers(clusterBootstrapServers)
                     .endTargetCluster()
-                    .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(new HostPort(DEFAULT_PROXY_BOOTSTRAP.host(), DEFAULT_PROXY_BOOTSTRAP.port() + i * 10))
+                    .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(DEFAULT_PROXY_BOOTSTRAP)
                             .build());
             configurationBuilder
                     .addToVirtualClusters(vcb.build());

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousTester.java
@@ -18,6 +18,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.serialization.Serde;
 
 import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.reload.ReconfigureResult;
 import io.kroxylicious.testing.integration.client.KafkaClient;
 
@@ -340,8 +341,21 @@ public interface KroxyliciousTester extends Closeable {
 
     /**
      * Restarts the Kroxylicious server under test without closing any other resources.
+     * Throws {@link IllegalStateException} if any gateway is configured with an OS-assigned
+     * (port 0) bootstrap port: after restart the proxy would bind to a different ephemeral
+     * port and existing clients would be unable to reconnect. Use
+     * {@link #restartProxy(ConfigurationBuilder)} with fixed ports in that case.
      */
     void restartProxy();
+
+    /**
+     * Restarts the Kroxylicious server under test using {@code configForRestart}, without
+     * closing any other resources. The caller is responsible for ensuring the new configuration
+     * uses ports that existing clients can reconnect to.
+     *
+     * @param configForRestart configuration to use for the restarted proxy
+     */
+    void restartProxy(ConfigurationBuilder configForRestart);
 
     /**
      * Submits {@code newConfig} to the underlying Kroxylicious server's

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousTester.java
@@ -21,6 +21,8 @@ import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.reload.ReconfigureResult;
 import io.kroxylicious.testing.integration.client.KafkaClient;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 /**
  * A convenient tester for a Kroxylicious instance. Implementations of this will
  * typically create a Kroxylicious server and clean it up on {@link #close()}. It provides
@@ -371,6 +373,19 @@ public interface KroxyliciousTester extends Closeable {
      * @param virtualCluster the virtual cluster whose cached clients should be evicted
      */
     void closeClientsFor(String virtualCluster);
+
+    /**
+     * Returns the actual local port that the proxy is listening on for the given bind address
+     * and configured port. Useful when the configured port is
+     * {@link io.kroxylicious.proxy.internal.net.EndpointRegistry#OS_ASSIGNED_PORT} so tests
+     * do not need to hard-code port numbers.
+     *
+     * @param bindAddress the bind address used in the proxy configuration, or {@code null} for any-address bindings
+     * @param port        the port number used in the proxy configuration
+     * @return the actual local port the proxy is listening on
+     * @throws UnsupportedOperationException if the underlying proxy is not a {@link io.kroxylicious.proxy.KafkaProxy}
+     */
+    int listeningPort(@Nullable String bindAddress, int port);
 
     /**
      * Close the Kroxylicious server under test and any other resources that need cleaning.

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousTester.java
@@ -21,8 +21,6 @@ import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.reload.ReconfigureResult;
 import io.kroxylicious.testing.integration.client.KafkaClient;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
-
 /**
  * A convenient tester for a Kroxylicious instance. Implementations of this will
  * typically create a Kroxylicious server and clean it up on {@link #close()}. It provides
@@ -373,19 +371,6 @@ public interface KroxyliciousTester extends Closeable {
      * @param virtualCluster the virtual cluster whose cached clients should be evicted
      */
     void closeClientsFor(String virtualCluster);
-
-    /**
-     * Returns the actual local port that the proxy is listening on for the given bind address
-     * and configured port. Useful when the configured port is
-     * {@link io.kroxylicious.proxy.internal.net.EndpointRegistry#OS_ASSIGNED_PORT} so tests
-     * do not need to hard-code port numbers.
-     *
-     * @param bindAddress the bind address used in the proxy configuration, or {@code null} for any-address bindings
-     * @param port        the port number used in the proxy configuration
-     * @return the actual local port the proxy is listening on
-     * @throws UnsupportedOperationException if the underlying proxy is not a {@link io.kroxylicious.proxy.KafkaProxy}
-     */
-    int listeningPort(@Nullable String bindAddress, int port);
 
     /**
      * Close the Kroxylicious server under test and any other resources that need cleaning.

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTesterTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTesterTest.java
@@ -699,7 +699,8 @@ class DefaultKroxyliciousTesterTest {
         // Multiple gateways on port 0 can't share an endpoint binding, and these tests exercise
         // tester client routing via mocks — they don't need real port bindings.
         return new KroxyliciousTesterBuilder().setConfigurationBuilder(configurationBuilder)
-                .setKroxyliciousFactory((config, features) -> () -> {})
+                .setKroxyliciousFactory((config, features) -> () -> {
+                })
                 .setClientFactory(clientFactory)
                 .createDefaultKroxyliciousTester();
     }

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTesterTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTesterTest.java
@@ -330,7 +330,6 @@ class DefaultKroxyliciousTesterTest {
         }
     }
 
-    @SuppressWarnings("resource")
     @Test
     void closeClientsForEvictsOnlyTheNamedClustersClients() {
         // Given — touch every cluster so each has a cached KroxyliciousClients in the tester.
@@ -368,7 +367,6 @@ class DefaultKroxyliciousTesterTest {
         }
     }
 
-    @SuppressWarnings("resource")
     @Test
     void closeClientsForIsNoOpWhenClusterHasNoCachedClient() {
         try (var tester = buildTester()) {
@@ -745,7 +743,11 @@ class DefaultKroxyliciousTesterTest {
     private KroxyliciousTester buildTester() {
         return new KroxyliciousTesterBuilder()
                 .setConfigurationBuilder(proxy(backingCluster, VIRTUAL_CLUSTER_A, VIRTUAL_CLUSTER_B, VIRTUAL_CLUSTER_C))
-                .setKroxyliciousFactory(DefaultKroxyliciousTester::spawnProxy).setClientFactory(clientFactory)
+                // Multiple PortIdentifiesNode clusters on port 0 can't share an endpoint binding, and these
+                // tests exercise tester lifecycle via mocks — they don't need real port bindings.
+                .setKroxyliciousFactory((config, features) -> () -> {
+                })
+                .setClientFactory(clientFactory)
                 .createDefaultKroxyliciousTester();
     }
 

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTesterTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTesterTest.java
@@ -40,7 +40,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterGatewayBuilder;
-import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -692,13 +691,15 @@ class DefaultKroxyliciousTesterTest {
                 .addToGateways(new VirtualClusterGatewayBuilder()
                         .withName(CUSTOM_GATEWAY_NAME)
                         .withNewPortIdentifiesNode()
-                        .withBootstrapAddress(new HostPort(DEFAULT_PROXY_BOOTSTRAP.host(), DEFAULT_PROXY_BOOTSTRAP.port() + 10))
+                        .withBootstrapAddress(DEFAULT_PROXY_BOOTSTRAP)
                         .endPortIdentifiesNode()
                         .build());
         configurationBuilder
                 .addToVirtualClusters(vcb.build());
+        // Multiple gateways on port 0 can't share an endpoint binding, and these tests exercise
+        // tester client routing via mocks — they don't need real port bindings.
         return new KroxyliciousTesterBuilder().setConfigurationBuilder(configurationBuilder)
-                .setKroxyliciousFactory(DefaultKroxyliciousTester::spawnProxy)
+                .setKroxyliciousFactory((config, features) -> () -> {})
                 .setClientFactory(clientFactory)
                 .createDefaultKroxyliciousTester();
     }

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/tester/KroxyliciousTestersTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/tester/KroxyliciousTestersTest.java
@@ -61,6 +61,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.DEFAULT_GATEWAY_NAME;
 import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.DEFAULT_VIRTUAL_CLUSTER;
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.baseConfigurationBuilder;
 import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
 import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.proxy;
 import static io.kroxylicious.testing.integration.tester.KroxyliciousTesters.kroxyliciousTester;
@@ -262,6 +263,7 @@ class KroxyliciousTestersTest {
 
     @Test
     void testRestartingProxyDoesNotCloseClients(@Name("underlyingCluster") Topic topic) throws Exception {
+        // Given
         try (var tester = kroxyliciousTester(proxy(kafkaCluster))) {
             var admin = tester.admin();
             var producer = tester.producer();
@@ -270,7 +272,15 @@ class KroxyliciousTestersTest {
             send(producer, topic.name());
             consumer.subscribe(List.of(topic.name()));
             assertThat(consumer.poll(Duration.ofSeconds(10))).isNotNull();
-            tester.restartProxy();
+            // Capture the bootstrap port the proxy actually bound too, then restart on that same fixed address.
+            String resolvedBootstrap = tester.getBootstrapAddress();
+            var fixedPortConfig = addVirtualCluster(kafkaCluster.getBootstrapServers(),
+                    baseConfigurationBuilder(), DEFAULT_VIRTUAL_CLUSTER, resolvedBootstrap);
+
+            // When
+            tester.restartProxy(fixedPortConfig);
+
+            // Then
             // assert some basic things here but if restarting the proxy restarted the clients these would except
             assertThat(admin.describeCluster()).isNotNull();
             send(producer, topic.name());

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/MetricsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/MetricsIT.java
@@ -53,6 +53,7 @@ import io.kroxylicious.it.net.IntegrationTestInetAddressResolverProvider;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.VirtualClusterGateway;
+import io.kroxylicious.proxy.internal.net.EndpointRegistry;
 import io.kroxylicious.proxy.micrometer.CommonTagsHook;
 import io.kroxylicious.proxy.micrometer.StandardBindersHook;
 import io.kroxylicious.proxy.service.HostPort;
@@ -93,7 +94,7 @@ class MetricsIT {
     private static final HostPort PORT_IDENTIFIES_BROKER_BOOTSTRAP = new HostPort("localhost", 9092);
     private static final String SNI_IDENTIFIES_BROKER_BASE_ADDRESS = IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName("sni");
 
-    private static final HostPort SNI_IDENTIFIES_BROKER_BOOTSTRAP = new HostPort("bootstrap." + SNI_IDENTIFIES_BROKER_BASE_ADDRESS, 9192);
+    private static final HostPort SNI_IDENTIFIES_BROKER_BOOTSTRAP = new HostPort("bootstrap." + SNI_IDENTIFIES_BROKER_BASE_ADDRESS, EndpointRegistry.OS_ASSIGNED_PORT);
     private static final String SNI_IDENTIFIES_BROKER_ADDRESS_PATTERN = "broker-$(nodeId)." + SNI_IDENTIFIES_BROKER_BASE_ADDRESS;
 
     static KafkaCluster cluster; // Injected once by KafkaClusterExtension

--- a/kroxylicious-integration-tests/src/test/resources/log4j2-test.yaml
+++ b/kroxylicious-integration-tests/src/test/resources/log4j2-test.yaml
@@ -14,7 +14,7 @@ Configuration:
         type: Console
         target: SYSTEM_OUT
         PatternLayout:
-            pattern: '%d{yyyy-MM-dd HH:mm:ss} %-5p <%t> %c{1.} - %m%replace{ %K{ctx}}{'' $''}{}%n'
+            pattern: '%d{yyyy-MM-dd HH:mm:ss} %-5p <%t> %c{1.} - %m%replace{ %mdc}{'' $''}{}%n'
   Loggers:
     Root:
       additivity: false

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -62,7 +62,6 @@ import io.kroxylicious.proxy.internal.VirtualClusterRegistry;
 import io.kroxylicious.proxy.internal.admin.ManagementInitializer;
 import io.kroxylicious.proxy.internal.config.Features;
 import io.kroxylicious.proxy.internal.net.DefaultNetworkBindingOperationProcessor;
-import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.EndpointRegistry;
 import io.kroxylicious.proxy.internal.net.NetworkBindingOperationProcessor;
 import io.kroxylicious.proxy.internal.reload.ConfigurationReloadOrchestrator;
@@ -520,7 +519,7 @@ public final class KafkaProxy implements AutoCloseable {
      */
     @VisibleForTesting
     public int listeningPort(@Nullable String bindAddress, int port) {
-        return endpointRegistry.localPortFor(Endpoint.createEndpoint(Optional.ofNullable(bindAddress), port, false));
+        return endpointRegistry.localPortFor(Optional.ofNullable(bindAddress), port);
     }
 
     @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -519,7 +519,7 @@ public final class KafkaProxy implements AutoCloseable {
      * @return the actual local port the proxy is listening on
      */
     @VisibleForTesting
-    int listeningPort(@Nullable String bindAddress, int port) {
+    public int listeningPort(@Nullable String bindAddress, int port) {
         return endpointRegistry.localPortFor(Endpoint.createEndpoint(Optional.ofNullable(bindAddress), port, false));
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/BrokerAddressPatternUtils.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/BrokerAddressPatternUtils.java
@@ -21,7 +21,7 @@ final class BrokerAddressPatternUtils {
     static final String LITERAL_VIRTUAL_CLUSTER_NAME = "$(virtualClusterName)";
     static final String LITERAL_UNRESOLVED_ROUTE_HOST = "$(unresolvedRouteHost)";
     private static final Pattern LITERAL_NODE_ID_PATTERN = Pattern.compile(Pattern.quote(LITERAL_NODE_ID));
-    private static final Pattern PORT_SPECIFIER_RE = Pattern.compile("^(.*):([1-9]\\d*)$");
+    private static final Pattern PORT_SPECIFIER_RE = Pattern.compile("^(.*):(0|[1-9]\\d*)$");
     private static final Pattern TOKEN_RE = Pattern.compile("(\\$\\([^)]+\\))");
 
     private BrokerAddressPatternUtils() {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/PortIdentifiesNodeIdentificationStrategy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/PortIdentifiesNodeIdentificationStrategy.java
@@ -251,6 +251,21 @@ public class PortIdentifiesNodeIdentificationStrategy
 
     private class Strategy implements NodeIdentificationStrategy {
 
+        // When bootstrapAddress.port() == 0 and nodeStartPort == null, node ports are offsets
+        // from the bootstrap port rather than absolute port numbers. This field receives the
+        // resolved OS-assigned bootstrap port via notifyBootstrapPortResolved() so the offsets
+        // can be converted to actual ports.
+        private volatile int resolvedBootstrapPort;
+
+        private boolean isRelative() {
+            return bootstrapAddress.port() == 0 && nodeStartPort == null;
+        }
+
+        @Override
+        public void notifyBootstrapPortResolved(int resolvedPort) {
+            this.resolvedBootstrapPort = resolvedPort;
+        }
+
         @Override
         public HostPort getClusterBootstrapAddress() {
             return bootstrapAddress;
@@ -265,17 +280,25 @@ public class PortIdentifiesNodeIdentificationStrategy
                                         nodeId,
                                         bootstrapAddress));
             }
-            int port = nodeIdToPort.get(nodeId);
+            int offset = nodeIdToPort.get(nodeId);
+            int port = isRelative() ? resolvedBootstrapPort + offset : offset;
             return new HostPort(BrokerAddressPatternUtils.replaceLiteralNodeId(computedAdvertisedBrokerAddressPattern, nodeId), port);
         }
 
         @Override
         public Set<Integer> getExclusivePorts() {
-            return exclusivePorts;
+            // When node ports are relative to the OS-assigned bootstrap, the actual node ports
+            // are unknown until the bootstrap binds. Only the bootstrap port (0) is known upfront.
+            return isRelative() ? Set.of(0) : exclusivePorts;
         }
 
         @Override
         public Map<Integer, HostPort> discoveryAddressMap() {
+            // With relative node ports, return empty until the bootstrap port is resolved —
+            // the EndpointRegistry will call this again after notifyBootstrapPortResolved fires.
+            if (isRelative() && resolvedBootstrapPort == 0) {
+                return Map.of();
+            }
             return nodeIdToPort.keySet().stream()
                     .collect(Collectors.toMap(Function.identity(), this::getBrokerAddress));
         }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/PortConflictDetector.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/PortConflictDetector.java
@@ -13,6 +13,9 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
@@ -23,6 +26,7 @@ import io.kroxylicious.proxy.service.HostPort;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class PortConflictDetector {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(PortConflictDetector.class);
     private static final String ANY_STRING = "<any>";
 
     private enum BindingScope {
@@ -87,9 +91,19 @@ public class PortConflictDetector {
      */
     public void validate(Collection<VirtualClusterModel> virtualClusterModelMap, Optional<HostPort> otherExclusivePort) {
         List<CandidateBinding> candidateBindings = candidateBindings(virtualClusterModelMap);
+        warnIfOsAssignedPorts(candidateBindings);
         validateCandidatesDoNotConflictWithOtherExclusivePort(candidateBindings, otherExclusivePort);
         validateSharedPortsRequireServerNameIndication(candidateBindings);
         validateCandidatesDoNotConflictWithEachOther(candidateBindings);
+    }
+
+    private static void warnIfOsAssignedPorts(List<CandidateBinding> candidateBindings) {
+        candidateBindings.stream()
+                .filter(binding -> binding.port() == 0)
+                .forEach(binding -> LOGGER.atWarn()
+                        .addKeyValue("virtualCluster", binding.gateway().virtualCluster().getClusterName())
+                        .addKeyValue("gateway", binding.gateway().name())
+                        .log("Gateway is configured with OS-assigned port (0). Advertised broker addresses will reflect the OS-assigned port rather than the configured value."));
     }
 
     private void validateSharedPortsRequireServerNameIndication(List<CandidateBinding> candidateBindings) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/PortConflictDetector.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/PortConflictDetector.java
@@ -51,6 +51,11 @@ public class PortConflictDetector {
 
     private record CandidateBinding(EndpointGateway gateway, int port, BindAddress bindAddress, BindingScope scope) {
         void validateNonConflicting(CandidateBinding other) {
+            // Port 0 means OS-assigned: the OS will bind to different ephemeral ports at runtime, so
+            // two port-0 gateways can never truly conflict and cannot be validated at configuration time.
+            if (port == 0 || other.port == 0) {
+                return;
+            }
             if (this.port == other.port && bindAddress.overlaps(other.bindAddress)) {
                 if (scope == BindingScope.EXCLUSIVE || other.scope == BindingScope.EXCLUSIVE) {
                     throw conflictException(other, "exclusive port collision");

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/Endpoint.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/Endpoint.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 import io.netty.channel.Channel;
 import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.util.AttributeKey;
 
 /**
  * Represents a network endpoint.  Network endpoints accepts Kafka protocol traffic on behalf of a virtual clusters.
@@ -20,6 +21,14 @@ import io.netty.channel.socket.ServerSocketChannel;
  * @param tls true if TLS is in use for this endpoint.
  */
 public record Endpoint(Optional<String> bindingAddress, int port, boolean tls) {
+
+    /**
+     * Channel attribute key used to store the configured {@link Endpoint} on the server socket channel at bind time.
+     * Allows incoming connections to recover the configured endpoint (e.g. port 0) rather than the OS-assigned port,
+     * enabling direct lookup in the endpoint registry map.
+     */
+    public static final AttributeKey<Endpoint> CONFIGURED_ENDPOINT = AttributeKey.newInstance("configuredEndpoint");
+
     public Endpoint {
         Objects.requireNonNull(bindingAddress);
     }
@@ -27,6 +36,10 @@ public record Endpoint(Optional<String> bindingAddress, int port, boolean tls) {
     public static Endpoint createEndpoint(Channel ch, boolean tls) {
         try {
             if (ch.parent() instanceof ServerSocketChannel serverSocketChannel) {
+                var configured = serverSocketChannel.attr(CONFIGURED_ENDPOINT).get();
+                if (configured != null) {
+                    return configured;
+                }
                 var serverSocketAddress = serverSocketChannel.localAddress();
                 var bindingAddress = serverSocketAddress.getAddress().isAnyLocalAddress() ? Optional.<String> empty()
                         : Optional.of(serverSocketAddress.getAddress().getHostAddress());

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointGateway.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointGateway.java
@@ -111,4 +111,14 @@ public interface EndpointGateway {
      */
     String name();
 
+    /**
+     * Notifies the gateway of the actual port assigned by the OS when the configured port was 0.
+     * Called by the endpoint registry after the listening socket is bound.
+     * No-op when the configured port is non-zero.
+     *
+     * @param actualPort the actual port the OS assigned
+     */
+    default void resolveActualPort(int actualPort) {
+    }
+
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointRegistry.java
@@ -458,6 +458,16 @@ public class EndpointRegistry implements EndpointReconciler, EndpointBindingReso
         return ((InetSocketAddress) record.bindingStage().toCompletableFuture().join().localAddress()).getPort();
     }
 
+    @VisibleForTesting
+    public int localPortFor(Optional<String> bindAddress, int port) {
+        return listeningChannels.entrySet().stream()
+                .filter(e -> e.getKey().bindingAddress().equals(bindAddress) && e.getKey().port() == port)
+                .findFirst()
+                .map(e -> ((InetSocketAddress) e.getValue().bindingStage().toCompletableFuture().join().localAddress()).getPort())
+                .orElseThrow(() -> new IllegalStateException(
+                        "No listening channel for (" + bindAddress.orElse("*") + ":" + port + ")"));
+    }
+
     private CompletionStage<Endpoint> registerBinding(Endpoint key, String host, EndpointBinding virtualClusterBinding) {
         Objects.requireNonNull(key, "key cannot be null");
         Objects.requireNonNull(virtualClusterBinding, "virtualClusterBinding cannot be null");

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointRegistry.java
@@ -221,6 +221,9 @@ public class EndpointRegistry implements EndpointReconciler, EndpointBindingReso
                         rollbackRelatedBindings(virtualClusterModel, t, future);
                     }
                     else {
+                        if (key.port() == OS_ASSIGNED_PORT) {
+                            virtualClusterModel.resolveActualPort(localPortFor(key.bindingAddress(), key.port()));
+                        }
                         handleSuccessfulBinding(bootstrapEndpointFuture, future);
                     }
                 });
@@ -498,6 +501,7 @@ public class EndpointRegistry implements EndpointReconciler, EndpointBindingReso
         }
 
         return lcr.bindingStage().thenApply(acceptorChannel -> {
+            acceptorChannel.attr(Endpoint.CONFIGURED_ENDPOINT).setIfAbsent(key);
             synchronized (lcr) {
                 var bindings = acceptorChannel.attr(CHANNEL_BINDINGS);
                 bindings.setIfAbsent(new ConcurrentHashMap<>());

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointRegistry.java
@@ -202,33 +202,46 @@ public class EndpointRegistry implements EndpointReconciler, EndpointBindingReso
 
         vcr.reconciliationRecord().set(ReconciliationRecord.createEmptyReconcileRecord());
 
-        // bind any discovery binding to the bootstrap address
-        var discoveryAddressesMapStage = allOfStage(virtualClusterModel.discoveryAddressMap()
-                .entrySet()
-                .stream()
-                .sorted(Map.Entry.comparingByKey()) // ordering not functionality important, but simplifies the unit testing
-                .map(e -> {
-                    var nodeId = e.getKey();
-                    var bhp = e.getValue();
-                    return registerBinding(new Endpoint(virtualClusterModel.getBindAddress(), bhp.port(), virtualClusterModel.isUseTls()), bhp.host(),
-                            new MetadataDiscoveryBrokerEndpointBinding(virtualClusterModel, nodeId));
-                }));
+        // When bootstrap is OS-assigned the node ports are relative to the resolved bootstrap port
+        // and cannot be computed until after the bootstrap binds. Sequence: bind bootstrap → resolve
+        // port (which notifies the strategy) → bind discovery addresses. For fixed-port bootstrap
+        // both steps can run in parallel since the node ports are known upfront.
+        CompletionStage<Void> discoveryBindingsStage;
+        if (key.port() == OS_ASSIGNED_PORT) {
+            discoveryBindingsStage = bootstrapEndpointFuture.thenCompose(ch -> {
+                virtualClusterModel.resolveActualPort(localPortFor(key.bindingAddress(), key.port()));
+                return bindDiscoveryAddresses(virtualClusterModel);
+            });
+        }
+        else {
+            discoveryBindingsStage = bindDiscoveryAddresses(virtualClusterModel);
+        }
 
-        bootstrapEndpointFuture.thenCombine(discoveryAddressesMapStage, (bef, bps) -> bef)
+        bootstrapEndpointFuture.thenCombine(discoveryBindingsStage, (bef, bps) -> bef)
                 .whenComplete((u, t) -> {
                     var future = vcr.registrationStage.toCompletableFuture();
                     if (t != null) {
                         rollbackRelatedBindings(virtualClusterModel, t, future);
                     }
                     else {
-                        if (key.port() == OS_ASSIGNED_PORT) {
-                            virtualClusterModel.resolveActualPort(localPortFor(key.bindingAddress(), key.port()));
-                        }
                         handleSuccessfulBinding(bootstrapEndpointFuture, future);
                     }
                 });
 
         return vcr.registrationStage();
+    }
+
+    private CompletionStage<Void> bindDiscoveryAddresses(EndpointGateway virtualClusterModel) {
+        return allOfStage(virtualClusterModel.discoveryAddressMap()
+                .entrySet()
+                .stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(e -> {
+                    var nodeId = e.getKey();
+                    var bhp = e.getValue();
+                    return registerBinding(new Endpoint(virtualClusterModel.getBindAddress(), bhp.port(), virtualClusterModel.isUseTls()), bhp.host(),
+                            new MetadataDiscoveryBrokerEndpointBinding(virtualClusterModel, nodeId));
+                }));
     }
 
     private static void handleSuccessfulBinding(CompletableFuture<Endpoint> bootstrapEndpointFuture, CompletableFuture<Endpoint> future) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/NetworkBindRequest.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/NetworkBindRequest.java
@@ -67,9 +67,11 @@ public class NetworkBindRequest extends NetworkBindingOperation<Channel> {
                         .log("Binding");
                 bind = serverBootstrap.bind(port);
             }
+            var address = bindingAddress.orElse("<any>");
             bind.addListener((ChannelFutureListener) channelFuture -> executorService.execute(() -> {
                 if (channelFuture.cause() != null) {
-                    future.completeExceptionally(channelFuture.cause());
+                    future.completeExceptionally(new RuntimeException(
+                            "Failed to bind to " + address + ":" + port, channelFuture.cause()));
                 }
                 else {
                     future.complete(channelFuture.channel());

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -462,6 +463,7 @@ public class VirtualClusterModel implements AutoCloseable {
         private final Optional<Tls> tls;
         private final Optional<SslContext> downstreamSslContext;
         private final String name;
+        private final AtomicInteger resolvedPort = new AtomicInteger(0);
 
         @VisibleForTesting
         VirtualClusterGatewayModel(VirtualClusterModel virtualCluster, NodeIdentificationStrategy nodeIdentificationStrategy, Optional<Tls> tls, String name) {
@@ -472,6 +474,16 @@ public class VirtualClusterModel implements AutoCloseable {
             validatePortUsage(nodeIdentificationStrategy);
             validateTLsSettings(nodeIdentificationStrategy, tls);
             this.downstreamSslContext = buildDownstreamSslContext();
+            warnIfOsAssignedPort(nodeIdentificationStrategy);
+        }
+
+        private void warnIfOsAssignedPort(NodeIdentificationStrategy strategy) {
+            if (strategy.getClusterBootstrapAddress().port() == 0) {
+                LOGGER.atWarn()
+                        .addKeyValue("virtualCluster", virtualCluster.getClusterName())
+                        .addKeyValue("gateway", name)
+                        .log("Gateway is configured with OS-assigned port (0). Advertised broker addresses will reflect the OS-assigned port rather than the configured value.");
+            }
         }
 
         private void validatePortUsage(NodeIdentificationStrategy nodeIdentificationStrategy) {
@@ -543,18 +555,40 @@ public class VirtualClusterModel implements AutoCloseable {
         }
 
         @Override
-        public @Nullable Integer getBrokerIdFromBrokerAddress(HostPort brokerAddress) {
-            return getNodeIdentificationStrategy().getBrokerIdFromBrokerAddress(brokerAddress);
-        }
-
-        @Override
         public String name() {
             return name;
         }
 
         @Override
+        public void resolveActualPort(int actualPort) {
+            resolvedPort.set(actualPort);
+        }
+
+        @Override
         public HostPort getAdvertisedBrokerAddress(int nodeId) {
-            return getNodeIdentificationStrategy().getAdvertisedBrokerAddress(nodeId);
+            HostPort address = getNodeIdentificationStrategy().getAdvertisedBrokerAddress(nodeId);
+            int configuredPort = address.port();
+            if (configuredPort == 0) {
+                int actual = resolvedPort.get();
+                if (actual == 0) {
+                    throw new IllegalStateException(
+                            "Gateway '%s' cannot advertise broker address for node %d: OS-assigned port has not been resolved yet".formatted(name, nodeId));
+                }
+                return new HostPort(address.host(), actual);
+            }
+            return address;
+        }
+
+        @Override
+        public @Nullable Integer getBrokerIdFromBrokerAddress(HostPort brokerAddress) {
+            int configuredPort = nodeIdentificationStrategy.getClusterBootstrapAddress().port();
+            if (configuredPort == 0) {
+                int actual = resolvedPort.get();
+                if (actual != 0 && brokerAddress.port() == actual) {
+                    brokerAddress = new HostPort(brokerAddress.host(), 0);
+                }
+            }
+            return nodeIdentificationStrategy.getBrokerIdFromBrokerAddress(brokerAddress);
         }
 
         @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -552,6 +552,7 @@ public class VirtualClusterModel implements AutoCloseable {
         @Override
         public void resolveActualPort(int actualPort) {
             resolvedPort.set(actualPort);
+            nodeIdentificationStrategy.notifyBootstrapPortResolved(actualPort);
         }
 
         @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -474,16 +474,6 @@ public class VirtualClusterModel implements AutoCloseable {
             validatePortUsage(nodeIdentificationStrategy);
             validateTLsSettings(nodeIdentificationStrategy, tls);
             this.downstreamSslContext = buildDownstreamSslContext();
-            warnIfOsAssignedPort(nodeIdentificationStrategy);
-        }
-
-        private void warnIfOsAssignedPort(NodeIdentificationStrategy strategy) {
-            if (strategy.getClusterBootstrapAddress().port() == 0) {
-                LOGGER.atWarn()
-                        .addKeyValue("virtualCluster", virtualCluster.getClusterName())
-                        .addKeyValue("gateway", name)
-                        .log("Gateway is configured with OS-assigned port (0). Advertised broker addresses will reflect the OS-assigned port rather than the configured value.");
-            }
         }
 
         private void validatePortUsage(NodeIdentificationStrategy nodeIdentificationStrategy) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/service/NodeIdentificationStrategy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/service/NodeIdentificationStrategy.java
@@ -73,6 +73,17 @@ public interface NodeIdentificationStrategy {
     }
 
     /**
+     * Notifies the strategy of the actual port the bootstrap endpoint was bound to.  Called
+     * after an OS-assigned (port 0) bootstrap endpoint is bound and the OS has allocated a port.
+     * Strategies that compute node ports relative to the bootstrap port use this to resolve
+     * those ports.  The default implementation is a no-op.
+     *
+     * @param resolvedPort the actual OS-assigned port the bootstrap endpoint was bound to
+     */
+    default void notifyBootstrapPortResolved(int resolvedPort) {
+    }
+
+    /**
      * Gets the bind address used when binding socket.  Used to restrict
      * listening to particular network interfaces.
      * @return bind address such as "127.0.0.1" or {@code }Optional.empty()} if all address should be bound.

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/PortIdentifiesNodeIdentificationStrategyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/PortIdentifiesNodeIdentificationStrategyTest.java
@@ -29,7 +29,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     public static final String ADVERTISED_BROKER_ADDRESS_PATTERN = "broker$(nodeId).kafka.example.com";
 
     @Test
-    void brokerAddressSingleRange() {
+    void shouldReturnBrokerAddressForSingleRange() {
         NodeIdentificationStrategy strategy = new PortIdentifiesNodeIdentificationStrategy(BOOSTRAP_HOSTPORT,
                 ADVERTISED_BROKER_ADDRESS_PATTERN, null,
                 List.of(new NamedRange("brokers", 0, 2))).buildStrategy("cluster");
@@ -38,7 +38,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void brokerAddressDefaultRange() {
+    void shouldReturnBrokerAddressForDefaultRange() {
         NodeIdentificationStrategy strategy = new PortIdentifiesNodeIdentificationStrategy(BOOSTRAP_HOSTPORT,
                 ADVERTISED_BROKER_ADDRESS_PATTERN, null,
                 null).buildStrategy("cluster");
@@ -50,7 +50,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void brokerAddressInferredFromBootstrapIfNotExplicitlySupplied() {
+    void shouldInferAdvertisedBrokerAddressFromBootstrap() {
         List<NamedRange> namedRangeSpecs = List.of(new NamedRange("brokers", 0, 2));
         NodeIdentificationStrategy strategy = new PortIdentifiesNodeIdentificationStrategy(BOOSTRAP_HOSTPORT,
                 null, null,
@@ -60,7 +60,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void nodeAddressPatternCannotBeBlank() {
+    void shouldRejectBlankNodeAddressPattern() {
         assertThatThrownBy(() -> new PortIdentifiesNodeIdentificationStrategy(BOOSTRAP_HOSTPORT,
                 "", null,
                 null))
@@ -69,7 +69,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void nodeAddressPatternCannotContainUnexpectedReplacementPatterns() {
+    void shouldRejectNodeAddressPatternWithUnexpectedReplacementTokens() {
         assertThatThrownBy(() -> new PortIdentifiesNodeIdentificationStrategy(BOOSTRAP_HOSTPORT,
                 "node-$(typoedNodeId).broker.com", null,
                 null))
@@ -78,7 +78,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void nodeAddressPatternCannotContainVirtualClusterNameReplacementPattern() {
+    void shouldRejectNodeAddressPatternContainingVirtualClusterNameToken() {
         assertThatThrownBy(() -> new PortIdentifiesNodeIdentificationStrategy(BOOSTRAP_HOSTPORT,
                 "node-$(virtualClusterName).broker.com", null,
                 null))
@@ -87,7 +87,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void nodeAddressPatternCannotContainPort() {
+    void shouldRejectNodeAddressPatternContainingPortSpecifier() {
         assertThatThrownBy(() -> new PortIdentifiesNodeIdentificationStrategy(BOOSTRAP_HOSTPORT,
                 "localhost:8080", null,
                 null))
@@ -96,7 +96,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void computedNodeStartPortCannotBeLessThanOne() {
+    void shouldRejectNodeStartPortLessThanOne() {
         assertThatThrownBy(() -> new PortIdentifiesNodeIdentificationStrategy(BOOSTRAP_HOSTPORT,
                 "localhost", 0,
                 null))
@@ -105,7 +105,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void nodePortRangeCannotCollideWithBootstrapPort() {
+    void shouldRejectNodePortRangeThatCollidesWithBootstrapPort() {
         List<NamedRange> rangeSpecs = List.of(new NamedRange("brokers", 0, 3));
         HostPort bootstrapAddress = HostPort.parse(BOOTSTRAP_HOST + ":1235");
         assertThatThrownBy(() -> new PortIdentifiesNodeIdentificationStrategy(bootstrapAddress,
@@ -118,7 +118,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void getClusterBootstrap() {
+    void shouldReturnConfiguredBootstrapAddress() {
         NodeIdentificationStrategy strategy = new PortIdentifiesNodeIdentificationStrategy(BOOSTRAP_HOSTPORT,
                 "broker$(nodeId).kafka.example.com",
                 1236,
@@ -127,7 +127,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void exclusivePortsSingleRange() {
+    void shouldReportExclusivePortsForSingleRange() {
         NodeIdentificationStrategy strategy = new PortIdentifiesNodeIdentificationStrategy(BOOSTRAP_HOSTPORT,
                 ADVERTISED_BROKER_ADDRESS_PATTERN,
                 null,
@@ -136,7 +136,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void discoveryAddressMapSingleRange() {
+    void shouldPopulateDiscoveryAddressMapForSingleRange() {
         NodeIdentificationStrategy strategy = new PortIdentifiesNodeIdentificationStrategy(BOOSTRAP_HOSTPORT,
                 ADVERTISED_BROKER_ADDRESS_PATTERN,
                 null,
@@ -148,7 +148,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void brokerAddressMultipleRanges() {
+    void shouldReturnBrokerAddressForMultipleRanges() {
         NodeIdentificationStrategy strategy = new PortIdentifiesNodeIdentificationStrategy(BOOSTRAP_HOSTPORT,
                 ADVERTISED_BROKER_ADDRESS_PATTERN,
                 null,
@@ -160,7 +160,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void brokerAddressUnknownNodeId() {
+    void shouldThrowForUnknownNodeId() {
         NodeIdentificationStrategy strategy = new PortIdentifiesNodeIdentificationStrategy(BOOSTRAP_HOSTPORT,
                 ADVERTISED_BROKER_ADDRESS_PATTERN,
                 null,
@@ -171,7 +171,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void discoveryAddressMapMultipleRanges() {
+    void shouldPopulateDiscoveryAddressMapForMultipleRanges() {
         NodeIdentificationStrategy strategy = new PortIdentifiesNodeIdentificationStrategy(BOOSTRAP_HOSTPORT,
                 ADVERTISED_BROKER_ADDRESS_PATTERN,
                 null,
@@ -185,7 +185,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
         assertThat(strategy.discoveryAddressMap()).isEqualTo(expected);
     }
 
-    static Stream<Arguments> overlappingComputedNodeIdRangesAreInvalid() {
+    static Stream<Arguments> shouldRejectOverlappingNodeIdRanges() {
         Arguments twoRangesWithOverlap = Arguments.arguments(
                 List.of(new NamedRange("brokers", 0, 1), new NamedRange("controllers", 1, 1)),
                 "some nodeIdRanges collided (one or more node ids are duplicated in the following ranges): 'brokers:[0,1]' collides with 'controllers:[1,1]'");
@@ -202,7 +202,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
 
     @MethodSource
     @ParameterizedTest
-    void overlappingComputedNodeIdRangesAreInvalid(List<NamedRange> namedRangeSpecs, String expectedException) {
+    void shouldRejectOverlappingNodeIdRanges(List<NamedRange> namedRangeSpecs, String expectedException) {
         assertThatThrownBy(() -> new PortIdentifiesNodeIdentificationStrategy(BOOSTRAP_HOSTPORT,
                 ADVERTISED_BROKER_ADDRESS_PATTERN,
                 null,
@@ -212,7 +212,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void rangesMustHaveUniqueNames() {
+    void shouldRejectDuplicateRangeNames() {
         List<NamedRange> nodeIdRanges = List.of(new NamedRange("brokers", 0, 1), new NamedRange("brokers", 1, 2));
         assertThatThrownBy(() -> new PortIdentifiesNodeIdentificationStrategy(BOOSTRAP_HOSTPORT,
                 ADVERTISED_BROKER_ADDRESS_PATTERN,
@@ -223,7 +223,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void exclusivePortsMultipleRanges() {
+    void shouldReportExclusivePortsForMultipleRanges() {
         List<NamedRange> nodeIdRanges = List.of(new NamedRange("brokers", 0, 1), new NamedRange("controllers", 3, 4));
         NodeIdentificationStrategy strategy = new PortIdentifiesNodeIdentificationStrategy(BOOSTRAP_HOSTPORT,
                 ADVERTISED_BROKER_ADDRESS_PATTERN,
@@ -233,7 +233,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void allNodeIdsMustBeMappableToAValidPort() {
+    void shouldRejectConfigurationThatExceedsMaximumPortNumber() {
         List<NamedRange> ranges = List.of(new NamedRange("brokers", 0, 65534));
         HostPort bootstrapAddress = HostPort.parse(BOOTSTRAP_HOST + ":1");
         assertThatThrownBy(() -> {
@@ -247,7 +247,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void getBootstrapAddressFromConfig() {
+    void shouldExposeBootstrapAddress() {
         var bootstrapAddress = HostPort.parse(BOOTSTRAP);
         var config = new PortIdentifiesNodeIdentificationStrategy(bootstrapAddress,
                 ADVERTISED_BROKER_ADDRESS_PATTERN,
@@ -257,7 +257,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void canBuildNodeIdentificationStrategy() {
+    void shouldBuildNodeIdentificationStrategy() {
         var bootstrap = HostPort.parse("boot:1234");
         var config = new PortIdentifiesNodeIdentificationStrategy(bootstrap, "mybroker", null, null);
         var strategy = buildNodeIdentificationStrategy(config);
@@ -265,7 +265,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void providesDefaultRange() {
+    void shouldUseDefaultNodeIdRangeWhenNotConfigured() {
         var bootstrap = HostPort.parse("boot:1234");
         var config = new PortIdentifiesNodeIdentificationStrategy(bootstrap, "mybroker", null, null);
         var strategy = buildNodeIdentificationStrategy(config);
@@ -277,7 +277,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void respectsSingleRange() {
+    void shouldUseConfiguredSingleNodeIdRange() {
         var bootstrap = HostPort.parse("boot:1234");
         var config = new PortIdentifiesNodeIdentificationStrategy(bootstrap, "mybroker", null, List.of(new NamedRange("foo", 10, 11)));
         var strategy = buildNodeIdentificationStrategy(config);
@@ -292,11 +292,69 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
-    void respectsStartPort() {
+    void shouldUseConfiguredNodeStartPort() {
         var bootstrap = HostPort.parse("boot:1234");
         var config = new PortIdentifiesNodeIdentificationStrategy(bootstrap, "mybroker", 1240, null);
         var strategy = buildNodeIdentificationStrategy(config);
         assertThat(strategy.getAdvertisedBrokerAddress(0)).isEqualTo(HostPort.parse("mybroker:1240"));
+    }
+
+    @Test
+    void shouldOnlyReportBootstrapPortPriorToBinding() {
+        // Given
+        var strategy = new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 0),
+                ADVERTISED_BROKER_ADDRESS_PATTERN, null, null).buildStrategy("cluster");
+        // When/Then - node ports are not known until bootstrap resolves; only port 0 reported
+        assertThat(strategy.getExclusivePorts()).containsExactly(0);
+    }
+
+    @Test
+    void shouldReturnEmptyDiscoveryMapPriorToBootstrapBinding() {
+        // Given
+        var strategy = new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 0),
+                ADVERTISED_BROKER_ADDRESS_PATTERN, null, null).buildStrategy("cluster");
+        // When/Then - cannot compute node ports until the resolved bootstrap port is known
+        assertThat(strategy.discoveryAddressMap()).isEmpty();
+    }
+
+    @Test
+    void shouldAdvertiseBrokerPortsRelativeToResolvedBootstrapPort() {
+        // Given
+        var strategy = new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 0),
+                ADVERTISED_BROKER_ADDRESS_PATTERN, null, null).buildStrategy("cluster");
+        // When
+        strategy.notifyBootstrapPortResolved(54321);
+        // Then - node ports are bootstrap + offset (same relationship as for fixed ports)
+        assertThat(strategy.getBrokerAddress(0)).isEqualTo(new HostPort("broker0.kafka.example.com", 54322));
+        assertThat(strategy.getBrokerAddress(1)).isEqualTo(new HostPort("broker1.kafka.example.com", 54323));
+        assertThat(strategy.getBrokerAddress(2)).isEqualTo(new HostPort("broker2.kafka.example.com", 54324));
+    }
+
+    @Test
+    void shouldPopulateDiscoveryMapRelativeToResolvedBootstrapPort() {
+        // Given
+        var strategy = new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 0),
+                ADVERTISED_BROKER_ADDRESS_PATTERN, null, null).buildStrategy("cluster");
+        // When
+        strategy.notifyBootstrapPortResolved(54321);
+        // Then
+        assertThat(strategy.discoveryAddressMap()).isEqualTo(Map.of(
+                0, new HostPort("broker0.kafka.example.com", 54322),
+                1, new HostPort("broker1.kafka.example.com", 54323),
+                2, new HostPort("broker2.kafka.example.com", 54324)));
+    }
+
+    @Test
+    void shouldTreatExplicitNodeStartPortAsAbsoluteNotRelativeToBootstrap() {
+        // Given - explicitly configured nodeStartPort should be an absolute port, not an offset
+        var strategy = new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 0),
+                ADVERTISED_BROKER_ADDRESS_PATTERN, 5000, null).buildStrategy("cluster");
+        // When
+        strategy.notifyBootstrapPortResolved(54321);
+        // Then - node ports are the explicit absolute values, not relative to resolved bootstrap
+        assertThat(strategy.getBrokerAddress(0)).isEqualTo(new HostPort("broker0.kafka.example.com", 5000));
+        assertThat(strategy.getBrokerAddress(1)).isEqualTo(new HostPort("broker1.kafka.example.com", 5001));
+        assertThat(strategy.getExclusivePorts()).contains(0, 5000, 5001, 5002);
     }
 
     private NodeIdentificationStrategy buildNodeIdentificationStrategy(PortIdentifiesNodeIdentificationStrategy config) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/SniHostIdentifiesNodeIdentificationStrategyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/SniHostIdentifiesNodeIdentificationStrategyTest.java
@@ -212,6 +212,17 @@ class SniHostIdentifiesNodeIdentificationStrategyTest {
     }
 
     @Test
+    void bootstrapPortZeroIsAccepted() {
+        var config = new SniHostIdentifiesNodeIdentificationStrategy("boot.kafka:0", "broker-$(nodeId).kafka");
+        assertThat(config.getBootstrapAddressPattern()).isEqualTo("boot.kafka");
+        assertThat(config.getAdvertisedPort()).isEqualTo(0);
+        var strategy = config.buildStrategy("cluster");
+        assertThat(strategy.getClusterBootstrapAddress()).isEqualTo(HostPort.parse("boot.kafka:0"));
+        assertThat(strategy.getBrokerAddress(0).port()).isEqualTo(0);
+        assertThat(strategy.getSharedPorts()).containsExactly(0);
+    }
+
+    @Test
     void containsOpenshiftRoutePlaceholderToken() {
         var strategy = new SniHostIdentifiesNodeIdentificationStrategy("one-bootstrap.$(unresolvedRouteHost):9291", "one-$(nodeId).$(unresolvedRouteHost):443");
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -46,6 +46,7 @@ import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SniHandler;
 import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.util.Attribute;
 import io.netty.util.internal.StringUtil;
 
 import io.kroxylicious.proxy.config.CacheConfiguration;
@@ -122,6 +123,9 @@ class KafkaProxyInitializerTest {
         when(channel.closeFuture()).thenReturn(mock(ChannelFuture.class));
 
         when(acceptingSocketChannel.localAddress()).thenReturn(localhost);
+        @SuppressWarnings("unchecked")
+        Attribute<Endpoint> noConfiguredEndpoint = mock(Attribute.class);
+        when(acceptingSocketChannel.attr(Endpoint.CONFIGURED_ENDPOINT)).thenReturn(noConfiguredEndpoint);
         when(endpointBinding.endpointGateway()).thenReturn(virtualClusterModel.gateways().values().iterator().next());
     }
 
@@ -129,7 +133,7 @@ class KafkaProxyInitializerTest {
         final Optional<Tls> tls = Optional.empty();
         VirtualClusterModel testCluster = new VirtualClusterModel("testCluster", new TargetCluster("localhost:9090", tls), logNetwork,
                 logFrames, List.of(), CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10));
-        testCluster.addGateway("defaullt", mock(NodeIdentificationStrategy.class), tls);
+        testCluster.addGateway("default", mock(NodeIdentificationStrategy.class), tls);
         return testCluster;
 
     }
@@ -342,7 +346,8 @@ class KafkaProxyInitializerTest {
         var embeddedChannel = new EmbeddedChannel(acceptingSocketChannel, DefaultChannelId.newInstance(), true, false);
         kafkaProxyInitializer = createKafkaProxyInitializer(true, endpointBindingResolver);
         kafkaProxyInitializer.initChannel(embeddedChannel);
-        when(endpointBindingResolver.resolve(any(), eq("chat4.leancloud.cn"))).thenReturn(CompletableFuture.failedStage(new EndpointResolutionException("not resolved")));
+        Mockito.lenient().when(endpointBindingResolver.resolve(any(), eq("chat4.leancloud.cn")))
+                .thenReturn(CompletableFuture.failedStage(new EndpointResolutionException("not resolved")));
 
         // Using SNI test data from Netty
         // https://github.com/netty/netty/blob/57bea3bea22717639ba200432c81b23154e4bbd9/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java#L222
@@ -399,13 +404,11 @@ class KafkaProxyInitializerTest {
         assertThatCode(embeddedChannel::checkException).doesNotThrowAnyException();
     }
 
-    @SuppressWarnings("DataFlowIssue")
     private KafkaProxyInitializer createKafkaProxyInitializer(boolean tls,
                                                               EndpointBindingResolver bindingResolver) {
         return createKafkaProxyInitializer(tls, ProxyProtocolMode.DISABLED, bindingResolver);
     }
 
-    @SuppressWarnings("DataFlowIssue")
     private KafkaProxyInitializer createKafkaProxyInitializer(boolean tls,
                                                               ProxyProtocolMode proxyProtocolMode,
                                                               EndpointBindingResolver bindingResolver) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/PortConflictDetectorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/PortConflictDetectorTest.java
@@ -26,6 +26,7 @@ import io.kroxylicious.proxy.service.HostPort;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -153,6 +154,20 @@ class PortConflictDetectorTest {
                         Set.of("shared TLS bind of 192.168.0.1:9080 for gateway 'default' of virtual cluster 'one' is misconfigured, shared port bindings must use server name indication, or connections cannot be routed correctly"),
                         new HostPort(loopback, 9080),
                         List.of(createMockVirtualCluster("one", getVirtualClusterGatewayModel(Set.of(), Set.of(9080), privateUse, true, "default", false)))),
+                argumentSet("two OS-assigned (port 0) exclusive gateways - no conflict",
+                        Set.of(),
+                        null,
+                        List.of(createMockVirtualCluster("one", Set.of(0), Set.of(), any),
+                                createMockVirtualCluster("two", Set.of(0), Set.of(), any))),
+                argumentSet("OS-assigned (port 0) exclusive gateway alongside fixed-port gateway - no conflict",
+                        Set.of(),
+                        null,
+                        List.of(createMockVirtualCluster("one", Set.of(0), Set.of(), any),
+                                createMockVirtualCluster("two", Set.of(9080), Set.of(), any))),
+                argumentSet("OS-assigned (port 0) exclusive gateway vs other exclusive port - no conflict",
+                        Set.of(),
+                        new HostPort("0.0.0.0", 9080),
+                        List.of(createMockVirtualCluster("one", Set.of(0), Set.of(), any))),
                 argumentSet("any:single conflict within virtual cluster",
                         Set.of("exclusive TCP bind of <any>:9080 for gateway 'gateway1' of virtual cluster 'one' conflicts with exclusive TCP bind of <any>:9080 for gateway 'gateway2' of virtual cluster 'one': exclusive port collision"),
                         null,
@@ -212,8 +227,8 @@ class PortConflictDetectorTest {
         when(cluster.getExclusivePorts()).thenReturn(exclusivePorts);
         when(cluster.getSharedPorts()).thenReturn(sharedPorts);
         when(cluster.getBindAddress()).thenReturn(Optional.ofNullable(bindAddress));
-        when(cluster.isUseTls()).thenReturn(tls);
-        when(cluster.requiresServerNameIndication()).thenReturn(requiresServerNameIndication);
+        lenient().when(cluster.isUseTls()).thenReturn(tls);
+        lenient().when(cluster.requiresServerNameIndication()).thenReturn(requiresServerNameIndication);
         when(cluster.name()).thenReturn(gatewayName);
         return cluster;
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/net/EndpointRegistryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/net/EndpointRegistryTest.java
@@ -46,6 +46,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -695,6 +696,42 @@ class EndpointRegistryTest {
     }
 
     @Test
+    void registerVirtualClusterWithOsAssignedPortCallsResolveActualPort() {
+        var bootstrapWithPortZero = new HostPort(DOWNSTREAM_BOOTSTRAP.host(), EndpointRegistry.OS_ASSIGNED_PORT);
+        configureVirtualClusterMock(virtualClusterModel1, bootstrapWithPortZero, UPSTREAM_BOOTSTRAP, false);
+
+        var rf = endpointRegistry.registerVirtualCluster(virtualClusterModel1).toCompletableFuture();
+
+        int actualPort = 54321;
+        var channelMock = createMockNettyChannel(actualPort);
+        verifyAndProcessNetworkEventQueue(
+                createTestNetworkBindRequest(Optional.empty(), EndpointRegistry.OS_ASSIGNED_PORT, false, CompletableFuture.completedFuture(channelMock)));
+
+        assertThat(rf).succeedsWithin(Duration.ofSeconds(1));
+        verify(virtualClusterModel1).resolveActualPort(actualPort);
+    }
+
+    @Test
+    void resolveSucceedsForOsAssignedPortViaConfiguredEndpointAttribute() {
+        var bootstrapWithPortZero = new HostPort(DOWNSTREAM_BOOTSTRAP.host(), EndpointRegistry.OS_ASSIGNED_PORT);
+        configureVirtualClusterMock(virtualClusterModel1, bootstrapWithPortZero, UPSTREAM_BOOTSTRAP, false);
+
+        var rf = endpointRegistry.registerVirtualCluster(virtualClusterModel1).toCompletableFuture();
+
+        int actualPort = 54321;
+        var channelMock = createMockNettyChannel(actualPort);
+        verifyAndProcessNetworkEventQueue(
+                createTestNetworkBindRequest(Optional.empty(), EndpointRegistry.OS_ASSIGNED_PORT, false, CompletableFuture.completedFuture(channelMock)));
+
+        assertThat(rf).succeedsWithin(Duration.ofSeconds(1));
+
+        // createEndpoint(Channel, boolean) reads the CONFIGURED_ENDPOINT attribute (port 0), enabling direct map lookup
+        assertThat(endpointRegistry.resolve(Endpoint.createEndpoint(EndpointRegistry.OS_ASSIGNED_PORT, false), null))
+                .succeedsWithin(Duration.ofSeconds(1))
+                .isEqualTo(new BootstrapEndpointBinding(virtualClusterModel1));
+    }
+
+    @Test
     void localPortForReturnsActualPortAfterBinding() throws Exception {
         configureVirtualClusterMock(virtualClusterModel1, DOWNSTREAM_BOOTSTRAP, UPSTREAM_BOOTSTRAP, false);
         var rf = endpointRegistry.registerVirtualCluster(virtualClusterModel1).toCompletableFuture();
@@ -715,8 +752,8 @@ class EndpointRegistryTest {
 
     private Channel createMockNettyChannel(int port) {
         var channel = mock(Channel.class);
-        var attr = createTestAttribute(EndpointRegistry.CHANNEL_BINDINGS);
-        when(channel.attr(EndpointRegistry.CHANNEL_BINDINGS)).thenReturn(attr);
+        when(channel.attr(EndpointRegistry.CHANNEL_BINDINGS)).thenReturn(createTestAttribute(EndpointRegistry.CHANNEL_BINDINGS));
+        when(channel.attr(Endpoint.CONFIGURED_ENDPOINT)).thenReturn(createTestAttribute(Endpoint.CONFIGURED_ENDPOINT));
         var localAddress = InetSocketAddress.createUnresolved("localhost", port); // This is lenient because not all tests exercise the unbind path
         lenient().when(channel.localAddress()).thenReturn(localAddress);
         return channel;

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/net/EndpointRegistryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/net/EndpointRegistryTest.java
@@ -43,7 +43,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mock.Strictness.LENIENT;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -96,6 +98,33 @@ class EndpointRegistryTest {
         verifyVirtualClusterRegisterFuture(DOWNSTREAM_BOOTSTRAP.port(), false, rf);
 
         assertThat(endpointRegistry.isRegistered(virtualClusterModel1)).isTrue();
+        assertThat(endpointRegistry.listeningChannelCount()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldBindBrokerPortsAfterBootstrapResolved() throws Exception {
+        // Given - bootstrap is OS-assigned (port 0); discovery addresses are unknown until bootstrap resolves
+        var osAssignedBootstrap = new HostPort("downstream-bootstrap", 0);
+        var resolvedBroker0 = new HostPort("downstream-broker0", 54322);
+        var resolvedBroker1 = new HostPort("downstream-broker1", 54323);
+        configureVirtualClusterMock(virtualClusterModel1, osAssignedBootstrap, UPSTREAM_BOOTSTRAP, false, false,
+                Map.of(), new FixedBootstrapSelectionStrategy(0));
+        // When bootstrap resolves, simulate the strategy updating its discovery map
+        doAnswer(invocation -> {
+            when(virtualClusterModel1.discoveryAddressMap()).thenReturn(Map.of(0, resolvedBroker0, 1, resolvedBroker1));
+            return null;
+        }).when(virtualClusterModel1).resolveActualPort(anyInt());
+
+        // When
+        var rf = endpointRegistry.registerVirtualCluster(virtualClusterModel1).toCompletableFuture();
+
+        // Then: only the OS-assigned bootstrap bind is queued initially (discovery map is empty)
+        verifyAndProcessNetworkEventQueue(createTestNetworkBindRequest(0, false));
+        // After the bootstrap binds, resolveActualPort fires → discovery addresses become known → those bind next
+        verifyAndProcessNetworkEventQueue(
+                createTestNetworkBindRequest(resolvedBroker0.port(), false),
+                createTestNetworkBindRequest(resolvedBroker1.port(), false));
+        assertThat(rf).isCompleted();
         assertThat(endpointRegistry.listeningChannelCount()).isEqualTo(3);
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/net/EndpointTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/net/EndpointTest.java
@@ -46,6 +46,23 @@ class EndpointTest {
     }
 
     @Test
+    void shouldPreferConfiguredEndpointAttributeOverLocalAddress() {
+        var configuredEndpoint = Endpoint.createEndpoint(Optional.empty(), 0, true);
+        Channel ch = new EmbeddedChannel(new NioServerSocketChannel() {
+            {
+                attr(Endpoint.CONFIGURED_ENDPOINT).set(configuredEndpoint);
+            }
+
+            @Override
+            public InetSocketAddress localAddress() {
+                return new InetSocketAddress("localhost", 54321);
+            }
+        }, DefaultChannelId.newInstance(), true, false);
+
+        assertThat(Endpoint.createEndpoint(ch, false)).isEqualTo(configuredEndpoint);
+    }
+
+    @Test
     void shouldCreateEndpointFromPort() {
         // Given
         int port = 1234;

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterGatewayModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterGatewayModelTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.model;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.kroxylicious.proxy.config.CacheConfiguration;
+import io.kroxylicious.proxy.config.TargetCluster;
+import io.kroxylicious.proxy.service.HostPort;
+import io.kroxylicious.proxy.service.NodeIdentificationStrategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class VirtualClusterGatewayModelTest {
+
+    private static final String CLUSTER_NAME = "test-cluster";
+    private static final String GATEWAY_NAME = "test-gateway";
+    private static final HostPort BOOTSTRAP_NON_ZERO = HostPort.parse("boot.kafka:9192");
+    private static final HostPort BOOTSTRAP_PORT_ZERO = HostPort.parse("boot.kafka:0");
+
+    @Mock
+    private NodeIdentificationStrategy strategy;
+
+    private VirtualClusterModel makeVirtualClusterModel() {
+        var targetCluster = new TargetCluster("upstream:9092", Optional.empty());
+        return new VirtualClusterModel(CLUSTER_NAME, targetCluster, false, false, List.of(),
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10));
+    }
+
+    private VirtualClusterModel.VirtualClusterGatewayModel makeGatewayModel(HostPort bootstrap) {
+        when(strategy.getClusterBootstrapAddress()).thenReturn(bootstrap);
+        return new VirtualClusterModel.VirtualClusterGatewayModel(makeVirtualClusterModel(), strategy, Optional.empty(), GATEWAY_NAME);
+    }
+
+    @Test
+    void constructionWithPortZeroSucceeds() {
+        // Port 0 is accepted — this exercises the warning log path without asserting on log output
+        assertThat(makeGatewayModel(BOOTSTRAP_PORT_ZERO)).isNotNull();
+    }
+
+    @Test
+    void advertisedBrokerAddressReturnsDelegateAddressForNonZeroPort() {
+        var brokerAddress = HostPort.parse("broker-0.kafka:9192");
+        when(strategy.getAdvertisedBrokerAddress(0)).thenReturn(brokerAddress);
+        var model = makeGatewayModel(BOOTSTRAP_NON_ZERO);
+
+        assertThat(model.getAdvertisedBrokerAddress(0)).isEqualTo(brokerAddress);
+    }
+
+    @Test
+    void advertisedBrokerAddressThrowsWhenPortZeroAndNotYetResolved() {
+        when(strategy.getAdvertisedBrokerAddress(0)).thenReturn(HostPort.parse("broker-0.kafka:0"));
+        var model = makeGatewayModel(BOOTSTRAP_PORT_ZERO);
+
+        assertThatThrownBy(() -> model.getAdvertisedBrokerAddress(0))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("OS-assigned port has not been resolved yet");
+    }
+
+    @Test
+    void advertisedBrokerAddressSubstitutesActualPortAfterResolve() {
+        when(strategy.getAdvertisedBrokerAddress(0)).thenReturn(HostPort.parse("broker-0.kafka:0"));
+        var model = makeGatewayModel(BOOTSTRAP_PORT_ZERO);
+        model.resolveActualPort(54321);
+
+        assertThat(model.getAdvertisedBrokerAddress(0)).isEqualTo(HostPort.parse("broker-0.kafka:54321"));
+    }
+
+    @Test
+    void getBrokerIdFromBrokerAddressDelegatesToStrategyForNonZeroPort() {
+        var brokerAddress = HostPort.parse("broker-0.kafka:9192");
+        when(strategy.getBrokerIdFromBrokerAddress(brokerAddress)).thenReturn(0);
+        var model = makeGatewayModel(BOOTSTRAP_NON_ZERO);
+
+        assertThat(model.getBrokerIdFromBrokerAddress(brokerAddress)).isEqualTo(0);
+    }
+
+    @Test
+    void getBrokerIdFromBrokerAddressNormalizesActualPortToZeroBeforeDelegating() {
+        var brokerAddressWithActualPort = HostPort.parse("broker-0.kafka:54321");
+        var brokerAddressNormalized = HostPort.parse("broker-0.kafka:0");
+        when(strategy.getBrokerIdFromBrokerAddress(brokerAddressNormalized)).thenReturn(0);
+        var model = makeGatewayModel(BOOTSTRAP_PORT_ZERO);
+        model.resolveActualPort(54321);
+
+        assertThat(model.getBrokerIdFromBrokerAddress(brokerAddressWithActualPort)).isEqualTo(0);
+    }
+
+    @Test
+    void getBrokerIdFromBrokerAddressDoesNotNormalizeWhenActualPortNotYetResolved() {
+        var brokerAddress = HostPort.parse("broker-0.kafka:54321");
+        when(strategy.getBrokerIdFromBrokerAddress(brokerAddress)).thenReturn(null);
+        var model = makeGatewayModel(BOOTSTRAP_PORT_ZERO);
+        // resolveActualPort not called
+
+        assertThat(model.getBrokerIdFromBrokerAddress(brokerAddress)).isNull();
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterGatewayModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterGatewayModelTest.java
@@ -32,7 +32,7 @@ class VirtualClusterGatewayModelTest {
     private static final HostPort BOOTSTRAP_NON_ZERO = HostPort.parse("boot.kafka:9192");
     private static final HostPort BOOTSTRAP_PORT_ZERO = HostPort.parse("boot.kafka:0");
 
-    @Mock
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private NodeIdentificationStrategy strategy;
 
     private VirtualClusterModel makeVirtualClusterModel() {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterListenerModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterListenerModelTest.java
@@ -44,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class VirtualClusterListenerModelTest {
@@ -101,6 +102,18 @@ class VirtualClusterListenerModelTest {
         var brokerAddress = new HostPort("broker", 55);
         when(strategy.getBrokerIdFromBrokerAddress(brokerAddress)).thenReturn(1);
         assertThat(listener.getBrokerIdFromBrokerAddress(brokerAddress)).isEqualTo(1);
+    }
+
+    @Test
+    void resolveActualPortNotifiesStrategy() {
+        // Given
+        var strategy = mock(NodeIdentificationStrategy.class);
+        when(strategy.getClusterBootstrapAddress()).thenReturn(new HostPort("bootstrap", 0));
+        var listener = new VirtualClusterGatewayModel(mock(VirtualClusterModel.class), strategy, Optional.empty(), "default");
+        // When
+        listener.resolveActualPort(54321);
+        // Then - strategy is notified so it can compute relative node ports
+        verify(strategy).notifyBootstrapPortResolved(54321);
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterListenerModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterListenerModelTest.java
@@ -95,10 +95,11 @@ class VirtualClusterListenerModelTest {
 
     @Test
     void delegatesToStrategyForBrokerIdFromBrokerAddress() {
-        var mock = mock(NodeIdentificationStrategy.class);
-        var listener = new VirtualClusterGatewayModel(mock(VirtualClusterModel.class), mock, Optional.empty(), "default");
+        var strategy = mock(NodeIdentificationStrategy.class);
+        when(strategy.getClusterBootstrapAddress()).thenReturn(new HostPort("bootstrap", 9090));
+        var listener = new VirtualClusterGatewayModel(mock(VirtualClusterModel.class), strategy, Optional.empty(), "default");
         var brokerAddress = new HostPort("broker", 55);
-        when(mock.getBrokerIdFromBrokerAddress(brokerAddress)).thenReturn(1);
+        when(strategy.getBrokerIdFromBrokerAddress(brokerAddress)).thenReturn(1);
         assertThat(listener.getBrokerIdFromBrokerAddress(brokerAddress)).isEqualTo(1);
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterListenerModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterListenerModelTest.java
@@ -104,6 +104,36 @@ class VirtualClusterListenerModelTest {
     }
 
     @Test
+    void getBrokerIdNormalisesResolvedOsPortToZeroBeforeDelegating() {
+        // Given - strategy configured with OS-assigned bootstrap port; OS resolves it to 54321
+        var strategy = mock(NodeIdentificationStrategy.class);
+        when(strategy.getClusterBootstrapAddress()).thenReturn(new HostPort("bootstrap", 0));
+        var listener = new VirtualClusterGatewayModel(mock(VirtualClusterModel.class), strategy, Optional.empty(), "default");
+        listener.resolveActualPort(54321);
+        var normalised = new HostPort("broker", 0);
+        when(strategy.getBrokerIdFromBrokerAddress(normalised)).thenReturn(1);
+
+        // When - caller supplies the OS-assigned port in the broker address
+        // Then - port is normalised back to 0 before delegation so the strategy sees a stable address
+        assertThat(listener.getBrokerIdFromBrokerAddress(new HostPort("broker", 54321))).isEqualTo(1);
+    }
+
+    @Test
+    void getBrokerIdPassesThroughAddressUnchangedWhenPortDoesNotMatchResolved() {
+        // Given - strategy configured with OS-assigned bootstrap port; OS resolves it to 54321
+        var strategy = mock(NodeIdentificationStrategy.class);
+        when(strategy.getClusterBootstrapAddress()).thenReturn(new HostPort("bootstrap", 0));
+        var listener = new VirtualClusterGatewayModel(mock(VirtualClusterModel.class), strategy, Optional.empty(), "default");
+        listener.resolveActualPort(54321);
+        var differentPort = new HostPort("broker", 9090);
+        when(strategy.getBrokerIdFromBrokerAddress(differentPort)).thenReturn(2);
+
+        // When - caller supplies a port that is not the OS-assigned port
+        // Then - address passes through unchanged
+        assertThat(listener.getBrokerIdFromBrokerAddress(differentPort)).isEqualTo(2);
+    }
+
+    @Test
     void delegatesToStrategyForServerNameIndication() {
         var mock = mock(NodeIdentificationStrategy.class);
         var listener = new VirtualClusterGatewayModel(mock(VirtualClusterModel.class), mock, Optional.empty(), "default");


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Eliminates hardcoded port 9192 from integration test infrastructure by switching to OS-assigned (ephemeral) ports.

**Commit 1**: Expose `listeningPort()` via `KroxyliciousTester`

Widens `KafkaProxy.listeningPort()` from package-private to `public`, adds the method to the `KroxyliciousTester` interface, and implements it in `DefaultKroxyliciousTester` using the same `instanceof KafkaProxy` guard already used by `reconfigure()`.

**Commit 2**: Switch `DEFAULT_PROXY_BOOTSTRAP` to `OS_ASSIGNED_PORT` (port 0)

Changes `KroxyliciousConfigUtils.DEFAULT_PROXY_BOOTSTRAP` from `localhost:9192` to `localhost:0`, and updates `DefaultKroxyliciousTester.getBootstrapAddress()` to resolve the OS-assigned port at runtime when port 0 is detected. Also updates `MetricsIT.SNI_IDENTIFIES_BROKER_BOOTSTRAP` (the first SNI-based constant outside the tester) to port 0.

### Additional Context

Integration tests that use `KroxyliciousConfigUtils.proxy(cluster)` (the majority) were all bound to port 9192. If two test processes ran in the same JVM, or if port 9192 was already in use, tests would fail with a bind error. PR #3763 worked around this with an env-var override; this change fixes it properly.

The remaining hardcoded ports in `AbstractTlsIT`, `ExpositionIT`, and `BaseMultiTenantIT` use `PortIdentifiesNode` gateways. Switching those to port 0 is not feasible with the current design because `PortIdentifiesNode` computes node ports as `bootstrapPort + 1`, which would resolve to port 1 (a privileged port) when bootstrap is 0. That work is deferred.

### Checklist

- [x] New tests written (where applicable). *(infrastructure change — existing IT suite exercises the new behaviour)*
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [ ] For user facing changes, update CHANGELOG.md.