### PR TITLE
build(benchmarks): added multiarch support for kroxylicious OMB image

### DIFF
--- a/.github/workflows/build-omb-image.yml
+++ b/.github/workflows/build-omb-image.yml
@@ -87,6 +87,7 @@ jobs:
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: kroxylicious-openmessaging-benchmarks
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           file: kroxylicious-openmessaging-benchmarks/Containerfile
           push: ${{ steps.build_configuration.outputs.push_images == 'true' }}
           build-args: |


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Kroxylicious OMB image is currently created only for x86 architecture, so we need to add `platforms` supported when pushing the image using docker buildx.

### Additional Context

openjdk-21 has support for all these architectures: [amd64](https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21/6501cdb5c34ae048c44f7814?image=6a1581a186eefb7978c35dd5&architecture=amd64), [arm64](https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21/6501cdb5c34ae048c44f7814?image=6a1581a186eefb7978c35dd5&architecture=arm64), [s390x](https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21/6501cdb5c34ae048c44f7814?image=6a1581a186eefb7978c35dd5&architecture=s390x) and [ppc64le](https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21/6501cdb5c34ae048c44f7814?image=6a1581a186eefb7978c35dd5&architecture=ppc64le)

openjdk-21-runtime as well: [amd64](https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f?image=6a157ef7183aacab3f296933&architecture=amd64), [arm64](https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f?image=6a157ef7183aacab3f296933&architecture=arm64), [s390x](https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f?image=6a157ef7183aacab3f296933&architecture=s390x) and [ppc64le](https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f?image=6a157ef7183aacab3f296933&architecture=ppc64le)

Closes #4005 

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
