### PR TITLE
fix(ci): fix renovate regex patterns to match unquoted YAML image references

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -82,8 +82,8 @@
         "/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/values.yaml/"
       ],
       "matchStrings": [
-        "(?<depName>hashicorp/vault):(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>.*)\"",
-        "tag:.*(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>.*)"
+        "(?<depName>hashicorp/vault):(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>sha256:[a-f0-9]{64})",
+        "tag:.*(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
       "depNameTemplate": "hashicorp/vault",
       "datasourceTemplate": "docker"
@@ -96,7 +96,7 @@
         "/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/azure/LowkeyVault.java/"
       ],
       "matchStrings": [
-        "(?<depName>nagyesta/lowkey-vault):(?<currentValue>\\d+\\.\\d+\\.\\d+(?:-[a-z0-9-]+)?)@(?<currentDigest>.*)\""
+        "(?<depName>nagyesta/lowkey-vault):(?<currentValue>\\d+\\.\\d+\\.\\d+(?:-[a-z0-9-]+)?)@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
       "datasourceTemplate": "docker"
     },
@@ -119,9 +119,9 @@
         "/kroxylicious-docs/docs/record-encryption-quickstart/index.adoc/"
       ],
       "matchStrings": [
-        "(?<depName>localstack/localstack):(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>.*)\"",
-        "tag:.*(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>.*)",
-        ":localstack-tag: *(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>.*)"
+        "(?<depName>localstack/localstack):(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>sha256:[a-f0-9]{64})",
+        "tag:.*(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>sha256:[a-f0-9]{64})",
+        ":localstack-tag: *(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
       "depNameTemplate": "localstack/localstack",
       "datasourceTemplate": "docker"
@@ -134,7 +134,7 @@
         "/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/azure/MockOauthServer.java/"
       ],
       "matchStrings": [
-        "(?<depName>ghcr.io/navikt/mock-oauth2-server):(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>.*)\"",
+        "(?<depName>ghcr.io/navikt/mock-oauth2-server):(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>sha256:[a-f0-9]{64})",
         "(?<depName>ghcr.io/navikt/mock-oauth2-server):(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "datasourceTemplate": "docker"
@@ -145,7 +145,7 @@
         "/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/JsonSchemaRecordValidation.*IT.java/"
       ],
       "matchStrings": [
-        "(?<depName>quay.io/apicurio/apicurio-registry):(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>.*)\""
+        "(?<depName>quay.io/apicurio/apicurio-registry):(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
       "datasourceTemplate": "docker"
     },
@@ -155,7 +155,7 @@
         "/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java/"
       ],
       "matchStrings": [
-        "(?<depName>quay.io/kroxylicious/python-kafka-test-client):(?<currentValue>\\d+\\.\\d+\\.\\d+-\\d+\\.\\d+\\.\\d+)@(?<currentDigest>.*)\""
+        "(?<depName>quay.io/kroxylicious/python-kafka-test-client):(?<currentValue>\\d+\\.\\d+\\.\\d+-\\d+\\.\\d+\\.\\d+)@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
       "datasourceTemplate": "docker",
       "extractVersionTemplate": "^(?<version>.*)?(-(?<build>.*))?$",
@@ -167,8 +167,8 @@
         "/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java/"
       ],
       "matchStrings": [
-        "(?<depName>quay.io/kroxylicious/kcat):(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>.*)\"",
-        "(?<depName>quay.io/kroxylicious/kaf):(?<currentValue>v\\d+\\.\\d+\\.\\d+)@(?<currentDigest>.*)\""
+        "(?<depName>quay.io/kroxylicious/kcat):(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>sha256:[a-f0-9]{64})",
+        "(?<depName>quay.io/kroxylicious/kaf):(?<currentValue>v\\d+\\.\\d+\\.\\d+)@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
       "datasourceTemplate": "docker"
     },
@@ -179,7 +179,7 @@
         "/DEV_GUIDE.md/"
       ],
       "matchStrings": [
-        "(?<depName>curlimages/curl):(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>.*)\""
+        "(?<depName>curlimages/curl):(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
       "datasourceTemplate": "docker"
     },


### PR DESCRIPTION
## Summary

Fixes Renovate regex patterns that were failing to match Docker image references in YAML files.

## Problem

The regex patterns for Docker image digests used greedy wildcards with closing quote requirements (`(?<currentDigest>.*)\"`) that only matched quoted strings in Java/shell files. This caused Renovate to miss image references in YAML files like `values.yaml` where image values are unquoted.

For example, this pattern failed to match:
```yaml
image: docker.io/hashicorp/vault:2.0.0@sha256:e40c741ed95bb271425e3e6ca6c222d620cf8682f6f7a1b1e7c9d49d0aba484b
```

## Solution

Replaced greedy digest patterns with specific SHA256 format:
```regex
(?<currentDigest>sha256:[a-f0-9]{64})
```

This pattern:
- Works in both quoted (Java/shell) and unquoted (YAML) contexts
- Matches exactly 64 hex characters (standard SHA256 digest length)
- Prevents over-capturing trailing delimiters like `";` or `"}`
- More precise and maintainable

Applied the fix consistently across all 8 Docker image custom managers in the Renovate configuration:
- hashicorp/vault
- nagyesta/lowkey-vault
- localstack/localstack
- ghcr.io/navikt/mock-oauth2-server
- quay.io/apicurio/apicurio-registry
- quay.io/kroxylicious/python-kafka-test-client
- quay.io/kroxylicious/kcat and kaf
- curlimages/curl

Fixes #4035