### PR TITLE
feat(epic/routing-prototype): routing api and config

### DIFF
--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/Response.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/Response.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.router;
+
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+/**
+ * A response received from a route target (backing cluster or nested router).
+ */
+public interface Response {
+
+    /**
+     * @return the response header
+     */
+    ResponseHeaderData header();
+
+    /**
+     * @return the response body
+     */
+    ApiMessage body();
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/Router.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/Router.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.router;
+
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+/**
+ * A router decides which route should handle a given incoming Kafka request.
+ *
+ * <p>Router implementations use the {@link RouterContext} to send requests
+ * down named routes and to deliver a response back to the client. A single
+ * incoming request may result in multiple outgoing requests to different
+ * routes (e.g. fan-out), with the router composing the final response.</p>
+ *
+ * <h2>Observability guidelines for router implementations</h2>
+ *
+ * <p>The runtime automatically logs and measures the following on behalf of
+ * all router implementations:</p>
+ * <ul>
+ *   <li>Which route each request was sent to (at TRACE level, with {@code route} key)</li>
+ *   <li>Request/response correlation</li>
+ *   <li>Per-route request counts, error counts, and latency (as Micrometer metrics)</li>
+ *   <li>Error conditions such as unknown routes and router failures</li>
+ * </ul>
+ *
+ * <p>Router implementations should <strong>not</strong> duplicate the above.
+ * Instead, implementations should log:</p>
+ * <ul>
+ *   <li><strong>Routing rationale at DEBUG:</strong> explain <em>why</em> a
+ *       particular route was chosen when the logic is non-trivial. Always
+ *       include {@link RouterContext#sessionId()} for correlation with
+ *       runtime logs.</li>
+ *   <li><strong>Configuration at INFO during initialisation:</strong> log once
+ *       from {@link RouterFactory#createRouter} to describe the router's
+ *       configuration.</li>
+ *   <li><strong>Response mutation at DEBUG:</strong> if the router modifies
+ *       responses (e.g. version capping in {@code API_VERSIONS}), log the
+ *       modification since it changes protocol behaviour visible to
+ *       clients.</li>
+ *   <li><strong>Recovered errors at WARN:</strong> if the router catches
+ *       exceptions internally and recovers, log them with conditional stack
+ *       traces (include the full stack trace only when DEBUG is enabled).</li>
+ * </ul>
+ *
+ * <p>Router implementations <strong>must not</strong>:</p>
+ * <ul>
+ *   <li>Log Kafka message content (may contain sensitive data).</li>
+ *   <li>Log at INFO or above on every request (reserve INFO+ for lifecycle
+ *       events; per-request logging at that level causes excessive volume
+ *       in production).</li>
+ * </ul>
+ */
+public interface Router {
+
+    /**
+     * Called for each incoming client request that is dynamically routed.
+     *
+     * <p>The implementation inspects the request, sends one or more requests
+     * via {@link RouterContext#sendRequestToNode}, and returns a
+     * {@link RouterResult} encoding the outcome. Use
+     * {@link RouterResult.Completed Completed} to deliver a response,
+     * {@link RouterResult.CompletedNoResponse CompletedNoResponse} for
+     * acks=0 {@code Produce} requests, or {@link RouterResult.Disconnect Disconnect}
+     * to close the client connection.</p>
+     *
+     * <p><strong>Threading model</strong></p>
+     *
+     * <p>All invocations of this method, all calls to
+     * {@link RouterContext#sendRequestToNode}, and all
+     * {@link CompletionStage} callbacks chained on the futures returned
+     * by {@code sendRequestToNode}, execute on the same Netty event loop
+     * thread. Router implementations do not need to synchronise access
+     * to their own state.</p>
+     *
+     * @param apiVersion the API version of the request
+     * @param apiKey the API key identifying the request type
+     * @param header the request header
+     * @param request the request body
+     * @param context the router context for sending requests
+     * @return a stage that completes with the routing outcome
+     */
+    CompletionStage<RouterResult> onRequest(
+                                            short apiVersion,
+                                            ApiKeys apiKey,
+                                            RequestHeaderData header,
+                                            ApiMessage request,
+                                            RouterContext context);
+
+    /**
+     * Called by the runtime when the client connection is torn down.
+     *
+     * <p>Implementations should release any per-connection resources
+     * (e.g. reclaim cache slots).</p>
+     *
+     * <p>Guaranteed to be called on the same event loop thread as
+     * {@link #onRequest}. Called at most once per router instance.</p>
+     */
+    default void close() {
+    }
+
+    /**
+     * Declares API keys that are always forwarded to a fixed named route
+     * without deserialisation. For these API keys the runtime forwards
+     * frames directly (opaque or decoded) without calling
+     * {@link #onRequest}. API keys absent from this map are
+     * considered dynamically routed and will be decoded so that
+     * {@code onRequest} can inspect them.
+     *
+     * @return a map from API key to route name; empty means all API keys
+     *         are dynamically routed (the default)
+     */
+    default Map<ApiKeys, String> staticRoutes() {
+        return Map.of();
+    }
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterContext.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.router;
+
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import io.kroxylicious.proxy.authentication.Subject;
+
+/**
+ * Context passed to {@link Router#onRequest} for issuing requests
+ * to named routes.
+ */
+public interface RouterContext {
+
+    /**
+     * Returns the virtual node ID of a broker on the named route's cluster.
+     *
+     * <p>This is used to send initial requests (e.g. {@code METADATA}) before
+     * the router has discovered the cluster's full broker topology. Once
+     * {@code METADATA} responses arrive, the router uses the virtual node IDs
+     * from those responses to address specific brokers.</p>
+     *
+     * <p>The runtime selects which broker to return.</p>
+     *
+     * @param route the name of the route
+     * @return the virtual node ID of a bootstrap broker on the route's cluster
+     * @throws IllegalArgumentException if the route name is not known
+     */
+    int bootstrapNodeId(String route);
+
+    /**
+     * Sends a request to a specific broker identified by route and virtual node ID.
+     *
+     * <p>The runtime uses the route to determine which target cluster, and
+     * resolves the virtual node ID to a specific upstream broker address,
+     * opening a new connection if necessary. The returned stage completes
+     * when the broker produces a response.</p>
+     *
+     * @param route the name of the route
+     * @param virtualNodeId the virtual node ID of the target broker
+     * @param header the request header
+     * @param request the request body
+     * @return a stage that completes with the response from the broker
+     * @throws IllegalArgumentException if the route name is not known
+     * @throws IllegalStateException if the upstream address for the node is
+     *         not yet known (metadata not yet reconciled)
+     */
+    CompletionStage<Response> sendRequestToNode(
+                                                String route,
+                                                int virtualNodeId,
+                                                RequestHeaderData header,
+                                                ApiMessage request);
+
+    /**
+     * Returns the unique identifier for the current proxy session.
+     * The same session id will be observed for all routers and filters
+     * that observe the requests from a given client connection.
+     * @return the unique identifier for the current proxy session
+     */
+    String sessionId();
+
+    /**
+     * <p>Returns the client subject.</p>
+     *
+     * <p>Depending on configuration, the subject can be based on network-level
+     * or Kafka protocol-level information (or both):</p>
+     * <ul>
+     *   <li>This will return an anonymous {@code Subject} (one with an empty
+     *   {@code principals} set) when no authentication is configured, or the
+     *   transport layer cannot provide authentication (e.g. TCP or non-mutual
+     *   TLS transports).</li>
+     *   <li>When client mutual TLS authentication is configured this will
+     *   initially return a non-anonymous {@code Subject} based on the TLS
+     *   certificate presented by the client.</li>
+     *   <li>Because of the possibility of <em>reauthentication</em> it is
+     *   also possible for the subject to change.</li>
+     * </ul>
+     *
+     * <p>Because the subject can change, callers are advised to avoid caching
+     * subjects, or decisions derived from them.</p>
+     *
+     * <p>Which principals are present in the returned subject, and what their
+     * {@code name}s look like, depends on the configuration of network and/or
+     * authentication filters. In general, routers should be configurable with
+     * respect to the principal type when interrogating the returned subject.</p>
+     *
+     * @return the client subject
+     */
+    Subject authenticatedSubject();
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterFactory.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.router;
+
+import io.kroxylicious.proxy.plugin.PluginConfigurationException;
+
+import edu.umd.cs.findbugs.annotations.UnknownNullness;
+
+/**
+ * A pluggable source of {@link Router} instances.
+ *
+ * <p>RouterFactories are {@linkplain java.util.ServiceLoader service}
+ * implementations called by the proxy
+ * runtime to create router instances.</p>
+ *
+ * <p>The proxy runtime guarantees that:</p>
+ * <ol>
+ *   <li>instances will be {@linkplain #initialize initialized} before
+ *       any attempt to {@linkplain #createRouter create} router instances,</li>
+ *   <li>instances will eventually be {@linkplain #close closed} if and only
+ *       if they were successfully initialized,</li>
+ *   <li>no attempts to create router instances will be made once a
+ *       {@code RouterFactory} instance is closed,</li>
+ *   <li>instances will be initialized and closed on the same thread.</li>
+ * </ol>
+ *
+ * <p><strong>Per-connection router instances:</strong>
+ * {@link #createRouter} is called once per client connection, so each
+ * connection gets its own {@link Router} instance. Any state that must
+ * survive a client disconnect and reconnect (e.g. producer ID mappings)
+ * must be stored in the shared initialisation data {@code I}, not in
+ * the {@code Router} instance itself.</p>
+ *
+ * @param <C> the configuration type. Use {@link Void} if not configurable.
+ * @param <I> the initialisation data type
+ */
+public interface RouterFactory<C, I> {
+
+    /**
+     * Initializes the factory with the given configuration.
+     *
+     * @param context the factory context
+     * @param config the configuration
+     * @return initialisation data to be passed to {@link #createRouter}
+     * @throws PluginConfigurationException if the configuration is invalid
+     */
+    @UnknownNullness
+    I initialize(
+                 RouterFactoryContext context,
+                 @UnknownNullness C config)
+            throws PluginConfigurationException;
+
+    /**
+     * Creates a new router instance.
+     *
+     * <p>This may be called on a different thread from
+     * {@link #initialize} and {@link #close}.</p>
+     *
+     * @param context the factory context
+     * @param initializationData the data returned from {@link #initialize}
+     * @return a new router instance
+     */
+    Router createRouter(
+                        RouterFactoryContext context,
+                        @UnknownNullness I initializationData);
+
+    /**
+     * Releases resources associated with the given initialisation data.
+     *
+     * @param initializationData the data returned from {@link #initialize}
+     */
+    default void close(@UnknownNullness I initializationData) {
+    }
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterFactoryContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterFactoryContext.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.router;
+
+import java.util.Set;
+
+import io.kroxylicious.proxy.plugin.UnknownPluginInstanceException;
+
+/**
+ * Context for {@link RouterFactory} initialisation and router creation,
+ * providing access to the plugin registry and router identity.
+ */
+public interface RouterFactoryContext {
+
+    /**
+     * Returns the name of the virtual cluster that owns this router.
+     *
+     * @return the virtual cluster name
+     */
+    String virtualClusterName();
+
+    /**
+     * Returns the name of this router, as declared in the router definition.
+     *
+     * @return the router name
+     */
+    String routerName();
+
+    /**
+     * Gets a plugin instance for the given plugin type and name.
+     *
+     * @param <P> the plugin type
+     * @param pluginClass the plugin class
+     * @param implementationName the plugin implementation name
+     * @return the plugin instance
+     * @throws UnknownPluginInstanceException if the named implementation is unknown
+     */
+    <P> P pluginInstance(Class<P> pluginClass, String implementationName);
+
+    /**
+     * Returns the implementation names of the registered instances
+     * of the given plugin type.
+     *
+     * @param <P> the plugin type
+     * @param pluginClass the plugin class
+     * @return the set of known implementation names
+     */
+    <P> Set<String> pluginImplementationNames(Class<P> pluginClass);
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterResult.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterResult.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.router;
+
+/**
+ * The outcome of {@link Router#onRequest} processing. Encodes the result
+ * as a value rather than a side-effect on the context.
+ */
+public sealed interface RouterResult {
+
+    /**
+     * The router has produced a response for the client. The runtime delivers
+     * the response, automatically rewriting the correlation ID to match the
+     * client's original request.
+     *
+     * @param response the response to deliver to the client
+     */
+    record Completed(Response response) implements RouterResult {}
+
+    /**
+     * The router has finished processing but there is no response to deliver.
+     * This is the correct result for fire-and-forget requests (e.g.
+     * {@code PRODUCE} with {@code acks=0}).
+     */
+    record CompletedNoResponse() implements RouterResult {}
+
+    /**
+     * The router requests that the client connection be closed.
+     */
+    record Disconnect() implements RouterResult {}
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/package-info.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * The router API.
+ *
+ * <p>A {@link io.kroxylicious.proxy.router.Router} is a plugin that decides which
+ * {@linkplain io.kroxylicious.proxy.router.RouterContext#sendRequestToNode route}
+ * should handle a given incoming Kafka request. Routes lead to targets &mdash;
+ * either a backing Kafka cluster or another {@code Router}.
+ * The routers defined in a proxy configuration are validated at startup
+ * to ensure that all routes end in a defined target and to ensure the
+ * router graph is acyclic.</p>
+ *
+ * <p>Router implementations are discovered at runtime via
+ * {@link java.util.ServiceLoader} using
+ * {@link io.kroxylicious.proxy.router.RouterFactory} as the service type.</p>
+ */
+@ReturnValuesAreNonnullByDefault
+@DefaultAnnotationForParameters(NonNull.class)
+@DefaultAnnotation(NonNull.class)
+package io.kroxylicious.proxy.router;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotationForParameters;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/router/RouterResultTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/router/RouterResultTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.router;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class RouterResultTest {
+
+    @Mock
+    Response response;
+
+    @Test
+    void completedHoldsResponse() {
+        var result = new RouterResult.Completed(response);
+
+        assertThat(result.response()).isSameAs(response);
+        assertThat(result).isInstanceOf(RouterResult.class);
+    }
+
+    @Test
+    void completedNoResponseIsRouterResult() {
+        var result = new RouterResult.CompletedNoResponse();
+
+        assertThat(result).isInstanceOf(RouterResult.class);
+    }
+
+    @Test
+    void disconnectIsRouterResult() {
+        var result = new RouterResult.Disconnect();
+
+        assertThat(result).isInstanceOf(RouterResult.class);
+    }
+}

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/router/TestingRouterFactory.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/router/TestingRouterFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.router;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class TestingRouterFactory implements RouterFactory<Void, String> {
+
+    @Override
+    public String initialize(RouterFactoryContext context, Void config) {
+        return "init-data";
+    }
+
+    @Override
+    public Router createRouter(RouterFactoryContext context, String initializationData) {
+        return null;
+    }
+
+    @Test
+    void defaultCloseIsNoOp() {
+        assertThatCode(() -> new TestingRouterFactory().close("init-data")).doesNotThrowAnyException();
+    }
+}

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/config/ConfigurationTest.java
@@ -590,15 +590,7 @@ class ConfigurationTest {
                 new NamedFilterDefinition("foo", "", ""));
         Optional<Map<String, Object>> development = Optional.empty();
         var virtualCluster = List.of(VIRTUAL_CLUSTER);
-        assertThatThrownBy(() -> new Configuration(null,
-                filterDefinitions,
-                null,
-                virtualCluster,
-                null,
-                false,
-                development,
-                null,
-                null))
+        assertThatThrownBy(() -> new Configuration(null, null, filterDefinitions, null, null, virtualCluster, null, false, development, null, null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("'filterDefinitions' contains multiple items with the same names: [foo]");
     }
@@ -609,14 +601,7 @@ class ConfigurationTest {
         List<NamedFilterDefinition> filterDefinitions = List.of();
         List<String> defaultFilters = List.of("missing");
         var virtualCluster = List.of(VIRTUAL_CLUSTER);
-        assertThatThrownBy(() -> new Configuration(null, filterDefinitions,
-                defaultFilters,
-                virtualCluster,
-                null,
-                false,
-                development,
-                null,
-                null))
+        assertThatThrownBy(() -> new Configuration(null, null, filterDefinitions, defaultFilters, null, virtualCluster, null, false, development, null, null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("'defaultFilters' references filters not defined in 'filterDefinitions': [missing]");
     }
@@ -629,15 +614,7 @@ class ConfigurationTest {
         TargetCluster targetCluster = new TargetCluster("unused:9082", Optional.empty());
         List<VirtualCluster> virtualClusters = List
                 .of(new VirtualCluster("vc1", targetCluster, defaultGateway, false, false, List.of("missing")));
-        assertThatThrownBy(() -> new Configuration(
-                null,
-                filterDefinitions,
-                null,
-                virtualClusters,
-                null, false,
-                development,
-                null,
-                null))
+        assertThatThrownBy(() -> new Configuration(null, null, filterDefinitions, null, null, virtualClusters, null, false, development, null, null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("'virtualClusters.vc1.filters' references filters not defined in 'filterDefinitions': [missing]");
     }
@@ -656,15 +633,7 @@ class ConfigurationTest {
         List<VirtualClusterGateway> defaultGateway = List.of(VIRTUAL_CLUSTER_GATEWAY);
         TargetCluster targetCluster = new TargetCluster("unused:9082", Optional.empty());
         List<VirtualCluster> virtualClusters = List.of(new VirtualCluster("vc1", targetCluster, defaultGateway, false, false, List.of("used2")));
-        assertThatThrownBy(() -> new Configuration(null,
-                filterDefinitions,
-                defaultFilters,
-                virtualClusters,
-                null,
-                false,
-                development,
-                null,
-                null))
+        assertThatThrownBy(() -> new Configuration(null, null, filterDefinitions, defaultFilters, null, virtualClusters, null, false, development, null, null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage(
                         "'filterDefinitions' defines filters which are not used in 'defaultFilters', in any virtual cluster's 'filters', or in any route's 'filters': [unused]");
@@ -680,16 +649,8 @@ class ConfigurationTest {
         VirtualCluster direct = buildVirtualCluster("direct", "y:9092", List.of("foo")); // filters defined on cluster
         VirtualCluster defaulted = buildVirtualCluster("defaulted", "x:9092", null); // filters not defined => should default to the top level
 
-        Configuration configuration = new Configuration(
-                null,
-                filterDefinitions,
-                List.of("bar"),
-                List.of(direct, defaulted),
-                null,
-                false,
-                Optional.empty(),
-                null,
-                null);
+        Configuration configuration = new Configuration(null, null, filterDefinitions, List.of("bar"), null, List.of(direct, defaulted), null, false, Optional.empty(),
+                null, null);
 
         // When
         var model = configuration.virtualClusterModel(null);
@@ -705,37 +666,29 @@ class ConfigurationTest {
 
     @Test
     void proxyProtocolModeShouldReturnRequiredWhenRequired() {
-        Configuration configuration = new Configuration(null, null, null,
-                List.of(buildVirtualCluster("vc", "x:9092", null)),
-                null, false, Optional.empty(), null,
-                new ProxyProtocolConfig(ProxyProtocolMode.REQUIRED));
+        Configuration configuration = new Configuration(null, null, null, null, null, List.of(buildVirtualCluster("vc", "x:9092", null)), null, false, Optional.empty(),
+                null, new ProxyProtocolConfig(ProxyProtocolMode.REQUIRED));
         assertThat(configuration.proxyProtocolMode()).isEqualTo(ProxyProtocolMode.REQUIRED);
     }
 
     @Test
     void proxyProtocolModeShouldReturnAllowedWhenAllowed() {
-        Configuration configuration = new Configuration(null, null, null,
-                List.of(buildVirtualCluster("vc", "x:9092", null)),
-                null, false, Optional.empty(), null,
-                new ProxyProtocolConfig(ProxyProtocolMode.ALLOWED));
+        Configuration configuration = new Configuration(null, null, null, null, null, List.of(buildVirtualCluster("vc", "x:9092", null)), null, false, Optional.empty(),
+                null, new ProxyProtocolConfig(ProxyProtocolMode.ALLOWED));
         assertThat(configuration.proxyProtocolMode()).isEqualTo(ProxyProtocolMode.ALLOWED);
     }
 
     @Test
     void proxyProtocolModeShouldReturnDisabledWhenDisabled() {
-        Configuration configuration = new Configuration(null, null, null,
-                List.of(buildVirtualCluster("vc", "x:9092", null)),
-                null, false, Optional.empty(), null,
-                new ProxyProtocolConfig(ProxyProtocolMode.DISABLED));
+        Configuration configuration = new Configuration(null, null, null, null, null, List.of(buildVirtualCluster("vc", "x:9092", null)), null, false, Optional.empty(),
+                null, new ProxyProtocolConfig(ProxyProtocolMode.DISABLED));
         assertThat(configuration.proxyProtocolMode()).isEqualTo(ProxyProtocolMode.DISABLED);
     }
 
     @Test
     void proxyProtocolDefaultsToDisabledWhenNull() {
-        Configuration configuration = new Configuration(null, null, null,
-                List.of(buildVirtualCluster("vc", "x:9092", null)),
-                null, false, Optional.empty(), null,
-                null);
+        Configuration configuration = new Configuration(null, null, null, null, null, List.of(buildVirtualCluster("vc", "x:9092", null)), null, false, Optional.empty(),
+                null, null);
         assertThat(configuration.proxyProtocolMode()).isEqualTo(ProxyProtocolMode.DISABLED);
     }
 

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/config/ConfigurationTest.java
@@ -666,7 +666,8 @@ class ConfigurationTest {
                 null,
                 null))
                 .isInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("'filterDefinitions' defines filters which are not used in 'defaultFilters' or in any virtual cluster's 'filters': [unused]");
+                .hasMessage(
+                        "'filterDefinitions' defines filters which are not used in 'defaultFilters', in any virtual cluster's 'filters', or in any route's 'filters': [unused]");
     }
 
     @Test

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGenerator.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGenerator.java
@@ -127,16 +127,7 @@ class ProxyConfigGenerator {
                 ? filterDefs.stream().map(NamedFilterDefinition::name).toList()
                 : null;
 
-        var configuration = new Configuration(
-                management,
-                filterDefs,
-                defaultFilters,
-                List.of(virtualCluster),
-                null,
-                false,
-                Optional.empty(),
-                null,
-                null);
+        var configuration = new Configuration(management, null, filterDefs, defaultFilters, null, List.of(virtualCluster), null, false, Optional.empty(), null, null);
 
         return toYaml(configuration);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/assertj/OperatorAssertionsTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/assertj/OperatorAssertionsTest.java
@@ -91,23 +91,15 @@ class OperatorAssertionsTest {
     @Test
     void shouldReturnConfigurationAssert() {
         // Given
-        var configurations = new Configuration(null,
-                List.of(),
-                List.of(),
-                List.of(new VirtualCluster("Bob",
-                        new TargetCluster("", Optional.empty()),
-                        List.of(new VirtualClusterGateway("gateway",
-                                new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9090), null, null, List.of()),
-                                null,
-                                Optional.empty())),
-                        false,
-                        false,
-                        List.of())),
-                List.of(),
+        var configurations = new Configuration(null, null, List.of(), List.of(), null, List.of(new VirtualCluster("Bob",
+                new TargetCluster("", Optional.empty()),
+                List.of(new VirtualClusterGateway("gateway",
+                        new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9090), null, null, List.of()),
+                        null,
+                        Optional.empty())),
                 false,
-                Optional.empty(),
-                null,
-                null);
+                false,
+                List.of())), List.of(), false, Optional.empty(), null, null);
 
         // When
         Assert<?, ?> actualAssertion = OperatorAssertions.assertThat(configurations);

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/assertj/ProxyConfigAssertTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/assertj/ProxyConfigAssertTest.java
@@ -29,7 +29,7 @@ class ProxyConfigAssertTest {
         VirtualCluster virtualCluster = new VirtualCluster("cluster", new TargetCluster("localhost:9092", Optional.empty()),
                 List.of(virtualClusterGateway), false,
                 false, List.of());
-        Configuration config = new Configuration(null, null, null, List.of(virtualCluster), List.of(), false, Optional.empty(), null, null);
+        Configuration config = new Configuration(null, null, null, null, null, List.of(virtualCluster), List.of(), false, Optional.empty(), null, null);
 
         Assertions.assertThatThrownBy(() -> {
             OperatorAssertions.assertThat(config).cluster("arbitrary");
@@ -44,7 +44,7 @@ class ProxyConfigAssertTest {
         VirtualCluster virtualCluster = new VirtualCluster(clusterName, new TargetCluster("localhost:9092", Optional.empty()),
                 List.of(virtualClusterGateway), false,
                 false, List.of());
-        Configuration config = new Configuration(null, null, null, List.of(virtualCluster), List.of(), false, Optional.empty(), null, null);
+        Configuration config = new Configuration(null, null, null, null, null, List.of(virtualCluster), List.of(), false, Optional.empty(), null, null);
 
         ProxyConfigAssert.ProxyConfigClusterAssert cluster = OperatorAssertions.assertThat(config).cluster(clusterName);
         Assertions.assertThat(cluster.actual()).isNotNull().isSameAs(virtualCluster);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconciler.java
@@ -215,16 +215,8 @@ public class KafkaProxyReconciler implements
                 .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(VolumeMount::getMountPath).reversed())));
 
         return new ConfigurationFragment<>(
-                new Configuration(
-                        new ManagementConfiguration(null, null, new EndpointsConfiguration(new PrometheusMetricsConfig())),
-                        referencedFilters,
-                        null, // no defaultFilters <= each of the virtualClusters specifies its own
-                        virtualClusters.stream().map(ConfigurationFragment::fragment).toList(),
-                        List.of(),
-                        false,
-                        // micrometer
-                        Optional.empty(),
-                        NetworkDefinitionBuilder.build(proxy),
+                new Configuration(new ManagementConfiguration(null, null, new EndpointsConfiguration(new PrometheusMetricsConfig())), null, referencedFilters, null, null,
+                        virtualClusters.stream().map(ConfigurationFragment::fragment).toList(), List.of(), false, Optional.empty(), NetworkDefinitionBuilder.build(proxy),
                         null),
                 allVolumes,
                 allMounts);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/NetworkDefinitionBuilderTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/NetworkDefinitionBuilderTest.java
@@ -13,7 +13,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
+import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.config.NettySettings;
 import io.kroxylicious.proxy.config.NetworkDefinition;
 
@@ -261,5 +264,15 @@ class NetworkDefinitionBuilderTest {
         assertThatThrownBy(() -> NetworkDefinitionBuilder.build(proxy))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("not-a-duration");
+    }
+
+    @Test
+    void serializesDeterministically() throws JsonProcessingException {
+        NettySettings management = new NettySettings(Optional.of(1), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        NettySettings proxy = new NettySettings(Optional.of(2), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        NetworkDefinition networkDefinition = new NetworkDefinition(management, proxy);
+        String a = ConfigParser.createBaseObjectMapper().writeValueAsString(networkDefinition);
+        String b = ConfigParser.createBaseObjectMapper().writeValueAsString(networkDefinition);
+        assertThat(b).isEqualTo(a);
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/ClusterDefinition.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/ClusterDefinition.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.kroxylicious.proxy.config.tls.Tls;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * A named cluster definition, referenced by routes and virtual clusters.
+ *
+ * @param name unique name for this cluster
+ * @param bootstrapServers comma-separated list of host:port pairs
+ * @param tls optional TLS configuration for the upstream connection
+ */
+public record ClusterDefinition(
+                                @JsonProperty(required = true) String name,
+                                @JsonProperty(required = true) String bootstrapServers,
+                                @Nullable Tls tls) {
+
+    @JsonCreator
+    public ClusterDefinition {
+        Objects.requireNonNull(name, "'name' is required in a cluster definition");
+        Objects.requireNonNull(bootstrapServers, "'bootstrapServers' is required in a cluster definition");
+        bootstrapServers = bootstrapServers.replaceAll("\\s", "");
+    }
+
+    /**
+     * Converts this definition to a {@link TargetCluster} for use in the runtime.
+     */
+    public TargetCluster toTargetCluster() {
+        return new TargetCluster(bootstrapServers, Optional.ofNullable(tls));
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -33,6 +33,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * <br>
  *
  * @param management management configuration
+ * @param clusterDefinitions Named target cluster definitions, referenced by virtual clusters via {@code target.cluster}.
  * @param filterDefinitions A list of named filter definitions (names must be unique)
  * @param defaultFilters The names of the {@link #filterDefinitions()} to be use when a {@link VirtualCluster} doesn't specify its own {@link VirtualCluster#filters()}.
  * @param virtualClusters The virtual clusters
@@ -42,9 +43,11 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * @param network Controls aspects of network configuration for the proxy.
  * @param proxyProtocol PROXY protocol configuration.
  */
-@JsonPropertyOrder({ "management", "filterDefinitions", "defaultFilters", "virtualClusters", "micrometer", "useIoUring", "development", "network", "proxyProtocol" })
+@JsonPropertyOrder({ "management", "clusterDefinitions", "filterDefinitions", "defaultFilters", "virtualClusters", "micrometer", "useIoUring", "development", "network",
+        "proxyProtocol" })
 public record Configuration(
                             @Nullable ManagementConfiguration management,
+                            @Nullable List<ClusterDefinition> clusterDefinitions,
                             @Nullable List<NamedFilterDefinition> filterDefinitions,
                             @Nullable List<String> defaultFilters,
                             @JsonProperty(required = true) List<VirtualCluster> virtualClusters,
@@ -57,6 +60,22 @@ public record Configuration(
     private static final Logger LOGGER = LoggerFactory.getLogger(Configuration.class);
 
     /**
+     * Convenience constructor matching main branch signature, setting {@code clusterDefinitions} to {@code null}.
+     */
+    public Configuration(
+                         @Nullable ManagementConfiguration management,
+                         @Nullable List<NamedFilterDefinition> filterDefinitions,
+                         @Nullable List<String> defaultFilters,
+                         List<VirtualCluster> virtualClusters,
+                         @Nullable List<MicrometerDefinition> micrometer,
+                         boolean useIoUring,
+                         Optional<Map<String, Object>> development,
+                         @Nullable NetworkDefinition network,
+                         @Nullable ProxyProtocolConfig proxyProtocol) {
+        this(management, null, filterDefinitions, defaultFilters, virtualClusters, micrometer, useIoUring, development, network, proxyProtocol);
+    }
+
+    /**
      * Creates an instance of configuration.
      *
      */
@@ -67,6 +86,8 @@ public record Configuration(
         }
 
         validateNoDuplicatedClusterNames(virtualClusters);
+        Set<String> targetClusterNames = validateClusterDefinitions(clusterDefinitions);
+        validateVirtualClusterNamedTargets(virtualClusters, targetClusterNames);
 
         // Enforce post condition: filterDefinitions have a unique name
         if (filterDefinitions != null) {
@@ -76,15 +97,38 @@ public record Configuration(
                 throw new IllegalConfigurationException("'filterDefinitions' contains multiple items with the same names: " + duplicatedNames);
             }
 
-            // Enforce post condition: Every filter referenced by a name is defined in the filterDefinitions
-            Set<String> filterDefsByName = Optional.ofNullable(filterDefinitions).orElse(List.of()).stream().map(NamedFilterDefinition::name).collect(
-                    Collectors.toSet());
+            Set<String> filterDefsByName = filterDefinitions.stream().map(NamedFilterDefinition::name).collect(Collectors.toSet());
             checkNamedFiltersAreDefined(filterDefsByName, defaultFilters, "defaultFilters");
             for (var virtualCluster : virtualClusters) {
                 checkNamedFiltersAreDefined(filterDefsByName, virtualCluster.filters(), "virtualClusters." + virtualCluster.name() + ".filters");
             }
 
             checkAllNamedFilterAreUsed(filterDefinitions, virtualClusters, defaultFilters);
+        }
+    }
+
+    private static Set<String> validateClusterDefinitions(@Nullable List<ClusterDefinition> clusterDefinitions) {
+        if (clusterDefinitions == null || clusterDefinitions.isEmpty()) {
+            return Set.of();
+        }
+        var names = clusterDefinitions.stream().map(ClusterDefinition::name).toList();
+        var duplicates = names.stream()
+                .filter(n -> Collections.frequency(names, n) > 1)
+                .collect(Collectors.toSet());
+        if (!duplicates.isEmpty()) {
+            throw new IllegalConfigurationException(
+                    "'clusterDefinitions' contains duplicate names: " + duplicates);
+        }
+        return new HashSet<>(names);
+    }
+
+    private static void validateVirtualClusterNamedTargets(List<VirtualCluster> virtualClusters,
+                                                           Set<String> targetClusterNames) {
+        for (var vc : virtualClusters) {
+            if (vc.namedTargetCluster() != null && !targetClusterNames.contains(vc.namedTargetCluster())) {
+                throw new IllegalConfigurationException(
+                        "Virtual cluster '" + vc.name() + "' references unknown target cluster '" + vc.namedTargetCluster() + "'");
+            }
         }
     }
 
@@ -132,12 +176,13 @@ public record Configuration(
         }
     }
 
-    private static VirtualClusterModel toVirtualClusterModel(VirtualCluster virtualCluster,
-                                                             List<NamedFilterDefinition> filterDefinitions,
-                                                             PluginFactoryRegistry pfr) {
+    private VirtualClusterModel toVirtualClusterModel(VirtualCluster virtualCluster,
+                                                      List<NamedFilterDefinition> filterDefinitions,
+                                                      PluginFactoryRegistry pfr) {
+        TargetCluster resolvedTargetCluster = resolveTargetCluster(virtualCluster);
 
         VirtualClusterModel virtualClusterModel = new VirtualClusterModel(virtualCluster.name(),
-                virtualCluster.targetCluster(),
+                resolvedTargetCluster,
                 virtualCluster.logNetwork(),
                 virtualCluster.logFrames(),
                 filterDefinitions,
@@ -150,6 +195,26 @@ public record Configuration(
         virtualClusterModel.logVirtualClusterSummary();
 
         return virtualClusterModel;
+    }
+
+    private TargetCluster resolveTargetCluster(VirtualCluster virtualCluster) {
+        if (virtualCluster.targetCluster() != null) {
+            return virtualCluster.targetCluster();
+        }
+        if (virtualCluster.namedTargetCluster() != null) {
+            return resolveNamedTargetCluster(virtualCluster.namedTargetCluster(), virtualCluster.name());
+        }
+        throw new IllegalConfigurationException(
+                "Virtual cluster '" + virtualCluster.name() + "' has no resolvable target cluster");
+    }
+
+    private TargetCluster resolveNamedTargetCluster(String clusterName, String virtualClusterName) {
+        return Optional.ofNullable(clusterDefinitions).orElse(List.of()).stream()
+                .filter(cd -> cd.name().equals(clusterName))
+                .findFirst()
+                .orElseThrow(() -> new IllegalConfigurationException(
+                        "Virtual cluster '" + virtualClusterName + "' references unknown target cluster '" + clusterName + "'"))
+                .toTargetCluster();
     }
 
     private static void addGateways(List<VirtualClusterGateway> gateways, VirtualClusterModel virtualClusterModel) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -62,22 +62,6 @@ public record Configuration(
     private static final Logger LOGGER = LoggerFactory.getLogger(Configuration.class);
 
     /**
-     * Convenience constructor matching main branch signature, setting {@code clusterDefinitions} and {@code routerDefinitions} to {@code null}.
-     */
-    public Configuration(
-                         @Nullable ManagementConfiguration management,
-                         @Nullable List<NamedFilterDefinition> filterDefinitions,
-                         @Nullable List<String> defaultFilters,
-                         List<VirtualCluster> virtualClusters,
-                         @Nullable List<MicrometerDefinition> micrometer,
-                         boolean useIoUring,
-                         Optional<Map<String, Object>> development,
-                         @Nullable NetworkDefinition network,
-                         @Nullable ProxyProtocolConfig proxyProtocol) {
-        this(management, null, filterDefinitions, defaultFilters, null, virtualClusters, micrometer, useIoUring, development, network, proxyProtocol);
-    }
-
-    /**
      * Creates an instance of configuration.
      *
      */

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -6,8 +6,8 @@
 package io.kroxylicious.proxy.config;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -33,9 +33,10 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * <br>
  *
  * @param management management configuration
- * @param clusterDefinitions Named target cluster definitions, referenced by virtual clusters via {@code target.cluster}.
+ * @param clusterDefinitions Named target cluster definitions, referenced by virtual clusters and routes.
  * @param filterDefinitions A list of named filter definitions (names must be unique)
  * @param defaultFilters The names of the {@link #filterDefinitions()} to be use when a {@link VirtualCluster} doesn't specify its own {@link VirtualCluster#filters()}.
+ * @param routerDefinitions Named router definitions.
  * @param virtualClusters The virtual clusters
  * @param micrometer The micrometer config
  * @param useIoUring true to use iouring
@@ -43,13 +44,14 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * @param network Controls aspects of network configuration for the proxy.
  * @param proxyProtocol PROXY protocol configuration.
  */
-@JsonPropertyOrder({ "management", "clusterDefinitions", "filterDefinitions", "defaultFilters", "virtualClusters", "micrometer", "useIoUring", "development", "network",
-        "proxyProtocol" })
+@JsonPropertyOrder({ "management", "clusterDefinitions", "filterDefinitions", "defaultFilters", "routerDefinitions", "virtualClusters", "micrometer", "useIoUring",
+        "development", "network", "proxyProtocol" })
 public record Configuration(
                             @Nullable ManagementConfiguration management,
                             @Nullable List<ClusterDefinition> clusterDefinitions,
                             @Nullable List<NamedFilterDefinition> filterDefinitions,
                             @Nullable List<String> defaultFilters,
+                            @Nullable List<RouterDefinition> routerDefinitions,
                             @JsonProperty(required = true) List<VirtualCluster> virtualClusters,
                             @Nullable List<MicrometerDefinition> micrometer,
                             boolean useIoUring,
@@ -60,7 +62,7 @@ public record Configuration(
     private static final Logger LOGGER = LoggerFactory.getLogger(Configuration.class);
 
     /**
-     * Convenience constructor matching main branch signature, setting {@code clusterDefinitions} to {@code null}.
+     * Convenience constructor matching main branch signature, setting {@code clusterDefinitions} and {@code routerDefinitions} to {@code null}.
      */
     public Configuration(
                          @Nullable ManagementConfiguration management,
@@ -72,7 +74,7 @@ public record Configuration(
                          Optional<Map<String, Object>> development,
                          @Nullable NetworkDefinition network,
                          @Nullable ProxyProtocolConfig proxyProtocol) {
-        this(management, null, filterDefinitions, defaultFilters, virtualClusters, micrometer, useIoUring, development, network, proxyProtocol);
+        this(management, null, filterDefinitions, defaultFilters, null, virtualClusters, micrometer, useIoUring, development, network, proxyProtocol);
     }
 
     /**
@@ -89,7 +91,7 @@ public record Configuration(
         Set<String> targetClusterNames = validateClusterDefinitions(clusterDefinitions);
         validateVirtualClusterNamedTargets(virtualClusters, targetClusterNames);
 
-        // Enforce post condition: filterDefinitions have a unique name
+        Set<String> filterDefsByName = Set.of();
         if (filterDefinitions != null) {
             Map<String, List<NamedFilterDefinition>> groupdByName = filterDefinitions.stream().collect(Collectors.groupingBy(NamedFilterDefinition::name));
             var duplicatedNames = groupdByName.entrySet().stream().filter(entry -> entry.getValue().size() > 1).map(Map.Entry::getKey).toList();
@@ -97,37 +99,87 @@ public record Configuration(
                 throw new IllegalConfigurationException("'filterDefinitions' contains multiple items with the same names: " + duplicatedNames);
             }
 
-            Set<String> filterDefsByName = filterDefinitions.stream().map(NamedFilterDefinition::name).collect(Collectors.toSet());
+            filterDefsByName = filterDefinitions.stream().map(NamedFilterDefinition::name).collect(Collectors.toSet());
             checkNamedFiltersAreDefined(filterDefsByName, defaultFilters, "defaultFilters");
             for (var virtualCluster : virtualClusters) {
                 checkNamedFiltersAreDefined(filterDefsByName, virtualCluster.filters(), "virtualClusters." + virtualCluster.name() + ".filters");
             }
+        }
 
-            checkAllNamedFilterAreUsed(filterDefinitions, virtualClusters, defaultFilters);
+        validateRouterDefinitions(routerDefinitions, targetClusterNames, filterDefsByName);
+        validateVirtualClusterReceivers(virtualClusters, targetClusterNames, routerDefinitions);
+
+        if (filterDefinitions != null) {
+            checkAllNamedFilterAreUsed(filterDefinitions, virtualClusters, defaultFilters, routerDefinitions);
         }
     }
 
+    /**
+     * Validates that cluster definition names are unique and returns the set of names.
+     */
     private static Set<String> validateClusterDefinitions(@Nullable List<ClusterDefinition> clusterDefinitions) {
         if (clusterDefinitions == null || clusterDefinitions.isEmpty()) {
             return Set.of();
         }
-        var names = clusterDefinitions.stream().map(ClusterDefinition::name).toList();
-        var duplicates = names.stream()
-                .filter(n -> Collections.frequency(names, n) > 1)
-                .collect(Collectors.toSet());
-        if (!duplicates.isEmpty()) {
-            throw new IllegalConfigurationException(
-                    "'clusterDefinitions' contains duplicate names: " + duplicates);
-        }
-        return new HashSet<>(names);
+        return validateUniqueNames(clusterDefinitions, ClusterDefinition::name, "clusterDefinitions");
     }
 
+    /**
+     * Validates that router definition names are unique, that all route filter references
+     * are defined, and that the router graph is a valid DAG.
+     */
+    private static void validateRouterDefinitions(@Nullable List<RouterDefinition> routerDefinitions,
+                                                  Set<String> targetClusterNames,
+                                                  Set<String> filterDefsByName) {
+        if (routerDefinitions == null || routerDefinitions.isEmpty()) {
+            return;
+        }
+        validateUniqueNames(routerDefinitions, RouterDefinition::name, "routerDefinitions");
+
+        for (var router : routerDefinitions) {
+            for (var route : router.routes()) {
+                if (route.filters() != null) {
+                    checkNamedFiltersAreDefined(filterDefsByName, route.filters(),
+                            "routerDefinitions." + router.name() + ".routes." + route.name() + ".filters");
+                }
+            }
+        }
+
+        RouterGraphValidator.validate(routerDefinitions, targetClusterNames);
+    }
+
+    /**
+     * Validates that named target cluster references in virtual clusters resolve to known cluster definitions.
+     */
     private static void validateVirtualClusterNamedTargets(List<VirtualCluster> virtualClusters,
                                                            Set<String> targetClusterNames) {
         for (var vc : virtualClusters) {
             if (vc.namedTargetCluster() != null && !targetClusterNames.contains(vc.namedTargetCluster())) {
                 throw new IllegalConfigurationException(
                         "Virtual cluster '" + vc.name() + "' references unknown target cluster '" + vc.namedTargetCluster() + "'");
+            }
+        }
+    }
+
+    /**
+     * Validates that virtual cluster target references (both cluster and router) resolve
+     * to known definitions.
+     */
+    private static void validateVirtualClusterReceivers(List<VirtualCluster> virtualClusters,
+                                                        Set<String> targetClusterNames,
+                                                        @Nullable List<RouterDefinition> routerDefinitions) {
+        Set<String> routerNames = Optional.ofNullable(routerDefinitions).orElse(List.of()).stream()
+                .map(RouterDefinition::name)
+                .collect(Collectors.toSet());
+
+        for (var vc : virtualClusters) {
+            if (vc.namedTargetCluster() != null && !targetClusterNames.contains(vc.namedTargetCluster())) {
+                throw new IllegalConfigurationException(
+                        "Virtual cluster '" + vc.name() + "' references unknown target cluster '" + vc.namedTargetCluster() + "'");
+            }
+            if (vc.router() != null && !routerNames.contains(vc.router())) {
+                throw new IllegalConfigurationException(
+                        "Virtual cluster '" + vc.name() + "' references unknown router '" + vc.router() + "'");
             }
         }
     }
@@ -145,14 +197,17 @@ public record Configuration(
         }
     }
 
+    /**
+     * Validates that virtual cluster names are unique (case-insensitive comparison).
+     */
     private void validateNoDuplicatedClusterNames(List<VirtualCluster> clusters) {
-        var names = clusters.stream()
-                .map(VirtualCluster::name)
-                .map(name -> name.toLowerCase(Locale.ROOT))
-                .toList();
-        var duplicates = names.stream()
-                .filter(i -> Collections.frequency(names, i) > 1)
-                .collect(Collectors.toSet());
+        Set<String> seen = new HashSet<>();
+        Set<String> duplicates = new LinkedHashSet<>();
+        for (var vc : clusters) {
+            if (!seen.add(vc.name().toLowerCase(Locale.ROOT))) {
+                duplicates.add(vc.name().toLowerCase(Locale.ROOT));
+            }
+        }
         if (!duplicates.isEmpty()) {
             throw new IllegalConfigurationException(
                     "Virtual cluster must be unique (case insensitive). The following virtual cluster names are duplicated: [%s]".formatted(
@@ -160,7 +215,27 @@ public record Configuration(
         }
     }
 
-    private void checkAllNamedFilterAreUsed(List<NamedFilterDefinition> filterDefinitions, List<VirtualCluster> clusters, List<String> defaultFilters) {
+    private static <T> Set<String> validateUniqueNames(List<T> items,
+                                                       Function<T, String> nameExtractor,
+                                                       String context) {
+        Set<String> seen = new HashSet<>();
+        Set<String> duplicates = new LinkedHashSet<>();
+        for (T item : items) {
+            if (!seen.add(nameExtractor.apply(item))) {
+                duplicates.add(nameExtractor.apply(item));
+            }
+        }
+        if (!duplicates.isEmpty()) {
+            throw new IllegalConfigurationException(
+                    "'" + context + "' contains duplicate names: " + duplicates);
+        }
+        return seen;
+    }
+
+    private static void checkAllNamedFilterAreUsed(List<NamedFilterDefinition> filterDefinitions,
+                                                   List<VirtualCluster> clusters,
+                                                   @Nullable List<String> defaultFilters,
+                                                   @Nullable List<RouterDefinition> routerDefinitions) {
         var defined = filterDefinitions.stream().map(NamedFilterDefinition::name).collect(Collectors.toCollection(HashSet::new));
         if (defaultFilters != null) {
             defaultFilters.forEach(defined::remove);
@@ -170,9 +245,18 @@ public record Configuration(
                 .filter(Objects::nonNull)
                 .flatMap(Collection::stream)
                 .forEach(defined::remove);
+        if (routerDefinitions != null) {
+            routerDefinitions.stream()
+                    .flatMap(r -> r.routes().stream())
+                    .map(RouteDefinition::filters)
+                    .filter(Objects::nonNull)
+                    .flatMap(Collection::stream)
+                    .forEach(defined::remove);
+        }
         if (!defined.isEmpty()) {
             throw new IllegalConfigurationException(
-                    "'filterDefinitions' defines filters which are not used in 'defaultFilters' or in any virtual cluster's 'filters': " + defined);
+                    "'filterDefinitions' defines filters which are not used in 'defaultFilters', "
+                            + "in any virtual cluster's 'filters', or in any route's 'filters': " + defined);
         }
     }
 
@@ -245,6 +329,8 @@ public record Configuration(
     }
 
     public List<VirtualClusterModel> virtualClusterModel(PluginFactoryRegistry pfr) {
+        rejectUnsupportedRoutingConfig();
+
         var filterDefinitionsByName = Optional.ofNullable(this.filterDefinitions()).orElse(List.of())
                 .stream()
                 .collect(Collectors.toMap(NamedFilterDefinition::name, Function.identity()));
@@ -255,6 +341,20 @@ public record Configuration(
                     return toVirtualClusterModel(virtualCluster, filterDefinitions, pfr);
                 })
                 .toList();
+    }
+
+    private void rejectUnsupportedRoutingConfig() {
+        if (routerDefinitions != null && !routerDefinitions.isEmpty()) {
+            throw new IllegalConfigurationException(
+                    "Routing is not yet supported in this version. Remove 'routerDefinitions' from configuration.");
+        }
+        for (var vc : virtualClusters) {
+            if (vc.router() != null) {
+                throw new IllegalConfigurationException(
+                        "Routing is not yet supported in this version. Virtual cluster '"
+                                + vc.name() + "' uses a router target, which is not yet implemented.");
+            }
+        }
     }
 
     private List<NamedFilterDefinition> namedFilterDefinitionsForCluster(Map<String, NamedFilterDefinition> filterDefinitionsByName,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouteDefinition.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouteDefinition.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * A route within a router definition.
+ *
+ * @param name unique name within the enclosing router
+ * @param id numeric identifier for this route, used in the virtual node ID mapping formula
+ * @param filters optional list of filter names applied to requests on this route
+ * @param target the route's target (a cluster or another router)
+ */
+public record RouteDefinition(
+                              @JsonProperty(required = true) String name,
+                              @JsonInclude(JsonInclude.Include.ALWAYS) @JsonProperty(required = true) int id,
+                              @Nullable List<String> filters,
+                              @JsonProperty(required = true) RouteTarget target) {
+
+    @JsonCreator
+    public RouteDefinition {
+        Objects.requireNonNull(name, "'name' is required in a route definition");
+        Objects.requireNonNull(target, "'target' is required in route '" + name + "'");
+        if (id < 0) {
+            throw new IllegalConfigurationException(
+                    "Route '" + name + "' has invalid id " + id + ": must be >= 0");
+        }
+    }
+
+    @Nullable
+    public String cluster() {
+        return target.cluster();
+    }
+
+    @Nullable
+    public String router() {
+        return target.router();
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouteTarget.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouteTarget.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * A target for a route: exactly one of {@code cluster} or {@code router} must be specified.
+ *
+ * @param cluster name of a cluster defined in {@code clusterDefinitions}
+ * @param router name of a router defined in {@code routerDefinitions}
+ */
+public record RouteTarget(@Nullable String cluster,
+                          @Nullable String router) {
+
+    @JsonCreator
+    public RouteTarget {
+        if (cluster != null && router != null) {
+            throw new IllegalConfigurationException(
+                    "Route target must specify exactly one of 'cluster' or 'router', but both were provided");
+        }
+        if (cluster == null && router == null) {
+            throw new IllegalConfigurationException(
+                    "Route target must specify exactly one of 'cluster' or 'router', but neither was provided");
+        }
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouterDefinition.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouterDefinition.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.kroxylicious.proxy.plugin.PluginImplConfig;
+import io.kroxylicious.proxy.plugin.PluginImplName;
+import io.kroxylicious.proxy.router.RouterFactory;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * A named router definition referencing a {@link RouterFactory} plugin type.
+ *
+ * @param name unique name for this router
+ * @param type the {@link RouterFactory} plugin implementation name
+ * @param config optional plugin-specific configuration
+ * @param routes the routes available from this router
+ */
+public record RouterDefinition(
+                               @JsonProperty(required = true) String name,
+                               @PluginImplName(RouterFactory.class) @JsonProperty(required = true) String type,
+                               @Nullable @PluginImplConfig(implNameProperty = "type") Object config,
+                               @JsonProperty(required = true) List<RouteDefinition> routes) {
+
+    @JsonCreator
+    public RouterDefinition {
+        Objects.requireNonNull(name, "'name' is required in a router definition");
+        Objects.requireNonNull(type, "'type' is required in a router definition");
+        if (routes == null || routes.isEmpty()) {
+            throw new IllegalConfigurationException("Router '" + name + "' must have at least one route");
+        }
+        var routeNames = routes.stream()
+                .map(RouteDefinition::name)
+                .toList();
+        var nameDuplicates = routeNames.stream()
+                .filter(n -> Collections.frequency(routeNames, n) > 1)
+                .collect(Collectors.toSet());
+        if (!nameDuplicates.isEmpty()) {
+            throw new IllegalConfigurationException(
+                    "Router '" + name + "' has duplicate route names: " + nameDuplicates);
+        }
+        var routeIds = routes.stream()
+                .map(RouteDefinition::id)
+                .toList();
+        var idDuplicates = routeIds.stream()
+                .filter(id -> Collections.frequency(routeIds, id) > 1)
+                .collect(Collectors.toSet());
+        if (!idDuplicates.isEmpty()) {
+            throw new IllegalConfigurationException(
+                    "Router '" + name + "' has duplicate route ids: " + idDuplicates);
+        }
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouterGraphValidator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouterGraphValidator.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Validates that router definitions form a directed acyclic graph (DAG).
+ */
+class RouterGraphValidator {
+
+    static final int MAX_SAFE_TARGET_NODE_ID = 100_000;
+
+    private RouterGraphValidator() {
+    }
+
+    /**
+     * Validates that the given router definitions form a DAG, and that all
+     * target cluster and router references are resolvable.
+     *
+     * @param routerDefinitions the router definitions to validate
+     * @param targetClusterNames the set of known target cluster names
+     * @throws IllegalConfigurationException if the graph contains a cycle or a dangling reference
+     */
+    static void validate(List<RouterDefinition> routerDefinitions,
+                         Set<String> targetClusterNames) {
+        Map<String, RouterDefinition> routersByName = routerDefinitions.stream()
+                .collect(Collectors.toMap(RouterDefinition::name, r -> r));
+
+        validateReferences(routerDefinitions, routersByName, targetClusterNames);
+        validateRouteIds(routerDefinitions);
+        detectCycles(routerDefinitions, routersByName);
+    }
+
+    private static void validateReferences(List<RouterDefinition> routerDefinitions,
+                                           Map<String, RouterDefinition> routersByName,
+                                           Set<String> targetClusterNames) {
+        for (var router : routerDefinitions) {
+            for (var route : router.routes()) {
+                if (route.cluster() != null && !targetClusterNames.contains(route.cluster())) {
+                    throw new IllegalConfigurationException(
+                            "Route '" + route.name() + "' in router '" + router.name()
+                                    + "' references unknown cluster '" + route.cluster() + "'");
+                }
+                if (route.router() != null && !routersByName.containsKey(route.router())) {
+                    throw new IllegalConfigurationException(
+                            "Route '" + route.name() + "' in router '" + router.name()
+                                    + "' references unknown router '" + route.router() + "'");
+                }
+            }
+        }
+    }
+
+    private static void validateRouteIds(List<RouterDefinition> routerDefinitions) {
+        for (var router : routerDefinitions) {
+            int routeCount = router.routes().size();
+            for (var route : router.routes()) {
+                if (route.id() >= routeCount) {
+                    throw new IllegalConfigurationException(
+                            "Route '" + route.name() + "' in router '" + router.name()
+                                    + "' has id " + route.id()
+                                    + " which is outside the valid range [0, " + routeCount + ")");
+                }
+            }
+            if (routeCount >= 2) {
+                long maxVirtual = (long) routeCount * MAX_SAFE_TARGET_NODE_ID;
+                if (maxVirtual > Integer.MAX_VALUE) {
+                    throw new IllegalConfigurationException(
+                            "Router '" + router.name() + "' has " + routeCount
+                                    + " routes which risks integer overflow in virtual node ID mapping"
+                                    + " for target node IDs up to " + MAX_SAFE_TARGET_NODE_ID);
+                }
+            }
+        }
+    }
+
+    private static void detectCycles(List<RouterDefinition> routerDefinitions,
+                                     Map<String, RouterDefinition> routersByName) {
+        Set<String> visited = new HashSet<>();
+        Set<String> inStack = new HashSet<>();
+
+        for (var router : routerDefinitions) {
+            if (!visited.contains(router.name())) {
+                List<String> path = new ArrayList<>();
+                // When hasCycle returns true, path ends with the repeated node that closes
+                // the cycle (e.g. [A, B, C, A]). formatCycle uses this to extract and
+                // format just the cycle portion.
+                if (hasCycle(router.name(), routersByName, visited, inStack, path)) {
+                    throw new IllegalConfigurationException(
+                            "Router definitions contain a cycle: " + formatCycle(path));
+                }
+            }
+        }
+    }
+
+    private static boolean hasCycle(String routerName,
+                                    Map<String, RouterDefinition> routersByName,
+                                    Set<String> visited,
+                                    Set<String> inStack,
+                                    List<String> path) {
+        visited.add(routerName);
+        inStack.add(routerName);
+        path.add(routerName);
+
+        RouterDefinition router = routersByName.get(routerName);
+        if (router != null) {
+            for (var route : router.routes()) {
+                String target = route.router();
+                if (target != null) {
+                    if (inStack.contains(target)) {
+                        path.add(target);
+                        return true;
+                    }
+                    if (!visited.contains(target) && hasCycle(target, routersByName, visited, inStack, path)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        inStack.remove(routerName);
+        path.remove(path.size() - 1);
+        return false;
+    }
+
+    private static String formatCycle(List<String> path) {
+        int cycleStart = path.indexOf(path.get(path.size() - 1));
+        return String.join(" -> ", path.subList(cycleStart, path.size()));
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
@@ -31,7 +31,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * @param drainTimeout maximum time to wait for in-flight requests to complete during
  *                     graceful connection draining for this cluster
  */
-@SuppressWarnings("java:S1123")
+@SuppressWarnings("java:S1123") // suppressing the spurious warning about missing @deprecated in javadoc. It is the field that is deprecated, not the class.
 public record VirtualCluster(@JsonProperty(required = true) String name,
                              @Deprecated @Nullable TargetCluster targetCluster,
                              @Nullable RouteTarget target,
@@ -46,7 +46,7 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
     private static final Pattern DNS_LABEL_PATTERN = Pattern.compile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", Pattern.CASE_INSENSITIVE);
     private static final Duration DEFAULT_DRAIN_TIMEOUT = Duration.ofSeconds(10);
 
-    @SuppressWarnings("java:S2789")
+    @SuppressWarnings("java:S2789") // S2789 - checking for null tls is the intent
     public VirtualCluster {
         Objects.requireNonNull(name);
         if (!isDnsLabel(name)) {
@@ -66,6 +66,10 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
             throw new IllegalConfigurationException("one or more gateways were null for virtual cluster '" + name + "'");
         }
         validateNoDuplicatedGatewayNames(gateways);
+        // Validate explicitly-supplied drainTimeout. A null drainTimeout is allowed and
+        // means "use the proxy's default"; the resolved value is supplied by
+        // effectiveDrainTimeout() at the use site so that round-trip serialization
+        // preserves null and the operator-generated configs don't bake in today's default.
         if (drainTimeout != null && (drainTimeout.isZero() || drainTimeout.isNegative())) {
             throw new IllegalConfigurationException(
                     "drainTimeout for virtual cluster '" + name + "' must be positive, got: " + drainTimeout);
@@ -131,10 +135,29 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
         return topicNameCache == null ? CacheConfiguration.DEFAULT : topicNameCache;
     }
 
+    /**
+     * Resolves the {@code drainTimeout} for this virtual cluster, applying the proxy's
+     * default when the field is {@code null}. Used at the construction site of
+     * {@link io.kroxylicious.proxy.model.VirtualClusterModel} so that the raw record
+     * component remains nullable (preserving Jackson round-trip fidelity), while the
+     * runtime always sees a resolved {@link java.time.Duration}.
+     */
     Duration effectiveDrainTimeout() {
         return drainTimeout == null ? DEFAULT_DRAIN_TIMEOUT : drainTimeout;
     }
 
+    /**
+     * Returns {@code true} if this cluster's deployment-time configuration is semantically
+     * identical to {@code other}'s. Used by the configuration change-detection pipeline
+     * (see {@code VirtualClusterChangeDetector}) to decide whether a virtual cluster needs
+     * to be restarted across a {@code reconfigure()}.
+     *
+     * <p>Implementation uses the record's auto-generated {@link #equals(Object)} after
+     * canonicalising gateway order &mdash; {@code gateways} is a name-keyed semantic set,
+     * so reordering YAML entries is a no-op and must not produce a false positive. All
+     * other components (including any added in the future) are compared by the record's
+     * auto-equals, so this method extends automatically.
+     */
     public boolean sameAs(@Nullable VirtualCluster other) {
         if (this == other) {
             return true;
@@ -145,6 +168,11 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
         return this.canonical().equals(other.canonical());
     }
 
+    /**
+     * Returns an equivalent {@link VirtualCluster} with gateways sorted by name. Used only
+     * as an internal helper of {@link #sameAs(VirtualCluster)} to normalise the one
+     * order-insensitive component before the record's auto-equals does the rest.
+     */
     private VirtualCluster canonical() {
         List<VirtualClusterGateway> sortedGateways = gateways.stream()
                 .sorted(java.util.Comparator.comparing(VirtualClusterGateway::name))

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
@@ -20,26 +20,21 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * A virtual cluster.
  *
  * @param name virtual cluster name
- * @param targetCluster the cluster being proxied
+ * @param targetCluster inline target cluster definition (mutually exclusive with {@code target})
+ * @param target reference to a named cluster or router (mutually exclusive with {@code targetCluster})
  * @param gateways virtual cluster gateways
  * @param logNetwork if true, network will be logged
  * @param logFrames if true, kafka rpcs will be logged
- * @param filters filers.
+ * @param filters filters applied to requests
  * @param subjectBuilder subject builder configuration (optional)
  * @param topicNameCache topic-name cache configuration (optional)
  * @param drainTimeout maximum time to wait for in-flight requests to complete during
- *                     graceful connection draining for this cluster. Must be strictly
- *                     less than the Netty shutdown timeout (configured via
- *                     {@code network.proxy.shutdownTimeout}, default 15 s) — otherwise
- *                     Netty's force-close runs first and the per-connection drain timer
- *                     never fires. {@code null} means "use the proxy's default" — the
- *                     resolved value is supplied at the use site by
- *                     {@link #effectiveDrainTimeout()}. The default is currently 10 s
- *                     and may evolve in future proxy versions.
+ *                     graceful connection draining for this cluster
  */
-@SuppressWarnings("java:S1123") // suppressing the spurious warning about missing @deprecated in javadoc. It is the field that is deprecated, not the class.
+@SuppressWarnings("java:S1123")
 public record VirtualCluster(@JsonProperty(required = true) String name,
-                             @JsonProperty(required = true) TargetCluster targetCluster,
+                             @Deprecated @Nullable TargetCluster targetCluster,
+                             @Nullable RouteTarget target,
                              @JsonProperty(required = true) List<VirtualClusterGateway> gateways,
                              boolean logNetwork,
                              boolean logFrames,
@@ -51,14 +46,18 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
     private static final Pattern DNS_LABEL_PATTERN = Pattern.compile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", Pattern.CASE_INSENSITIVE);
     private static final Duration DEFAULT_DRAIN_TIMEOUT = Duration.ofSeconds(10);
 
-    @SuppressWarnings("java:S2789") // S2789 - checking for null tls is the intent
+    @SuppressWarnings("java:S2789")
     public VirtualCluster {
         Objects.requireNonNull(name);
-        Objects.requireNonNull(targetCluster);
         if (!isDnsLabel(name)) {
             throw new IllegalConfigurationException(
                     "Virtual cluster name '" + name + "' is invalid. It must be less than 64 characters long and match pattern " + DNS_LABEL_PATTERN.pattern()
                             + " (case insensitive)");
+        }
+        validateTargetExclusivity(name, targetCluster, target);
+        if (target != null && target.router() != null) {
+            throw new IllegalConfigurationException(
+                    "illegal target.router for virtual cluster '" + name + "'. Only target.cluster is supported currently, please change to this.");
         }
         if (gateways == null || gateways.isEmpty()) {
             throw new IllegalConfigurationException("no gateways configured for virtual cluster '" + name + "'");
@@ -67,23 +66,42 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
             throw new IllegalConfigurationException("one or more gateways were null for virtual cluster '" + name + "'");
         }
         validateNoDuplicatedGatewayNames(gateways);
-        // Validate explicitly-supplied drainTimeout. A null drainTimeout is allowed and
-        // means "use the proxy's default"; the resolved value is supplied by
-        // effectiveDrainTimeout() at the use site so that round-trip serialization
-        // preserves null and the operator-generated configs don't bake in today's default.
         if (drainTimeout != null && (drainTimeout.isZero() || drainTimeout.isNegative())) {
             throw new IllegalConfigurationException(
                     "drainTimeout for virtual cluster '" + name + "' must be positive, got: " + drainTimeout);
         }
     }
 
-    public VirtualCluster(@JsonProperty(required = true) String name,
-                          @JsonProperty(required = true) TargetCluster targetCluster,
-                          @JsonProperty(required = true) List<VirtualClusterGateway> gateways,
+    public VirtualCluster(String name,
+                          TargetCluster targetCluster,
+                          List<VirtualClusterGateway> gateways,
                           boolean logNetwork,
                           boolean logFrames,
                           @Nullable List<String> filters) {
-        this(name, targetCluster, gateways, logNetwork, logFrames, filters, null, null, null);
+        this(name, targetCluster, null, gateways, logNetwork, logFrames, filters, null, null, null);
+    }
+
+    @Nullable
+    public String router() {
+        return target != null ? target.router() : null;
+    }
+
+    @Nullable
+    public String namedTargetCluster() {
+        return target != null ? target.cluster() : null;
+    }
+
+    private static void validateTargetExclusivity(String name,
+                                                  @Nullable TargetCluster targetCluster,
+                                                  @Nullable RouteTarget target) {
+        if (targetCluster != null && target != null) {
+            throw new IllegalConfigurationException(
+                    "Virtual cluster '" + name + "' must specify exactly one of 'targetCluster' or 'target'");
+        }
+        if (targetCluster == null && target == null) {
+            throw new IllegalConfigurationException(
+                    "Virtual cluster '" + name + "' must specify exactly one of 'targetCluster' or 'target'");
+        }
     }
 
     boolean isDnsLabel(String name) {
@@ -113,29 +131,10 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
         return topicNameCache == null ? CacheConfiguration.DEFAULT : topicNameCache;
     }
 
-    /**
-     * Resolves the {@code drainTimeout} for this virtual cluster, applying the proxy's
-     * default when the field is {@code null}. Used at the construction site of
-     * {@link io.kroxylicious.proxy.model.VirtualClusterModel} so that the raw record
-     * component remains nullable (preserving Jackson round-trip fidelity), while the
-     * runtime always sees a resolved {@link Duration}.
-     */
     Duration effectiveDrainTimeout() {
         return drainTimeout == null ? DEFAULT_DRAIN_TIMEOUT : drainTimeout;
     }
 
-    /**
-     * Returns {@code true} if this cluster's deployment-time configuration is semantically
-     * identical to {@code other}'s. Used by the configuration change-detection pipeline
-     * (see {@code VirtualClusterChangeDetector}) to decide whether a virtual cluster needs
-     * to be restarted across a {@code reconfigure()}.
-     *
-     * <p>Implementation uses the record's auto-generated {@link #equals(Object)} after
-     * canonicalising gateway order &mdash; {@code gateways} is a name-keyed semantic set,
-     * so reordering YAML entries is a no-op and must not produce a false positive. All
-     * other components (including any added in the future) are compared by the record's
-     * auto-equals, so this method extends automatically.
-     */
     public boolean sameAs(@Nullable VirtualCluster other) {
         if (this == other) {
             return true;
@@ -146,11 +145,6 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
         return this.canonical().equals(other.canonical());
     }
 
-    /**
-     * Returns an equivalent {@link VirtualCluster} with gateways sorted by name. Used only
-     * as an internal helper of {@link #sameAs(VirtualCluster)} to normalise the one
-     * order-insensitive component before the record's auto-equals does the rest.
-     */
     private VirtualCluster canonical() {
         List<VirtualClusterGateway> sortedGateways = gateways.stream()
                 .sorted(java.util.Comparator.comparing(VirtualClusterGateway::name))
@@ -158,6 +152,7 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
         return new VirtualCluster(
                 name,
                 targetCluster,
+                target,
                 sortedGateways,
                 logNetwork,
                 logFrames,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ClusterDefinitionTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ClusterDefinitionTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.kroxylicious.proxy.config.tls.Tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterDefinitionTest {
+
+    @Mock
+    Tls tls;
+
+    @Test
+    void shouldCreateValidDefinition() {
+        var def = new ClusterDefinition("my-cluster", "broker1:9092,broker2:9092", null);
+
+        assertThat(def.name()).isEqualTo("my-cluster");
+        assertThat(def.bootstrapServers()).isEqualTo("broker1:9092,broker2:9092");
+        assertThat(def.tls()).isNull();
+    }
+
+    @Test
+    void shouldStripWhitespaceFromBootstrapServers() {
+        var def = new ClusterDefinition("c1", "broker1:9092 , broker2:9092", null);
+
+        assertThat(def.bootstrapServers()).isEqualTo("broker1:9092,broker2:9092");
+    }
+
+    @Test
+    void shouldRejectNullName() {
+        assertThatThrownBy(() -> new ClusterDefinition(null, "broker:9092", null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("name");
+    }
+
+    @Test
+    void shouldRejectNullBootstrapServers() {
+        assertThatThrownBy(() -> new ClusterDefinition("c1", null, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("bootstrapServers");
+    }
+
+    @Test
+    void toTargetClusterWithoutTls() {
+        var def = new ClusterDefinition("c1", "broker:9092", null);
+
+        var target = def.toTargetCluster();
+
+        assertThat(target.bootstrapServers()).isEqualTo("broker:9092");
+        assertThat(target.tls()).isEmpty();
+    }
+
+    @Test
+    void toTargetClusterWithTls() {
+        var def = new ClusterDefinition("c1", "broker:9092", tls);
+
+        var target = def.toTargetCluster();
+
+        assertThat(target.bootstrapServers()).isEqualTo("broker:9092");
+        assertThat(target.tls()).contains(tls);
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -317,6 +317,51 @@ class ConfigParserTest {
                           - name: mygateway
                             portIdentifiesNode:
                               bootstrapAddress: "localhost:9082"
+                        """),
+                argumentSet("Cluster definitions", """
+                        clusterDefinitions:
+                        - name: my-cluster
+                          bootstrapServers: broker1:9092,broker2:9092
+                        virtualClusters:
+                        - name: demo1
+                          target:
+                            cluster: my-cluster
+                          gateways:
+                          - name: mygateway
+                            portIdentifiesNode:
+                              bootstrapAddress: "localhost:9082"
+                        """),
+                argumentSet("Cluster definitions with TLS", """
+                        clusterDefinitions:
+                        - name: my-cluster
+                          bootstrapServers: broker1:9092
+                          tls:
+                            trust:
+                              storeFile: /tmp/trust.jks
+                              storePassword:
+                                password: changeit
+                              storeType: JKS
+                        virtualClusters:
+                        - name: demo1
+                          target:
+                            cluster: my-cluster
+                          gateways:
+                          - name: mygateway
+                            portIdentifiesNode:
+                              bootstrapAddress: "localhost:9082"
+                        """),
+                argumentSet("Virtual cluster with target cluster reference", """
+                        clusterDefinitions:
+                        - name: my-cluster
+                          bootstrapServers: broker:9092
+                        virtualClusters:
+                        - name: demo1
+                          target:
+                            cluster: my-cluster
+                          gateways:
+                          - name: mygateway
+                            portIdentifiesNode:
+                              bootstrapAddress: "localhost:9082"
                         """));
     }
 
@@ -610,7 +655,7 @@ class ConfigParserTest {
                 // Then
                 .isInstanceOf(IllegalArgumentException.class)
                 .cause()
-                .hasMessageContaining("Missing required creator property 'targetCluster'");
+                .hasMessageContaining("must specify exactly one of 'targetCluster' or 'target'");
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -878,15 +878,8 @@ class ConfigParserTest {
         var targetCluster = new TargetCluster("mycluster:9082", Optional.empty());
         var gateway = new VirtualClusterGateway("gw", new PortIdentifiesNodeIdentificationStrategy(HostPort.parse("localhost:9082"), null, null, null), null,
                 Optional.empty());
-        var config = new Configuration(null,
-                List.of(new NamedFilterDefinition("foo", "", new NonSerializableConfig(""))),
-                List.of("foo"),
-                List.of(new VirtualCluster("demo", targetCluster, List.of(gateway), false, false, List.of())),
-                null,
-                false,
-                Optional.empty(),
-                null,
-                null);
+        var config = new Configuration(null, null, List.of(new NamedFilterDefinition("foo", "", new NonSerializableConfig(""))), List.of("foo"), null,
+                List.of(new VirtualCluster("demo", targetCluster, List.of(gateway), false, false, List.of())), null, false, Optional.empty(), null, null);
 
         ConfigParser cp = new ConfigParser();
         assertThatThrownBy(() -> {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
@@ -30,7 +30,7 @@ class ConfigurationValidationTest {
     }
 
     private static Configuration config(List<VirtualCluster> vcs) {
-        return new Configuration(null, null, null, vcs, null, false, Optional.empty(), null, null);
+        return new Configuration(null, null, null, null, null, vcs, null, false, Optional.empty(), null, null);
     }
 
     @Test
@@ -126,16 +126,14 @@ class ConfigurationValidationTest {
     @Test
     void getMicrometerReturnsConfiguredValue() {
         var micrometer = List.of(new MicrometerDefinition("JmxMeterRegistry", null));
-        var config = new Configuration(null, null, null,
-                List.of(SIMPLE_VC), micrometer, false, Optional.empty(), null, null);
+        var config = new Configuration(null, null, null, null, null, List.of(SIMPLE_VC), micrometer, false, Optional.empty(), null, null);
 
         assertThat(config.getMicrometer()).isEqualTo(micrometer);
     }
 
     @Test
     void isUseIoUringReturnsConfiguredValue() {
-        var config = new Configuration(null, null, null,
-                List.of(SIMPLE_VC), null, true, Optional.empty(), null, null);
+        var config = new Configuration(null, null, null, null, null, List.of(SIMPLE_VC), null, true, Optional.empty(), null, null);
 
         assertThat(config.isUseIoUring()).isTrue();
     }
@@ -168,16 +166,14 @@ class ConfigurationValidationTest {
 
     @Test
     void shouldRejectNoVirtualClusters() {
-        assertThatThrownBy(() -> new Configuration(null, null, null,
-                List.of(), null, false, Optional.empty(), null, null))
+        assertThatThrownBy(() -> new Configuration(null, null, null, null, null, List.of(), null, false, Optional.empty(), null, null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("At least one virtual cluster");
     }
 
     @Test
     void shouldRejectNullVirtualClusters() {
-        assertThatThrownBy(() -> new Configuration(null, null, null,
-                null, null, false, Optional.empty(), null, null))
+        assertThatThrownBy(() -> new Configuration(null, null, null, null, null, null, null, false, Optional.empty(), null, null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("At least one virtual cluster");
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
@@ -33,15 +33,13 @@ class ConfigurationValidationTest {
         return new Configuration(null, null, null, vcs, null, false, Optional.empty(), null, null);
     }
 
-    // Cluster definition validation
-
     @Test
     void shouldRejectDuplicateClusterDefinitionNames() {
         var clusters = List.of(
                 new ClusterDefinition("dup", "broker1:9092", null),
                 new ClusterDefinition("dup", "broker2:9092", null));
 
-        assertThatThrownBy(() -> new Configuration(null, clusters, null, null,
+        assertThatThrownBy(() -> new Configuration(null, clusters, null, null, null,
                 List.of(SIMPLE_VC), null, false, Optional.empty(), null, null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("duplicate names")
@@ -54,7 +52,20 @@ class ConfigurationValidationTest {
                 .doesNotThrowAnyException();
     }
 
-    // Virtual cluster target validation
+    @Test
+    void shouldRejectDuplicateRouterDefinitionNames() {
+        var cluster = new ClusterDefinition("c1", "broker:9092", null);
+        var route = new RouteDefinition("route1", 0, null, new RouteTarget("c1", null));
+        var routers = List.of(
+                new RouterDefinition("dup", "Type", null, List.of(route)),
+                new RouterDefinition("dup", "Type", null, List.of(route)));
+
+        assertThatThrownBy(() -> new Configuration(null, List.of(cluster), null, null, routers,
+                List.of(SIMPLE_VC), null, false, Optional.empty(), null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("duplicate names")
+                .hasMessageContaining("dup");
+    }
 
     @Test
     void shouldRejectUnknownNamedTargetCluster() {
@@ -75,26 +86,35 @@ class ConfigurationValidationTest {
                 new RouteTarget("known", null),
                 List.of(simpleGateway("gw")), false, false, null, null, null, null);
 
-        assertThatCode(() -> new Configuration(null, List.of(cluster), null, null,
+        assertThatCode(() -> new Configuration(null, List.of(cluster), null, null, null,
                 List.of(vcWithNamedTarget), null, false, Optional.empty(), null, null))
                 .doesNotThrowAnyException();
     }
 
-    // TODO in future VCs will be allowed to target a router
     @Test
     void shouldRejectRouterTarget() {
         RouteTarget routerTarget = new RouteTarget(null, "nonexistent");
         List<VirtualClusterGateway> gateways = List.of(simpleGateway("gw"));
-        assertThatThrownBy(() -> {
-            new VirtualCluster("demo", null,
-                    routerTarget,
-                    gateways, false, false, null, null, null, null);
-        })
+        assertThatThrownBy(() -> new VirtualCluster("demo", null,
+                routerTarget,
+                gateways, false, false, null, null, null, null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("illegal target.router for virtual cluster 'demo'.");
     }
 
-    // Convenience methods
+    @Test
+    void virtualClusterModelRejectsRouterDefinitions() {
+        var cluster = new ClusterDefinition("c1", "broker:9092", null);
+        var route = new RouteDefinition("r", 0, null, new RouteTarget("c1", null));
+        var router = new RouterDefinition("myrouter", "Type", null, List.of(route));
+
+        var config = new Configuration(null, List.of(cluster), null, null, List.of(router),
+                List.of(SIMPLE_VC), null, false, Optional.empty(), null, null);
+
+        assertThatThrownBy(() -> config.virtualClusterModel(null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("Routing is not yet supported");
+    }
 
     @Test
     void getMicrometerReturnsEmptyListWhenNull() {
@@ -118,6 +138,32 @@ class ConfigurationValidationTest {
                 List.of(SIMPLE_VC), null, true, Optional.empty(), null, null);
 
         assertThat(config.isUseIoUring()).isTrue();
+    }
+
+    @Test
+    void shouldRejectFilterInRouteNotDefinedInFilterDefinitions() {
+        var cluster = new ClusterDefinition("c1", "broker:9092", null);
+        var filterDefs = List.of(new NamedFilterDefinition("f1", "Type1", null));
+        var route = new RouteDefinition("r", 0, List.of("undefined-filter"), new RouteTarget("c1", null));
+        var router = new RouterDefinition("myrouter", "Type", null, List.of(route));
+
+        assertThatThrownBy(() -> new Configuration(null, List.of(cluster), filterDefs, null, List.of(router),
+                List.of(SIMPLE_VC), null, false, Optional.empty(), null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("references filters not defined")
+                .hasMessageContaining("undefined-filter");
+    }
+
+    @Test
+    void shouldAcceptFilterUsedInRouteAsUsed() {
+        var cluster = new ClusterDefinition("c1", "broker:9092", null);
+        var filterDefs = List.of(new NamedFilterDefinition("f1", "Type1", null));
+        var route = new RouteDefinition("r", 0, List.of("f1"), new RouteTarget("c1", null));
+        var router = new RouterDefinition("myrouter", "Type", null, List.of(route));
+
+        assertThatCode(() -> new Configuration(null, List.of(cluster), filterDefs, null, List.of(router),
+                List.of(SIMPLE_VC), null, false, Optional.empty(), null, null))
+                .doesNotThrowAnyException();
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ConfigurationValidationTest {
+
+    private static final VirtualCluster SIMPLE_VC = new VirtualCluster("demo",
+            new TargetCluster("broker:9092", Optional.empty()),
+            List.of(simpleGateway("gw")),
+            false, false, null);
+
+    private static VirtualClusterGateway simpleGateway(String name) {
+        return new VirtualClusterGateway(name,
+                new PortIdentifiesNodeIdentificationStrategy(
+                        new io.kroxylicious.proxy.service.HostPort("localhost", 9192), null, null, null),
+                null, Optional.empty());
+    }
+
+    private static Configuration config(List<VirtualCluster> vcs) {
+        return new Configuration(null, null, null, vcs, null, false, Optional.empty(), null, null);
+    }
+
+    // Cluster definition validation
+
+    @Test
+    void shouldRejectDuplicateClusterDefinitionNames() {
+        var clusters = List.of(
+                new ClusterDefinition("dup", "broker1:9092", null),
+                new ClusterDefinition("dup", "broker2:9092", null));
+
+        assertThatThrownBy(() -> new Configuration(null, clusters, null, null,
+                List.of(SIMPLE_VC), null, false, Optional.empty(), null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("duplicate names")
+                .hasMessageContaining("dup");
+    }
+
+    @Test
+    void shouldAcceptNullClusterDefinitions() {
+        assertThatCode(() -> config(List.of(SIMPLE_VC)))
+                .doesNotThrowAnyException();
+    }
+
+    // Virtual cluster target validation
+
+    @Test
+    void shouldRejectUnknownNamedTargetCluster() {
+        var vcWithNamedTarget = new VirtualCluster("demo", null,
+                new RouteTarget("nonexistent", null),
+                List.of(simpleGateway("gw")), false, false, null, null, null, null);
+
+        assertThatThrownBy(() -> config(List.of(vcWithNamedTarget)))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("unknown target cluster")
+                .hasMessageContaining("nonexistent");
+    }
+
+    @Test
+    void shouldAcceptKnownNamedTargetCluster() {
+        var cluster = new ClusterDefinition("known", "broker:9092", null);
+        var vcWithNamedTarget = new VirtualCluster("demo", null,
+                new RouteTarget("known", null),
+                List.of(simpleGateway("gw")), false, false, null, null, null, null);
+
+        assertThatCode(() -> new Configuration(null, List.of(cluster), null, null,
+                List.of(vcWithNamedTarget), null, false, Optional.empty(), null, null))
+                .doesNotThrowAnyException();
+    }
+
+    // TODO in future VCs will be allowed to target a router
+    @Test
+    void shouldRejectRouterTarget() {
+        RouteTarget routerTarget = new RouteTarget(null, "nonexistent");
+        List<VirtualClusterGateway> gateways = List.of(simpleGateway("gw"));
+        assertThatThrownBy(() -> {
+            new VirtualCluster("demo", null,
+                    routerTarget,
+                    gateways, false, false, null, null, null, null);
+        })
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("illegal target.router for virtual cluster 'demo'.");
+    }
+
+    // Convenience methods
+
+    @Test
+    void getMicrometerReturnsEmptyListWhenNull() {
+        var config = config(List.of(SIMPLE_VC));
+
+        assertThat(config.getMicrometer()).isEmpty();
+    }
+
+    @Test
+    void getMicrometerReturnsConfiguredValue() {
+        var micrometer = List.of(new MicrometerDefinition("JmxMeterRegistry", null));
+        var config = new Configuration(null, null, null,
+                List.of(SIMPLE_VC), micrometer, false, Optional.empty(), null, null);
+
+        assertThat(config.getMicrometer()).isEqualTo(micrometer);
+    }
+
+    @Test
+    void isUseIoUringReturnsConfiguredValue() {
+        var config = new Configuration(null, null, null,
+                List.of(SIMPLE_VC), null, true, Optional.empty(), null, null);
+
+        assertThat(config.isUseIoUring()).isTrue();
+    }
+
+    @Test
+    void shouldRejectNoVirtualClusters() {
+        assertThatThrownBy(() -> new Configuration(null, null, null,
+                List.of(), null, false, Optional.empty(), null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("At least one virtual cluster");
+    }
+
+    @Test
+    void shouldRejectNullVirtualClusters() {
+        assertThatThrownBy(() -> new Configuration(null, null, null,
+                null, null, false, Optional.empty(), null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("At least one virtual cluster");
+    }
+
+    @Test
+    void shouldRejectDuplicateVirtualClusterNamesCaseInsensitive() {
+        var vc1 = new VirtualCluster("demo", new TargetCluster("b1:9092", Optional.empty()),
+                List.of(simpleGateway("gw1")), false, false, null);
+        var vc2 = new VirtualCluster("DEMO", new TargetCluster("b2:9092", Optional.empty()),
+                List.of(simpleGateway("gw2")), false, false, null);
+
+        assertThatThrownBy(() -> config(List.of(vc1, vc2)))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("duplicated");
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/RouteDefinitionTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/RouteDefinitionTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RouteDefinitionTest {
+
+    private static final RouteTarget CLUSTER_TARGET = new RouteTarget("c1", null);
+
+    @Test
+    void shouldCreateValidRoute() {
+        var route = new RouteDefinition("route1", 0, null, CLUSTER_TARGET);
+
+        assertThat(route.name()).isEqualTo("route1");
+        assertThat(route.id()).isZero();
+        assertThat(route.filters()).isNull();
+        assertThat(route.target()).isSameAs(CLUSTER_TARGET);
+    }
+
+    @Test
+    void shouldAcceptFilters() {
+        var route = new RouteDefinition("route1", 0, List.of("filter1", "filter2"), CLUSTER_TARGET);
+
+        assertThat(route.filters()).containsExactly("filter1", "filter2");
+    }
+
+    @Test
+    void clusterAccessorDelegatesToTarget() {
+        var route = new RouteDefinition("route1", 0, null, new RouteTarget("my-cluster", null));
+
+        assertThat(route.cluster()).isEqualTo("my-cluster");
+        assertThat(route.router()).isNull();
+    }
+
+    @Test
+    void routerAccessorDelegatesToTarget() {
+        var route = new RouteDefinition("route1", 0, null, new RouteTarget(null, "my-router"));
+
+        assertThat(route.cluster()).isNull();
+        assertThat(route.router()).isEqualTo("my-router");
+    }
+
+    @Test
+    void shouldRejectNullName() {
+        assertThatThrownBy(() -> new RouteDefinition(null, 0, null, CLUSTER_TARGET))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("name");
+    }
+
+    @Test
+    void shouldRejectNullTarget() {
+        assertThatThrownBy(() -> new RouteDefinition("route1", 0, null, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("target");
+    }
+
+    @Test
+    void shouldRejectNegativeId() {
+        assertThatThrownBy(() -> new RouteDefinition("route1", -1, null, CLUSTER_TARGET))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("invalid id -1")
+                .hasMessageContaining("must be >= 0");
+    }
+
+    @Test
+    void shouldAcceptZeroId() {
+        assertThatCode(() -> new RouteDefinition("route1", 0, null, CLUSTER_TARGET))
+                .doesNotThrowAnyException();
+    }
+
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/RouteTargetTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/RouteTargetTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RouteTargetTest {
+
+    @Test
+    void shouldAcceptClusterOnly() {
+        var target = new RouteTarget("my-cluster", null);
+
+        assertThat(target.cluster()).isEqualTo("my-cluster");
+        assertThat(target.router()).isNull();
+    }
+
+    @Test
+    void shouldAcceptRouterOnly() {
+        var target = new RouteTarget(null, "my-router");
+
+        assertThat(target.cluster()).isNull();
+        assertThat(target.router()).isEqualTo("my-router");
+    }
+
+    @Test
+    void shouldRejectBothProvided() {
+        assertThatThrownBy(() -> new RouteTarget("cluster", "router"))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("both were provided");
+    }
+
+    @Test
+    void shouldRejectNeitherProvided() {
+        assertThatThrownBy(() -> new RouteTarget(null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("neither was provided");
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/RouterDefinitionTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/RouterDefinitionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RouterDefinitionTest {
+
+    private static RouteDefinition route(String name, int id) {
+        return new RouteDefinition(name, id, null, new RouteTarget("c1", null));
+    }
+
+    @Test
+    void shouldCreateValidDefinition() {
+        var def = new RouterDefinition("r1", "MyRouterFactory", null, List.of(route("route1", 0)));
+
+        assertThat(def.name()).isEqualTo("r1");
+        assertThat(def.type()).isEqualTo("MyRouterFactory");
+        assertThat(def.config()).isNull();
+        assertThat(def.routes()).hasSize(1);
+    }
+
+    @Test
+    void shouldRejectNullName() {
+        assertThatThrownBy(() -> new RouterDefinition(null, "type", null, List.of(route("r", 0))))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("name");
+    }
+
+    @Test
+    void shouldRejectNullType() {
+        assertThatThrownBy(() -> new RouterDefinition("r1", null, null, List.of(route("r", 0))))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("type");
+    }
+
+    @Test
+    void shouldRejectNullRoutes() {
+        assertThatThrownBy(() -> new RouterDefinition("r1", "type", null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("must have at least one route");
+    }
+
+    @Test
+    void shouldRejectEmptyRoutes() {
+        assertThatThrownBy(() -> new RouterDefinition("r1", "type", null, List.of()))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("must have at least one route");
+    }
+
+    @Test
+    void shouldRejectDuplicateRouteNames() {
+        var routes = List.of(route("dup", 0), route("dup", 1));
+
+        assertThatThrownBy(() -> new RouterDefinition("r1", "type", null, routes))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("duplicate route names")
+                .hasMessageContaining("dup");
+    }
+
+    @Test
+    void shouldRejectDuplicateRouteIds() {
+        var routes = List.of(route("a", 0), route("b", 0));
+
+        assertThatThrownBy(() -> new RouterDefinition("r1", "type", null, routes))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("duplicate route ids")
+                .hasMessageContaining("0");
+    }
+
+    @Test
+    void shouldAcceptMultipleUniqueRoutes() {
+        var routes = List.of(route("a", 0), route("b", 1));
+
+        assertThatCode(() -> new RouterDefinition("r1", "type", null, routes))
+                .doesNotThrowAnyException();
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/RouterGraphValidatorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/RouterGraphValidatorTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RouterGraphValidatorTest {
+
+    private static RouteDefinition clusterRoute(String name, int id, String cluster) {
+        return new RouteDefinition(name, id, null, new RouteTarget(cluster, null));
+    }
+
+    private static RouteDefinition routerRoute(String name, int id, String router) {
+        return new RouteDefinition(name, id, null, new RouteTarget(null, router));
+    }
+
+    private static RouterDefinition router(String name, RouteDefinition... routes) {
+        return new RouterDefinition(name, "SomeType", null, List.of(routes));
+    }
+
+    @Test
+    void shouldAcceptSingleRouterWithClusterRoute() {
+        var routers = List.of(router("r1", clusterRoute("foo", 0, "c1")));
+        assertThatCode(() -> RouterGraphValidator.validate(routers, Set.of("c1")))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldAcceptLinearChain() {
+        var routers = List.of(
+                router("r1", routerRoute("next", 0, "r2")),
+                router("r2", clusterRoute("foo", 0, "c1")));
+        assertThatCode(() -> RouterGraphValidator.validate(routers, Set.of("c1")))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldAcceptDiamondDag() {
+        var routers = List.of(
+                router("r1", routerRoute("left", 0, "r2"), routerRoute("right", 1, "r3")),
+                router("r2", clusterRoute("foo", 0, "c1")),
+                router("r3", clusterRoute("bar", 0, "c1")));
+        assertThatCode(() -> RouterGraphValidator.validate(routers, Set.of("c1")))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldRejectSelfCycle() {
+        var routers = List.of(router("r1", routerRoute("loop", 0, "r1")));
+        assertThatThrownBy(() -> RouterGraphValidator.validate(routers, Set.of()))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("cycle")
+                .hasMessageContaining("r1");
+    }
+
+    @Test
+    void shouldRejectSimpleCycle() {
+        var routers = List.of(
+                router("r1", routerRoute("next", 0, "r2")),
+                router("r2", routerRoute("back", 0, "r1")));
+        assertThatThrownBy(() -> RouterGraphValidator.validate(routers, Set.of()))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("cycle")
+                .hasMessageContaining("r1")
+                .hasMessageContaining("r2");
+    }
+
+    @Test
+    void shouldRejectThreeNodeCycle() {
+        var routers = List.of(
+                router("r1", routerRoute("next", 0, "r2")),
+                router("r2", routerRoute("next", 0, "r3")),
+                router("r3", routerRoute("back", 0, "r1")));
+        assertThatThrownBy(() -> RouterGraphValidator.validate(routers, Set.of()))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("cycle");
+    }
+
+    @Test
+    void shouldRejectDanglingClusterReference() {
+        var routers = List.of(router("r1", clusterRoute("foo", 0, "nonexistent")));
+        assertThatThrownBy(() -> RouterGraphValidator.validate(routers, Set.of("c1")))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("unknown cluster")
+                .hasMessageContaining("nonexistent");
+    }
+
+    @Test
+    void shouldRejectDanglingRouterReference() {
+        var routers = List.of(router("r1", routerRoute("next", 0, "nonexistent")));
+        assertThatThrownBy(() -> RouterGraphValidator.validate(routers, Set.of()))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("unknown router")
+                .hasMessageContaining("nonexistent");
+    }
+
+    @Test
+    void shouldRejectRouteIdOutOfRange() {
+        var routers = List.of(router("r1",
+                clusterRoute("foo", 0, "c1"),
+                clusterRoute("bar", 5, "c1")));
+        assertThatThrownBy(() -> RouterGraphValidator.validate(routers, Set.of("c1")))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("outside the valid range")
+                .hasMessageContaining("[0, 2)");
+    }
+
+    @Test
+    void shouldRejectOverflowProneRouteCount() {
+        int routeCount = RouterGraphValidator.MAX_SAFE_TARGET_NODE_ID + 1;
+        RouteDefinition[] routes = new RouteDefinition[routeCount];
+        for (int i = 0; i < routeCount; i++) {
+            routes[i] = clusterRoute("r" + i, i, "c1");
+        }
+        var routers = List.of(router("r1", routes));
+        assertThatThrownBy(() -> RouterGraphValidator.validate(routers, Set.of("c1")))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("overflow");
+    }
+
+    @Test
+    void shouldAcceptValidRouteIds() {
+        var routers = List.of(router("r1",
+                clusterRoute("foo", 0, "c1"),
+                clusterRoute("bar", 1, "c1")));
+        assertThatCode(() -> RouterGraphValidator.validate(routers, Set.of("c1")))
+                .doesNotThrowAnyException();
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/VirtualClusterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/VirtualClusterTest.java
@@ -145,7 +145,7 @@ class VirtualClusterTest {
         // Given — VirtualCluster constructed with an explicit drainTimeout
         var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
         var explicitTimeout = Duration.ofSeconds(45);
-        var vc = new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS, null, null, explicitTimeout);
+        var vc = new VirtualCluster("mycluster", targetCluster, null, gateways, false, false, NO_FILTERS, null, null, explicitTimeout);
 
         // When
         var resolved = vc.effectiveDrainTimeout();
@@ -161,7 +161,7 @@ class VirtualClusterTest {
         var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
 
         // When/Then
-        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS, null, null, Duration.ZERO))
+        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, null, gateways, false, false, NO_FILTERS, null, null, Duration.ZERO))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("drainTimeout for virtual cluster 'mycluster' must be positive");
     }
@@ -172,7 +172,7 @@ class VirtualClusterTest {
         var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
 
         // When/Then
-        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS, null, null, Duration.ofSeconds(-5)))
+        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, null, gateways, false, false, NO_FILTERS, null, null, Duration.ofSeconds(-5)))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("drainTimeout for virtual cluster 'mycluster' must be positive");
     }
@@ -183,7 +183,103 @@ class VirtualClusterTest {
         var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
 
         // When/Then — happy path: a positive explicit drainTimeout passes validation
-        assertThatCode(() -> new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS, null, null, Duration.ofMillis(1)))
+        assertThatCode(() -> new VirtualCluster("mycluster", targetCluster, null, gateways, false, false, NO_FILTERS, null, null, Duration.ofMillis(1)))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    void routerReturnsNullWhenTargetIsNull() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var vc = new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS);
+
+        assertThat(vc.router()).isNull();
+    }
+
+    @Test
+    void namedTargetClusterReturnsNullWhenTargetIsNull() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var vc = new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS);
+
+        assertThat(vc.namedTargetCluster()).isNull();
+    }
+
+    @Test
+    void namedTargetClusterReturnsValueFromTarget() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var target = new RouteTarget("my-cluster", null);
+        var vc = new VirtualCluster("mycluster", null, target, gateways, false, false, NO_FILTERS, null, null, null);
+
+        assertThat(vc.namedTargetCluster()).isEqualTo("my-cluster");
+    }
+
+    @Test
+    void topicNameCacheConfigReturnsDefaultWhenNull() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var vc = new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS);
+
+        assertThat(vc.topicNameCacheConfig()).isEqualTo(CacheConfiguration.DEFAULT);
+    }
+
+    @Test
+    void topicNameCacheConfigReturnsExplicitValue() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var cacheConfig = new CacheConfiguration(1000, null, null);
+        var vc = new VirtualCluster("mycluster", targetCluster, null, gateways, false, false, NO_FILTERS, null, cacheConfig, null);
+
+        assertThat(vc.topicNameCacheConfig()).isSameAs(cacheConfig);
+    }
+
+    @Test
+    void sameAsSameInstanceReturnsTrue() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var vc = new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS);
+
+        assertThat(vc.sameAs(vc)).isTrue();
+    }
+
+    @Test
+    void sameAsNullReturnsFalse() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var vc = new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS);
+
+        assertThat(vc.sameAs(null)).isFalse();
+    }
+
+    @Test
+    void sameAsEqualClusterReturnsTrue() {
+        var gw1 = new VirtualClusterGateway("b", portIdentifiesNode1, null, Optional.empty());
+        var gw2 = new VirtualClusterGateway("a", portIdentifiesNode2, null, Optional.empty());
+        var vc1 = new VirtualCluster("mycluster", targetCluster, null, List.of(gw1, gw2), false, false, NO_FILTERS, null, null, null);
+        var vc2 = new VirtualCluster("mycluster", targetCluster, null, List.of(gw2, gw1), false, false, NO_FILTERS, null, null, null);
+
+        assertThat(vc1.sameAs(vc2)).isTrue();
+    }
+
+    @Test
+    void sameAsDifferentClusterReturnsFalse() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var vc1 = new VirtualCluster("cluster1", targetCluster, gateways, false, false, NO_FILTERS);
+        var vc2 = new VirtualCluster("cluster2", targetCluster, gateways, false, false, NO_FILTERS);
+
+        assertThat(vc1.sameAs(vc2)).isFalse();
+    }
+
+    @Test
+    void rejectsBothTargetClusterAndTarget() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var target = new RouteTarget("named-cluster", null);
+
+        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, target, gateways, false, false, NO_FILTERS, null, null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("must specify exactly one of 'targetCluster' or 'target'");
+    }
+
+    @Test
+    void rejectsNeitherTargetClusterNorTarget() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+
+        assertThatThrownBy(() -> new VirtualCluster("mycluster", null, null, gateways, false, false, NO_FILTERS, null, null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("must specify exactly one of 'targetCluster' or 'target'");
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/config/FeaturesTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/config/FeaturesTest.java
@@ -68,7 +68,7 @@ class FeaturesTest {
     void supportsValidTestConfiguration(Features features, Map<String, Object> developmentConfig) {
         VirtualCluster mockCluster = mock(VirtualCluster.class);
         when(mockCluster.name()).thenReturn("test");
-        Configuration configuration = new Configuration(null, List.of(), List.of(), List.of(mockCluster), null, false, Optional.ofNullable(developmentConfig),
+        Configuration configuration = new Configuration(null, null, List.of(), List.of(), null, List.of(mockCluster), null, false, Optional.ofNullable(developmentConfig),
                 null, null);
         List<String> errorMessages = features.supports(configuration);
         assertThat(errorMessages).isEmpty();
@@ -80,7 +80,7 @@ class FeaturesTest {
         Optional<Map<String, Object>> a = Optional.of(Map.of("a", "b"));
         VirtualCluster mockCluster = mock(VirtualCluster.class);
         when(mockCluster.name()).thenReturn("test");
-        Configuration configuration = new Configuration(null, List.of(), List.of(), List.of(mockCluster), null, false, a, null, null);
+        Configuration configuration = new Configuration(null, null, List.of(), List.of(), null, List.of(mockCluster), null, false, a, null, null);
         List<String> errors = Features.defaultFeatures().supports(configuration);
         assertThat(errors).containsExactly("test-only configuration for proxy present, but loading test-only configuration not enabled");
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ChangeDetectorPipelineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ChangeDetectorPipelineTest.java
@@ -51,10 +51,8 @@ class ChangeDetectorPipelineTest {
                 new TargetCluster("kafka:9092", Optional.empty()),
                 List.of(gateway("default", 9999)), // port changed
                 false, false, List.of("filter-a"));
-        var oldConfig = new Configuration(null, List.of(oldFilter), null,
-                List.of(oldVc), null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, List.of(newFilter), null,
-                List.of(newVc), null, false, Optional.empty(), null, null);
+        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null, List.of(oldVc), null, false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, null, List.of(newFilter), null, null, List.of(newVc), null, false, Optional.empty(), null, null);
         var context = new ConfigurationChangeContext(oldConfig, newConfig);
 
         // Both detectors independently flag the cluster
@@ -82,10 +80,8 @@ class ChangeDetectorPipelineTest {
         var newFilter = new NamedFilterDefinition("filter-a", "io.kroxylicious.test.FakeFilter", "v2");
         var existing = vc("existing", List.of("filter-a"));
         var newlyAdded = vc("newly-added", List.of("filter-a"));
-        var oldConfig = new Configuration(null, List.of(oldFilter), null,
-                List.of(existing), null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, List.of(newFilter), null,
-                List.of(existing, newlyAdded), null, false, Optional.empty(), null, null);
+        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null, List.of(existing), null, false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, null, List.of(newFilter), null, null, List.of(existing, newlyAdded), null, false, Optional.empty(), null, null);
         var context = new ConfigurationChangeContext(oldConfig, newConfig);
 
         var vccResult = vccDetector.detect(context);
@@ -112,10 +108,8 @@ class ChangeDetectorPipelineTest {
         var oldFilter = new NamedFilterDefinition("filter-a", "io.kroxylicious.test.FakeFilter", "v1");
         var goingAway = vc("going-away", List.of("filter-a"));
         var staying = vcWithoutFilters("staying");
-        var oldConfig = new Configuration(null, List.of(oldFilter), null,
-                List.of(goingAway, staying), null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, null, null,
-                List.of(staying), null, false, Optional.empty(), null, null);
+        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null, List.of(goingAway, staying), null, false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, null, null, null, null, List.of(staying), null, false, Optional.empty(), null, null);
         var context = new ConfigurationChangeContext(oldConfig, newConfig);
 
         var vccResult = vccDetector.detect(context);
@@ -152,12 +146,10 @@ class ChangeDetectorPipelineTest {
         var filterChangedCluster = vc("filter-changed", List.of("filter-x"));
         var addedCluster = vcWithoutFilters("added");
 
-        var oldConfig = new Configuration(null, List.of(oldFilter), null,
-                List.of(keepUnchanged, removedCluster, oldGatewayChanged, filterChangedCluster),
+        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null, List.of(keepUnchanged, removedCluster, oldGatewayChanged, filterChangedCluster),
                 null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, List.of(newFilter), null,
-                List.of(keepUnchanged, newGatewayChanged, filterChangedCluster, addedCluster),
-                null, false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, null, List.of(newFilter), null, null, List.of(keepUnchanged, newGatewayChanged, filterChangedCluster, addedCluster), null,
+                false, Optional.empty(), null, null);
         var context = new ConfigurationChangeContext(oldConfig, newConfig);
 
         var merged = vccDetector.detect(context).merge(filterDetector.detect(context));
@@ -174,8 +166,7 @@ class ChangeDetectorPipelineTest {
         // accidentally introduce non-empty defaults in a detector's output.
         var filter = new NamedFilterDefinition("filter-a", "io.kroxylicious.test.FakeFilter", "v1");
         var cluster = vc("cluster", List.of("filter-a"));
-        var config = new Configuration(null, List.of(filter), null,
-                List.of(cluster), null, false, Optional.empty(), null, null);
+        var config = new Configuration(null, null, List.of(filter), null, null, List.of(cluster), null, false, Optional.empty(), null, null);
         var context = new ConfigurationChangeContext(config, config);
 
         var vccResult = vccDetector.detect(context);
@@ -203,10 +194,10 @@ class ChangeDetectorPipelineTest {
                 false, false, List.of());
         var filterChangedCluster = vc("filter-changed", List.of("filter-x"));
 
-        var oldConfig = new Configuration(null, List.of(oldFilter), null,
-                List.of(oldGatewayChanged, filterChangedCluster), null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, List.of(newFilter), null,
-                List.of(newGatewayChanged, filterChangedCluster), null, false, Optional.empty(), null, null);
+        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null, List.of(oldGatewayChanged, filterChangedCluster), null, false, Optional.empty(),
+                null, null);
+        var newConfig = new Configuration(null, null, List.of(newFilter), null, null, List.of(newGatewayChanged, filterChangedCluster), null, false, Optional.empty(),
+                null, null);
         var context = new ConfigurationChangeContext(oldConfig, newConfig);
 
         var vccResult = vccDetector.detect(context);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
@@ -658,8 +658,7 @@ class ConfigurationReloadOrchestratorTest {
     }
 
     private static Configuration configWith(VirtualCluster... clusters) {
-        return new Configuration(null, null, null, List.of(clusters), null, false,
-                Optional.empty(), null, null);
+        return new Configuration(null, null, null, null, null, List.of(clusters), null, false, Optional.empty(), null, null);
     }
 
     private static Configuration withDifferentUseIoUring(Configuration base) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
@@ -664,7 +664,7 @@ class ConfigurationReloadOrchestratorTest {
 
     private static Configuration withDifferentUseIoUring(Configuration base) {
         return new Configuration(base.management(), base.clusterDefinitions(), base.filterDefinitions(), base.defaultFilters(),
-                base.virtualClusters(), base.micrometer(),
+                base.routerDefinitions(), base.virtualClusters(), base.micrometer(),
                 !base.useIoUring(),
                 base.development(), base.network(),
                 // also vary proxyProtocol just to make the diff non-empty even if useIoUring matches

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
@@ -663,7 +663,7 @@ class ConfigurationReloadOrchestratorTest {
     }
 
     private static Configuration withDifferentUseIoUring(Configuration base) {
-        return new Configuration(base.management(), base.filterDefinitions(), base.defaultFilters(),
+        return new Configuration(base.management(), base.clusterDefinitions(), base.filterDefinitions(), base.defaultFilters(),
                 base.virtualClusters(), base.micrometer(),
                 !base.useIoUring(),
                 base.development(), base.network(),

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/FilterChangeDetectorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/FilterChangeDetectorTest.java
@@ -173,8 +173,7 @@ class FilterChangeDetectorTest {
     private static Configuration configWith(@Nullable List<NamedFilterDefinition> filterDefs,
                                             @Nullable List<String> defaultFilters,
                                             VirtualCluster... clusters) {
-        return new Configuration(null, filterDefs, defaultFilters, List.of(clusters), null, false,
-                Optional.empty(), null, null);
+        return new Configuration(null, null, filterDefs, defaultFilters, null, List.of(clusters), null, false, Optional.empty(), null, null);
     }
 
     private static NamedFilterDefinition filterDef(String name, String opaqueConfig) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/OperationsPlannerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/OperationsPlannerTest.java
@@ -223,8 +223,7 @@ class OperationsPlannerTest {
 
     private static Configuration configWith(String... clusterNames) {
         var clusters = Arrays.stream(clusterNames).map(OperationsPlannerTest::vc).toList();
-        return new Configuration(null, null, null, clusters, null, false,
-                Optional.empty(), null, null);
+        return new Configuration(null, null, null, null, null, clusters, null, false, Optional.empty(), null, null);
     }
 
     private static VirtualCluster vc(String name) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/StaticSectionDifferTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/StaticSectionDifferTest.java
@@ -47,7 +47,7 @@ class StaticSectionDifferTest {
     @Test
     void differingUseIoUringIsDetected() {
         var oldConfig = baseConfig();
-        var newConfig = new Configuration(oldConfig.management(), oldConfig.filterDefinitions(),
+        var newConfig = new Configuration(oldConfig.management(), oldConfig.clusterDefinitions(), oldConfig.filterDefinitions(),
                 oldConfig.defaultFilters(), oldConfig.virtualClusters(), oldConfig.micrometer(),
                 !oldConfig.useIoUring(), // toggled
                 oldConfig.development(), oldConfig.network(), oldConfig.proxyProtocol());
@@ -64,7 +64,7 @@ class StaticSectionDifferTest {
     @Test
     void differingMicrometerIsDetected() {
         var oldConfig = baseConfig();
-        var newConfig = new Configuration(oldConfig.management(), oldConfig.filterDefinitions(),
+        var newConfig = new Configuration(oldConfig.management(), oldConfig.clusterDefinitions(), oldConfig.filterDefinitions(),
                 oldConfig.defaultFilters(), oldConfig.virtualClusters(),
                 List.of(new MicrometerDefinition("SomeMicrometerType", null)), // different from base's null
                 oldConfig.useIoUring(), oldConfig.development(), oldConfig.network(), oldConfig.proxyProtocol());
@@ -81,7 +81,7 @@ class StaticSectionDifferTest {
     @Test
     void differingDevelopmentIsDetected() {
         var oldConfig = baseConfig();
-        var newConfig = new Configuration(oldConfig.management(), oldConfig.filterDefinitions(),
+        var newConfig = new Configuration(oldConfig.management(), oldConfig.clusterDefinitions(), oldConfig.filterDefinitions(),
                 oldConfig.defaultFilters(), oldConfig.virtualClusters(), oldConfig.micrometer(),
                 oldConfig.useIoUring(),
                 Optional.of(Map.of("debug", "true")), // different from base's Optional.empty()
@@ -94,6 +94,7 @@ class StaticSectionDifferTest {
         var oldConfig = baseConfig();
         var newConfig = new Configuration(
                 new ManagementConfiguration(null, null, null), // changed: management
+                oldConfig.clusterDefinitions(),
                 oldConfig.filterDefinitions(),
                 oldConfig.defaultFilters(),
                 oldConfig.virtualClusters(),
@@ -113,6 +114,7 @@ class StaticSectionDifferTest {
         var oldConfig = baseConfig();
         var newConfig = new Configuration(
                 oldConfig.management(),
+                oldConfig.clusterDefinitions(),
                 List.of(new NamedFilterDefinition("filter-a", "SomeFilterType", null)), // changed: filterDefinitions
                 List.of("filter-a"), // changed: defaultFilters
                 List.of(vc("different-cluster")), // changed: virtualClusters
@@ -158,19 +160,19 @@ class StaticSectionDifferTest {
     }
 
     private static Configuration withManagement(Configuration base, ManagementConfiguration management) {
-        return new Configuration(management, base.filterDefinitions(), base.defaultFilters(),
+        return new Configuration(management, base.clusterDefinitions(), base.filterDefinitions(), base.defaultFilters(),
                 base.virtualClusters(), base.micrometer(),
                 base.useIoUring(), base.development(), base.network(), base.proxyProtocol());
     }
 
     private static Configuration withNetwork(Configuration base, NetworkDefinition network) {
-        return new Configuration(base.management(), base.filterDefinitions(), base.defaultFilters(),
+        return new Configuration(base.management(), base.clusterDefinitions(), base.filterDefinitions(), base.defaultFilters(),
                 base.virtualClusters(), base.micrometer(),
                 base.useIoUring(), base.development(), network, base.proxyProtocol());
     }
 
     private static Configuration withProxyProtocol(Configuration base, ProxyProtocolConfig proxyProtocol) {
-        return new Configuration(base.management(), base.filterDefinitions(), base.defaultFilters(),
+        return new Configuration(base.management(), base.clusterDefinitions(), base.filterDefinitions(), base.defaultFilters(),
                 base.virtualClusters(), base.micrometer(),
                 base.useIoUring(), base.development(), base.network(), proxyProtocol);
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/StaticSectionDifferTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/StaticSectionDifferTest.java
@@ -48,7 +48,7 @@ class StaticSectionDifferTest {
     void differingUseIoUringIsDetected() {
         var oldConfig = baseConfig();
         var newConfig = new Configuration(oldConfig.management(), oldConfig.clusterDefinitions(), oldConfig.filterDefinitions(),
-                oldConfig.defaultFilters(), oldConfig.virtualClusters(), oldConfig.micrometer(),
+                oldConfig.defaultFilters(), oldConfig.routerDefinitions(), oldConfig.virtualClusters(), oldConfig.micrometer(),
                 !oldConfig.useIoUring(), // toggled
                 oldConfig.development(), oldConfig.network(), oldConfig.proxyProtocol());
         assertThat(differ.diff(oldConfig, newConfig)).containsExactly("useIoUring");
@@ -65,7 +65,7 @@ class StaticSectionDifferTest {
     void differingMicrometerIsDetected() {
         var oldConfig = baseConfig();
         var newConfig = new Configuration(oldConfig.management(), oldConfig.clusterDefinitions(), oldConfig.filterDefinitions(),
-                oldConfig.defaultFilters(), oldConfig.virtualClusters(),
+                oldConfig.defaultFilters(), oldConfig.routerDefinitions(), oldConfig.virtualClusters(),
                 List.of(new MicrometerDefinition("SomeMicrometerType", null)), // different from base's null
                 oldConfig.useIoUring(), oldConfig.development(), oldConfig.network(), oldConfig.proxyProtocol());
         assertThat(differ.diff(oldConfig, newConfig)).containsExactly("micrometer");
@@ -82,7 +82,7 @@ class StaticSectionDifferTest {
     void differingDevelopmentIsDetected() {
         var oldConfig = baseConfig();
         var newConfig = new Configuration(oldConfig.management(), oldConfig.clusterDefinitions(), oldConfig.filterDefinitions(),
-                oldConfig.defaultFilters(), oldConfig.virtualClusters(), oldConfig.micrometer(),
+                oldConfig.defaultFilters(), oldConfig.routerDefinitions(), oldConfig.virtualClusters(), oldConfig.micrometer(),
                 oldConfig.useIoUring(),
                 Optional.of(Map.of("debug", "true")), // different from base's Optional.empty()
                 oldConfig.network(), oldConfig.proxyProtocol());
@@ -97,6 +97,7 @@ class StaticSectionDifferTest {
                 oldConfig.clusterDefinitions(),
                 oldConfig.filterDefinitions(),
                 oldConfig.defaultFilters(),
+                oldConfig.routerDefinitions(),
                 oldConfig.virtualClusters(),
                 oldConfig.micrometer(),
                 !oldConfig.useIoUring(), // changed: useIoUring
@@ -117,6 +118,7 @@ class StaticSectionDifferTest {
                 oldConfig.clusterDefinitions(),
                 List.of(new NamedFilterDefinition("filter-a", "SomeFilterType", null)), // changed: filterDefinitions
                 List.of("filter-a"), // changed: defaultFilters
+                oldConfig.routerDefinitions(),
                 List.of(vc("different-cluster")), // changed: virtualClusters
                 oldConfig.micrometer(),
                 oldConfig.useIoUring(),
@@ -161,19 +163,19 @@ class StaticSectionDifferTest {
 
     private static Configuration withManagement(Configuration base, ManagementConfiguration management) {
         return new Configuration(management, base.clusterDefinitions(), base.filterDefinitions(), base.defaultFilters(),
-                base.virtualClusters(), base.micrometer(),
+                base.routerDefinitions(), base.virtualClusters(), base.micrometer(),
                 base.useIoUring(), base.development(), base.network(), base.proxyProtocol());
     }
 
     private static Configuration withNetwork(Configuration base, NetworkDefinition network) {
         return new Configuration(base.management(), base.clusterDefinitions(), base.filterDefinitions(), base.defaultFilters(),
-                base.virtualClusters(), base.micrometer(),
+                base.routerDefinitions(), base.virtualClusters(), base.micrometer(),
                 base.useIoUring(), base.development(), network, base.proxyProtocol());
     }
 
     private static Configuration withProxyProtocol(Configuration base, ProxyProtocolConfig proxyProtocol) {
         return new Configuration(base.management(), base.clusterDefinitions(), base.filterDefinitions(), base.defaultFilters(),
-                base.virtualClusters(), base.micrometer(),
+                base.routerDefinitions(), base.virtualClusters(), base.micrometer(),
                 base.useIoUring(), base.development(), base.network(), proxyProtocol);
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/StaticSectionDifferTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/StaticSectionDifferTest.java
@@ -156,9 +156,7 @@ class StaticSectionDifferTest {
     // -------- fixture helpers --------
 
     private static Configuration baseConfig() {
-        return new Configuration(null, null, null,
-                List.of(vc("base-cluster")), null,
-                false, Optional.empty(), null, null);
+        return new Configuration(null, null, null, null, null, List.of(vc("base-cluster")), null, false, Optional.empty(), null, null);
     }
 
     private static Configuration withManagement(Configuration base, ManagementConfiguration management) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/VirtualClusterChangeDetectorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/VirtualClusterChangeDetectorTest.java
@@ -316,6 +316,7 @@ class VirtualClusterChangeDetectorTest {
                                                @Nullable Duration drainTimeout) {
         return new VirtualCluster(name,
                 new TargetCluster("kafka:9092", Optional.empty()),
+                null,
                 List.of(gateway("default", 9192)),
                 false, false, List.of(),
                 subjectBuilder, topicNameCache, drainTimeout);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/VirtualClusterChangeDetectorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/VirtualClusterChangeDetectorTest.java
@@ -118,12 +118,10 @@ class VirtualClusterChangeDetectorTest {
                 false, false,
                 List.of("filter-b", "filter-a"));
         // Build configs with the matching named filter definitions so Configuration validation passes.
-        var oldConfig = new Configuration(null,
-                List.of(filterDef("filter-a"), filterDef("filter-b")),
-                null, List.of(oldVc), null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null,
-                List.of(filterDef("filter-a"), filterDef("filter-b")),
-                null, List.of(newVc), null, false, Optional.empty(), null, null);
+        var oldConfig = new Configuration(null, null, List.of(filterDef("filter-a"), filterDef("filter-b")), null, null, List.of(oldVc), null, false, Optional.empty(),
+                null, null);
+        var newConfig = new Configuration(null, null, List.of(filterDef("filter-a"), filterDef("filter-b")), null, null, List.of(newVc), null, false, Optional.empty(),
+                null, null);
         var result = detector.detect(new ConfigurationChangeContext(oldConfig, newConfig));
         assertThat(result.clustersToModify()).containsExactly("cluster");
     }
@@ -149,8 +147,7 @@ class VirtualClusterChangeDetectorTest {
     }
 
     private static Configuration configWith(VirtualCluster... clusters) {
-        return new Configuration(null, null, null, List.of(clusters), null, false,
-                Optional.empty(), null, null);
+        return new Configuration(null, null, null, null, null, List.of(clusters), null, false, Optional.empty(), null, null);
     }
 
     /**
@@ -287,8 +284,8 @@ class VirtualClusterChangeDetectorTest {
                 List.of(gateway("default", 9192)),
                 false, false, List.of("filter-a"));
         // newConfig needs filter-a in filterDefinitions; old has no filter defs because filters list was empty.
-        var oldConfig = new Configuration(null, null, null, List.of(oldVc), null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, List.of(filterDef("filter-a")), null, List.of(newVc), null, false, Optional.empty(), null, null);
+        var oldConfig = new Configuration(null, null, null, null, null, List.of(oldVc), null, false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, null, List.of(filterDef("filter-a")), null, null, List.of(newVc), null, false, Optional.empty(), null, null);
         var result = detector.detect(new ConfigurationChangeContext(oldConfig, newConfig));
         assertThat(result.clustersToModify()).containsExactly("cluster");
     }
@@ -304,8 +301,8 @@ class VirtualClusterChangeDetectorTest {
                 new TargetCluster("kafka:9092", Optional.empty()),
                 List.of(gateway("default", 9192)),
                 false, false, List.of());
-        var oldConfig = new Configuration(null, List.of(filterDef("filter-a")), null, List.of(oldVc), null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, null, null, List.of(newVc), null, false, Optional.empty(), null, null);
+        var oldConfig = new Configuration(null, null, List.of(filterDef("filter-a")), null, null, List.of(oldVc), null, false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, null, null, null, null, List.of(newVc), null, false, Optional.empty(), null, null);
         var result = detector.detect(new ConfigurationChangeContext(oldConfig, newConfig));
         assertThat(result.clustersToModify()).containsExactly("cluster");
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/router/TestRouterFactory.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/router/TestRouterFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.router;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.router.RouterContext;
+import io.kroxylicious.proxy.router.RouterFactory;
+import io.kroxylicious.proxy.router.RouterFactoryContext;
+import io.kroxylicious.proxy.router.RouterResult;
+
+@Plugin(configType = Void.class)
+public class TestRouterFactory implements RouterFactory<Void, Void> {
+
+    @Override
+    public Void initialize(RouterFactoryContext context, Void config) {
+        return null;
+    }
+
+    @Override
+    public Router createRouter(RouterFactoryContext context, Void initializationData) {
+        return new Router() {
+            @Override
+            public CompletionStage<RouterResult> onRequest(short apiVersion, ApiKeys apiKey,
+                                                           RequestHeaderData header, ApiMessage request,
+                                                           RouterContext routerContext) {
+                return CompletableFuture.completedFuture(new RouterResult.Disconnect());
+            }
+        };
+    }
+}

--- a/kroxylicious-runtime/src/test/resources/META-INF/services/io.kroxylicious.proxy.router.RouterFactory
+++ b/kroxylicious-runtime/src/test/resources/META-INF/services/io.kroxylicious.proxy.router.RouterFactory
@@ -1,0 +1,1 @@
+io.kroxylicious.proxy.internal.router.TestRouterFactory


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

**This is a PR into a feature branch `epic/routing-prototype`**

feat(config): add router and route definitions to configuration model
5f1915f86 feat(config): add clusterDefinitions to configuration model
eaf9d089a feat(api): add Router and ProxyCluster APIs

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
