### PR TITLE
refactor ITs to delete KeytoolCertificateGenerator deprecated dependency

### DIFF
--- a/kroxylicious-integration-test-support/pom.xml
+++ b/kroxylicious-integration-test-support/pom.xml
@@ -207,6 +207,11 @@
             <artifactId>opentest4j</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-pkitesting</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/client/KafkaClientTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/client/KafkaClientTest.java
@@ -7,16 +7,10 @@
 package io.kroxylicious.testing.integration.client;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -33,7 +27,6 @@ import org.apache.kafka.common.requests.ApiVersionsRequest;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import io.netty.buffer.Unpooled;
 import io.netty.handler.ssl.SslContext;
@@ -44,26 +37,33 @@ import io.kroxylicious.testing.integration.Response;
 import io.kroxylicious.testing.integration.ResponsePayload;
 import io.kroxylicious.testing.integration.codec.OpaqueRequestFrame;
 import io.kroxylicious.testing.integration.server.MockServer;
-import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
+import io.kroxylicious.testing.kafka.common.KeystoreManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class KafkaClientTest {
 
-    private KeytoolCertificateGenerator downstreamCertificateGenerator;
-    private Path clientTrustStore;
+    private record KeystoreTrustStorePair(String brokerKeyStore, KeyStore keyStoreInstance, String clientTrustStore, String password) {}
 
-    @TempDir
-    private Path certsDirectory;
+    private static KeystoreTrustStorePair buildKeystoreTrustStorePair() throws Exception {
+        var keystoreManager = new KeystoreManager();
+        String dn = keystoreManager.buildDistinguishedName("test@kroxylicious.io", "localhost", "KI", "kroxylicious.io", null, null, "US");
+        var bundle = keystoreManager.createSelfSignedCertificate(keystoreManager.newCertificateBuilder(dn));
+        Path keystorePath = keystoreManager.generateCertificateFile(bundle);
+        String password = keystoreManager.getPassword(keystorePath);
+        // The generated JKS contains both the private key entry and the CA cert,
+        // so the same file serves as both the proxy keystore and the client truststore.
+        String keystore = keystorePath.toAbsolutePath().toString();
+        KeyStore keyStoreInstance = bundle.toKeyStore(password.toCharArray());
+
+        return new KeystoreTrustStorePair(keystore, keyStoreInstance, keystore, password);
+    }
+
+    private KeystoreTrustStorePair downstreamKeystoreTrustStorePair;
 
     @BeforeEach
     void beforeEach() throws Exception {
-        // Note that the KeytoolCertificateGenerator generates key stores that are PKCS12 format.
-        this.downstreamCertificateGenerator = new KeytoolCertificateGenerator();
-        this.downstreamCertificateGenerator.generateSelfSignedCertificateEntry("test@kroxylicious.io", "localhost", "KI", "kroxylicious.io", null, null, "US");
-        this.clientTrustStore = certsDirectory.resolve("kafka.truststore.jks");
-        this.downstreamCertificateGenerator.generateTrustStore(this.downstreamCertificateGenerator.getCertFilePath(), "client",
-                clientTrustStore.toAbsolutePath().toString());
+        this.downstreamKeystoreTrustStorePair = buildKeystoreTrustStorePair();
     }
 
     @Test
@@ -134,8 +134,7 @@ class KafkaClientTest {
     @Test
     void shouldWorkWithTls() throws Exception {
         shouldWorkWithTls(SslContextBuilder.forClient()
-                .trustManager(
-                        trustManagerFactory(clientTrustStore.toFile(), downstreamCertificateGenerator.getKeyStoreType(), downstreamCertificateGenerator.getPassword()))
+                .trustManager(trustManagerFactory(downstreamKeystoreTrustStorePair))
                 .build());
     }
 
@@ -147,9 +146,9 @@ class KafkaClientTest {
     private void shouldWorkWithTls(SslContext clientSslContext) throws SSLException {
         var message = new ApiVersionsResponseData();
 
-        var file = new File(downstreamCertificateGenerator.getKeyStoreLocation());
+        var file = new File(downstreamKeystoreTrustStorePair.brokerKeyStore());
         var serverSslContext = SslContextBuilder
-                .forServer(keyManagerFactory(file, downstreamCertificateGenerator.getKeyStoreType(), downstreamCertificateGenerator.getPassword())).build();
+                .forServer(keyManagerFactory(file, downstreamKeystoreTrustStorePair.password())).build();
 
         var serverResponse = new ResponsePayload(ApiKeys.API_VERSIONS, (short) 0, message);
 
@@ -163,10 +162,10 @@ class KafkaClientTest {
         }
     }
 
-    private KeyManagerFactory keyManagerFactory(File storeFile, String keyStoreType, String password) {
+    private KeyManagerFactory keyManagerFactory(File storeFile, String password) {
         try {
             var passwordChars = Optional.ofNullable(password).map(String::toCharArray).orElse(null);
-            var keyStore = loadKeyStore(storeFile, keyStoreType, passwordChars);
+            var keyStore = downstreamKeystoreTrustStorePair.keyStoreInstance();
             var keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
             keyManagerFactory.init(keyStore, passwordChars);
             return keyManagerFactory;
@@ -176,32 +175,15 @@ class KafkaClientTest {
         }
     }
 
-    private TrustManagerFactory trustManagerFactory(File storeFile, String keyStoreType, String password) {
-
+    private TrustManagerFactory trustManagerFactory(KeystoreTrustStorePair keystoreTrustStorePair) {
         try {
-            var passwordChars = Optional.ofNullable(password).map(String::toCharArray).orElse(null);
-            var keyStore = loadKeyStore(storeFile, keyStoreType, passwordChars);
+            var keyStore = keystoreTrustStorePair.keyStoreInstance();
             var trustManagerFactory = TrustManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
             trustManagerFactory.init(keyStore);
             return trustManagerFactory;
         }
         catch (GeneralSecurityException e) {
-            throw new RuntimeException("Error building TrustManagerFactory from : " + storeFile, e);
-        }
-
-    }
-
-    private KeyStore loadKeyStore(File storeFile, String keyStoreType, char[] passwordChars) {
-        try (var is = new FileInputStream(storeFile)) {
-            var keyStore = KeyStore.getInstance(keyStoreType);
-            keyStore.load(is, passwordChars);
-            return keyStore;
-        }
-        catch (CertificateException | KeyStoreException | NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException(e);
+            throw new RuntimeException("Error building TrustManagerFactory", e);
         }
     }
 }

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTesterTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTesterTest.java
@@ -6,9 +6,7 @@
 
 package io.kroxylicious.testing.integration.tester;
 
-import java.io.IOException;
 import java.nio.file.Path;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -41,7 +39,7 @@ import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterGatewayBuilder;
 import io.kroxylicious.proxy.service.HostPort;
-import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
+import io.kroxylicious.testing.kafka.common.KeystoreManager;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -98,6 +96,20 @@ class DefaultKroxyliciousTesterTest {
     private final MockProducer<String, String> producer = new MockProducer<>();
 
     private final MockConsumer<String, String> consumer = new MockConsumer<>(StrategyType.LATEST.toString());
+
+    protected record KeystoreTrustStorePair(String brokerKeyStore, String clientTrustStore, String password) {}
+
+    protected static KeystoreTrustStorePair buildKeystoreTrustStorePair(String domain) throws Exception {
+        var keystoreManager = new KeystoreManager();
+        String dn = keystoreManager.buildDistinguishedName("test@kroxylicious.io", domain, "KI", "kroxylicious.io", null, null, "US");
+        var bundle = keystoreManager.createSelfSignedCertificate(keystoreManager.newCertificateBuilder(dn));
+        Path keystorePath = keystoreManager.generateCertificateFile(bundle);
+        String password = keystoreManager.getPassword(keystorePath);
+        // The generated JKS contains both the private key entry and the CA cert,
+        // so the same file serves as both the proxy keystore and the client truststore.
+        String keystore = keystorePath.toAbsolutePath().toString();
+        return new KeystoreTrustStorePair(keystore, keystore, password);
+    }
 
     @BeforeEach
     void setUp() {
@@ -330,12 +342,10 @@ class DefaultKroxyliciousTesterTest {
     }
 
     @Test
-    void shouldConfigureConsumerForTls(@TempDir Path certsDirectory) throws IOException {
+    void shouldConfigureConsumerForTls(@TempDir Path certsDirectory) throws Exception {
         // Given
-        final String certFilePath = certsDirectory.resolve(Path.of("cert-file")).toAbsolutePath().toString();
-        final String trustStorePath = certsDirectory.resolve(Path.of("trust-store")).toAbsolutePath().toString();
-        var keytoolCertificateGenerator = new KeytoolCertificateGenerator(certFilePath, trustStorePath);
-        try (var tester = buildSecureTester(keytoolCertificateGenerator)) {
+        var keystoreTrustStorePair = buildKeystoreTrustStorePair("localhost");
+        try (var tester = buildSecureTester(keystoreTrustStorePair)) {
 
             // When
             tester.consumer(TLS_CLUSTER);
@@ -343,40 +353,36 @@ class DefaultKroxyliciousTesterTest {
             tester.admin(TLS_CLUSTER);
 
             // Then
-
-            verify(clientFactory).build(eq(new GatewayId(TLS_CLUSTER, DEFAULT_GATEWAY_NAME)), argThat(assertSslConfiguration(trustStorePath)));
+            verify(clientFactory).build(eq(new GatewayId(TLS_CLUSTER, DEFAULT_GATEWAY_NAME)),
+                    argThat(assertSslConfiguration(keystoreTrustStorePair.clientTrustStore())));
         }
     }
 
     @Test
-    void shouldConfigureProducerForTls(@TempDir Path certsDirectory) throws IOException {
+    void shouldConfigureProducerForTls(@TempDir Path certsDirectory) throws Exception {
         // Given
-        final String certFilePath = certsDirectory.resolve(Path.of("cert-file")).toAbsolutePath().toString();
-        final String trustStorePath = certsDirectory.resolve(Path.of("trust-store")).toAbsolutePath().toString();
-        var keytoolCertificateGenerator = new KeytoolCertificateGenerator(certFilePath, trustStorePath);
-        try (var tester = buildSecureTester(keytoolCertificateGenerator)) {
+        var keystoreTrustStorePair = buildKeystoreTrustStorePair("localhost");
+        try (var tester = buildSecureTester(keystoreTrustStorePair)) {
 
             // When
             tester.producer(TLS_CLUSTER);
 
             // Then
-            verify(clientFactory).build(eq(new GatewayId(TLS_CLUSTER, DEFAULT_GATEWAY_NAME)), argThat(assertSslConfiguration(trustStorePath)));
+            verify(clientFactory).build(eq(new GatewayId(TLS_CLUSTER, DEFAULT_GATEWAY_NAME)), argThat(assertSslConfiguration(keystoreTrustStorePair.clientTrustStore())));
         }
     }
 
     @Test
-    void shouldConfigureAdminForTls(@TempDir Path certsDirectory) throws IOException {
+    void shouldConfigureAdminForTls(@TempDir Path certsDirectory) throws Exception {
         // Given
-        final String certFilePath = certsDirectory.resolve(Path.of("cert-file")).toAbsolutePath().toString();
-        final String trustStorePath = certsDirectory.resolve(Path.of("trust-store")).toAbsolutePath().toString();
-        var keytoolCertificateGenerator = new KeytoolCertificateGenerator(certFilePath, trustStorePath);
-        try (var tester = buildSecureTester(keytoolCertificateGenerator)) {
+        var keystoreTrustStorePair = buildKeystoreTrustStorePair("localhost");
+        try (var tester = buildSecureTester(keystoreTrustStorePair)) {
 
             // When
             tester.admin(TLS_CLUSTER);
 
             // Then
-            verify(clientFactory).build(eq(new GatewayId(TLS_CLUSTER, DEFAULT_GATEWAY_NAME)), argThat(assertSslConfiguration(trustStorePath)));
+            verify(clientFactory).build(eq(new GatewayId(TLS_CLUSTER, DEFAULT_GATEWAY_NAME)), argThat(assertSslConfiguration(keystoreTrustStorePair.clientTrustStore())));
         }
     }
 
@@ -633,8 +639,7 @@ class DefaultKroxyliciousTesterTest {
     }
 
     @NonNull
-    private KroxyliciousTester buildSecureTester(KeytoolCertificateGenerator keytoolCertificateGenerator) {
-        generateSecurityCert(keytoolCertificateGenerator);
+    private KroxyliciousTester buildSecureTester(KeystoreTrustStorePair keystoreTrustStorePair) {
         final ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
         var vcb = new VirtualClusterBuilder()
                 .withName(TLS_CLUSTER)
@@ -644,8 +649,8 @@ class DefaultKroxyliciousTesterTest {
                 .addToGateways(KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder(DEFAULT_PROXY_BOOTSTRAP)
                         .withNewTls()
                         .withNewKeyStoreKey()
-                        .withStoreFile(keytoolCertificateGenerator.getKeyStoreLocation())
-                        .withNewInlinePasswordStoreProvider(keytoolCertificateGenerator.getPassword())
+                        .withStoreFile(keystoreTrustStorePair.brokerKeyStore())
+                        .withNewInlinePasswordStoreProvider(keystoreTrustStorePair.password())
                         .endKeyStoreKey()
                         .endTls()
                         .build());
@@ -653,20 +658,11 @@ class DefaultKroxyliciousTesterTest {
                 .addToVirtualClusters(vcb.build());
 
         return new KroxyliciousTesterBuilder().setConfigurationBuilder(configurationBuilder)
-                .setTrustStoreLocation(keytoolCertificateGenerator.getTrustStoreLocation())
-                .setTrustStorePassword(keytoolCertificateGenerator.getPassword())
+                .setTrustStoreLocation(keystoreTrustStorePair.clientTrustStore())
+                .setTrustStorePassword(keystoreTrustStorePair.password())
                 .setKroxyliciousFactory(DefaultKroxyliciousTester::spawnProxy)
                 .setClientFactory(clientFactory)
                 .createDefaultKroxyliciousTester();
-    }
-
-    private static void generateSecurityCert(KeytoolCertificateGenerator keytoolCertificateGenerator) {
-        try {
-            keytoolCertificateGenerator.generateSelfSignedCertificateEntry("webmaster@example.com", "example.com", "Engineering", "kroxylicious.io", null, null, "NZ");
-        }
-        catch (GeneralSecurityException | IOException e) {
-            fail("unable to generate security certificate", e);
-        }
     }
 
     private KroxyliciousTester buildTester() {

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -357,7 +357,7 @@
             <artifactId>apicurio-registry-serde-common</artifactId>
             <scope>test</scope>
         </dependency>
-<dependency>
+        <dependency>
             <groupId>net.javacrumbs.json-unit</groupId>
             <artifactId>json-unit-assertj</artifactId>
         </dependency>

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/BaseIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/BaseIT.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.it;
 
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
@@ -39,6 +40,7 @@ import io.kroxylicious.proxy.internal.subject.DefaultSaslSubjectBuilderService;
 import io.kroxylicious.testing.integration.config.NamedFilterDefinitionBuilder;
 import io.kroxylicious.testing.integration.tester.KroxyliciousTester;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.KeystoreManager;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 import io.kroxylicious.testing.kafka.junit5ext.Topic;
 
@@ -50,6 +52,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(KafkaClusterExtension.class)
 @ExtendWith(NettyLeakDetectorExtension.class)
 public abstract class BaseIT {
+
+    protected record KeystoreTrustStorePair(String brokerKeyStore, String clientTrustStore, String password) {}
+
+    protected static KeystoreTrustStorePair buildKeystoreTrustStorePair(String domain) throws Exception {
+        var keystoreManager = new KeystoreManager();
+        String dn = keystoreManager.buildDistinguishedName("test@kroxylicious.io", domain, "KI", "kroxylicious.io", null, null, "US");
+        var bundle = keystoreManager.createSelfSignedCertificate(keystoreManager.newCertificateBuilder(dn));
+        Path keystorePath = keystoreManager.generateCertificateFile(bundle);
+        String password = keystoreManager.getPassword(keystorePath);
+        // The generated JKS contains both the private key entry and the CA cert,
+        // so the same file serves as both the proxy keystore and the client truststore.
+        String keystore = keystorePath.toAbsolutePath().toString();
+        return new KeystoreTrustStorePair(keystore, keystore, password);
+    }
 
     static ConfigurationBuilder buildProxyConfigWithSaslInspection(KafkaCluster cluster, @Nullable Set<String> enableMechanisms,
                                                                    @Nullable DefaultSaslSubjectBuilderService.Config subjectBuilderConfig) {

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ExpositionIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ExpositionIT.java
@@ -60,7 +60,6 @@ import io.kroxylicious.testing.integration.tester.KroxyliciousTester;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.clients.CloseableAdmin;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
-import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
 import io.kroxylicious.testing.kafka.common.SaslMechanism;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
@@ -79,10 +78,10 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 /**
- * Integration tests that focus on the ability to present virtual clusters, with various numbers of brokers)
+ * Integration tests that focus on the ability to present virtual clusters, with various numbers of brokers
  * to the kafka clients
  * <br/>
- * TODO corner case test - verify kroxy's ability to recover for a temporary port already bound condition.
+ * TODO corner case test - verify Kroxylicious's ability to recover for a temporary port already bound condition.
  */
 @ExtendWith(KafkaClusterExtension.class)
 class ExpositionIT extends BaseIT {
@@ -464,10 +463,9 @@ class ExpositionIT extends BaseIT {
 
     @Test
     void exposesClusterOfTwoBrokers(@BrokerCluster(numBrokers = 2) KafkaCluster cluster) throws Exception {
-        HostPort proxyAddress = PROXY_ADDRESS;
         var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(KroxyliciousConfigUtils.baseVirtualClusterBuilder(cluster, "demo")
-                        .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(proxyAddress).build())
+                        .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS).build())
                         .build());
 
         var brokerEndpoints = Map.of(0, "localhost:" + (PROXY_ADDRESS.port() + 1), 1, "localhost:" + (PROXY_ADDRESS.port() + 2));
@@ -795,22 +793,5 @@ class ExpositionIT extends BaseIT {
 
     private static String toAddress(Node n) {
         return n.host() + ":" + n.port();
-    }
-
-    private record KeystoreTrustStorePair(String brokerKeyStore, String clientTrustStore, String password) {}
-
-    @NonNull
-    private static ExpositionIT.KeystoreTrustStorePair buildKeystoreTrustStorePair(String domain) throws Exception {
-        var brokerCertificateGenerator = new KeytoolCertificateGenerator();
-        brokerCertificateGenerator.generateSelfSignedCertificateEntry("test@redhat.com", domain, "KI", "kroxylicious.io", null, null, "US");
-        Path resolve = certsDirectory.resolve(UUID.randomUUID().toString());
-        if (!resolve.toFile().mkdirs()) {
-            throw new RuntimeException("Could not create directory " + resolve);
-        }
-        var clientTrustStore = resolve.resolve("kafka.truststore.jks");
-        brokerCertificateGenerator.generateTrustStore(brokerCertificateGenerator.getCertFilePath(), "client",
-                clientTrustStore.toAbsolutePath().toString());
-        return new KeystoreTrustStorePair(brokerCertificateGenerator.getKeyStoreLocation(), clientTrustStore.toAbsolutePath().toString(),
-                brokerCertificateGenerator.getPassword());
     }
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ExpositionIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ExpositionIT.java
@@ -5,7 +5,6 @@
  */
 package io.kroxylicious.it;
 
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -39,7 +38,6 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.plain.PlainLoginModule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -97,9 +95,6 @@ class ExpositionIT extends BaseIT {
     public static final String SNI_BROKER_ADDRESS_PATTERN_WITH_CLUSTER_NAME = "$(virtualClusterName)-broker-$(nodeId)." + SNI_BASE_ADDRESS;
     public static final String SASL_USER = "user";
     public static final String SASL_PASSWORD = "password";
-
-    @TempDir
-    private static Path certsDirectory;
 
     @ParameterizedTest
     @MethodSource("virtualClusterConfigurations")

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.it;
 
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -34,7 +33,6 @@ import io.kroxylicious.testing.integration.tester.KroxyliciousTester;
 import io.kroxylicious.testing.integration.tester.KroxyliciousTesters;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
-import io.kroxylicious.testing.kafka.common.KeystoreManager;
 
 import static io.kroxylicious.it.HotReloadIT.VcSlot.INCOMING;
 import static io.kroxylicious.it.HotReloadIT.VcSlot.OUTGOING;
@@ -331,20 +329,5 @@ class HotReloadIT extends BaseIT {
                 ProducerConfig.RETRIES_CONFIG, 1,
                 ProducerConfig.RECONNECT_BACKOFF_MS_CONFIG, 100,
                 ProducerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG, 500);
-    }
-
-    private record KeystoreTrustStorePair(String brokerKeyStore, String clientTrustStore, String password) {}
-
-    private static KeystoreTrustStorePair buildKeystoreTrustStorePair(String domain) throws Exception {
-        var keystoreManager = new KeystoreManager();
-        String dn = keystoreManager.buildDistinguishedName("test@kroxylicious.io", domain, "KI", "kroxylicious.io", null, null, "US");
-        var bundle = keystoreManager.createSelfSignedCertificate(
-                keystoreManager.newCertificateBuilder(dn));
-        Path keystorePath = keystoreManager.generateCertificateFile(bundle);
-        String password = keystoreManager.getPassword(keystorePath);
-        // The generated JKS contains both the private key entry and the CA cert,
-        // so the same file serves as both the proxy keystore and the client truststore.
-        String keystore = keystorePath.toAbsolutePath().toString();
-        return new KeystoreTrustStorePair(keystore, keystore, password);
     }
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/MetricsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/MetricsIT.java
@@ -11,7 +11,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -39,13 +38,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
 import io.micrometer.core.instrument.Metrics;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
@@ -63,8 +59,6 @@ import io.kroxylicious.testing.integration.tester.SimpleMetric;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.api.TerminationStyle;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
-import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
-import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 import io.kroxylicious.testing.kafka.junit5ext.Name;
 import io.kroxylicious.testing.kafka.junit5ext.Topic;
 import io.kroxylicious.testing.kafka.junit5ext.TopicPartitions;
@@ -83,12 +77,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
-@ExtendWith(KafkaClusterExtension.class)
-@ExtendWith(NettyLeakDetectorExtension.class)
-class MetricsIT {
-
-    @TempDir
-    private static Path certsDirectory;
+class MetricsIT extends BaseIT {
 
     private static final HostPort PORT_IDENTIFIES_BROKER_BOOTSTRAP = new HostPort("localhost", 9092);
     private static final String SNI_IDENTIFIES_BROKER_BASE_ADDRESS = IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName("sni");
@@ -610,12 +599,7 @@ class MetricsIT {
 
     static Stream<Arguments> createDownstreamConnectionError() throws Exception {
         var failQuickDescribeCluster = new DescribeClusterOptions().timeoutMs(2_000);
-        // Note that the KeytoolCertificateGenerator generates key stores that are PKCS12 format.
-        var downstreamCertificateGenerator = new KeytoolCertificateGenerator();
-        downstreamCertificateGenerator.generateSelfSignedCertificateEntry("test@gmail.com", "localhost", "foo", "bar", null, null, "US");
-        var clientTrustStore = certsDirectory.resolve("kafka.truststore.jks");
-        downstreamCertificateGenerator.generateTrustStore(downstreamCertificateGenerator.getCertFilePath(), "client",
-                clientTrustStore.toAbsolutePath().toString());
+        var downstreamCertificateGenerator = buildKeystoreTrustStorePair("localhost");
 
         return Stream.of(
                 argumentSet("gateway is tcp, client sends malformed kafka",
@@ -639,8 +623,8 @@ class MetricsIT {
                                 .withName("default")
                                 .withNewTls()
                                 .withNewKeyStoreKey()
-                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                .withStoreFile(downstreamCertificateGenerator.brokerKeyStore())
+                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.password())
                                 .endKeyStoreKey()
                                 .endTls()
                                 .build(),
@@ -661,8 +645,8 @@ class MetricsIT {
                                 .withName("default")
                                 .withNewTls()
                                 .withNewKeyStoreKey()
-                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                .withStoreFile(downstreamCertificateGenerator.brokerKeyStore())
+                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.password())
                                 .endKeyStoreKey()
                                 .endTls()
                                 .build(),
@@ -673,8 +657,8 @@ class MetricsIT {
 
                             try (var admin = kroxyliciousTester.admin(
                                     Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, unrecognisedHostPort,
-                                            SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, clientTrustStore.toAbsolutePath().toString(),
-                                            SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, downstreamCertificateGenerator.getPassword()))) {
+                                            SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, downstreamCertificateGenerator.clientTrustStore(),
+                                            SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, downstreamCertificateGenerator.password()))) {
                                 assertThat(admin.describeCluster(failQuickDescribeCluster).clusterId())
                                         .failsWithin(Duration.ofSeconds(5))
                                         .withThrowableThat()

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/multitenant/BaseMultiTenantIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/multitenant/BaseMultiTenantIT.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.it.filter.multitenant;
 
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Deque;
 import java.util.HashMap;
@@ -35,7 +34,6 @@ import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
 
 import io.kroxylicious.filter.multitenant.MultiTenant;
 import io.kroxylicious.it.BaseIT;
@@ -46,7 +44,6 @@ import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.integration.config.NamedFilterDefinitionBuilder;
 import io.kroxylicious.testing.integration.tester.KroxyliciousTester;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
-import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -69,36 +66,30 @@ public abstract class BaseMultiTenantIT extends BaseIT {
     Map<String, Object> clientConfig;
 
     TestInfo testInfo;
-    KeytoolCertificateGenerator certificateGenerator;
-    @TempDir
-    Path certsDirectory;
+    KeystoreTrustStorePair keystoreTrustStorePair;
 
     @BeforeEach
     void beforeEach(TestInfo testInfo) throws Exception {
         this.testInfo = testInfo;
         // TODO: use a per-tenant server certificate.
-        this.certificateGenerator = new KeytoolCertificateGenerator();
-        this.certificateGenerator.generateSelfSignedCertificateEntry("test@redhat.com", IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName("*"),
-                "KI", "RedHat", null, null, "US");
-        Path clientTrustStore = certsDirectory.resolve(certificateGenerator.getTrustStoreLocation());
-        this.certificateGenerator.generateTrustStore(this.certificateGenerator.getCertFilePath(), "client", clientTrustStore.toAbsolutePath().toString());
+        this.keystoreTrustStorePair = buildKeystoreTrustStorePair(IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName("*"));
         this.clientConfig = Map.of(CommonClientConfigs.CLIENT_ID_CONFIG, testInfo.getDisplayName(),
                 CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name,
-                SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, clientTrustStore.toAbsolutePath().toString(),
-                SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, certificateGenerator.getPassword());
+                SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, keystoreTrustStorePair.clientTrustStore(),
+                SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, keystoreTrustStorePair.password());
     }
 
-    static ConfigurationBuilder getConfig(KafkaCluster cluster, KeytoolCertificateGenerator certificateGenerator) {
-        return getConfig(cluster, certificateGenerator, (Map<String, Object>) null);
+    static ConfigurationBuilder getConfig(KafkaCluster cluster, KeystoreTrustStorePair keystoreTrustStorePair) {
+        return getConfig(cluster, keystoreTrustStorePair, (Map<String, Object>) null);
     }
 
-    static ConfigurationBuilder getConfig(KafkaCluster cluster, KeytoolCertificateGenerator certificateGenerator, Map<String, Object> filterConfig) {
+    static ConfigurationBuilder getConfig(KafkaCluster cluster, KeystoreTrustStorePair keystoreTrustStorePair, Map<String, Object> filterConfig) {
         var filterBuilder = new NamedFilterDefinitionBuilder("filter-1", MultiTenant.class.getName());
         Optional.ofNullable(filterConfig).ifPresent(filterBuilder::withConfig);
-        return getConfig(cluster, certificateGenerator, filterBuilder);
+        return getConfig(cluster, keystoreTrustStorePair, filterBuilder);
     }
 
-    static ConfigurationBuilder getConfig(KafkaCluster cluster, KeytoolCertificateGenerator certificateGenerator, NamedFilterDefinitionBuilder filterBuilder) {
+    static ConfigurationBuilder getConfig(KafkaCluster cluster, KeystoreTrustStorePair keystoreTrustStorePair, NamedFilterDefinitionBuilder filterBuilder) {
         return new ConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName(TENANT_1_CLUSTER)
@@ -108,8 +99,8 @@ public abstract class BaseMultiTenantIT extends BaseIT {
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(TENANT_1_PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
-                                .withStoreFile(certificateGenerator.getKeyStoreLocation())
-                                .withNewInlinePasswordStoreProvider(certificateGenerator.getPassword())
+                                .withStoreFile(keystoreTrustStorePair.brokerKeyStore())
+                                .withNewInlinePasswordStoreProvider(keystoreTrustStorePair.password())
                                 .endKeyStoreKey()
                                 .endTls()
                                 .build())
@@ -122,8 +113,8 @@ public abstract class BaseMultiTenantIT extends BaseIT {
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(TENANT_2_PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
-                                .withStoreFile(certificateGenerator.getKeyStoreLocation())
-                                .withNewInlinePasswordStoreProvider(certificateGenerator.getPassword())
+                                .withStoreFile(keystoreTrustStorePair.brokerKeyStore())
+                                .withNewInlinePasswordStoreProvider(keystoreTrustStorePair.password())
                                 .endKeyStoreKey()
                                 .endTls()
                                 .build())

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/multitenant/MultiTenantIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/multitenant/MultiTenantIT.java
@@ -81,7 +81,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
 
     @Test
     void createAndDeleteTopic(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster, this.certificateGenerator);
+        var config = getConfig(cluster, this.keystoreTrustStorePair);
 
         try (var tester = kroxyliciousTester(config);
                 var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
@@ -111,7 +111,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
 
     @Test
     void describeTopic(KafkaCluster cluster) {
-        var config = getConfig(cluster, this.certificateGenerator);
+        var config = getConfig(cluster, this.keystoreTrustStorePair);
         try (var tester = kroxyliciousTester(config);
                 var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
             var created = createTopics(admin, NEW_TOPIC_1);
@@ -127,7 +127,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
 
     @Test
     void produceOne(KafkaCluster cluster) {
-        var config = getConfig(cluster, this.certificateGenerator);
+        var config = getConfig(cluster, this.keystoreTrustStorePair);
         try (var tester = buildTester(config)) {
             final String topicName = tester.createTopic(TENANT_1_CLUSTER);
             produceAndAssert(tester, this.clientConfig, TENANT_1_CLUSTER, Stream.of(new ProducerRecord<>(topicName, MY_KEY, MY_VALUE)), Optional.empty());
@@ -136,14 +136,14 @@ class MultiTenantIT extends BaseMultiTenantIT {
 
     private KroxyliciousTester buildTester(ConfigurationBuilder config) {
         return KroxyliciousTesters.newBuilder(config)
-                .setTrustStoreLocation(this.certificateGenerator.getTrustStoreLocation())
-                .setTrustStorePassword(this.certificateGenerator.getPassword())
+                .setTrustStoreLocation(this.keystoreTrustStorePair.clientTrustStore())
+                .setTrustStorePassword(this.keystoreTrustStorePair.password())
                 .createDefaultKroxyliciousTester();
     }
 
     @Test
     void consumeOne(KafkaCluster cluster) {
-        var config = getConfig(cluster, this.certificateGenerator);
+        var config = getConfig(cluster, this.keystoreTrustStorePair);
         try (var tester = buildTester(config)) {
             var groupId = testInfo.getDisplayName();
             final String topicName = tester.createTopic(TENANT_1_CLUSTER);
@@ -155,7 +155,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
 
     @Test
     void consumeOneAndOffsetCommit(KafkaCluster cluster) {
-        var config = getConfig(cluster, this.certificateGenerator);
+        var config = getConfig(cluster, this.keystoreTrustStorePair);
         try (var tester = buildTester(config)) {
             var groupId = testInfo.getDisplayName();
             final String topicName = tester.createTopic(TENANT_1_CLUSTER);
@@ -168,7 +168,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
 
     @Test
     void alterOffsetCommit(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster, this.certificateGenerator);
+        var config = getConfig(cluster, this.keystoreTrustStorePair);
         try (var tester = buildTester(config);
                 var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
             var groupId = testInfo.getDisplayName();
@@ -186,7 +186,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
 
     @Test
     void deleteConsumerGroupOffsets(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster, this.certificateGenerator);
+        var config = getConfig(cluster, this.keystoreTrustStorePair);
         try (var tester = buildTester(config);
                 var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
             var groupId = testInfo.getDisplayName();
@@ -201,7 +201,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
 
     @Test
     void tenantTopicIsolation(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster, this.certificateGenerator);
+        var config = getConfig(cluster, this.keystoreTrustStorePair);
         try (var tester = kroxyliciousTester(config);
                 var adminTenant1 = tester.admin(TENANT_1_CLUSTER, this.clientConfig);
                 var adminTenant2 = tester.admin(TENANT_2_CLUSTER, this.clientConfig)) {
@@ -216,7 +216,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
     @ParameterizedTest
     @EnumSource
     void tenantConsumeWithGroup(ConsumerStyle consumerStyle, KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster, this.certificateGenerator);
+        var config = getConfig(cluster, this.keystoreTrustStorePair);
         try (var tester = kroxyliciousTester(config);
                 var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
             createTopics(admin, NEW_TOPIC_1);
@@ -228,7 +228,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
     @ParameterizedTest
     @EnumSource
     void tenantGroupIsolation(ConsumerStyle consumerStyle, KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster, this.certificateGenerator);
+        var config = getConfig(cluster, this.keystoreTrustStorePair);
         try (var tester = kroxyliciousTester(config);
                 var adminTenant1 = tester.admin(TENANT_1_CLUSTER, this.clientConfig);
                 var adminTenant2 = tester.admin(TENANT_2_CLUSTER, this.clientConfig)) {
@@ -243,7 +243,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
 
     @Test
     void describeGroup(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster, this.certificateGenerator);
+        var config = getConfig(cluster, this.keystoreTrustStorePair);
         try (var tester = kroxyliciousTester(config);
                 var adminTenant1 = tester.admin(TENANT_1_CLUSTER, this.clientConfig);
                 var adminTenant2 = tester.admin(TENANT_2_CLUSTER, this.clientConfig)) {
@@ -260,7 +260,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
 
     @Test
     void produceInTransaction(KafkaCluster cluster) {
-        var config = getConfig(cluster, this.certificateGenerator);
+        var config = getConfig(cluster, this.keystoreTrustStorePair);
         try (var tester = kroxyliciousTester(config);
                 var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
             createTopics(admin, NEW_TOPIC_1);
@@ -272,7 +272,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
 
     @Test
     void produceAndConsumeInTransaction(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster, this.certificateGenerator);
+        var config = getConfig(cluster, this.keystoreTrustStorePair);
         try (var tester = kroxyliciousTester(config);
                 var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
             // put some records in an input topic
@@ -327,7 +327,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
 
     @Test
     void describeTransaction(KafkaCluster cluster) {
-        var config = getConfig(cluster, this.certificateGenerator);
+        var config = getConfig(cluster, this.keystoreTrustStorePair);
         try (var tester = kroxyliciousTester(config)) {
             try (var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
                 createTopics(admin, NEW_TOPIC_1);
@@ -347,7 +347,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
 
     @Test
     void tenantTransactionalIdIsolation(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster, this.certificateGenerator);
+        var config = getConfig(cluster, this.keystoreTrustStorePair);
         try (var tester = kroxyliciousTester(config);
                 var adminTenant1 = tester.admin(TENANT_1_CLUSTER, this.clientConfig);
                 var adminTenant2 = tester.admin(TENANT_2_CLUSTER, this.clientConfig)) {
@@ -370,7 +370,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
     @Test
     void tenantPrefixUsingCustomSeparator(KafkaCluster cluster, KafkaAdminClient directAdmin) {
         var separator = ".";
-        var config = getConfig(cluster, this.certificateGenerator, Map.of("prefixResourceNameSeparator", separator));
+        var config = getConfig(cluster, this.keystoreTrustStorePair, Map.of("prefixResourceNameSeparator", separator));
         try (var tester = kroxyliciousTester(config);
                 var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
             createTopics(admin, NEW_TOPIC_1);

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/pom.xml
@@ -120,6 +120,10 @@
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-pkitesting</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/src/main/java/io/kroxylicious/testing/kms/azure/OauthServerContainer.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/src/main/java/io/kroxylicious/testing/kms/azure/OauthServerContainer.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.testing.kms.azure;
 
 import java.net.URI;
+import java.nio.file.Path;
 import java.time.Duration;
 
 import org.testcontainers.containers.GenericContainer;
@@ -14,35 +15,44 @@ import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
-import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
+import io.kroxylicious.testing.kafka.common.KeystoreManager;
 import io.kroxylicious.testing.kms.TestKmsFacadeException;
 
 @SuppressWarnings("java:S2160") // equals on superclass is not intended for use
 class OauthServerContainer extends GenericContainer<OauthServerContainer> {
 
+    private static final String PKCS12_KEYSTORE_TYPE = "PKCS12";
     // mock-oauth2-server is not uploaded to docker hub, so setting the digest doesn't work when looking for the image on docker hub.
     // When this issue https://github.com/testcontainers/testcontainers-java/issues/10527 is fixed, we can use the digest here.
     private static final DockerImageName DOCKER_IMAGE_NAME = DockerImageName.parse("ghcr.io/navikt/mock-oauth2-server:3.0.1");
     private static final String LOCALHOST = "localhost";
     private static final String CERT_FILE_MOUNT_PATH = "/etc/custom-certs";
-    private final KeytoolCertificateGenerator certs;
+    private final KeystoreTrustStorePair certs;
     private static final int INTERNAL_PORT = 8080;
 
-    private static KeytoolCertificateGenerator entraCerts() {
+    protected record KeystoreTrustStorePair(String brokerKeyStore, String keyStoreType, String clientTrustStore, String password) {}
+
+    protected static KeystoreTrustStorePair buildKeystoreTrustStorePair() {
+        var keystoreManager = new KeystoreManager();
+        String dn = keystoreManager.buildDistinguishedName("test@kroxylicious.io", LOCALHOST, "KI", "kroxylicious.io", null, null, "US");
+        Path keystorePath;
         try {
-            KeytoolCertificateGenerator entraCertGen = new KeytoolCertificateGenerator();
-            entraCertGen.generateSelfSignedCertificateEntry("webmaster@example.com", LOCALHOST, "Engineering", "kroxylicious.io", null, null, "NZ");
-            entraCertGen.generateTrustStore(entraCertGen.getCertFilePath(), "website");
-            return entraCertGen;
+            var bundle = keystoreManager.createSelfSignedCertificate(keystoreManager.newCertificateBuilder(dn));
+            keystorePath = keystoreManager.generateCertificateFile(bundle);
         }
         catch (Exception e) {
             throw new TestKmsFacadeException(e);
         }
+        String password = keystoreManager.getPassword(keystorePath);
+        // The generated JKS contains both the private key entry and the CA cert,
+        // so the same file serves as both the proxy keystore and the client truststore.
+        String keystore = keystorePath.toAbsolutePath().toString();
+        return new KeystoreTrustStorePair(keystore, PKCS12_KEYSTORE_TYPE, keystore, password);
     }
 
     OauthServerContainer() {
         super(DOCKER_IMAGE_NAME);
-        this.certs = entraCerts();
+        this.certs = buildKeystoreTrustStorePair();
         LogMessageWaitStrategy strategy = new LogMessageWaitStrategy().withRegEx(".*started server on address.*");
         strategy.withStartupTimeout(Duration.ofSeconds(10));
         setWaitStrategy(strategy);
@@ -60,22 +70,22 @@ class OauthServerContainer extends GenericContainer<OauthServerContainer> {
                         }
                     }
                 }
-                """.formatted(certs.getPassword(), CERT_FILE_MOUNT_PATH, certs.getKeyStoreType(), certs.getPassword());
+                """.formatted(certs.password(), CERT_FILE_MOUNT_PATH, certs.keyStoreType(), certs.password());
         withEnv("JSON_CONFIG", config);
         withEnv("LOG_LEVEL", "DEBUG"); // required to for the startup message to be logged.
-        withCopyFileToContainer(MountableFile.forHostPath(certs.getKeyStoreLocation()), CERT_FILE_MOUNT_PATH);
+        withCopyFileToContainer(MountableFile.forHostPath(certs.brokerKeyStore()), CERT_FILE_MOUNT_PATH);
     }
 
     public String getTrustStoreLocation() {
-        return certs.getTrustStoreLocation();
+        return certs.clientTrustStore();
     }
 
     public String getTrustStorePassword() {
-        return certs.getPassword();
+        return certs.password();
     }
 
     public String getTrustStoreType() {
-        return certs.getTrustStoreType();
+        return certs.keyStoreType();
     }
 
     public URI getBaseUri() {


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

`KeytoolCertificateGenerator` was deprecated on `kroxylicious-junit5-extension` 0.13.0 and we had still some ITs using it. In order to migrate IT cert fixtures from `KeytoolCertificateGenerator` to `KeystoreManager`, I have updated the following ITs:

### `kroxylicious-integration-tests` (3 files)
  
  | File | 
  |---|
  | `ExpositionIT.java` |
  | `MetricsIT.java` |
  | `filter/multitenant/BaseMultiTenantIT.java`  |

  ### `kroxylicious-integration-test-support` (2 files)

  | File | 
  |---|
  | `DefaultKroxyliciousTesterTest.java` | 
  | `KafkaClientTest.java` | 

  ### `kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support` (1 file)

  | File | 
  |---|
  | `OauthServerContainer.java` | 


### Additional Context

Partially covers #4008 

`AbstractTlsIT` and its extended class `TlsIT`, depend on [KafkaClusterConfig](https://github.com/kroxylicious/kroxylicious-junit5-extension/blob/main/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java#L377) class that still uses `KeytoolCertificateGenerator` as a parameter, so it cannot be removed until the kroxylicious-junit5-extension is updated.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
