### PR TITLE
build(ci): added CI runners hardening

### DIFF
--- a/.github/workflows/build-kroxylicious-artifacts.yaml
+++ b/.github/workflows/build-kroxylicious-artifacts.yaml
@@ -24,6 +24,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -68,6 +73,11 @@ jobs:
   build_artifacts:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/build-omb-image.yml
+++ b/.github/workflows/build-omb-image.yml
@@ -46,7 +46,7 @@ jobs:
           OMB_REF: ${{ inputs.omb_ref }}
         run: |
           if echo "${OMB_REF}" | grep -qE '^[a-f0-9]{7,40}$'; then
-            # Looks like a commit SHA ? use it directly
+            # Looks like a commit SHA — use it directly
             OMB_SHA="${OMB_REF}"
           else
             # Try to resolve as a ref name (branch or tag).
@@ -109,5 +109,5 @@ jobs:
           if [[ "${{ steps.build_configuration.outputs.push_images }}" == "true" ]]; then
             echo "Pushed ${{ steps.build_configuration.outputs.tags }}" >> "${GITHUB_STEP_SUMMARY}"
           else
-            echo "Registry not configured ? image built but not pushed." >> "${GITHUB_STEP_SUMMARY}"
+            echo "Registry not configured — image built but not pushed." >> "${GITHUB_STEP_SUMMARY}"
           fi

--- a/.github/workflows/build-omb-image.yml
+++ b/.github/workflows/build-omb-image.yml
@@ -22,11 +22,19 @@ on:
 env:
   IMAGE_NAME: kroxylicious-omb
 
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   build-and-push:
     name: Build and Push OMB Image
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -38,7 +46,7 @@ jobs:
           OMB_REF: ${{ inputs.omb_ref }}
         run: |
           if echo "${OMB_REF}" | grep -qE '^[a-f0-9]{7,40}$'; then
-            # Looks like a commit SHA — use it directly
+            # Looks like a commit SHA ? use it directly
             OMB_SHA="${OMB_REF}"
           else
             # Try to resolve as a ref name (branch or tag).
@@ -101,5 +109,5 @@ jobs:
           if [[ "${{ steps.build_configuration.outputs.push_images }}" == "true" ]]; then
             echo "Pushed ${{ steps.build_configuration.outputs.tags }}" >> "${GITHUB_STEP_SUMMARY}"
           else
-            echo "Registry not configured — image built but not pushed." >> "${GITHUB_STEP_SUMMARY}"
+            echo "Registry not configured ? image built but not pushed." >> "${GITHUB_STEP_SUMMARY}"
           fi

--- a/.github/workflows/check-fork-branch.yaml
+++ b/.github/workflows/check-fork-branch.yaml
@@ -30,9 +30,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: Check fork branch
         if: github.event.pull_request.head.repo.full_name != github.repository && github.head_ref == 'main'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             core.setFailed('main branch should not be used in pull requests from a fork"')

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,10 +13,10 @@
 # on the forks of developers who haven't configured the variables/secrets.
 #
 # Multi-arch proxy images are built as a 4-phase process:
-#   1. mvn install  — compile and install all module JARs into ~/.m2 once
-#   2. mvn + docker — dist packaging and image build for linux/amd64
-#   3. mvn + docker — dist packaging (with -Paarch64) and image build for linux/arm64
-#   4. manifest     — merge per-arch images into a multi-arch manifest list
+#   1. mvn install  ? compile and install all module JARs into ~/.m2 once
+#   2. mvn + docker ? dist packaging and image build for linux/amd64
+#   3. mvn + docker ? dist packaging (with -Paarch64) and image build for linux/arm64
+#   4. manifest     ? merge per-arch images into a multi-arch manifest list
 #
 # The operator has no architecture-specific native JARs, so a single multi-arch
 # Docker Buildx build covers both platforms without a paired Maven run.
@@ -40,6 +40,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Test for Slack secret'
         env:
           KROXYLICIOUS_SLACK_WEBHOOK: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
@@ -97,7 +102,7 @@ jobs:
             echo "admission_tags=${ADMISSION_IMAGE}:${RELEASE_VERSION},${ADMISSION_IMAGE}:latest" >> $GITHUB_OUTPUT
           fi
 
-      # ── Phase 1: compile and install ─────────────────────────────────────────
+      # ?? Phase 1: compile and install ?????????????????????????????????????????
       # Install (not just package) so the per-arch dist steps can resolve local
       # module JARs from ~/.m2 without needing --also-make.
 
@@ -123,7 +128,7 @@ jobs:
           username: ${{ vars.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_TOKEN }}
 
-      # ── Phase 2: amd64 dist + images ─────────────────────────────────────────
+      # ?? Phase 2: amd64 dist + images ?????????????????????????????????????????
 
       - name: Build amd64 distribution artifacts
         run: |
@@ -177,7 +182,7 @@ jobs:
           cache-from: type=gha,scope=admission
           cache-to: type=gha,mode=max,compression=zstd,scope=admission
 
-      # ── Phase 3: arm64 dist + image ──────────────────────────────────────────
+      # ?? Phase 3: arm64 dist + image ??????????????????????????????????????????
       # `clean package` on kroxylicious-app alone wipes its target/ directory so
       # the aarch64 assembly contains only linux-aarch_64 Netty native binaries
       # (no leftovers from the amd64 run above).
@@ -210,7 +215,7 @@ jobs:
           cache-from: type=gha,scope=proxy-arm64
           cache-to: type=gha,mode=max,compression=zstd,scope=proxy-arm64
 
-      # ── Phase 4: multi-arch manifest ─────────────────────────────────────────
+      # ?? Phase 4: multi-arch manifest ?????????????????????????????????????????
       # Assemble the canonical proxy tag and the legacy kroxylicious alias as
       # manifest lists pointing at the per-arch images pushed above.
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,4 +1,4 @@
-# docker.yaml - builds and pushes kroxylicious container images.
+# docker.yaml - builds and pushes Kroxylicious container images.
 #
 # Requires repository variables:
 # - REGISTRY_SERVER - the server of the container registry service e.g. `quay.io` or `docker.io`
@@ -13,10 +13,10 @@
 # on the forks of developers who haven't configured the variables/secrets.
 #
 # Multi-arch proxy images are built as a 4-phase process:
-#   1. mvn install  ? compile and install all module JARs into ~/.m2 once
-#   2. mvn + docker ? dist packaging and image build for linux/amd64
-#   3. mvn + docker ? dist packaging (with -Paarch64) and image build for linux/arm64
-#   4. manifest     ? merge per-arch images into a multi-arch manifest list
+#   1. mvn install  — compile and install all module JARs into ~/.m2 once
+#   2. mvn + docker — dist packaging and image build for linux/amd64
+#   3. mvn + docker — dist packaging (with -Paarch64) and image build for linux/arm64
+#   4. manifest     — merge per-arch images into a multi-arch manifest list
 #
 # The operator has no architecture-specific native JARs, so a single multi-arch
 # Docker Buildx build covers both platforms without a paired Maven run.
@@ -102,7 +102,7 @@ jobs:
             echo "admission_tags=${ADMISSION_IMAGE}:${RELEASE_VERSION},${ADMISSION_IMAGE}:latest" >> $GITHUB_OUTPUT
           fi
 
-      # ?? Phase 1: compile and install ?????????????????????????????????????????
+      # ── Phase 1: compile and install ─────────────────────────────────────────
       # Install (not just package) so the per-arch dist steps can resolve local
       # module JARs from ~/.m2 without needing --also-make.
 
@@ -128,7 +128,7 @@ jobs:
           username: ${{ vars.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_TOKEN }}
 
-      # ?? Phase 2: amd64 dist + images ?????????????????????????????????????????
+      # ── Phase 2: amd64 dist + images ─────────────────────────────────────────
 
       - name: Build amd64 distribution artifacts
         run: |
@@ -182,7 +182,7 @@ jobs:
           cache-from: type=gha,scope=admission
           cache-to: type=gha,mode=max,compression=zstd,scope=admission
 
-      # ?? Phase 3: arm64 dist + image ??????????????????????????????????????????
+      # ── Phase 3: arm64 dist + image ──────────────────────────────────────────
       # `clean package` on kroxylicious-app alone wipes its target/ directory so
       # the aarch64 assembly contains only linux-aarch_64 Netty native binaries
       # (no leftovers from the amd64 run above).
@@ -215,8 +215,8 @@ jobs:
           cache-from: type=gha,scope=proxy-arm64
           cache-to: type=gha,mode=max,compression=zstd,scope=proxy-arm64
 
-      # ?? Phase 4: multi-arch manifest ?????????????????????????????????????????
-      # Assemble the canonical proxy tag and the legacy kroxylicious alias as
+      # ── Phase 4: multi-arch manifest ─────────────────────────────────────────
+      # Assemble the canonical proxy tag and the legacy Kroxylicious alias as
       # manifest lists pointing at the per-arch images pushed above.
 
       - name: Create and push proxy multi-arch manifest

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -31,6 +31,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Test for Slack secret'
         env:
           KROXYLICIOUS_SLACK_WEBHOOK: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # StepSecurity harden-runner cannot be used here because of the limitation of running it on containers (minikube)
+      # https://github.com/step-security/harden-runner/blob/main/docs/limitations.md
       - name: 'Test for Slack secret'
         env:
           KROXYLICIOUS_SLACK_WEBHOOK: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -31,11 +31,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
       - name: 'Test for Slack secret'
         env:
           KROXYLICIOUS_SLACK_WEBHOOK: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -33,6 +33,11 @@ jobs:
       test_chunks: ${{ steps.discover.outputs.test_chunks }}
       modules: ${{ steps.discover.outputs.modules }}
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -70,6 +75,11 @@ jobs:
     outputs:
       kroxylicious_image: ${{ steps.build_image.outputs.KROXYLICIOUS_IMAGE }}
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -127,6 +137,11 @@ jobs:
       matrix:
         tests: ${{ fromJson(needs.discover_integration_test_chunks.outputs.test_chunks) }}
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: Parse test specifications
         id: parse
         run: |
@@ -260,6 +275,11 @@ jobs:
     needs: build_artifacts
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -288,19 +308,24 @@ jobs:
     permissions:
       actions: read
     steps:
-    - name: 'Check all matrix builds'
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        FAILED_JSON=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
-          --jq '.jobs[] | select(.conclusion=="failure") | {name: .name, url: .html_url}')
-        if [ -z "$FAILED_JSON" ]; then
-          echo "All jobs passed!" >> $GITHUB_STEP_SUMMARY
-          echo "No failures detected."
-          exit 0
-        fi
-        echo "Failed Matrix Jobs" >> $GITHUB_STEP_SUMMARY
-        echo "The following instances failed:"
-        echo "$FAILED_JSON" | jq -r '"* [\(.name)](\(.url))"' >> $GITHUB_STEP_SUMMARY
-        echo "$FAILED_JSON" | jq -r '"\(.name): \(.url)"'
-        exit 1
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: 'Check all matrix builds'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          FAILED_JSON=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+            --jq '.jobs[] | select(.conclusion=="failure") | {name: .name, url: .html_url}')
+          if [ -z "$FAILED_JSON" ]; then
+            echo "All jobs passed!" >> $GITHUB_STEP_SUMMARY
+            echo "No failures detected."
+            exit 0
+          fi
+          echo "Failed Matrix Jobs" >> $GITHUB_STEP_SUMMARY
+          echo "The following instances failed:"
+          echo "$FAILED_JSON" | jq -r '"* [\(.name)](\(.url))"' >> $GITHUB_STEP_SUMMARY
+          echo "$FAILED_JSON" | jq -r '"\(.name): \(.url)"'
+          exit 1

--- a/.github/workflows/kaf.yaml
+++ b/.github/workflows/kaf.yaml
@@ -6,7 +6,7 @@
 # - REGISTRY_TOKEN - the access token that corresponds to `REGISTRY_USERNAME`
 #
 
-name: Kaf Container 
+name: Kaf Container
 on:
   workflow_dispatch:
     inputs:
@@ -22,11 +22,19 @@ on:
         description: 'Ref (branch/tag) to build'
         required: true
         default: 'master'
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     if: ${{ vars.REGISTRY_SERVER != '' && vars.REGISTRY_USERNAME != '' }}
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,6 +28,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Test for Slack secret'
         env:
           KROXYLICIOUS_SLACK_WEBHOOK: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -37,6 +37,11 @@ jobs:
           - distro: 'corretto'
             version: '25'
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Test for Sonar secret'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -88,7 +93,7 @@ jobs:
             -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED} \
             install
       - name: Cache SonarCloud packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         if: github.ref_name == 'main' || env.SONAR_TOKEN_SET == 'true'
         with:
           path: ~/.sonar/cache

--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -31,6 +31,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Test for Sonar secret'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -50,7 +55,7 @@ jobs:
       - name: 'Cache Maven packages'
         uses: ./.github/actions/common/cache-maven-packages
       - name: Cache SonarCloud packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         if: github.ref_name == 'main' && env.SONAR_TOKEN_SET == 'true'
         with:
           path: ~/.sonar/cache

--- a/.github/workflows/operator-tests-microshift.yaml
+++ b/.github/workflows/operator-tests-microshift.yaml
@@ -22,7 +22,7 @@
 # operator works correctly on the OpenShift API surface.
 #
 # Prerequisites / secrets required in the repository:
-#   REDHAT_PULL_SECRET  ? Red Hat pull secret (JSON) downloaded from
+#   REDHAT_PULL_SECRET  – Red Hat pull secret (JSON) downloaded from
 #                         https://console.redhat.com/openshift/downloads#tool-pull-secret
 #                         Required to pull MicroShift's bundled OpenShift images.
 

--- a/.github/workflows/operator-tests-microshift.yaml
+++ b/.github/workflows/operator-tests-microshift.yaml
@@ -22,7 +22,7 @@
 # operator works correctly on the OpenShift API surface.
 #
 # Prerequisites / secrets required in the repository:
-#   REDHAT_PULL_SECRET  – Red Hat pull secret (JSON) downloaded from
+#   REDHAT_PULL_SECRET  ? Red Hat pull secret (JSON) downloaded from
 #                         https://console.redhat.com/openshift/downloads#tool-pull-secret
 #                         Required to pull MicroShift's bundled OpenShift images.
 
@@ -54,11 +54,16 @@ jobs:
     outputs:
       pull-secret-check: ${{ steps.pull-check.outputs.pullsecret }}
     steps:
-        - name: 'Test for presence of Red Hat pull-secret'
-          id: pull-check
-          env:
-            REDHAT_PULL_SECRET: ${{ secrets.REDHAT_PULL_SECRET }}
-          run: echo "pullsecret=$(test ${REDHAT_PULL_SECRET} && echo true)" >> "$GITHUB_OUTPUT"
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: 'Test for presence of Red Hat pull-secret'
+        id: pull-check
+        env:
+          REDHAT_PULL_SECRET: ${{ secrets.REDHAT_PULL_SECRET }}
+        run: echo "pullsecret=$(test ${REDHAT_PULL_SECRET} && echo true)" >> "$GITHUB_OUTPUT"
 
   operator-tests-microshift:
     name: Operator integration & system tests on MicroShift
@@ -68,6 +73,11 @@ jobs:
     if: needs.preflight.outputs.pull-secret-check == 'true' && (contains(fromJSON('["workflow_dispatch", "push"]'), github.event_name) || github.event.workflow_run.conclusion == 'success')
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Test for Slack secret'
         env:
           KROXYLICIOUS_SLACK_WEBHOOK: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}

--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -56,6 +56,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -113,19 +118,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
-            PR_APPROVAL="$(gh pr view ${{ inputs.release-pr-issue-number}} --json reviewDecision | jq -r .reviewDecision)"
-            if [[ "$PR_APPROVAL" != "APPROVED" ]]; then
-              gh issue comment  ${{ github.event.issue.number }} --body "PR is not Approved! You must approve the release PR before promoting it"
-              exit -1
-            fi
-            echo "PR is Approved, Continuing promotion."
+          PR_APPROVAL="$(gh pr view ${{ inputs.release-pr-issue-number}} --json reviewDecision | jq -r .reviewDecision)"
+          if [[ "$PR_APPROVAL" != "APPROVED" ]]; then
+            gh issue comment  ${{ github.event.issue.number }} --body "PR is not Approved! You must approve the release PR before promoting it"
+            exit -1
+          fi
+          echo "PR is Approved, Continuing promotion."
 
       - name: 'Get the branch name associated with the PR'
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
-            echo "PR_BRANCH=$(gh pr view ${{ inputs.release-pr-issue-number}} --json headRefName | jq -r .headRefName)" >> $GITHUB_ENV
-            echo "PR_BASE_BRANCH=$(gh pr view ${{ inputs.release-pr-issue-number}} --json baseRefName | jq -r .baseRefName)" >> $GITHUB_ENV
+          echo "PR_BRANCH=$(gh pr view ${{ inputs.release-pr-issue-number}} --json headRefName | jq -r .headRefName)" >> $GITHUB_ENV
+          echo "PR_BASE_BRANCH=$(gh pr view ${{ inputs.release-pr-issue-number}} --json baseRefName | jq -r .baseRefName)" >> $GITHUB_ENV
 
       - name: 'Branch name matches naming conventions'
         env:

--- a/.github/workflows/publish-snapshot-docs-to-website.yaml
+++ b/.github/workflows/publish-snapshot-docs-to-website.yaml
@@ -47,6 +47,11 @@ jobs:
         ports:
           - 5000:5000
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Test for Slack secret'
         env:
           KROXYLICIOUS_SLACK_WEBHOOK: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
@@ -61,15 +66,15 @@ jobs:
       # We need to call common action from kroxylicious path as it is the path used in the previous checkout
       - name: Setup Java
         uses: ./kroxylicious/.github/actions/common/setup-java
-      
+
       - name: Build and install BOM
         run: mvn clean install -pl :kroxylicious-bom
         working-directory: kroxylicious
-      
+
       - name: Build with Maven
         run: mvn -Dquick -P dist package --pl kroxylicious-docs --am
         working-directory: kroxylicious
-      
+
       - name: Checkout Website
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -92,7 +97,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Load Jekyll configuration overrides
-        run: | 
+        run: |
           echo "baseurl: kroxylicious" > _config-baseurl.yml
           echo "${{ vars.JEKYLL_CONFIG_OVERRIDES }}" > _config-overrides.yml
         working-directory: kroxylicious.github.io
@@ -133,6 +138,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Test for Slack secret'
         env:
           KROXYLICIOUS_SLACK_WEBHOOK: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -30,6 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: "Calculate effective token"
         env:
           EFFECTIVE_TOKEN: "${{ secrets.KROXYLICIOUS_GITHUB_READWRITE_TOKEN || secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/robot-command-dispatcher.yaml
+++ b/.github/workflows/robot-command-dispatcher.yaml
@@ -26,6 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '@kroxylicious-robot')  && !contains(github.event.comment.body, '@kroxylicious-robot run')}}
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -80,6 +85,11 @@ jobs:
     needs: process-command
     if: ${{ needs.process-command.outputs.unrecognized == 'true' }}
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/run-system-tests.yaml
+++ b/.github/workflows/run-system-tests.yaml
@@ -52,6 +52,11 @@ jobs:
     outputs:
       test_chunks: ${{ steps.discover.outputs.test_chunks }}
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -72,6 +77,11 @@ jobs:
         tests: ${{ fromJson(needs.discover_system_test_chunks.outputs.test_chunks) }}
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: Log tests to run
         run: echo "Running tests on classes '${{ matrix.tests }}'"
       - name: 'Check out repository'
@@ -189,6 +199,11 @@ jobs:
     permissions:
       actions: read
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Check all matrix builds'
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/run-system-tests.yaml
+++ b/.github/workflows/run-system-tests.yaml
@@ -52,11 +52,6 @@ jobs:
     outputs:
       test_chunks: ${{ steps.discover.outputs.test_chunks }}
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -77,11 +72,6 @@ jobs:
         tests: ${{ fromJson(needs.discover_system_test_chunks.outputs.test_chunks) }}
 
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
       - name: Log tests to run
         run: echo "Running tests on classes '${{ matrix.tests }}'"
       - name: 'Check out repository'
@@ -199,11 +189,6 @@ jobs:
     permissions:
       actions: read
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
       - name: 'Check all matrix builds'
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/run-system-tests.yaml
+++ b/.github/workflows/run-system-tests.yaml
@@ -52,6 +52,7 @@ jobs:
     outputs:
       test_chunks: ${{ steps.discover.outputs.test_chunks }}
     steps:
+
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/run-system-tests.yaml
+++ b/.github/workflows/run-system-tests.yaml
@@ -52,7 +52,10 @@ jobs:
     outputs:
       test_chunks: ${{ steps.discover.outputs.test_chunks }}
     steps:
-
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -73,6 +76,8 @@ jobs:
         tests: ${{ fromJson(needs.discover_system_test_chunks.outputs.test_chunks) }}
 
     steps:
+      # StepSecurity harden-runner cannot be used here because of the limitation of running it on containers (minikube)
+      # https://github.com/step-security/harden-runner/blob/main/docs/limitations.md
       - name: Log tests to run
         run: echo "Running tests on classes '${{ matrix.tests }}'"
       - name: 'Check out repository'

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Test for Sonar secret'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -78,7 +83,7 @@ jobs:
       - name: 'Cache Maven packages'
         uses: ./.github/actions/common/cache-maven-packages
       - name: Cache SonarCloud packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         if: env.SONAR_TOKEN_SET == 'true'
         with:
           path: ~/.sonar/cache

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -61,6 +61,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/system-tests-merge.yaml
+++ b/.github/workflows/system-tests-merge.yaml
@@ -50,11 +50,8 @@ jobs:
     outputs:
       test_clients: ${{ steps.discover.outputs.test_clients }}
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
+      # StepSecurity harden-runner cannot be used here because of the limitation of running it on containers
+      # https://github.com/step-security/harden-runner/blob/main/docs/limitations.md
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -93,11 +90,8 @@ jobs:
     permissions:
       actions: read
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
+      # StepSecurity harden-runner cannot be used here because of the limitation of running it on containers
+      # https://github.com/step-security/harden-runner/blob/main/docs/limitations.md
       - name: 'Check all matrix builds'
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/system-tests-merge.yaml
+++ b/.github/workflows/system-tests-merge.yaml
@@ -50,6 +50,11 @@ jobs:
     outputs:
       test_clients: ${{ steps.discover.outputs.test_clients }}
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -88,6 +93,11 @@ jobs:
     permissions:
       actions: read
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Check all matrix builds'
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/system-tests-pr.yaml
+++ b/.github/workflows/system-tests-pr.yaml
@@ -48,6 +48,10 @@ jobs:
     outputs:
       kafka_client: ${{ steps.kafkaClient.outputs.kafka_client }}
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/system-tests-pr.yaml
+++ b/.github/workflows/system-tests-pr.yaml
@@ -48,11 +48,6 @@ jobs:
     outputs:
       kafka_client: ${{ steps.kafkaClient.outputs.kafka_client }}
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/system-tests-pr.yaml
+++ b/.github/workflows/system-tests-pr.yaml
@@ -48,6 +48,11 @@ jobs:
     outputs:
       kafka_client: ${{ steps.kafkaClient.outputs.kafka_client }}
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Hardening our CI workflows helps reducing the risk of supply chain attacks etc. It uses it prevent unexpected `sudos` and prevent unexpected network traffic.

To make these changes, we have used this suggested [StepSecurity online tool](https://app.stepsecurity.io/secure-workflow)

Once the workflows are run with the hardening, we need to follow this [instructions](https://github.com/step-security/harden-runner#step-2-access-security-insights) to see the weaknesses.

Installing the [app](https://github.com/apps/stepsecurity-actions-security) on GitHub could allow us to include it as a requirement for merging the PR.

### Additional Context

Closes #3098 

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
