### PR TITLE
refactor(runtime): move backend connection setup into ServerConnectionStateMachine

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -793,21 +793,27 @@ public class ClientConnectionStateMachine {
     private void toForwarding(Forwarding forwarding,
                               HostPort remote) {
         setState(forwarding);
-        boolean upstreamRequiresTls = virtualCluster().getUpstreamSslContext().isPresent();
-        serverConnectionStateMachine = new ServerConnectionStateMachine(
-                remote,
-                upstreamRequiresTls,
-                this,
-                proxyToServerConnectionCounter,
-                proxyToServerErrorCounter,
-                serverToProxyBackpressureMeter,
-                proxyToServerConnectionToken);
+        proxyToServerConnectionCounter.increment();
+        serverConnectionStateMachine = createServerConnection(remote);
         var frontend = Objects.requireNonNull(frontendHandler);
-        frontend.initiateBackendConnect(remote, serverConnectionStateMachine.backendHandler());
+        serverConnectionStateMachine.connect(Objects.requireNonNull(frontend.clientChannel()));
         log(Level.DEBUG)
                 .addKeyValue("remote", remote)
                 .addKeyValue("clientAddress", () -> HostPort.asString(frontend.remoteHost(), frontend.remotePort()))
                 .log("Upstream connection initiated for client");
+    }
+
+    @VisibleForTesting
+    ServerConnectionStateMachine createServerConnection(HostPort remote) {
+        return new ServerConnectionStateMachine(
+                remote,
+                this,
+                virtualCluster(),
+                clusterName(),
+                nodeId(),
+                proxyToServerErrorCounter,
+                serverToProxyBackpressureMeter,
+                proxyToServerConnectionToken);
     }
 
     /**

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -146,12 +146,6 @@ public class ClientConnectionStateMachine {
 
     private final ActivationToken clientToProxyConnectionToken;
 
-    // Server-side metrics (passed to SCSM at construction)
-    private final Counter proxyToServerConnectionCounter;
-    private final Counter proxyToServerErrorCounter;
-    private final Timer serverToProxyBackpressureMeter;
-    private final ActivationToken proxyToServerConnectionToken;
-
     @VisibleForTesting
     @Nullable
     Timer.Sample clientToProxyBackpressureTimer;
@@ -219,12 +213,8 @@ public class ClientConnectionStateMachine {
         clientToProxyDisconnectsDrainCompletedCounter = Metrics.clientToProxyDisconnectsCounter(clusterName, nodeId, DisconnectCause.DRAIN_COMPLETED.label()).withTags();
         clientToProxyDisconnectsDrainTimeoutCounter = Metrics.clientToProxyDisconnectsCounter(clusterName, nodeId, DisconnectCause.DRAIN_TIMEOUT.label()).withTags();
         clientToProxyErrorCounter = Metrics.clientToProxyErrorCounter(clusterName, nodeId).withTags();
-        proxyToServerConnectionCounter = Metrics.proxyToServerConnectionCounter(clusterName, nodeId).withTags();
-        proxyToServerErrorCounter = Metrics.proxyToServerErrorCounter(clusterName, nodeId).withTags();
-        serverToProxyBackpressureMeter = Metrics.serverToProxyBackpressureTimer(clusterName, nodeId).withTags();
         clientToProxyBackPressureMeter = Metrics.clientToProxyBackpressureTimer(clusterName, nodeId).withTags();
         clientToProxyConnectionToken = Metrics.clientToProxyConnectionToken(node);
-        proxyToServerConnectionToken = Metrics.proxyToServerConnectionToken(node);
     }
 
     ClientConnectionState state() {
@@ -657,14 +647,6 @@ public class ClientConnectionStateMachine {
     }
 
     /**
-     * Temporary mechanism to route exception to SCSM
-     * TODO remove once KafkaProxyFrontendHandler is no longer responsible for backend connection work.
-     */
-    void notifyServerConnectionException(@Nullable Throwable cause) {
-        Objects.requireNonNull(serverConnectionStateMachine).onServerException(cause);
-    }
-
-    /**
      * Callback from {@link ServerConnectionStateMachine} when something exceptional and
      * un-recoverable has happened on the upstream side.
      * @param cause the exception that triggered the issue
@@ -793,7 +775,6 @@ public class ClientConnectionStateMachine {
     private void toForwarding(Forwarding forwarding,
                               HostPort remote) {
         setState(forwarding);
-        proxyToServerConnectionCounter.increment();
         serverConnectionStateMachine = createServerConnection(remote);
         var frontend = Objects.requireNonNull(frontendHandler);
         serverConnectionStateMachine.connect(Objects.requireNonNull(frontend.clientChannel()));
@@ -810,10 +791,7 @@ public class ClientConnectionStateMachine {
                 this,
                 virtualCluster(),
                 clusterName(),
-                nodeId(),
-                proxyToServerErrorCounter,
-                serverToProxyBackpressureMeter,
-                proxyToServerConnectionToken);
+                nodeId());
     }
 
     /**

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -14,7 +14,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSession;
@@ -23,22 +22,15 @@ import org.apache.kafka.common.message.ResponseHeaderData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelId;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
-import io.netty.handler.logging.LogLevel;
-import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SniCompletionEvent;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.handler.timeout.IdleState;
@@ -47,40 +39,23 @@ import io.netty.handler.timeout.IdleStateHandler;
 
 import io.kroxylicious.proxy.authentication.TransportSubjectBuilder;
 import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
-import io.kroxylicious.proxy.bootstrap.TlsCredentialSupplierManager;
-import io.kroxylicious.proxy.config.IllegalConfigurationException;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.NettySettings;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
-import io.kroxylicious.proxy.config.tls.TrustOptions;
-import io.kroxylicious.proxy.config.tls.TrustProvider;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.frame.ResponseFrame;
 import io.kroxylicious.proxy.internal.ClientConnectionState.ClientActive;
 import io.kroxylicious.proxy.internal.ClientConnectionState.Closed;
-import io.kroxylicious.proxy.internal.codec.CorrelationManager;
 import io.kroxylicious.proxy.internal.codec.DecodePredicate;
-import io.kroxylicious.proxy.internal.codec.KafkaMessageListener;
-import io.kroxylicious.proxy.internal.codec.KafkaRequestEncoder;
-import io.kroxylicious.proxy.internal.codec.KafkaResponseDecoder;
 import io.kroxylicious.proxy.internal.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.internal.filter.NettyFilterContext;
 import io.kroxylicious.proxy.internal.filter.impl.ApiVersionsDowngradeFilter;
 import io.kroxylicious.proxy.internal.filter.impl.ApiVersionsIntersectFilter;
 import io.kroxylicious.proxy.internal.filter.impl.BrokerAddressFilter;
 import io.kroxylicious.proxy.internal.filter.impl.EagerMetadataLearner;
-import io.kroxylicious.proxy.internal.metrics.MetricEmittingKafkaMessageListener;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
-import io.kroxylicious.proxy.internal.tls.ServerTlsCredentialSupplierContextImpl;
-import io.kroxylicious.proxy.internal.tls.TlsCredentialsImpl;
-import io.kroxylicious.proxy.internal.util.Metrics;
-import io.kroxylicious.proxy.model.VirtualClusterModel;
-import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
-import io.kroxylicious.proxy.tls.ClientTlsContext;
-import io.kroxylicious.proxy.tls.ServerTlsCredentialSupplier;
-import io.kroxylicious.proxy.tls.TlsCredentials;
 
 import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -322,219 +297,6 @@ public class KafkaProxyFrontendHandler
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         clientConnectionStateMachine.onClientException(cause);
-    }
-
-    /**
-     * Initiates the connection to a server.
-     * Called by the {@link ClientConnectionStateMachine} to initiate a backend connection.
-     * Configures the backend channel pipeline and starts the TCP connection.
-     * @param remote upstream broker target
-     * @param backendHandler the handler for the backend channel
-     */
-    void initiateBackendConnect(
-                                HostPort remote,
-                                KafkaProxyBackendHandler backendHandler) {
-        final Channel inboundChannel = clientCtx().channel();
-        // Start the upstream connection attempt.
-        final Bootstrap bootstrap = configureBootstrap(backendHandler, inboundChannel);
-
-        LOGGER.atDebug()
-                .addKeyValue("sessionId", this.clientConnectionStateMachine.sessionId())
-                .addKeyValue("remote", remote)
-                .log("Connecting to outbound");
-        ChannelFuture serverTcpConnectFuture = initConnection(remote.host(), remote.port(), bootstrap);
-        Channel outboundChannel = serverTcpConnectFuture.channel();
-        ChannelPipeline pipeline = outboundChannel.pipeline();
-
-        var correlationManager = new CorrelationManager();
-
-        // Note: Because we are acting as a client of the target cluster and are thus writing Request data to an outbound channel, the Request flows from the
-        // last outbound handler in the pipeline to the first. When Responses are read from the cluster, the inbound handlers of the pipeline are invoked in
-        // the reverse order, from first to last. This is the opposite of how we configure a server pipeline like we do in KafkaProxyInitializer where the channel
-        // reads Kafka requests, as the message flows are reversed. This is also the opposite of the order that Filters are declared in the Kroxylicious configuration
-        // file. The Netty Channel pipeline documentation provides an illustration https://netty.io/4.0/api/io/netty/channel/ChannelPipeline.html
-        if (clientConnectionStateMachine.virtualCluster().isLogFrames()) {
-            pipeline.addFirst("frameLogger", new LoggingHandler("io.kroxylicious.proxy.internal.UpstreamFrameLogger", LogLevel.INFO));
-        }
-
-        var encoderListener = buildMetricsMessageListenerForEncode();
-        var decoderListener = buildMetricsMessageListenerForDecode();
-
-        pipeline.addFirst("responseDecoder",
-                new KafkaResponseDecoder(correlationManager, clientConnectionStateMachine.virtualCluster().socketFrameMaxSizeBytes(), decoderListener));
-        pipeline.addFirst("requestEncoder", new KafkaRequestEncoder(correlationManager, encoderListener));
-        if (clientConnectionStateMachine.virtualCluster().isLogNetwork()) {
-            pipeline.addFirst("networkLogger", new LoggingHandler("io.kroxylicious.proxy.internal.UpstreamNetworkLogger", LogLevel.INFO));
-        }
-
-        // Check if we need to use dynamic TLS credential supplier
-        if (clientConnectionStateMachine.virtualCluster().usesDynamicTlsCredentials()) {
-            // Dynamic credential supplier - invoke it asynchronously
-            invokeTlsCredentialSupplier(remote, outboundChannel, pipeline);
-        }
-        else {
-            // Static TLS configuration - use pre-built SslContext
-            clientConnectionStateMachine.virtualCluster().getUpstreamSslContext().ifPresent(sslContext -> {
-                final SslHandler handler = sslContext.newHandler(outboundChannel.alloc(), remote.host(), remote.port());
-                pipeline.addFirst("ssl", handler);
-            });
-        }
-
-        LOGGER.atDebug()
-                .addKeyValue("pipeline", pipeline)
-                .log("Configured broker channel pipeline");
-
-        serverTcpConnectFuture.addListener(future -> {
-            if (future.isSuccess()) {
-                LOGGER.atTrace()
-                        .addKeyValue("channelId", clientCtx().channel().id())
-                        .log("Outbound connected");
-                // This branch does not cause the transition to Connected:
-                // That happens when the backend filter call #onUpstreamChannelActive(ChannelHandlerContext).
-            }
-            else {
-                clientConnectionStateMachine.notifyServerConnectionException(future.cause());
-            }
-        });
-    }
-
-    /**
-     * Invokes the TLS credential supplier asynchronously and configures the SSL handler once credentials are available.
-     */
-    private void invokeTlsCredentialSupplier(HostPort remote, Channel outboundChannel, ChannelPipeline pipeline) {
-        try {
-            TlsCredentialSupplierManager manager = clientConnectionStateMachine.virtualCluster().getTlsCredentialSupplierManager();
-            ServerTlsCredentialSupplier supplier = manager.getSupplier();
-
-            ClientTlsContext clientCtx = clientConnectionStateMachine.clientTlsContext().orElse(null);
-            ServerTlsCredentialSupplierContextImpl supplierContext = new ServerTlsCredentialSupplierContextImpl(clientCtx);
-
-            outboundChannel.eventLoop().execute(() -> requestTlsCredentials(supplier, supplierContext, remote, outboundChannel, pipeline));
-        }
-        catch (Exception e) {
-            LOGGER.atError()
-                    .addKeyValue("remote", remote)
-                    .addKeyValue("error", e.getMessage())
-                    .setCause(LOGGER.isDebugEnabled() ? e : null)
-                    .log("Error invoking TLS credential supplier{}",
-                            LOGGER.isDebugEnabled() ? "" : " increase log level to DEBUG for stacktrace");
-            clientConnectionStateMachine.notifyServerConnectionException(e);
-        }
-    }
-
-    @VisibleForTesting
-    void requestTlsCredentials(ServerTlsCredentialSupplier supplier, ServerTlsCredentialSupplierContextImpl supplierContext, HostPort remote,
-                               Channel outboundChannel,
-                               ChannelPipeline pipeline) {
-        supplier.tlsCredentials(supplierContext).whenComplete((credentials, throwable) -> outboundChannel.eventLoop()
-                .execute(() -> handleTlsCredentialSupplierResult(credentials, throwable, remote, outboundChannel, pipeline)));
-    }
-
-    @VisibleForTesting
-    void handleTlsCredentialSupplierResult(TlsCredentials credentials, Throwable throwable, HostPort remote, Channel outboundChannel, ChannelPipeline pipeline) {
-        if (throwable != null) {
-            handleTlsCredentialSupplierFailure(remote, throwable);
-            return;
-        }
-        if (credentials == null) {
-            clientConnectionStateMachine.notifyServerConnectionException(new IllegalStateException("TLS credential supplier returned null"));
-            return;
-        }
-        applySslContextToChannel(credentials, remote, outboundChannel, pipeline);
-    }
-
-    private void handleTlsCredentialSupplierFailure(HostPort remote, Throwable throwable) {
-        LOGGER.atError()
-                .addKeyValue("remote", remote)
-                .addKeyValue("error", throwable.getMessage())
-                .setCause(LOGGER.isDebugEnabled() ? throwable : null)
-                .log("TLS credential supplier failed{}",
-                        LOGGER.isDebugEnabled() ? "" : " increase log level to DEBUG for stacktrace");
-        clientConnectionStateMachine.notifyServerConnectionException(new IllegalStateException("Failed to obtain TLS credentials", throwable));
-    }
-
-    /**
-     * Applies the obtained TLS credentials to the channel by building an SslContext and adding an SslHandler.
-     */
-    void applySslContextToChannel(TlsCredentials credentials, HostPort remote, Channel outboundChannel, ChannelPipeline pipeline) {
-        try {
-            if (!(credentials instanceof TlsCredentialsImpl credentialsImpl)) {
-                throw new IllegalStateException("Unexpected TlsCredentials implementation: " + credentials.getClass().getName());
-            }
-
-            // Build SslContextBuilder with trust configuration from target cluster
-            SslContextBuilder sslContextBuilder = SslContextBuilder.forClient()
-                    .keyManager(credentialsImpl.privateKey(), credentialsImpl.certificateChain());
-
-            clientConnectionStateMachine.virtualCluster().targetCluster().tls().ifPresent(tls -> {
-                VirtualClusterModel.configureCipherSuites(sslContextBuilder, tls);
-                VirtualClusterModel.configureEnabledProtocols(sslContextBuilder, tls);
-                Optional.ofNullable(tls.trust())
-                        .map(TrustProvider::trustOptions)
-                        .filter(Predicate.not(TrustOptions::forClient))
-                        .ifPresent(to -> {
-                            throw new IllegalConfigurationException("Cannot apply trust options " + to + " to upstream (client) TLS.)");
-                        });
-                VirtualClusterModel.configureTrustProvider(tls).apply(sslContextBuilder);
-            });
-
-            // Build the SslContext
-            SslContext sslContext = sslContextBuilder.build();
-
-            // Create and add the SslHandler to the pipeline
-            final SslHandler handler = sslContext.newHandler(outboundChannel.alloc(), remote.host(), remote.port());
-            pipeline.addFirst("ssl", handler);
-
-            LOGGER.atDebug()
-                    .addKeyValue("remote", remote)
-                    .log("Successfully configured dynamic TLS credentials");
-        }
-        catch (Exception e) {
-            LOGGER.atError()
-                    .addKeyValue("remote", remote)
-                    .addKeyValue("error", e.getMessage())
-                    .setCause(LOGGER.isDebugEnabled() ? e : null)
-                    .log("Error applying TLS credentials to channel{}",
-                            LOGGER.isDebugEnabled() ? "" : " increase log level to DEBUG for stacktrace");
-            clientConnectionStateMachine.notifyServerConnectionException(e);
-        }
-    }
-
-    private MetricEmittingKafkaMessageListener buildMetricsMessageListenerForEncode() {
-        var clusterName = this.clientConnectionStateMachine.clusterName();
-        var nodeId = clientConnectionStateMachine.nodeId();
-        var proxyToServerMessageCounterProvider = Metrics.proxyToServerMessageCounterProvider(clusterName, nodeId);
-        var proxyToServerMessageSizeDistributionProvider = Metrics.proxyToServerMessageSizeDistributionProvider(clusterName,
-                nodeId);
-        return new MetricEmittingKafkaMessageListener(proxyToServerMessageCounterProvider, proxyToServerMessageSizeDistributionProvider);
-    }
-
-    private KafkaMessageListener buildMetricsMessageListenerForDecode() {
-        var clusterName = clientConnectionStateMachine.clusterName();
-        var nodeId = clientConnectionStateMachine.nodeId();
-        var serverToProxyMessageCounterProvider = Metrics.serverToProxyMessageCounterProvider(clusterName, nodeId);
-
-        var serverToProxyMessageSizeDistributionProvider = Metrics.serverToProxyMessageSizeDistributionProvider(clusterName,
-                nodeId);
-        return new MetricEmittingKafkaMessageListener(serverToProxyMessageCounterProvider, serverToProxyMessageSizeDistributionProvider);
-    }
-
-    /** Ugly hack used for testing */
-    @VisibleForTesting
-    Bootstrap configureBootstrap(KafkaProxyBackendHandler backendHandler, Channel inboundChannel) {
-        Bootstrap bootstrap = new Bootstrap();
-        bootstrap.group(inboundChannel.eventLoop())
-                .channel(inboundChannel.getClass())
-                .handler(backendHandler)
-                .option(ChannelOption.AUTO_READ, true)
-                .option(ChannelOption.TCP_NODELAY, true);
-        return bootstrap;
-    }
-
-    /** Ugly hack used for testing */
-    @VisibleForTesting
-    ChannelFuture initConnection(String remoteHost, int remotePort, Bootstrap bootstrap) {
-        return bootstrap.connect(remoteHost, remotePort);
     }
 
     /**

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachine.java
@@ -9,6 +9,8 @@ package io.kroxylicious.proxy.internal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
 
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
@@ -16,11 +18,35 @@ import org.slf4j.spi.LoggingEventBuilder;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslHandler;
 import io.netty.util.ReferenceCountUtil;
 
+import io.kroxylicious.proxy.config.IllegalConfigurationException;
+import io.kroxylicious.proxy.config.tls.TrustOptions;
+import io.kroxylicious.proxy.config.tls.TrustProvider;
+import io.kroxylicious.proxy.internal.codec.CorrelationManager;
+import io.kroxylicious.proxy.internal.codec.KafkaRequestEncoder;
+import io.kroxylicious.proxy.internal.codec.KafkaResponseDecoder;
+import io.kroxylicious.proxy.internal.metrics.MetricEmittingKafkaMessageListener;
+import io.kroxylicious.proxy.internal.tls.ServerTlsCredentialSupplierContextImpl;
+import io.kroxylicious.proxy.internal.tls.TlsCredentialsImpl;
 import io.kroxylicious.proxy.internal.util.ActivationToken;
+import io.kroxylicious.proxy.internal.util.Metrics;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
+import io.kroxylicious.proxy.tls.ClientTlsContext;
+import io.kroxylicious.proxy.tls.ServerTlsCredentialSupplier;
+import io.kroxylicious.proxy.tls.TlsCredentials;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
@@ -47,7 +73,10 @@ class ServerConnectionStateMachine {
 
     private final ClientConnectionStateMachine ccsm;
     private final KafkaProxyBackendHandler backendHandler;
-    private final boolean upstreamRequiresTls;
+    private final VirtualClusterModel virtualCluster;
+    private final String clusterName;
+    @Nullable
+    private final Integer nodeId;
 
     int serverMessagesInFlightCount;
 
@@ -66,20 +95,22 @@ class ServerConnectionStateMachine {
 
     ServerConnectionStateMachine(
                                  HostPort remote,
-                                 boolean upstreamRequiresTls,
                                  ClientConnectionStateMachine ccsm,
-                                 Counter proxyToServerConnectionCounter,
+                                 VirtualClusterModel virtualCluster,
+                                 String clusterName,
+                                 @Nullable Integer nodeId,
                                  Counter proxyToServerErrorCounter,
                                  Timer serverToProxyBackpressureMeter,
                                  ActivationToken proxyToServerConnectionToken) {
         this.state = new ServerConnectionState.Connecting(remote);
-        this.upstreamRequiresTls = upstreamRequiresTls;
+        this.virtualCluster = Objects.requireNonNull(virtualCluster);
+        this.clusterName = Objects.requireNonNull(clusterName);
+        this.nodeId = nodeId;
         this.ccsm = Objects.requireNonNull(ccsm);
         this.backendHandler = new KafkaProxyBackendHandler(this);
         this.proxyToServerErrorCounter = proxyToServerErrorCounter;
         this.serverToProxyBackpressureMeter = serverToProxyBackpressureMeter;
         this.proxyToServerConnectionToken = proxyToServerConnectionToken;
-        proxyToServerConnectionCounter.increment();
     }
 
     ServerConnectionState state() {
@@ -91,7 +122,222 @@ class ServerConnectionStateMachine {
     }
 
     boolean isUpstreamTls() {
-        return upstreamRequiresTls;
+        return virtualCluster.getUpstreamSslContext().isPresent();
+    }
+
+    // === Connection setup ===
+
+    /**
+     * Initiates the TCP connection to the upstream broker.
+     * Configures the backend channel pipeline (codecs, TLS, logging) and starts the connect.
+     *
+     * @param inboundChannel the client-side channel, used for event loop and channel class
+     */
+    void connect(Channel inboundChannel) {
+        if (!(state instanceof ServerConnectionState.Connecting connecting)) {
+            ccsm.illegalState("connect() called while not in Connecting state");
+            return;
+        }
+        HostPort remote = connecting.remote();
+        final Bootstrap bootstrap = configureBootstrap(backendHandler, inboundChannel);
+
+        log(Level.DEBUG)
+                .addKeyValue("remote", remote)
+                .log("Connecting to outbound");
+        ChannelFuture serverTcpConnectFuture = initConnection(remote.host(), remote.port(), bootstrap);
+        Channel outboundChannel = serverTcpConnectFuture.channel();
+        ChannelPipeline pipeline = outboundChannel.pipeline();
+
+        var correlationManager = new CorrelationManager();
+
+        if (virtualCluster.isLogFrames()) {
+            pipeline.addFirst("frameLogger",
+                    new LoggingHandler("io.kroxylicious.proxy.internal.UpstreamFrameLogger", LogLevel.INFO));
+        }
+
+        var encoderListener = buildMetricsMessageListenerForEncode();
+        var decoderListener = buildMetricsMessageListenerForDecode();
+
+        pipeline.addFirst("responseDecoder",
+                new KafkaResponseDecoder(correlationManager, virtualCluster.socketFrameMaxSizeBytes(), decoderListener));
+        pipeline.addFirst("requestEncoder", new KafkaRequestEncoder(correlationManager, encoderListener));
+        if (virtualCluster.isLogNetwork()) {
+            pipeline.addFirst("networkLogger",
+                    new LoggingHandler("io.kroxylicious.proxy.internal.UpstreamNetworkLogger", LogLevel.INFO));
+        }
+
+        if (virtualCluster.usesDynamicTlsCredentials()) {
+            invokeTlsCredentialSupplier(remote, outboundChannel, pipeline);
+        }
+        else {
+            virtualCluster.getUpstreamSslContext().ifPresent(sslContext -> {
+                final SslHandler handler = sslContext.newHandler(outboundChannel.alloc(), remote.host(), remote.port());
+                pipeline.addFirst("ssl", handler);
+            });
+        }
+
+        log(Level.DEBUG)
+                .addKeyValue("pipeline", pipeline)
+                .log("Configured broker channel pipeline");
+
+        serverTcpConnectFuture.addListener(future -> {
+            if (future.isSuccess()) {
+                log(Level.TRACE)
+                        .log("Outbound connected");
+            }
+            else {
+                onServerException(future.cause());
+            }
+        });
+    }
+
+    @VisibleForTesting
+    Bootstrap configureBootstrap(
+                                 KafkaProxyBackendHandler backendHandler,
+                                 Channel inboundChannel) {
+        Bootstrap bootstrap = new Bootstrap();
+        bootstrap.group(inboundChannel.eventLoop())
+                .channel(inboundChannel.getClass())
+                .handler(backendHandler)
+                .option(ChannelOption.AUTO_READ, true)
+                .option(ChannelOption.TCP_NODELAY, true);
+        return bootstrap;
+    }
+
+    @VisibleForTesting
+    ChannelFuture initConnection(
+                                 String remoteHost,
+                                 int remotePort,
+                                 Bootstrap bootstrap) {
+        return bootstrap.connect(remoteHost, remotePort);
+    }
+
+    private void invokeTlsCredentialSupplier(
+                                             HostPort remote,
+                                             Channel outboundChannel,
+                                             ChannelPipeline pipeline) {
+        try {
+            var manager = virtualCluster.getTlsCredentialSupplierManager();
+            ServerTlsCredentialSupplier supplier = manager.getSupplier();
+
+            ClientTlsContext clientCtx = ccsm.clientTlsContext().orElse(null);
+            var supplierContext = new ServerTlsCredentialSupplierContextImpl(clientCtx);
+
+            outboundChannel.eventLoop().execute(
+                    () -> requestTlsCredentials(supplier, supplierContext, remote, outboundChannel, pipeline));
+        }
+        catch (Exception e) {
+            log(Level.ERROR)
+                    .addKeyValue("remote", remote)
+                    .addKeyValue("error", e.getMessage())
+                    .setCause(LOGGER.isDebugEnabled() ? e : null)
+                    .log(LOGGER.isDebugEnabled()
+                            ? "Error invoking TLS credential supplier"
+                            : "Error invoking TLS credential supplier, increase log level to DEBUG for stacktrace");
+            onServerException(e);
+        }
+    }
+
+    @VisibleForTesting
+    void requestTlsCredentials(
+                               ServerTlsCredentialSupplier supplier,
+                               ServerTlsCredentialSupplierContextImpl supplierContext,
+                               HostPort remote,
+                               Channel outboundChannel,
+                               ChannelPipeline pipeline) {
+        supplier.tlsCredentials(supplierContext).whenComplete(
+                (credentials, throwable) -> outboundChannel.eventLoop().execute(
+                        () -> handleTlsCredentialSupplierResult(credentials, throwable, remote, outboundChannel, pipeline)));
+    }
+
+    @VisibleForTesting
+    void handleTlsCredentialSupplierResult(
+                                           TlsCredentials credentials,
+                                           Throwable throwable,
+                                           HostPort remote,
+                                           Channel outboundChannel,
+                                           ChannelPipeline pipeline) {
+        if (throwable != null) {
+            handleTlsCredentialSupplierFailure(remote, throwable);
+            return;
+        }
+        if (credentials == null) {
+            onServerException(new IllegalStateException("TLS credential supplier returned null"));
+            return;
+        }
+        applySslContextToChannel(credentials, remote, outboundChannel, pipeline);
+    }
+
+    private void handleTlsCredentialSupplierFailure(
+                                                    HostPort remote,
+                                                    Throwable throwable) {
+        log(Level.ERROR)
+                .addKeyValue("remote", remote)
+                .addKeyValue("error", throwable.getMessage())
+                .setCause(LOGGER.isDebugEnabled() ? throwable : null)
+                .log(LOGGER.isDebugEnabled()
+                        ? "TLS credential supplier failed"
+                        : "TLS credential supplier failed, increase log level to DEBUG for stacktrace");
+        onServerException(new IllegalStateException("Failed to obtain TLS credentials", throwable));
+    }
+
+    @VisibleForTesting
+    void applySslContextToChannel(
+                                  TlsCredentials credentials,
+                                  HostPort remote,
+                                  Channel outboundChannel,
+                                  ChannelPipeline pipeline) {
+        try {
+            if (!(credentials instanceof TlsCredentialsImpl credentialsImpl)) {
+                throw new IllegalStateException("Unexpected TlsCredentials implementation: " + credentials.getClass().getName());
+            }
+
+            SslContextBuilder sslContextBuilder = SslContextBuilder.forClient()
+                    .keyManager(credentialsImpl.privateKey(), credentialsImpl.certificateChain());
+
+            virtualCluster.targetCluster().tls().ifPresent(tls -> {
+                VirtualClusterModel.configureCipherSuites(sslContextBuilder, tls);
+                VirtualClusterModel.configureEnabledProtocols(sslContextBuilder, tls);
+                Optional.ofNullable(tls.trust())
+                        .map(TrustProvider::trustOptions)
+                        .filter(Predicate.not(TrustOptions::forClient))
+                        .ifPresent(to -> {
+                            throw new IllegalConfigurationException("Cannot apply trust options " + to + " to upstream (client) TLS.)");
+                        });
+                VirtualClusterModel.configureTrustProvider(tls).apply(sslContextBuilder);
+            });
+
+            SslContext sslContext = sslContextBuilder.build();
+
+            final SslHandler handler = sslContext.newHandler(outboundChannel.alloc(), remote.host(), remote.port());
+            pipeline.addFirst("ssl", handler);
+
+            log(Level.DEBUG)
+                    .addKeyValue("remote", remote)
+                    .log("Successfully configured dynamic TLS credentials");
+        }
+        catch (Exception e) {
+            log(Level.ERROR)
+                    .addKeyValue("remote", remote)
+                    .addKeyValue("error", e.getMessage())
+                    .setCause(LOGGER.isDebugEnabled() ? e : null)
+                    .log(LOGGER.isDebugEnabled()
+                            ? "Error applying TLS credentials to channel"
+                            : "Error applying TLS credentials to channel, increase log level to DEBUG for stacktrace");
+            onServerException(e);
+        }
+    }
+
+    private MetricEmittingKafkaMessageListener buildMetricsMessageListenerForEncode() {
+        var proxyToServerMessageCounterProvider = Metrics.proxyToServerMessageCounterProvider(clusterName, nodeId);
+        var proxyToServerMessageSizeDistributionProvider = Metrics.proxyToServerMessageSizeDistributionProvider(clusterName, nodeId);
+        return new MetricEmittingKafkaMessageListener(proxyToServerMessageCounterProvider, proxyToServerMessageSizeDistributionProvider);
+    }
+
+    private io.kroxylicious.proxy.internal.codec.KafkaMessageListener buildMetricsMessageListenerForDecode() {
+        var serverToProxyMessageCounterProvider = Metrics.serverToProxyMessageCounterProvider(clusterName, nodeId);
+        var serverToProxyMessageSizeDistributionProvider = Metrics.serverToProxyMessageSizeDistributionProvider(clusterName, nodeId);
+        return new MetricEmittingKafkaMessageListener(serverToProxyMessageCounterProvider, serverToProxyMessageSizeDistributionProvider);
     }
 
     // === Events from KafkaProxyBackendHandler ===
@@ -231,7 +477,7 @@ class ServerConnectionStateMachine {
         };
         return builder
                 .addKeyValue("sessionId", ccsm.sessionId())
-                .addKeyValue("virtualCluster", ccsm.clusterName());
+                .addKeyValue("virtualCluster", clusterName);
     }
 
     @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachine.java
@@ -41,6 +41,7 @@ import io.kroxylicious.proxy.internal.tls.ServerTlsCredentialSupplierContextImpl
 import io.kroxylicious.proxy.internal.tls.TlsCredentialsImpl;
 import io.kroxylicious.proxy.internal.util.ActivationToken;
 import io.kroxylicious.proxy.internal.util.Metrics;
+import io.kroxylicious.proxy.internal.util.VirtualClusterNode;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
@@ -89,6 +90,7 @@ class ServerConnectionStateMachine {
     @Nullable
     private List<Object> pendingRequests;
 
+    private final Counter proxyToServerConnectionCounter;
     private final Counter proxyToServerErrorCounter;
     private final Timer serverToProxyBackpressureMeter;
     private final ActivationToken proxyToServerConnectionToken;
@@ -98,19 +100,19 @@ class ServerConnectionStateMachine {
                                  ClientConnectionStateMachine ccsm,
                                  VirtualClusterModel virtualCluster,
                                  String clusterName,
-                                 @Nullable Integer nodeId,
-                                 Counter proxyToServerErrorCounter,
-                                 Timer serverToProxyBackpressureMeter,
-                                 ActivationToken proxyToServerConnectionToken) {
+                                 @Nullable Integer nodeId) {
         this.state = new ServerConnectionState.Connecting(remote);
         this.virtualCluster = Objects.requireNonNull(virtualCluster);
         this.clusterName = Objects.requireNonNull(clusterName);
         this.nodeId = nodeId;
         this.ccsm = Objects.requireNonNull(ccsm);
         this.backendHandler = new KafkaProxyBackendHandler(this);
-        this.proxyToServerErrorCounter = proxyToServerErrorCounter;
-        this.serverToProxyBackpressureMeter = serverToProxyBackpressureMeter;
-        this.proxyToServerConnectionToken = proxyToServerConnectionToken;
+
+        var node = new VirtualClusterNode(clusterName, nodeId);
+        this.proxyToServerConnectionCounter = Metrics.proxyToServerConnectionCounter(clusterName, nodeId).withTags();
+        this.proxyToServerErrorCounter = Metrics.proxyToServerErrorCounter(clusterName, nodeId).withTags();
+        this.serverToProxyBackpressureMeter = Metrics.serverToProxyBackpressureTimer(clusterName, nodeId).withTags();
+        this.proxyToServerConnectionToken = Metrics.proxyToServerConnectionToken(node);
     }
 
     ServerConnectionState state() {
@@ -138,6 +140,7 @@ class ServerConnectionStateMachine {
             ccsm.illegalState("connect() called while not in Connecting state");
             return;
         }
+        proxyToServerConnectionCounter.increment();
         HostPort remote = connecting.remote();
         final Bootstrap bootstrap = configureBootstrap(backendHandler, inboundChannel);
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachine.java
@@ -127,8 +127,6 @@ class ServerConnectionStateMachine {
         return virtualCluster.getUpstreamSslContext().isPresent();
     }
 
-    // === Connection setup ===
-
     /**
      * Initiates the TCP connection to the upstream broker.
      * Configures the backend channel pipeline (codecs, TLS, logging) and starts the connect.
@@ -268,7 +266,7 @@ class ServerConnectionStateMachine {
             onServerException(new IllegalStateException("TLS credential supplier returned null"));
             return;
         }
-        applySslContextToChannel(credentials, remote, outboundChannel, pipeline);
+        applyTlsContextToChannel(credentials, remote, outboundChannel, pipeline);
     }
 
     private void handleTlsCredentialSupplierFailure(
@@ -285,7 +283,7 @@ class ServerConnectionStateMachine {
     }
 
     @VisibleForTesting
-    void applySslContextToChannel(
+    void applyTlsContextToChannel(
                                   TlsCredentials credentials,
                                   HostPort remote,
                                   Channel outboundChannel,
@@ -343,8 +341,6 @@ class ServerConnectionStateMachine {
         return new MetricEmittingKafkaMessageListener(serverToProxyMessageCounterProvider, serverToProxyMessageSizeDistributionProvider);
     }
 
-    // === Events from KafkaProxyBackendHandler ===
-
     void onServerActive() {
         if (state instanceof ServerConnectionState.Connecting connecting) {
             setState(connecting.toActive());
@@ -395,8 +391,6 @@ class ServerConnectionStateMachine {
     void onServerWritable() {
         ccsm.onServerWritable();
     }
-
-    // === Called by ClientConnectionStateMachine ===
 
     void sendRequest(Object msg) {
         if (state instanceof ServerConnectionState.Connecting) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
@@ -108,6 +108,7 @@ class ClientConnectionStateMachineEndToEndTest {
 
     ClientConnectionStateMachine clientConnectionStateMachine(EndpointBinding binding) {
         var kafkaSession = new KafkaSession(KafkaSessionState.ESTABLISHING);
+        // Override createServerConnection to substitute EmbeddedChannels for real TCP connections
         return new ClientConnectionStateMachine(binding, new DefaultSubjectBuilder(List.of()), kafkaSession) {
             @Override
             ServerConnectionStateMachine createServerConnection(HostPort remote) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
@@ -37,6 +37,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -66,6 +68,7 @@ import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
 import io.kroxylicious.proxy.internal.subject.DefaultSubjectBuilder;
+import io.kroxylicious.proxy.internal.util.ActivationToken;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 
@@ -108,7 +111,49 @@ class ClientConnectionStateMachineEndToEndTest {
 
     ClientConnectionStateMachine clientConnectionStateMachine(EndpointBinding binding) {
         var kafkaSession = new KafkaSession(KafkaSessionState.ESTABLISHING);
-        return new ClientConnectionStateMachine(binding, new DefaultSubjectBuilder(List.of()), kafkaSession);
+        return new ClientConnectionStateMachine(binding, new DefaultSubjectBuilder(List.of()), kafkaSession) {
+            @Override
+            ServerConnectionStateMachine createServerConnection(HostPort remote) {
+                return new ServerConnectionStateMachine(
+                        remote,
+                        this,
+                        virtualCluster(),
+                        clusterName(),
+                        nodeId(),
+                        mock(Counter.class),
+                        mock(Timer.class),
+                        mock(ActivationToken.class)) {
+                    @Override
+                    Bootstrap configureBootstrap(
+                                                 KafkaProxyBackendHandler capturedBackendHandler,
+                                                 Channel inboundChannel) {
+                        ClientConnectionStateMachineEndToEndTest.this.backendHandler = capturedBackendHandler;
+                        newOutboundChannel();
+                        Bootstrap bootstrap = new Bootstrap();
+                        bootstrap.group(outboundChannel.eventLoop())
+                                .channel(outboundChannel.getClass())
+                                .handler(capturedBackendHandler)
+                                .option(ChannelOption.AUTO_READ, true)
+                                .option(ChannelOption.TCP_NODELAY, true);
+                        return bootstrap;
+                    }
+
+                    @Override
+                    ChannelFuture initConnection(
+                                                 String remoteHost,
+                                                 int remotePort,
+                                                 Bootstrap bootstrap) {
+                        outboundChannel.pipeline().addFirst(
+                                ClientConnectionStateMachineEndToEndTest.this.backendHandler);
+                        outboundChannel.pipeline().fireChannelRegistered();
+                        if (ClientConnectionStateMachineEndToEndTest.this.activateOutboundChannelAutomatically) {
+                            outboundChannel.pipeline().fireChannelActive();
+                        }
+                        return outboundChannel.newPromise();
+                    }
+                };
+            }
+        };
     }
 
     @AfterEach
@@ -449,36 +494,7 @@ class ClientConnectionStateMachineEndToEndTest {
                 new ApiVersionsServiceImpl(),
                 dp,
                 new DefaultSubjectBuilder(List.of()),
-                clientConnectionStateMachine, Optional.empty()) {
-            @NonNull
-            @Override
-            Bootstrap configureBootstrap(@NonNull KafkaProxyBackendHandler capturedBackendHandler, @NonNull Channel inboundChannel) {
-                ClientConnectionStateMachineEndToEndTest.this.backendHandler = capturedBackendHandler;
-                newOutboundChannel();
-                Bootstrap bootstrap = new Bootstrap();
-                bootstrap.group(outboundChannel.eventLoop())
-                        .channel(outboundChannel.getClass())
-                        .handler(capturedBackendHandler)
-                        .option(ChannelOption.AUTO_READ, true)
-                        .option(ChannelOption.TCP_NODELAY, true);
-                return bootstrap;
-            }
-
-            @NonNull
-            @Override
-            ChannelFuture initConnection(@NonNull String remoteHost, int remotePort, @NonNull Bootstrap bootstrap) {
-                // This is ugly... basically the EmbeddedChannel doesn't seem to handle the case
-                // of a handler creating an outgoing connection and ends up
-                // trying to re-register the outbound channel => IllegalStateException
-                // So we override this method to short-circuit that
-                outboundChannel.pipeline().addFirst(ClientConnectionStateMachineEndToEndTest.this.backendHandler);
-                outboundChannel.pipeline().fireChannelRegistered();
-                if (ClientConnectionStateMachineEndToEndTest.this.activateOutboundChannelAutomatically) {
-                    outboundChannel.pipeline().fireChannelActive();
-                }
-                return outboundChannel.newPromise();
-            }
-        };
+                clientConnectionStateMachine, Optional.empty());
     }
 
     ClientConnectionStateMachine buildFrontendHandler(boolean tlsConfigured) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
@@ -37,8 +37,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Timer;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -68,7 +66,6 @@ import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
 import io.kroxylicious.proxy.internal.subject.DefaultSubjectBuilder;
-import io.kroxylicious.proxy.internal.util.ActivationToken;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 
@@ -119,10 +116,7 @@ class ClientConnectionStateMachineEndToEndTest {
                         this,
                         virtualCluster(),
                         clusterName(),
-                        nodeId(),
-                        mock(Counter.class),
-                        mock(Timer.class),
-                        mock(ActivationToken.class)) {
+                        nodeId()) {
                     @Override
                     Bootstrap configureBootstrap(
                                                  KafkaProxyBackendHandler capturedBackendHandler,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
@@ -183,23 +183,6 @@ class ClientConnectionStateMachineTest {
     }
 
     @Test
-    void shouldCountProxyToServerConnections() {
-        // Given
-        stateMachineInClientActive();
-        when(endpointBinding.upstreamTarget()).thenReturn(BROKER_ADDRESS);
-
-        // When — first client request triggers SCSM creation which increments the counter
-        clientConnectionStateMachine.onClientRequest(metadataRequest());
-
-        // Then
-        assertThat(Metrics.globalRegistry.get("kroxylicious_proxy_to_server_connections").counter())
-                .isNotNull()
-                .satisfies(counter -> assertThat(counter.getId()).isNotNull())
-                .satisfies(counter -> assertThat(counter.count())
-                        .isCloseTo(1.0, CLOSE_ENOUGH));
-    }
-
-    @Test
     void shouldTransitionToClosedOnServerExceptionInForwardingAwaitingBackend() {
         // Given
         stateMachineInForwardingAwaitingTransportSubject();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
@@ -70,7 +70,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -116,10 +115,16 @@ class ClientConnectionStateMachineTest {
         when(endpointBinding.endpointGateway()).thenReturn(endpointGateway);
         when(endpointGateway.virtualCluster()).thenReturn(VIRTUAL_CLUSTER_MODEL);
         clientConnectionStateMachine = new ClientConnectionStateMachine(endpointBinding, new DefaultSubjectBuilder(List.of()),
-                new KafkaSession(KafkaSessionState.ESTABLISHING));
+                new KafkaSession(KafkaSessionState.ESTABLISHING)) {
+            @Override
+            ServerConnectionStateMachine createServerConnection(HostPort remote) {
+                return serverConnectionStateMachine;
+            }
+        };
         when(frontendHandler.channelId()).thenReturn(DefaultChannelId.newInstance());
         when(frontendHandler.remoteHost()).thenReturn("testhost.example.com");
         when(frontendHandler.remotePort()).thenReturn(9476);
+        when(frontendHandler.clientChannel()).thenReturn(mock(Channel.class));
         // Make the executor run tasks synchronously for tests
         when(frontendHandler.eventLoopExecutor()).thenReturn(Runnable::run);
     }
@@ -351,7 +356,7 @@ class ClientConnectionStateMachineTest {
         assertThat(clientConnectionStateMachine.state())
                 .isInstanceOf(ClientConnectionState.Forwarding.class);
         verify(frontendHandler).bufferMsg(msg);
-        verify(frontendHandler).initiateBackendConnect(eq(BROKER_ADDRESS), notNull(KafkaProxyBackendHandler.class));
+        verify(serverConnectionStateMachine).connect(notNull(Channel.class));
     }
 
     @Test
@@ -368,7 +373,7 @@ class ClientConnectionStateMachineTest {
         assertThat(clientConnectionStateMachine.state())
                 .isInstanceOf(ClientConnectionState.Forwarding.class);
         verify(frontendHandler).bufferMsg(msg);
-        verify(frontendHandler).initiateBackendConnect(eq(BROKER_ADDRESS), notNull(KafkaProxyBackendHandler.class));
+        verify(serverConnectionStateMachine).connect(notNull(Channel.class));
     }
 
     @Test
@@ -399,7 +404,7 @@ class ClientConnectionStateMachineTest {
         assertThat(clientConnectionStateMachine.state())
                 .isInstanceOf(ClientConnectionState.Forwarding.class);
         verify(frontendHandler).bufferMsg(msg);
-        verify(frontendHandler).initiateBackendConnect(eq(BROKER_ADDRESS), notNull(KafkaProxyBackendHandler.class));
+        verify(serverConnectionStateMachine).connect(notNull(Channel.class));
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerMockCollaboratorsTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerMockCollaboratorsTest.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.proxy.internal;
 
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -24,7 +23,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.EventLoop;
 import io.netty.handler.codec.haproxy.HAProxyCommand;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
@@ -44,10 +42,7 @@ import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
 import io.kroxylicious.proxy.internal.subject.DefaultSubjectBuilder;
-import io.kroxylicious.proxy.internal.tls.ServerTlsCredentialSupplierContextImpl;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
-import io.kroxylicious.proxy.service.HostPort;
-import io.kroxylicious.proxy.tls.ServerTlsCredentialSupplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -368,158 +363,5 @@ class KafkaProxyFrontendHandlerMockCollaboratorsTest {
 
         // Then
         assertThat(result).isSameAs(executor);
-    }
-
-    // --- TLS credential supplier tests ---
-
-    @Test
-    void invokeTlsCredentialSupplierReportsSynchronousFailure() throws Exception {
-        // Given
-        RuntimeException failure = new RuntimeException("manager failed");
-        when(virtualCluster.getTlsCredentialSupplierManager()).thenThrow(failure);
-        Channel channel = mock(Channel.class);
-        ChannelPipeline pipeline = mock(ChannelPipeline.class);
-        HostPort remote = new HostPort("localhost", 9092);
-        Method method = KafkaProxyFrontendHandler.class.getDeclaredMethod("invokeTlsCredentialSupplier", HostPort.class, Channel.class, ChannelPipeline.class);
-        method.setAccessible(true);
-
-        // When
-        method.invoke(handler, remote, channel, pipeline);
-
-        // Then
-        verify(clientConnectionStateMachine).notifyServerConnectionException(failure);
-    }
-
-    @Test
-    void requestTlsCredentialsAppliesCredentialsOnEventLoop() {
-        // Given
-        io.kroxylicious.proxy.tls.TlsCredentials badCreds = mock(io.kroxylicious.proxy.tls.TlsCredentials.class);
-        ServerTlsCredentialSupplier supplier = context -> CompletableFuture.completedFuture(badCreds);
-        ServerTlsCredentialSupplierContextImpl supplierContext = new ServerTlsCredentialSupplierContextImpl(null);
-        Channel channel = mock(Channel.class);
-        EventLoop eventLoop = mock(EventLoop.class);
-        when(channel.eventLoop()).thenReturn(eventLoop);
-        doAnswer(invocation -> {
-            invocation.getArgument(0, Runnable.class).run();
-            return null;
-        }).when(eventLoop).execute(any(Runnable.class));
-        HostPort remote = new HostPort("localhost", 9092);
-
-        // When
-        handler.requestTlsCredentials(supplier, supplierContext, remote, channel, mock(ChannelPipeline.class));
-
-        // Then
-        ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
-        verify(clientConnectionStateMachine).notifyServerConnectionException(captor.capture());
-        assertThat(captor.getValue())
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("Unexpected TlsCredentials implementation");
-    }
-
-    @Test
-    void requestTlsCredentialsReportsSupplierFailureOnEventLoop() {
-        // Given
-        RuntimeException failure = new RuntimeException("boom");
-        ServerTlsCredentialSupplier supplier = context -> CompletableFuture.failedFuture(failure);
-        ServerTlsCredentialSupplierContextImpl supplierContext = new ServerTlsCredentialSupplierContextImpl(null);
-        Channel channel = mock(Channel.class);
-        EventLoop eventLoop = mock(EventLoop.class);
-        when(channel.eventLoop()).thenReturn(eventLoop);
-        doAnswer(invocation -> {
-            invocation.getArgument(0, Runnable.class).run();
-            return null;
-        }).when(eventLoop).execute(any(Runnable.class));
-        HostPort remote = new HostPort("localhost", 9092);
-
-        // When
-        handler.requestTlsCredentials(supplier, supplierContext, remote, channel, mock(ChannelPipeline.class));
-
-        // Then
-        ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
-        verify(clientConnectionStateMachine).notifyServerConnectionException(captor.capture());
-        assertThat(captor.getValue())
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("Failed to obtain TLS credentials")
-                .hasCause(failure);
-    }
-
-    @Test
-    void handleTlsCredentialSupplierResultReportsNullCredentials() {
-        // Given
-        Channel channel = mock(Channel.class);
-        ChannelPipeline pipeline = mock(ChannelPipeline.class);
-        HostPort remote = new HostPort("localhost", 9092);
-
-        // When
-        handler.handleTlsCredentialSupplierResult(null, null, remote, channel, pipeline);
-
-        // Then
-        ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
-        verify(clientConnectionStateMachine).notifyServerConnectionException(captor.capture());
-        assertThat(captor.getValue())
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("TLS credential supplier returned null");
-    }
-
-    @Test
-    void handleTlsCredentialSupplierResultAppliesCredentials() {
-        // Given
-        io.kroxylicious.proxy.tls.TlsCredentials badCreds = mock(io.kroxylicious.proxy.tls.TlsCredentials.class);
-        Channel channel = mock(Channel.class);
-        ChannelPipeline pipeline = mock(ChannelPipeline.class);
-        HostPort remote = new HostPort("localhost", 9092);
-
-        // When
-        handler.handleTlsCredentialSupplierResult(badCreds, null, remote, channel, pipeline);
-
-        // Then
-        ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
-        verify(clientConnectionStateMachine).notifyServerConnectionException(captor.capture());
-        assertThat(captor.getValue())
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("Unexpected TlsCredentials implementation");
-    }
-
-    @Test
-    void applySslContextToChannelRejectsNonTlsCredentialsImpl() {
-        // Given
-        io.kroxylicious.proxy.tls.TlsCredentials badCreds = mock(io.kroxylicious.proxy.tls.TlsCredentials.class);
-        Channel channel = mock(Channel.class);
-        ChannelPipeline pipeline = mock(ChannelPipeline.class);
-        HostPort remote = new HostPort("localhost", 9092);
-
-        // When
-        handler.applySslContextToChannel(badCreds, remote, channel, pipeline);
-
-        // Then - should report error to state machine
-        ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
-        verify(clientConnectionStateMachine).notifyServerConnectionException(captor.capture());
-        assertThat(captor.getValue())
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("Unexpected TlsCredentials implementation");
-    }
-
-    @Test
-    void applySslContextToChannelAddsSslHandlerWithValidCredentials() throws Exception {
-        // Given
-        var keyAndCert = io.kroxylicious.proxy.internal.tls.TestCertificateUtil.generateKeyStoreAndCert();
-        var creds = new io.kroxylicious.proxy.internal.tls.TlsCredentialsImpl(
-                keyAndCert.privateKey(), new java.security.cert.X509Certificate[]{ keyAndCert.cert() });
-
-        io.netty.channel.embedded.EmbeddedChannel channel = new io.netty.channel.embedded.EmbeddedChannel();
-        HostPort remote = new HostPort("localhost", 9092);
-
-        // Configure virtualCluster to have no TLS config (no cipher/protocol/trust overrides)
-        when(virtualCluster.targetCluster()).thenReturn(mock(io.kroxylicious.proxy.config.TargetCluster.class));
-        when(virtualCluster.targetCluster().tls()).thenReturn(Optional.empty());
-
-        // When
-        handler.applySslContextToChannel(creds, remote, channel, channel.pipeline());
-
-        // Then - SSL handler should be added to pipeline
-        assertThat(channel.pipeline().get("ssl")).isNotNull();
-        verify(clientConnectionStateMachine, never()).notifyServerConnectionException(any());
-
-        channel.close();
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -26,8 +26,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Timer;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -57,7 +55,6 @@ import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
 import io.kroxylicious.proxy.internal.net.HaProxyContext;
 import io.kroxylicious.proxy.internal.subject.DefaultSubjectBuilder;
-import io.kroxylicious.proxy.internal.util.ActivationToken;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.model.VirtualClusterModel.VirtualClusterGatewayModel;
 import io.kroxylicious.proxy.service.HostPort;
@@ -94,10 +91,7 @@ class KafkaProxyFrontendHandlerTest {
                         this,
                         virtualCluster(),
                         clusterName(),
-                        nodeId(),
-                        mock(Counter.class),
-                        mock(Timer.class),
-                        mock(ActivationToken.class)) {
+                        nodeId()) {
                     @Override
                     Bootstrap configureBootstrap(
                                                  KafkaProxyBackendHandler capturedBackendHandler,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -55,6 +57,7 @@ import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
 import io.kroxylicious.proxy.internal.net.HaProxyContext;
 import io.kroxylicious.proxy.internal.subject.DefaultSubjectBuilder;
+import io.kroxylicious.proxy.internal.util.ActivationToken;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.model.VirtualClusterModel.VirtualClusterGatewayModel;
 import io.kroxylicious.proxy.service.HostPort;
@@ -83,7 +86,45 @@ class KafkaProxyFrontendHandlerTest {
 
     ClientConnectionStateMachine clientConnectionStateMachine(EndpointBinding endpointBinding) {
         var kafkaSession = new KafkaSession(KafkaSessionState.ESTABLISHING);
-        return new ClientConnectionStateMachine(Objects.requireNonNull(endpointBinding), new DefaultSubjectBuilder(List.of()), kafkaSession);
+        return new ClientConnectionStateMachine(Objects.requireNonNull(endpointBinding), new DefaultSubjectBuilder(List.of()), kafkaSession) {
+            @Override
+            ServerConnectionStateMachine createServerConnection(HostPort remote) {
+                return new ServerConnectionStateMachine(
+                        remote,
+                        this,
+                        virtualCluster(),
+                        clusterName(),
+                        nodeId(),
+                        mock(Counter.class),
+                        mock(Timer.class),
+                        mock(ActivationToken.class)) {
+                    @Override
+                    Bootstrap configureBootstrap(
+                                                 KafkaProxyBackendHandler capturedBackendHandler,
+                                                 Channel inboundChannel) {
+                        backendHandler = capturedBackendHandler;
+                        outboundChannel = new EmbeddedChannel();
+                        Bootstrap bootstrap = new Bootstrap();
+                        bootstrap.group(outboundChannel.eventLoop())
+                                .channel(outboundChannel.getClass())
+                                .handler(capturedBackendHandler)
+                                .option(ChannelOption.AUTO_READ, true)
+                                .option(ChannelOption.TCP_NODELAY, true);
+                        return bootstrap;
+                    }
+
+                    @Override
+                    ChannelFuture initConnection(
+                                                 String remoteHost,
+                                                 int remotePort,
+                                                 Bootstrap bootstrap) {
+                        outboundChannel.pipeline().addFirst(backendHandler);
+                        outboundChannel.pipeline().fireChannelRegistered();
+                        return outboundChannel.newPromise();
+                    }
+                };
+            }
+        };
     }
 
     private PluginFactoryRegistry pfr;
@@ -312,32 +353,7 @@ class KafkaProxyFrontendHandlerTest {
                 dp,
                 new DefaultSubjectBuilder(List.of()),
                 clientConnectionStateMachine,
-                Optional.empty()) {
-
-            @Override
-            Bootstrap configureBootstrap(KafkaProxyBackendHandler capturedBackendHandler, Channel inboundChannel) {
-                backendHandler = capturedBackendHandler;
-                outboundChannel = new EmbeddedChannel();
-                Bootstrap bootstrap = new Bootstrap();
-                bootstrap.group(outboundChannel.eventLoop())
-                        .channel(outboundChannel.getClass())
-                        .handler(capturedBackendHandler)
-                        .option(ChannelOption.AUTO_READ, true)
-                        .option(ChannelOption.TCP_NODELAY, true);
-                return bootstrap;
-            }
-
-            @Override
-            ChannelFuture initConnection(String remoteHost, int remotePort, Bootstrap bootstrap) {
-                // This is ugly... basically the EmbeddedChannel doesn't seem to handle the case
-                // of a handler creating an outgoing connection and ends up
-                // trying to re-register the outbound channel => IllegalStateException
-                // So we override this method to short-circuit that
-                outboundChannel.pipeline().addFirst(backendHandler);
-                outboundChannel.pipeline().fireChannelRegistered();
-                return outboundChannel.newPromise();
-            }
-        };
+                Optional.empty());
     }
 
     /**

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachineTest.java
@@ -6,6 +6,11 @@
 
 package io.kroxylicious.proxy.internal;
 
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -20,24 +26,43 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoop;
 import io.netty.channel.embedded.EmbeddedChannel;
 
+import io.kroxylicious.proxy.internal.codec.KafkaRequestEncoder;
+import io.kroxylicious.proxy.internal.codec.KafkaResponseDecoder;
+import io.kroxylicious.proxy.internal.tls.ServerTlsCredentialSupplierContextImpl;
+import io.kroxylicious.proxy.internal.tls.TestCertificateUtil;
+import io.kroxylicious.proxy.internal.tls.TlsCredentialsImpl;
 import io.kroxylicious.proxy.internal.util.ActivationToken;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
+import io.kroxylicious.proxy.tls.ServerTlsCredentialSupplier;
+import io.kroxylicious.proxy.tls.TlsCredentials;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ServerConnectionStateMachineTest {
 
     private static final HostPort BROKER_ADDRESS = new HostPort("broker.example.com", 9092);
+    private static final String CLUSTER_NAME = "test-cluster";
     private static final Offset<Double> CLOSE_ENOUGH = Offset.offset(0.00005);
 
     @Mock
@@ -46,9 +71,11 @@ class ServerConnectionStateMachineTest {
     @Mock
     private ActivationToken activationToken;
 
+    @Mock
+    private VirtualClusterModel virtualCluster;
+
     private ServerConnectionStateMachine serverStateMachine;
     private SimpleMeterRegistry meterRegistry;
-    private Counter proxyToServerConnectionCounter;
     private Counter proxyToServerErrorCounter;
     private Timer serverToProxyBackpressureMeter;
 
@@ -57,18 +84,19 @@ class ServerConnectionStateMachineTest {
         meterRegistry = new SimpleMeterRegistry();
         Metrics.globalRegistry.add(meterRegistry);
 
-        proxyToServerConnectionCounter = meterRegistry.counter("test.proxy.to.server.connections");
         proxyToServerErrorCounter = meterRegistry.counter("test.proxy.to.server.errors");
         serverToProxyBackpressureMeter = meterRegistry.timer("test.server.to.proxy.backpressure");
 
         lenient().when(ccsm.sessionId()).thenReturn("test-session-123");
-        lenient().when(ccsm.clusterName()).thenReturn("test-cluster");
+        lenient().when(ccsm.clusterName()).thenReturn(CLUSTER_NAME);
+        lenient().when(virtualCluster.getUpstreamSslContext()).thenReturn(Optional.empty());
 
         serverStateMachine = new ServerConnectionStateMachine(
                 BROKER_ADDRESS,
-                false,
                 ccsm,
-                proxyToServerConnectionCounter,
+                virtualCluster,
+                CLUSTER_NAME,
+                null,
                 proxyToServerErrorCounter,
                 serverToProxyBackpressureMeter,
                 activationToken);
@@ -106,7 +134,6 @@ class ServerConnectionStateMachineTest {
 
     @Test
     void onServerActiveShouldFlushPendingRequests() {
-
         serverStateMachine.sendRequest("req-1");
         serverStateMachine.sendRequest("req-2");
         assertThat(serverStateMachine.serverMessagesInFlightCount).isZero();
@@ -178,7 +205,6 @@ class ServerConnectionStateMachineTest {
 
     @Test
     void pendingRequestsPreserveOrder() {
-
         for (int i = 0; i < 5; i++) {
             serverStateMachine.sendRequest("req-" + i);
         }
@@ -200,20 +226,18 @@ class ServerConnectionStateMachineTest {
                 .isEqualTo(BROKER_ADDRESS);
     }
 
-    @Test
-    void shouldIncrementConnectionCounterOnConstruction() {
-        assertThat(proxyToServerConnectionCounter.count())
-                .isCloseTo(1.0, CLOSE_ENOUGH);
-    }
-
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
     void shouldTrackTlsRequirement(boolean requiresTls) {
+        var vc = mock(VirtualClusterModel.class);
+        when(vc.getUpstreamSslContext()).thenReturn(requiresTls ? Optional.of(mock(io.netty.handler.ssl.SslContext.class)) : Optional.empty());
+
         ServerConnectionStateMachine sm = new ServerConnectionStateMachine(
                 BROKER_ADDRESS,
-                requiresTls,
                 ccsm,
-                proxyToServerConnectionCounter,
+                vc,
+                CLUSTER_NAME,
+                null,
                 proxyToServerErrorCounter,
                 serverToProxyBackpressureMeter,
                 activationToken);
@@ -254,6 +278,16 @@ class ServerConnectionStateMachineTest {
         assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Closed.class);
         verify(ccsm).onServerConnectionClosed(ClientConnectionStateMachine.DisconnectCause.SERVER_CLOSED);
         verify(activationToken).release();
+    }
+
+    @Test
+    void onServerInactiveWhileConnectingShouldTransitionToClosedAndNotifyCcsm() {
+        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Connecting.class);
+
+        serverStateMachine.onServerInactive();
+
+        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Closed.class);
+        verify(ccsm).onServerConnectionClosed(ClientConnectionStateMachine.DisconnectCause.SERVER_CLOSED);
     }
 
     @Test
@@ -469,5 +503,314 @@ class ServerConnectionStateMachineTest {
         serverStateMachine.onServerException(exception);
 
         verify(ccsm).onServerConnectionException(exception);
+    }
+
+    // === connect() tests ===
+
+    private ServerConnectionStateMachine createConnectableScsm(ClientConnectionStateMachine mockCcsm,
+                                                               VirtualClusterModel mockVirtualCluster,
+                                                               EmbeddedChannel[] outboundHolder) {
+        lenient().when(mockCcsm.sessionId()).thenReturn("test-session");
+        lenient().when(mockCcsm.clusterName()).thenReturn(CLUSTER_NAME);
+        lenient().when(mockVirtualCluster.getUpstreamSslContext()).thenReturn(Optional.empty());
+        when(mockVirtualCluster.usesDynamicTlsCredentials()).thenReturn(false);
+        when(mockVirtualCluster.socketFrameMaxSizeBytes()).thenReturn(
+                VirtualClusterModel.DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES);
+        return new ServerConnectionStateMachine(
+                BROKER_ADDRESS, mockCcsm, mockVirtualCluster, CLUSTER_NAME, null,
+                mock(Counter.class), mock(Timer.class), mock(ActivationToken.class)) {
+            @Override
+            Bootstrap configureBootstrap(KafkaProxyBackendHandler backendHandler,
+                                         Channel inboundChannel) {
+                outboundHolder[0] = new EmbeddedChannel();
+                Bootstrap bootstrap = new Bootstrap();
+                bootstrap.group(outboundHolder[0].eventLoop())
+                        .channel(outboundHolder[0].getClass())
+                        .handler(backendHandler)
+                        .option(ChannelOption.AUTO_READ, true)
+                        .option(ChannelOption.TCP_NODELAY, true);
+                return bootstrap;
+            }
+
+            @Override
+            ChannelFuture initConnection(String remoteHost, int remotePort, Bootstrap bootstrap) {
+                outboundHolder[0].pipeline().addFirst(backendHandler());
+                return outboundHolder[0].newSucceededFuture();
+            }
+        };
+    }
+
+    @Test
+    void connectInWrongStateShouldCallIllegalState() {
+        var mockCcsm = mock(ClientConnectionStateMachine.class);
+        var mockVirtualCluster = mock(VirtualClusterModel.class);
+        var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
+
+        // Force to Active state
+        new EmbeddedChannel(scsm.backendHandler());
+        assertThat(scsm.state()).isInstanceOf(ServerConnectionState.Active.class);
+
+        // Calling connect() in Active state should trigger illegalState
+        scsm.connect(mock(Channel.class));
+
+        verify(mockCcsm).illegalState("connect() called while not in Connecting state");
+    }
+
+    @Test
+    void connectShouldAssemblePipelineInCorrectOrder() {
+        var mockCcsm = mock(ClientConnectionStateMachine.class);
+        var mockVirtualCluster = mock(VirtualClusterModel.class);
+        var outboundHolder = new EmbeddedChannel[1];
+        var scsm = createConnectableScsm(mockCcsm, mockVirtualCluster, outboundHolder);
+
+        scsm.connect(new EmbeddedChannel());
+
+        var pipeline = outboundHolder[0].pipeline();
+        List<String> handlerNames = pipeline.names().stream()
+                .filter(n -> !n.contains("DefaultChannelPipeline"))
+                .toList();
+
+        // Pipeline uses addFirst, so the order in the list is the reverse of insertion order.
+        // Expected from head to tail: networkLogger (absent), requestEncoder, responseDecoder,
+        // frameLogger (absent), backendHandler, then tail sentinel.
+        assertThat(handlerNames)
+                .filteredOn(n -> !n.equals("DefaultChannelPipeline$TailContext#0"))
+                .containsSubsequence("requestEncoder", "responseDecoder");
+        assertThat(pipeline.get(KafkaRequestEncoder.class)).isNotNull();
+        assertThat(pipeline.get(KafkaResponseDecoder.class)).isNotNull();
+    }
+
+    @Test
+    void connectShouldAddFrameLoggerWhenLogFramesEnabled() {
+        var mockCcsm = mock(ClientConnectionStateMachine.class);
+        var mockVirtualCluster = mock(VirtualClusterModel.class);
+        when(mockVirtualCluster.isLogFrames()).thenReturn(true);
+        var outboundHolder = new EmbeddedChannel[1];
+        var scsm = createConnectableScsm(mockCcsm, mockVirtualCluster, outboundHolder);
+
+        scsm.connect(new EmbeddedChannel());
+
+        assertThat(outboundHolder[0].pipeline().get("frameLogger")).isNotNull();
+    }
+
+    @Test
+    void connectShouldAddNetworkLoggerWhenLogNetworkEnabled() {
+        var mockCcsm = mock(ClientConnectionStateMachine.class);
+        var mockVirtualCluster = mock(VirtualClusterModel.class);
+        when(mockVirtualCluster.isLogNetwork()).thenReturn(true);
+        var outboundHolder = new EmbeddedChannel[1];
+        var scsm = createConnectableScsm(mockCcsm, mockVirtualCluster, outboundHolder);
+
+        scsm.connect(new EmbeddedChannel());
+
+        assertThat(outboundHolder[0].pipeline().get("networkLogger")).isNotNull();
+    }
+
+    @Test
+    void connectTcpFailureShouldCallOnServerException() {
+        var mockCcsm = mock(ClientConnectionStateMachine.class);
+        var mockVirtualCluster = mock(VirtualClusterModel.class);
+        lenient().when(mockCcsm.sessionId()).thenReturn("test-session");
+        lenient().when(mockCcsm.clusterName()).thenReturn(CLUSTER_NAME);
+        when(mockVirtualCluster.getUpstreamSslContext()).thenReturn(Optional.empty());
+        when(mockVirtualCluster.usesDynamicTlsCredentials()).thenReturn(false);
+        when(mockVirtualCluster.socketFrameMaxSizeBytes()).thenReturn(
+                VirtualClusterModel.DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES);
+        var tcpFailure = new RuntimeException("Connection refused");
+        var scsm = new ServerConnectionStateMachine(
+                BROKER_ADDRESS, mockCcsm, mockVirtualCluster, CLUSTER_NAME, null,
+                mock(Counter.class), mock(Timer.class), mock(ActivationToken.class)) {
+            @Override
+            Bootstrap configureBootstrap(KafkaProxyBackendHandler backendHandler,
+                                         Channel inboundChannel) {
+                var ch = new EmbeddedChannel();
+                Bootstrap bootstrap = new Bootstrap();
+                bootstrap.group(ch.eventLoop())
+                        .channel(ch.getClass())
+                        .handler(backendHandler)
+                        .option(ChannelOption.AUTO_READ, true);
+                return bootstrap;
+            }
+
+            @Override
+            ChannelFuture initConnection(String remoteHost, int remotePort, Bootstrap bootstrap) {
+                var ch = new EmbeddedChannel();
+                return ch.newFailedFuture(tcpFailure);
+            }
+        };
+
+        scsm.connect(new EmbeddedChannel());
+
+        verify(mockCcsm).onServerConnectionException(tcpFailure);
+        assertThat(scsm.state()).isInstanceOf(ServerConnectionState.Closed.class);
+    }
+
+    // === TLS credential tests ===
+
+    private ServerConnectionStateMachine createScsmWithMocks(ClientConnectionStateMachine mockCcsm,
+                                                             VirtualClusterModel mockVirtualCluster) {
+        lenient().when(mockCcsm.sessionId()).thenReturn("test-session");
+        lenient().when(mockCcsm.clusterName()).thenReturn(CLUSTER_NAME);
+        lenient().when(mockVirtualCluster.getUpstreamSslContext()).thenReturn(Optional.empty());
+        return new ServerConnectionStateMachine(
+                BROKER_ADDRESS,
+                mockCcsm,
+                mockVirtualCluster,
+                CLUSTER_NAME,
+                null,
+                mock(Counter.class),
+                mock(Timer.class),
+                mock(ActivationToken.class));
+    }
+
+    @Test
+    void invokeTlsCredentialSupplierReportsSynchronousFailure() throws Exception {
+        var mockCcsm = mock(ClientConnectionStateMachine.class);
+        var mockVirtualCluster = mock(VirtualClusterModel.class);
+        RuntimeException failure = new RuntimeException("manager failed");
+        when(mockVirtualCluster.getTlsCredentialSupplierManager()).thenThrow(failure);
+        var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
+
+        Channel channel = mock(Channel.class);
+        ChannelPipeline pipeline = mock(ChannelPipeline.class);
+        Method method = ServerConnectionStateMachine.class.getDeclaredMethod(
+                "invokeTlsCredentialSupplier", HostPort.class, Channel.class, ChannelPipeline.class);
+        method.setAccessible(true);
+
+        method.invoke(scsm, BROKER_ADDRESS, channel, pipeline);
+
+        verify(mockCcsm).onServerConnectionException(failure);
+    }
+
+    @Test
+    void requestTlsCredentialsAppliesCredentialsOnEventLoop() {
+        var mockCcsm = mock(ClientConnectionStateMachine.class);
+        var mockVirtualCluster = mock(VirtualClusterModel.class);
+        var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
+
+        TlsCredentials badCreds = mock(TlsCredentials.class);
+        ServerTlsCredentialSupplier supplier = context -> CompletableFuture.completedFuture(badCreds);
+        var supplierContext = new ServerTlsCredentialSupplierContextImpl(null);
+        Channel channel = mock(Channel.class);
+        EventLoop eventLoop = mock(EventLoop.class);
+        when(channel.eventLoop()).thenReturn(eventLoop);
+        doAnswer(invocation -> {
+            invocation.getArgument(0, Runnable.class).run();
+            return null;
+        }).when(eventLoop).execute(any(Runnable.class));
+
+        scsm.requestTlsCredentials(supplier, supplierContext, BROKER_ADDRESS, channel, mock(ChannelPipeline.class));
+
+        ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
+        verify(mockCcsm).onServerConnectionException(captor.capture());
+        assertThat(captor.getValue())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Unexpected TlsCredentials implementation");
+    }
+
+    @Test
+    void requestTlsCredentialsReportsSupplierFailureOnEventLoop() {
+        var mockCcsm = mock(ClientConnectionStateMachine.class);
+        var mockVirtualCluster = mock(VirtualClusterModel.class);
+        var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
+
+        RuntimeException failure = new RuntimeException("boom");
+        ServerTlsCredentialSupplier supplier = context -> CompletableFuture.failedFuture(failure);
+        var supplierContext = new ServerTlsCredentialSupplierContextImpl(null);
+        Channel channel = mock(Channel.class);
+        EventLoop eventLoop = mock(EventLoop.class);
+        when(channel.eventLoop()).thenReturn(eventLoop);
+        doAnswer(invocation -> {
+            invocation.getArgument(0, Runnable.class).run();
+            return null;
+        }).when(eventLoop).execute(any(Runnable.class));
+
+        scsm.requestTlsCredentials(supplier, supplierContext, BROKER_ADDRESS, channel, mock(ChannelPipeline.class));
+
+        ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
+        verify(mockCcsm).onServerConnectionException(captor.capture());
+        assertThat(captor.getValue())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to obtain TLS credentials")
+                .hasCause(failure);
+    }
+
+    @Test
+    void handleTlsCredentialSupplierResultReportsNullCredentials() {
+        var mockCcsm = mock(ClientConnectionStateMachine.class);
+        var mockVirtualCluster = mock(VirtualClusterModel.class);
+        var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
+
+        Channel channel = mock(Channel.class);
+        ChannelPipeline pipeline = mock(ChannelPipeline.class);
+
+        scsm.handleTlsCredentialSupplierResult(null, null, BROKER_ADDRESS, channel, pipeline);
+
+        ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
+        verify(mockCcsm).onServerConnectionException(captor.capture());
+        assertThat(captor.getValue())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("TLS credential supplier returned null");
+    }
+
+    @Test
+    void handleTlsCredentialSupplierResultAppliesCredentials() {
+        var mockCcsm = mock(ClientConnectionStateMachine.class);
+        var mockVirtualCluster = mock(VirtualClusterModel.class);
+        var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
+
+        TlsCredentials badCreds = mock(TlsCredentials.class);
+        Channel channel = mock(Channel.class);
+        ChannelPipeline pipeline = mock(ChannelPipeline.class);
+
+        scsm.handleTlsCredentialSupplierResult(badCreds, null, BROKER_ADDRESS, channel, pipeline);
+
+        ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
+        verify(mockCcsm).onServerConnectionException(captor.capture());
+        assertThat(captor.getValue())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Unexpected TlsCredentials implementation");
+    }
+
+    @Test
+    void applySslContextToChannelRejectsNonTlsCredentialsImpl() {
+        var mockCcsm = mock(ClientConnectionStateMachine.class);
+        var mockVirtualCluster = mock(VirtualClusterModel.class);
+        var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
+
+        TlsCredentials badCreds = mock(TlsCredentials.class);
+        Channel channel = mock(Channel.class);
+        ChannelPipeline pipeline = mock(ChannelPipeline.class);
+
+        scsm.applySslContextToChannel(badCreds, BROKER_ADDRESS, channel, pipeline);
+
+        ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
+        verify(mockCcsm).onServerConnectionException(captor.capture());
+        assertThat(captor.getValue())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Unexpected TlsCredentials implementation");
+    }
+
+    @Test
+    void applySslContextToChannelAddsSslHandlerWithValidCredentials() throws Exception {
+        var mockCcsm = mock(ClientConnectionStateMachine.class);
+        var mockVirtualCluster = mock(VirtualClusterModel.class);
+        var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
+
+        var keyAndCert = TestCertificateUtil.generateKeyStoreAndCert();
+        var creds = new TlsCredentialsImpl(
+                keyAndCert.privateKey(), new java.security.cert.X509Certificate[]{ keyAndCert.cert() });
+
+        EmbeddedChannel channel = new EmbeddedChannel();
+
+        when(mockVirtualCluster.targetCluster()).thenReturn(mock(io.kroxylicious.proxy.config.TargetCluster.class));
+        when(mockVirtualCluster.targetCluster().tls()).thenReturn(Optional.empty());
+
+        scsm.applySslContextToChannel(creds, BROKER_ADDRESS, channel, channel.pipeline());
+
+        assertThat(channel.pipeline().get("ssl")).isNotNull();
+        verify(mockCcsm, never()).onServerConnectionException(any());
+
+        channel.close();
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachineTest.java
@@ -33,6 +33,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoop;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.ssl.SslContext;
 
 import io.kroxylicious.proxy.internal.codec.KafkaRequestEncoder;
 import io.kroxylicious.proxy.internal.codec.KafkaResponseDecoder;
@@ -217,7 +218,7 @@ class ServerConnectionStateMachineTest {
     @ValueSource(booleans = { true, false })
     void shouldTrackTlsRequirement(boolean requiresTls) {
         var vc = mock(VirtualClusterModel.class);
-        when(vc.getUpstreamSslContext()).thenReturn(requiresTls ? Optional.of(mock(io.netty.handler.ssl.SslContext.class)) : Optional.empty());
+        when(vc.getUpstreamSslContext()).thenReturn(requiresTls ? Optional.of(mock(SslContext.class)) : Optional.empty());
 
         ServerConnectionStateMachine sm = new ServerConnectionStateMachine(
                 BROKER_ADDRESS,
@@ -496,8 +497,6 @@ class ServerConnectionStateMachineTest {
         verify(ccsm).onServerConnectionException(exception);
     }
 
-    // === connect() tests ===
-
     private ServerConnectionStateMachine createConnectableScsm(ClientConnectionStateMachine mockCcsm,
                                                                VirtualClusterModel mockVirtualCluster,
                                                                EmbeddedChannel[] outboundHolder) {
@@ -645,8 +644,6 @@ class ServerConnectionStateMachineTest {
         assertThat(scsm.state()).isInstanceOf(ServerConnectionState.Closed.class);
     }
 
-    // === TLS credential tests ===
-
     private ServerConnectionStateMachine createScsmWithMocks(ClientConnectionStateMachine mockCcsm,
                                                              VirtualClusterModel mockVirtualCluster) {
         lenient().when(mockCcsm.sessionId()).thenReturn("test-session");
@@ -770,7 +767,7 @@ class ServerConnectionStateMachineTest {
     }
 
     @Test
-    void applySslContextToChannelRejectsNonTlsCredentialsImpl() {
+    void applyTlsContextToChannelRejectsNonTlsCredentialsImpl() {
         var mockCcsm = mock(ClientConnectionStateMachine.class);
         var mockVirtualCluster = mock(VirtualClusterModel.class);
         var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
@@ -779,7 +776,7 @@ class ServerConnectionStateMachineTest {
         Channel channel = mock(Channel.class);
         ChannelPipeline pipeline = mock(ChannelPipeline.class);
 
-        scsm.applySslContextToChannel(badCreds, BROKER_ADDRESS, channel, pipeline);
+        scsm.applyTlsContextToChannel(badCreds, BROKER_ADDRESS, channel, pipeline);
 
         ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
         verify(mockCcsm).onServerConnectionException(captor.capture());
@@ -789,7 +786,7 @@ class ServerConnectionStateMachineTest {
     }
 
     @Test
-    void applySslContextToChannelAddsSslHandlerWithValidCredentials() throws Exception {
+    void applyTlsContextToChannelAddsSslHandlerWithValidCredentials() throws Exception {
         var mockCcsm = mock(ClientConnectionStateMachine.class);
         var mockVirtualCluster = mock(VirtualClusterModel.class);
         var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
@@ -803,7 +800,7 @@ class ServerConnectionStateMachineTest {
         when(mockVirtualCluster.targetCluster()).thenReturn(mock(io.kroxylicious.proxy.config.TargetCluster.class));
         when(mockVirtualCluster.targetCluster().tls()).thenReturn(Optional.empty());
 
-        scsm.applySslContextToChannel(creds, BROKER_ADDRESS, channel, channel.pipeline());
+        scsm.applyTlsContextToChannel(creds, BROKER_ADDRESS, channel, channel.pipeline());
 
         assertThat(channel.pipeline().get("ssl")).isNotNull();
         verify(mockCcsm, never()).onServerConnectionException(any());

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachineTest.java
@@ -22,9 +22,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
@@ -41,7 +39,7 @@ import io.kroxylicious.proxy.internal.codec.KafkaResponseDecoder;
 import io.kroxylicious.proxy.internal.tls.ServerTlsCredentialSupplierContextImpl;
 import io.kroxylicious.proxy.internal.tls.TestCertificateUtil;
 import io.kroxylicious.proxy.internal.tls.TlsCredentialsImpl;
-import io.kroxylicious.proxy.internal.util.ActivationToken;
+import io.kroxylicious.proxy.internal.util.VirtualClusterNode;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.tls.ServerTlsCredentialSupplier;
@@ -53,7 +51,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -63,29 +60,22 @@ class ServerConnectionStateMachineTest {
 
     private static final HostPort BROKER_ADDRESS = new HostPort("broker.example.com", 9092);
     private static final String CLUSTER_NAME = "test-cluster";
+    private static final VirtualClusterNode VIRTUAL_CLUSTER_NODE = new VirtualClusterNode(CLUSTER_NAME, null);
     private static final Offset<Double> CLOSE_ENOUGH = Offset.offset(0.00005);
 
     @Mock
     private ClientConnectionStateMachine ccsm;
 
     @Mock
-    private ActivationToken activationToken;
-
-    @Mock
     private VirtualClusterModel virtualCluster;
 
     private ServerConnectionStateMachine serverStateMachine;
     private SimpleMeterRegistry meterRegistry;
-    private Counter proxyToServerErrorCounter;
-    private Timer serverToProxyBackpressureMeter;
 
     @BeforeEach
     void setUp() {
         meterRegistry = new SimpleMeterRegistry();
         Metrics.globalRegistry.add(meterRegistry);
-
-        proxyToServerErrorCounter = meterRegistry.counter("test.proxy.to.server.errors");
-        serverToProxyBackpressureMeter = meterRegistry.timer("test.server.to.proxy.backpressure");
 
         lenient().when(ccsm.sessionId()).thenReturn("test-session-123");
         lenient().when(ccsm.clusterName()).thenReturn(CLUSTER_NAME);
@@ -96,10 +86,7 @@ class ServerConnectionStateMachineTest {
                 ccsm,
                 virtualCluster,
                 CLUSTER_NAME,
-                null,
-                proxyToServerErrorCounter,
-                serverToProxyBackpressureMeter,
-                activationToken);
+                null);
     }
 
     @AfterEach
@@ -237,10 +224,7 @@ class ServerConnectionStateMachineTest {
                 ccsm,
                 vc,
                 CLUSTER_NAME,
-                null,
-                proxyToServerErrorCounter,
-                serverToProxyBackpressureMeter,
-                activationToken);
+                null);
 
         assertThat(sm.isUpstreamTls()).isEqualTo(requiresTls);
     }
@@ -252,10 +236,12 @@ class ServerConnectionStateMachineTest {
 
     @Test
     void onServerActiveShouldTransitionToActiveAndNotifyClientStateMachine() {
+        int initialActiveCount = getActiveServerConnections();
+
         serverStateMachine.onServerActive();
 
         assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Active.class);
-        verify(activationToken).acquire();
+        assertThat(getActiveServerConnections()).isEqualTo(initialActiveCount + 1);
         verify(ccsm).onServerConnectionActive();
     }
 
@@ -272,12 +258,13 @@ class ServerConnectionStateMachineTest {
     @Test
     void onServerInactiveShouldTransitionToClosedAndNotifyClientStateMachine() {
         serverStateMachine.onServerActive();
+        int countAfterActive = getActiveServerConnections();
 
         serverStateMachine.onServerInactive();
 
         assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Closed.class);
         verify(ccsm).onServerConnectionClosed(ClientConnectionStateMachine.DisconnectCause.SERVER_CLOSED);
-        verify(activationToken).release();
+        assertThat(getActiveServerConnections()).isEqualTo(countAfterActive - 1);
     }
 
     @Test
@@ -302,14 +289,15 @@ class ServerConnectionStateMachineTest {
     @Test
     void onServerExceptionShouldIncrementErrorCounterAndTransitionToClosed() {
         serverStateMachine.onServerActive();
+        int countAfterActive = getActiveServerConnections();
         RuntimeException cause = new RuntimeException("Connection failed");
 
         serverStateMachine.onServerException(cause);
 
         assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Closed.class);
-        assertThat(proxyToServerErrorCounter.count()).isCloseTo(1.0, CLOSE_ENOUGH);
+        assertThat(getProxyToServerErrorCount()).isCloseTo(1.0, CLOSE_ENOUGH);
         verify(ccsm).onServerConnectionException(cause);
-        verify(activationToken).release();
+        assertThat(getActiveServerConnections()).isEqualTo(countAfterActive - 1);
     }
 
     @Test
@@ -319,18 +307,18 @@ class ServerConnectionStateMachineTest {
         serverStateMachine.onServerException(null);
 
         assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Closed.class);
-        assertThat(proxyToServerErrorCounter.count()).isCloseTo(1.0, CLOSE_ENOUGH);
+        assertThat(getProxyToServerErrorCount()).isCloseTo(1.0, CLOSE_ENOUGH);
         verify(ccsm).onServerConnectionException(null);
     }
 
     @Test
     void onServerExceptionWhenAlreadyClosedShouldNotIncrementErrorCounter() {
         serverStateMachine.close();
-        double errorCountBefore = proxyToServerErrorCounter.count();
+        double errorCountBefore = getProxyToServerErrorCount();
 
         serverStateMachine.onServerException(new RuntimeException("test"));
 
-        assertThat(proxyToServerErrorCounter.count()).isEqualTo(errorCountBefore);
+        assertThat(getProxyToServerErrorCount()).isEqualTo(errorCountBefore);
         verify(ccsm, never()).onServerConnectionException(null);
     }
 
@@ -427,7 +415,7 @@ class ServerConnectionStateMachineTest {
         serverStateMachine.relieveBackpressure();
 
         assertThat(serverStateMachine).extracting("serverBackpressureTimer").isNull();
-        assertThat(serverToProxyBackpressureMeter.count()).isGreaterThanOrEqualTo(1);
+        assertThat(getBackpressureTimerCount()).isGreaterThanOrEqualTo(1);
     }
 
     @Test
@@ -436,9 +424,9 @@ class ServerConnectionStateMachineTest {
 
         serverStateMachine.applyBackpressure();
         serverStateMachine.relieveBackpressure();
-        long countAfterFirst = serverToProxyBackpressureMeter.count();
+        long countAfterFirst = getBackpressureTimerCount();
         serverStateMachine.relieveBackpressure();
-        long countAfterSecond = serverToProxyBackpressureMeter.count();
+        long countAfterSecond = getBackpressureTimerCount();
 
         assertThat(countAfterSecond).isEqualTo(countAfterFirst);
     }
@@ -448,27 +436,29 @@ class ServerConnectionStateMachineTest {
         serverStateMachine.relieveBackpressure();
 
         assertThat(serverStateMachine).extracting("serverBackpressureTimer").isNull();
-        assertThat(serverToProxyBackpressureMeter.count()).isZero();
+        assertThat(getBackpressureTimerCount()).isZero();
     }
 
     @Test
     void closeShouldTransitionToClosedAndReleaseActivationToken() {
         serverStateMachine.onServerActive();
+        int countAfterActive = getActiveServerConnections();
 
         serverStateMachine.close();
 
         assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Closed.class);
-        verify(activationToken).release();
+        assertThat(getActiveServerConnections()).isEqualTo(countAfterActive - 1);
     }
 
     @Test
     void closeShouldBeIdempotent() {
         serverStateMachine.onServerActive();
+        int countAfterActive = getActiveServerConnections();
 
         serverStateMachine.close();
         serverStateMachine.close();
 
-        verify(activationToken, times(1)).release();
+        assertThat(getActiveServerConnections()).isEqualTo(countAfterActive - 1);
     }
 
     @Test
@@ -487,12 +477,13 @@ class ServerConnectionStateMachineTest {
     @Test
     void shouldReleaseActivationTokenOnlyOnceWhenTransitioningToClosed() {
         serverStateMachine.onServerActive();
+        int countAfterActive = getActiveServerConnections();
 
         serverStateMachine.close();
         serverStateMachine.onServerInactive();
         serverStateMachine.onServerException(new RuntimeException("test"));
 
-        verify(activationToken, times(1)).release();
+        assertThat(getActiveServerConnections()).isEqualTo(countAfterActive - 1);
     }
 
     @Test
@@ -517,8 +508,7 @@ class ServerConnectionStateMachineTest {
         when(mockVirtualCluster.socketFrameMaxSizeBytes()).thenReturn(
                 VirtualClusterModel.DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES);
         return new ServerConnectionStateMachine(
-                BROKER_ADDRESS, mockCcsm, mockVirtualCluster, CLUSTER_NAME, null,
-                mock(Counter.class), mock(Timer.class), mock(ActivationToken.class)) {
+                BROKER_ADDRESS, mockCcsm, mockVirtualCluster, CLUSTER_NAME, null) {
             @Override
             Bootstrap configureBootstrap(KafkaProxyBackendHandler backendHandler,
                                          Channel inboundChannel) {
@@ -581,6 +571,17 @@ class ServerConnectionStateMachineTest {
     }
 
     @Test
+    void connecthouldIncrementConnectionCounter() {
+        double initialCount = getProxyToServerConnectionCount();
+        var mockCcsm = mock(ClientConnectionStateMachine.class);
+        var mockVirtualCluster = mock(VirtualClusterModel.class);
+        var outboundHolder = new EmbeddedChannel[1];
+        var scsm = createConnectableScsm(mockCcsm, mockVirtualCluster, outboundHolder);
+        scsm.connect(new EmbeddedChannel());
+        assertThat(getProxyToServerConnectionCount()).isCloseTo(initialCount + 1.0, CLOSE_ENOUGH);
+    }
+
+    @Test
     void connectShouldAddFrameLoggerWhenLogFramesEnabled() {
         var mockCcsm = mock(ClientConnectionStateMachine.class);
         var mockVirtualCluster = mock(VirtualClusterModel.class);
@@ -618,8 +619,7 @@ class ServerConnectionStateMachineTest {
                 VirtualClusterModel.DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES);
         var tcpFailure = new RuntimeException("Connection refused");
         var scsm = new ServerConnectionStateMachine(
-                BROKER_ADDRESS, mockCcsm, mockVirtualCluster, CLUSTER_NAME, null,
-                mock(Counter.class), mock(Timer.class), mock(ActivationToken.class)) {
+                BROKER_ADDRESS, mockCcsm, mockVirtualCluster, CLUSTER_NAME, null) {
             @Override
             Bootstrap configureBootstrap(KafkaProxyBackendHandler backendHandler,
                                          Channel inboundChannel) {
@@ -657,10 +657,7 @@ class ServerConnectionStateMachineTest {
                 mockCcsm,
                 mockVirtualCluster,
                 CLUSTER_NAME,
-                null,
-                mock(Counter.class),
-                mock(Timer.class),
-                mock(ActivationToken.class));
+                null);
     }
 
     @Test
@@ -812,5 +809,28 @@ class ServerConnectionStateMachineTest {
         verify(mockCcsm, never()).onServerConnectionException(any());
 
         channel.close();
+    }
+
+    private int getActiveServerConnections() {
+        return io.kroxylicious.proxy.internal.util.Metrics
+                .proxyToServerConnectionCounter(VIRTUAL_CLUSTER_NODE).get();
+    }
+
+    private double getProxyToServerConnectionCount() {
+        return Metrics.globalRegistry
+                .get("kroxylicious_proxy_to_server_connections")
+                .counter().count();
+    }
+
+    private double getProxyToServerErrorCount() {
+        return Metrics.globalRegistry
+                .get("kroxylicious_proxy_to_server_errors")
+                .counter().count();
+    }
+
+    private long getBackpressureTimerCount() {
+        return Metrics.globalRegistry
+                .get("kroxylicious_server_to_proxy_reads_paused")
+                .timer().count();
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Moves the entire backend connection lifecycle (Bootstrap configuration, TCP connect, TLS credential handling, codec pipeline setup, per-connection metrics) from KafkaProxyFrontendHandler into ServerConnectionStateMachine. CCSM now creates SCSMs via a @VisibleForTesting factory method and calls scsm.connect(inboundChannel) instead of frontendHandler.initiateBackendConnect().

This completes the decomposition: KafkaProxyFrontendHandler handles the client channel, CCSM orchestrates session state, and SCSM owns the server connection lifecycle end-to-end.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

Closes #4015 

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
