### PR TITLE
(feat) Hot reload Implementation (7/N) - Add ReplaceCluster operation to support modified cluster reload

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
@@ -328,6 +328,24 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     }
 
     @Override
+    public void closeClientsFor(String virtualCluster) {
+        var exceptions = new ArrayList<Exception>();
+        clients.entrySet().removeIf(e -> {
+            if (e.getKey().virtualCluster().equals(virtualCluster)) {
+                closeCloseable(e.getValue()).ifPresent(exceptions::add);
+                return true;
+            }
+            return false;
+        });
+        if (!exceptions.isEmpty()) {
+            // Log each close-failure (so a stuck client doesn't hide behind the rest) and
+            // surface the first as the test-visible failure. Matches the close() pattern.
+            exceptions.forEach(ex -> LOGGER.error(ex.getMessage(), ex));
+            throw new IllegalStateException(exceptions.get(0));
+        }
+    }
+
+    @Override
     public void close() {
         try {
             List<Exception> exceptions = new ArrayList<>();

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
@@ -341,7 +341,10 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
             // Log each close-failure (so a stuck client doesn't hide behind the rest) and
             // surface the first as the test-visible failure. Matches the close() pattern.
             exceptions.forEach(ex -> LOGGER.error(ex.getMessage(), ex));
-            throw new IllegalStateException(exceptions.get(0));
+            throw new IllegalStateException(
+                    "%d client(s) failed to close cleanly. First client close chained, others have been logged at ERROR"
+                            .formatted(exceptions.size()),
+                    exceptions.get(0));
         }
     }
 

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousTester.java
@@ -355,6 +355,24 @@ public interface KroxyliciousTester extends Closeable {
     CompletableFuture<ReconfigureResult> reconfigure(Configuration newConfig);
 
     /**
+     * Closes and evicts any cached Kafka clients (admin, producer, consumer) that this tester
+     * has previously created for {@code virtualCluster}, across every gateway. Subsequent
+     * client requests for the same cluster will rebuild fresh clients against the tester's
+     * current configuration.
+     * <p>
+     * Useful after a {@link #reconfigure(Configuration)} that changes a cluster's transport
+     * addressing (e.g. port relocation, SNI hostname change, TLS swap): the tester's
+     * per-{@code (cluster, gateway)} client cache holds Kafka clients whose internal
+     * bootstrap is fixed at construction time, and those clients can't follow the cluster
+     * to its new address. Calling this method invalidates the cached clients so that the
+     * next {@link #producer(String)} / {@link #consumer(String)} call resolves a fresh
+     * bootstrap and constructs a new Kafka client around it.
+     *
+     * @param virtualCluster the virtual cluster whose cached clients should be evicted
+     */
+    void closeClientsFor(String virtualCluster);
+
+    /**
      * Close the Kroxylicious server under test and any other resources that need cleaning.
      */
     @Override

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTesterTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTesterTest.java
@@ -60,6 +60,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -323,6 +324,78 @@ class DefaultKroxyliciousTesterTest {
             // When
             // Then
             assertThatThrownBy(tester::close)
+                    .cause()
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage(EXCEPTION_MESSAGE);
+        }
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    void closeClientsForEvictsOnlyTheNamedClustersClients() {
+        // Given — touch every cluster so each has a cached KroxyliciousClients in the tester.
+        try (var tester = buildTester()) {
+            tester.admin(VIRTUAL_CLUSTER_A);
+            tester.admin(VIRTUAL_CLUSTER_B);
+            tester.admin(VIRTUAL_CLUSTER_C);
+
+            // When — evict only cluster A's clients.
+            tester.closeClientsFor(VIRTUAL_CLUSTER_A);
+
+            // Then — A is closed, B and C are untouched.
+            verify(kroxyliciousClientsA).close();
+            verify(kroxyliciousClientsB, never()).close();
+            verify(kroxyliciousClientsC, never()).close();
+        }
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    void closeClientsForCausesNextAccessToRebuildTheClient() {
+        // Given — touch cluster A so the cache holds a client built for it.
+        try (var tester = buildTester()) {
+            tester.admin(VIRTUAL_CLUSTER_A);
+
+            // When — evict, then access again.
+            tester.closeClientsFor(VIRTUAL_CLUSTER_A);
+            tester.admin(VIRTUAL_CLUSTER_A);
+
+            // Then — ClientFactory.build was called twice: once for the original cached client,
+            // and once for the rebuilt-after-eviction client. This is the load-bearing property
+            // for callers — closeClientsFor must invalidate, not just close, so that the next
+            // tester.producer/consumer/admin picks up the current configuration.
+            verify(clientFactory, times(2)).build(eq(new GatewayId(VIRTUAL_CLUSTER_A, DEFAULT_GATEWAY_NAME)), anyMap());
+        }
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    void closeClientsForIsNoOpWhenClusterHasNoCachedClient() {
+        try (var tester = buildTester()) {
+            // Don't touch cluster A — nothing is cached for it.
+
+            // When
+            tester.closeClientsFor(VIRTUAL_CLUSTER_A);
+
+            // Then — no close call attempted on any per-cluster client mock.
+            verify(kroxyliciousClientsA, never()).close();
+            verify(kroxyliciousClientsB, never()).close();
+            verify(kroxyliciousClientsC, never()).close();
+        }
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    void closeClientsForSurfacesCloseFailureAsIllegalStateException() {
+        // Given — cluster A's cached client throws on close. doNothing on the second
+        // invocation so the try-with-resources block doesn't fail when it cleans up.
+        try (var tester = buildTester()) {
+            tester.admin(VIRTUAL_CLUSTER_A);
+            doThrow(new IllegalStateException(EXCEPTION_MESSAGE)).doNothing().when(kroxyliciousClientsA).close();
+
+            // When — closeClientsFor must NOT swallow the failure silently; tests need to see it.
+            assertThatThrownBy(() -> tester.closeClientsFor(VIRTUAL_CLUSTER_A))
+                    .isInstanceOf(IllegalStateException.class)
                     .cause()
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage(EXCEPTION_MESSAGE);

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -34,6 +34,7 @@ import io.kroxylicious.it.net.IntegrationTestInetAddressResolverProvider;
 import io.kroxylicious.proxy.KafkaProxy;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.VirtualCluster;
+import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.reload.ReconfigureError;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils;
@@ -436,9 +437,162 @@ class HotReloadIT extends BaseIT {
         }
     }
 
+    @Test
+    void shouldModifyPortAddressedVcWithSamePort(@BrokerCluster KafkaCluster cluster) throws Exception {
+        // Same-port modify is the tight-timing case: ReplaceCluster's internal unbind happens
+        // immediately before its rebind of the SAME port. Triggered here by flipping logNetwork
+        // (a runtime-observable field whose change `VirtualCluster.sameAs` reports as a modify
+        // but which doesn't affect client behaviour, so the cluster keeps working).
+        int port = PORT_BLOCK_MODIFY_SAME_PORT;
+        var startingConfig = portConfig(portVc(cluster, "vc-modify", port));
+        var afterConfig = portConfig(portVcWithLogNetwork(cluster, "vc-modify", port, true));
+
+        var testerBuilder = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToVirtualClusters(startingConfig.virtualClusters().toArray(new VirtualCluster[0]));
+        try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(testerBuilder).createDefaultKroxyliciousTester()) {
+
+            String topic = tester.createTopic("vc-modify");
+            assertProduceConsumeRoundTrip(tester, "vc-modify", topic, "phase1-pre-modify");
+
+            LOGGER.info("Reconfiguring to modify vc-modify (same port {}, logNetwork=true)", port);
+            assertThat(tester.reconfigure(afterConfig))
+                    .succeedsWithin(RECONFIGURE_TIMEOUT)
+                    .satisfies(rr -> assertThat(rr.hasErrors())
+                            .as("ReconfigureResult should have no errors for a clean same-port modify")
+                            .isFalse());
+
+            // The same port is now serving the new shape of the VC. Tight unbind-then-rebind
+            // worked: clients connecting after the reconfigure are accepted on the same port.
+            assertProduceConsumeRoundTrip(tester, "vc-modify", topic, "phase2-post-modify");
+        }
+    }
+
+    @Test
+    void shouldModifyPortAddressedVcWithDifferentPort(@BrokerCluster KafkaCluster cluster) throws Exception {
+        // Port change is itself a modify trigger. After the reconfigure, the old port should
+        // be released and the new port should be serving real Kafka traffic. The tester's
+        // per-(cluster, gateway) client cache holds Kafka clients constructed against the
+        // old bootstrap and can't follow the cluster to its new port — closeClientsFor
+        // evicts them so the post-modify produce/consume round-trip rebuilds against the
+        // new bootstrap and exercises the new port end-to-end.
+        int oldPort = PORT_BLOCK_MODIFY_DIFF_PORT;
+        int newPort = PORT_BLOCK_MODIFY_DIFF_PORT + PORT_STRIDE;
+        var startingConfig = portConfig(portVc(cluster, "vc-relocate", oldPort));
+        var afterConfig = portConfig(portVc(cluster, "vc-relocate", newPort));
+
+        var testerBuilder = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToVirtualClusters(startingConfig.virtualClusters().toArray(new VirtualCluster[0]));
+        try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(testerBuilder).createDefaultKroxyliciousTester()) {
+
+            String topicBefore = tester.createTopic("vc-relocate");
+            assertProduceConsumeRoundTrip(tester, "vc-relocate", topicBefore, "phase1-old-port");
+
+            LOGGER.info("Reconfiguring to modify vc-relocate from port {} to port {}", oldPort, newPort);
+            assertThat(tester.reconfigure(afterConfig))
+                    .succeedsWithin(RECONFIGURE_TIMEOUT)
+                    .satisfies(rr -> assertThat(rr.hasErrors())
+                            .as("ReconfigureResult should have no errors for a port-relocation modify")
+                            .isFalse());
+
+            // The old port is reclaimable from outside the proxy — the remove half of the
+            // replace freed the binding.
+            assertPortIsBindable(oldPort);
+
+            // Drop the cached clients built around the old bootstrap so the next
+            // tester.producer/consumer call rebuilds against the new port.
+            tester.closeClientsFor("vc-relocate");
+
+            // Independent external evidence that the new port serves real traffic: a fresh
+            // Kafka client connects, produces, and consumes through localhost:newPort.
+            String topicAfter = tester.createTopic("vc-relocate");
+            assertProduceConsumeRoundTrip(tester, "vc-relocate", topicAfter, "phase2-new-port");
+        }
+    }
+
+    @Test
+    void shouldSurfaceModifyFailureAsReconfigureError(@BrokerCluster KafkaCluster cluster) throws Exception {
+        // ReplaceCluster's internal add-half can fail (e.g. the new port is held externally).
+        // The orchestrator surfaces this as a per-cluster ReconfigureError carrying the bind
+        // cause — same shape as a pure-add bind failure. The cluster ends up offline.
+        int oldPort = PORT_BLOCK_MODIFY_FAIL;
+        int contestedPort = PORT_BLOCK_MODIFY_FAIL + PORT_STRIDE;
+
+        try (var externalHolder = openSocketOnPort(contestedPort)) {
+            assertThat(externalHolder.getLocalPort()).isEqualTo(contestedPort);
+
+            var startingConfig = portConfig(portVc(cluster, "vc-fail-modify", oldPort));
+            var afterConfig = portConfig(portVc(cluster, "vc-fail-modify", contestedPort));
+
+            var testerBuilder = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                    .addToVirtualClusters(startingConfig.virtualClusters().toArray(new VirtualCluster[0]));
+            try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(testerBuilder).createDefaultKroxyliciousTester()) {
+
+                LOGGER.info("Reconfiguring vc-fail-modify from port {} to port {} (held externally)", oldPort, contestedPort);
+                assertThat(tester.reconfigure(afterConfig))
+                        .succeedsWithin(RECONFIGURE_TIMEOUT)
+                        .satisfies(rr -> {
+                            assertThat(rr.hasErrors())
+                                    .as("ReconfigureResult should report the bind failure on the new port")
+                                    .isTrue();
+                            assertThat(rr.errors())
+                                    .extracting(ReconfigureError::humanReadableIdentifier)
+                                    .containsExactly("vc-fail-modify");
+                        });
+                // Old port is freed (the remove half of the replace ran cleanly).
+                assertPortIsBindable(oldPort);
+            }
+        }
+    }
+
+    @Test
+    void shouldModifySniAddressedVcWithoutDisturbingOthers(@BrokerCluster KafkaCluster cluster) throws Exception {
+        // SNI-addressed modify: both VCs share the proxy's SNI acceptor port. Flipping a
+        // non-network field on one VC must not disturb the other.
+        KeystoreTrustStorePair certs = buildKeystoreTrustStorePair("*" + SNI_BASE_DOMAIN);
+        var baselineVc = buildSniVirtualCluster(cluster, certs, VC_BASELINE_NAME, VC_BASELINE_BOOTSTRAP, VC_BASELINE_BROKER_PATTERN);
+        var modifyVcBefore = buildSniVirtualCluster(cluster, certs, VC_OUTGOING_NAME, VC_OUTGOING_BOOTSTRAP, VC_OUTGOING_BROKER_PATTERN);
+        var modifyVcAfter = new VirtualClusterBuilder(modifyVcBefore).withLogNetwork(true).build();
+
+        var startingConfig = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToVirtualClusters(baselineVc, modifyVcBefore).build();
+        var afterConfig = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToVirtualClusters(baselineVc, modifyVcAfter).build();
+
+        var testerBuilder = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToVirtualClusters(startingConfig.virtualClusters().toArray(new VirtualCluster[0]));
+        try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(testerBuilder)
+                .setTrustStoreLocation(certs.clientTrustStore())
+                .setTrustStorePassword(certs.password())
+                .createDefaultKroxyliciousTester()) {
+
+            String topic = tester.createTopic(VC_BASELINE_NAME);
+            assertProduceConsumeRoundTrip(tester, VC_BASELINE_NAME, topic, "phase1-baseline");
+            assertProduceConsumeRoundTrip(tester, VC_OUTGOING_NAME, topic, "phase1-modify");
+
+            LOGGER.info("Reconfiguring to modify '{}' (flip logNetwork)", VC_OUTGOING_NAME);
+            assertThat(tester.reconfigure(afterConfig))
+                    .succeedsWithin(RECONFIGURE_TIMEOUT)
+                    .satisfies(rr -> assertThat(rr.hasErrors())
+                            .as("ReconfigureResult should have no errors for a clean SNI modify")
+                            .isFalse());
+
+            // Baseline is undisturbed.
+            assertProduceConsumeRoundTrip(tester, VC_BASELINE_NAME, topic, "phase3-baseline");
+            // Modified VC continues to serve.
+            assertProduceConsumeRoundTrip(tester, VC_OUTGOING_NAME, topic, "phase3-modify");
+        }
+    }
+
     private static VirtualCluster portVc(KafkaCluster cluster, String name, int port) {
         return KroxyliciousConfigUtils.baseVirtualClusterBuilder(cluster, name)
                 .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(new HostPort("localhost", port)).build())
+                .build();
+    }
+
+    private static VirtualCluster portVcWithLogNetwork(KafkaCluster cluster, String name, int port, boolean logNetwork) {
+        return KroxyliciousConfigUtils.baseVirtualClusterBuilder(cluster, name)
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(new HostPort("localhost", port)).build())
+                .withLogNetwork(logNetwork)
                 .build();
     }
 
@@ -456,6 +610,9 @@ class HotReloadIT extends BaseIT {
     private static final int PORT_BLOCK_BINDFAIL = 51200; // shouldSurfaceBindFailureAsReconfigureError...
     private static final int PORT_BLOCK_REUSE = 51300; // shouldSupportPortReuseAcrossReconfigures
     private static final int PORT_BLOCK_ADD_THEN_REMOVE = 51400; // shouldRemoveRuntimeAddedPortAddressedVc
+    private static final int PORT_BLOCK_MODIFY_SAME_PORT = 51500; // shouldModifyPortAddressedVcWithSamePort
+    private static final int PORT_BLOCK_MODIFY_DIFF_PORT = 51600; // shouldModifyPortAddressedVcWithDifferentPort
+    private static final int PORT_BLOCK_MODIFY_FAIL = 51700; // shouldSurfaceModifyFailureAsReconfigureError
 
     /**
      * Asserts the port is bindable from outside the proxy within 5s.

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -76,31 +76,18 @@ class HotReloadIT extends BaseIT {
     private static final Duration PRODUCE_CONSUME_TIMEOUT = Duration.ofSeconds(15);
     private static final Duration REJECTION_TIMEOUT = Duration.ofSeconds(5);
 
-    // Port blocks per port-addressed test. The BASE is randomized once per JVM run so a
-    // re-run within the OS's TIME_WAIT window (60-240s) doesn't collide with the previous
-    // run's sockets. Chosen range [20000, 28000) sits below the OS ephemeral ranges on both
-    // Linux (32768-61000) and macOS (49152-65535), reducing collisions with unrelated
-    // processes' transient sockets. PORT_STRIDE is the within-test offset between adjacent
-    // bootstrap ports used by a single test.
-    private static final int PORT_BLOCK_BASE = 20000 + ThreadLocalRandom.current().nextInt(8000);
+    // Hard-coded port blocks per port-addressed test, so concurrent test instances on the same
+    // host don't collide. PORT_STRIDE is the within-test offset between adjacent bootstrap
+    // ports used by a single test (bootstrap + brokers + add/remove targets).
     private static final int PORT_STRIDE = 10;
-    private static final int PORT_BLOCK_REMOVE = PORT_BLOCK_BASE; // shouldReleasePortWhenPortAddressedVcIsRemoved
-    private static final int PORT_BLOCK_ADD = PORT_BLOCK_BASE + 100; // shouldStartServingAddedPortAddressedVcEndToEnd
-    private static final int PORT_BLOCK_BINDFAIL = PORT_BLOCK_BASE + 200; // shouldSurfaceBindFailureAsReconfigureError...
-    private static final int PORT_BLOCK_REUSE = PORT_BLOCK_BASE + 300; // shouldSupportPortReuseAcrossReconfigures
-    private static final int PORT_BLOCK_ADD_THEN_REMOVE = PORT_BLOCK_BASE + 400; // shouldRemoveRuntimeAddedPortAddressedVc
-    private static final int PORT_BLOCK_MODIFY_SAME_PORT = PORT_BLOCK_BASE + 500; // shouldModifyPortAddressedVcWithSamePort
-    private static final int PORT_BLOCK_MODIFY_DIFF_PORT = PORT_BLOCK_BASE + 600; // shouldModifyPortAddressedVcWithDifferentPort
-    private static final int PORT_BLOCK_MODIFY_FAIL = PORT_BLOCK_BASE + 700; // shouldSurfaceModifyFailureAsReconfigureError
-
-    static {
-        // Log the chosen base so a CI failure with EADDRINUSE can be reproduced (and the
-        // suspect port range identified) without re-running the suite.
-        LoggerFactory.getLogger(HotReloadIT.class)
-                .atInfo()
-                .addKeyValue("portBlockBase", PORT_BLOCK_BASE)
-                .log("HotReloadIT: per-JVM port block base chosen");
-    }
+    private static final int PORT_BLOCK_REMOVE = 51000; // shouldReleasePortWhenPortAddressedVcIsRemoved
+    private static final int PORT_BLOCK_ADD = 51100; // shouldStartServingAddedPortAddressedVcEndToEnd
+    private static final int PORT_BLOCK_BINDFAIL = 51200; // shouldSurfaceBindFailureAsReconfigureError...
+    private static final int PORT_BLOCK_REUSE = 51300; // shouldSupportPortReuseAcrossReconfigures
+    private static final int PORT_BLOCK_ADD_THEN_REMOVE = 51400; // shouldRemoveRuntimeAddedPortAddressedVc
+    private static final int PORT_BLOCK_MODIFY_SAME_PORT = 51500; // shouldModifyPortAddressedVcWithSamePort
+    private static final int PORT_BLOCK_MODIFY_DIFF_PORT = 51600; // shouldModifyPortAddressedVcWithDifferentPort
+    private static final int PORT_BLOCK_MODIFY_FAIL = 51700; // shouldSurfaceModifyFailureAsReconfigureError
 
     /**
      * Identifies a non-baseline VC slot used by the tests. {@link #buildConfig} takes a

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -76,18 +76,31 @@ class HotReloadIT extends BaseIT {
     private static final Duration PRODUCE_CONSUME_TIMEOUT = Duration.ofSeconds(15);
     private static final Duration REJECTION_TIMEOUT = Duration.ofSeconds(5);
 
-    // Hard-coded port blocks per port-addressed test, so concurrent test instances on the same
-    // host don't collide. PORT_STRIDE is the within-test offset between ports a single test uses
-    // (bootstrap + brokers + add/remove targets).
+    // Port blocks per port-addressed test. The BASE is randomized once per JVM run so a
+    // re-run within the OS's TIME_WAIT window (60-240s) doesn't collide with the previous
+    // run's sockets. Chosen range [20000, 28000) sits below the OS ephemeral ranges on both
+    // Linux (32768-61000) and macOS (49152-65535), reducing collisions with unrelated
+    // processes' transient sockets. PORT_STRIDE is the within-test offset between adjacent
+    // bootstrap ports used by a single test.
+    private static final int PORT_BLOCK_BASE = 20000 + ThreadLocalRandom.current().nextInt(8000);
     private static final int PORT_STRIDE = 10;
-    private static final int PORT_BLOCK_REMOVE = 51000; // shouldReleasePortWhenPortAddressedVcIsRemoved
-    private static final int PORT_BLOCK_ADD = 51100; // shouldStartServingAddedPortAddressedVcEndToEnd
-    private static final int PORT_BLOCK_BINDFAIL = 51200; // shouldSurfaceBindFailureAsReconfigureError...
-    private static final int PORT_BLOCK_REUSE = 51300; // shouldSupportPortReuseAcrossReconfigures
-    private static final int PORT_BLOCK_ADD_THEN_REMOVE = 51400; // shouldRemoveRuntimeAddedPortAddressedVc
-    private static final int PORT_BLOCK_MODIFY_SAME_PORT = 51500; // shouldModifyPortAddressedVcWithSamePort
-    private static final int PORT_BLOCK_MODIFY_DIFF_PORT = 51600; // shouldModifyPortAddressedVcWithDifferentPort
-    private static final int PORT_BLOCK_MODIFY_FAIL = 51700; // shouldSurfaceModifyFailureAsReconfigureError
+    private static final int PORT_BLOCK_REMOVE = PORT_BLOCK_BASE; // shouldReleasePortWhenPortAddressedVcIsRemoved
+    private static final int PORT_BLOCK_ADD = PORT_BLOCK_BASE + 100; // shouldStartServingAddedPortAddressedVcEndToEnd
+    private static final int PORT_BLOCK_BINDFAIL = PORT_BLOCK_BASE + 200; // shouldSurfaceBindFailureAsReconfigureError...
+    private static final int PORT_BLOCK_REUSE = PORT_BLOCK_BASE + 300; // shouldSupportPortReuseAcrossReconfigures
+    private static final int PORT_BLOCK_ADD_THEN_REMOVE = PORT_BLOCK_BASE + 400; // shouldRemoveRuntimeAddedPortAddressedVc
+    private static final int PORT_BLOCK_MODIFY_SAME_PORT = PORT_BLOCK_BASE + 500; // shouldModifyPortAddressedVcWithSamePort
+    private static final int PORT_BLOCK_MODIFY_DIFF_PORT = PORT_BLOCK_BASE + 600; // shouldModifyPortAddressedVcWithDifferentPort
+    private static final int PORT_BLOCK_MODIFY_FAIL = PORT_BLOCK_BASE + 700; // shouldSurfaceModifyFailureAsReconfigureError
+
+    static {
+        // Log the chosen base so a CI failure with EADDRINUSE can be reproduced (and the
+        // suspect port range identified) without re-running the suite.
+        LoggerFactory.getLogger(HotReloadIT.class)
+                .atInfo()
+                .addKeyValue("portBlockBase", PORT_BLOCK_BASE)
+                .log("HotReloadIT: per-JVM port block base chosen");
+    }
 
     /**
      * Identifies a non-baseline VC slot used by the tests. {@link #buildConfig} takes a

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -76,18 +76,30 @@ class HotReloadIT extends BaseIT {
     private static final Duration PRODUCE_CONSUME_TIMEOUT = Duration.ofSeconds(15);
     private static final Duration REJECTION_TIMEOUT = Duration.ofSeconds(5);
 
-    // Hard-coded port blocks per port-addressed test, so concurrent test instances on the same
-    // host don't collide. PORT_STRIDE is the within-test offset between adjacent bootstrap
-    // ports used by a single test (bootstrap + brokers + add/remove targets).
+    // Port blocks per port-addressed test. The BASE is randomized once per JVM run so a re-run
+    // within the OS's TIME_WAIT window (60-240s) doesn't collide with the previous run's sockets.
+    // Chosen range [20000, 28000) sits below the OS ephemeral ranges on both Linux (32768-61000)
+    // and macOS (49152-65535), reducing collisions with unrelated processes' transient sockets.
+    // PORT_STRIDE is the within-test offset between adjacent bootstrap ports used by a single test.
+    private static final int PORT_BLOCK_BASE = 20000 + ThreadLocalRandom.current().nextInt(8000);
     private static final int PORT_STRIDE = 10;
-    private static final int PORT_BLOCK_REMOVE = 51000; // shouldReleasePortWhenPortAddressedVcIsRemoved
-    private static final int PORT_BLOCK_ADD = 51100; // shouldStartServingAddedPortAddressedVcEndToEnd
-    private static final int PORT_BLOCK_BINDFAIL = 51200; // shouldSurfaceBindFailureAsReconfigureError...
-    private static final int PORT_BLOCK_REUSE = 51300; // shouldSupportPortReuseAcrossReconfigures
-    private static final int PORT_BLOCK_ADD_THEN_REMOVE = 51400; // shouldRemoveRuntimeAddedPortAddressedVc
-    private static final int PORT_BLOCK_MODIFY_SAME_PORT = 51500; // shouldModifyPortAddressedVcWithSamePort
-    private static final int PORT_BLOCK_MODIFY_DIFF_PORT = 51600; // shouldModifyPortAddressedVcWithDifferentPort
-    private static final int PORT_BLOCK_MODIFY_FAIL = 51700; // shouldSurfaceModifyFailureAsReconfigureError
+    private static final int PORT_BLOCK_REMOVE = PORT_BLOCK_BASE; // shouldReleasePortWhenPortAddressedVcIsRemoved
+    private static final int PORT_BLOCK_ADD = PORT_BLOCK_BASE + 100; // shouldStartServingAddedPortAddressedVcEndToEnd
+    private static final int PORT_BLOCK_BINDFAIL = PORT_BLOCK_BASE + 200; // shouldSurfaceBindFailureAsReconfigureError...
+    private static final int PORT_BLOCK_REUSE = PORT_BLOCK_BASE + 300; // shouldSupportPortReuseAcrossReconfigures
+    private static final int PORT_BLOCK_ADD_THEN_REMOVE = PORT_BLOCK_BASE + 400; // shouldRemoveRuntimeAddedPortAddressedVc
+    private static final int PORT_BLOCK_MODIFY_SAME_PORT = PORT_BLOCK_BASE + 500; // shouldModifyPortAddressedVcWithSamePort
+    private static final int PORT_BLOCK_MODIFY_DIFF_PORT = PORT_BLOCK_BASE + 600; // shouldModifyPortAddressedVcWithDifferentPort
+    private static final int PORT_BLOCK_MODIFY_FAIL = PORT_BLOCK_BASE + 700; // shouldSurfaceModifyFailureAsReconfigureError
+
+    static {
+        // Log the chosen base so a CI failure with EADDRINUSE can be reproduced (and the
+        // suspect port range identified) without re-running the suite.
+        LoggerFactory.getLogger(HotReloadIT.class)
+                .atInfo()
+                .addKeyValue("portBlockBase", PORT_BLOCK_BASE)
+                .log("HotReloadIT: per-JVM port block base chosen");
+    }
 
     /**
      * Identifies a non-baseline VC slot used by the tests. {@link #buildConfig} takes a

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -76,6 +76,19 @@ class HotReloadIT extends BaseIT {
     private static final Duration PRODUCE_CONSUME_TIMEOUT = Duration.ofSeconds(15);
     private static final Duration REJECTION_TIMEOUT = Duration.ofSeconds(5);
 
+    // Hard-coded port blocks per port-addressed test, so concurrent test instances on the same
+    // host don't collide. PORT_STRIDE is the within-test offset between ports a single test uses
+    // (bootstrap + brokers + add/remove targets).
+    private static final int PORT_STRIDE = 10;
+    private static final int PORT_BLOCK_REMOVE = 51000; // shouldReleasePortWhenPortAddressedVcIsRemoved
+    private static final int PORT_BLOCK_ADD = 51100; // shouldStartServingAddedPortAddressedVcEndToEnd
+    private static final int PORT_BLOCK_BINDFAIL = 51200; // shouldSurfaceBindFailureAsReconfigureError...
+    private static final int PORT_BLOCK_REUSE = 51300; // shouldSupportPortReuseAcrossReconfigures
+    private static final int PORT_BLOCK_ADD_THEN_REMOVE = 51400; // shouldRemoveRuntimeAddedPortAddressedVc
+    private static final int PORT_BLOCK_MODIFY_SAME_PORT = 51500; // shouldModifyPortAddressedVcWithSamePort
+    private static final int PORT_BLOCK_MODIFY_DIFF_PORT = 51600; // shouldModifyPortAddressedVcWithDifferentPort
+    private static final int PORT_BLOCK_MODIFY_FAIL = 51700; // shouldSurfaceModifyFailureAsReconfigureError
+
     /**
      * Identifies a non-baseline VC slot used by the tests. {@link #buildConfig} takes a
      * varargs of these to declare which extras (beyond BASELINE) should appear in the
@@ -603,16 +616,6 @@ class HotReloadIT extends BaseIT {
         }
         return builder.build();
     }
-
-    private static final int PORT_STRIDE = 10;
-    private static final int PORT_BLOCK_REMOVE = 51000; // shouldReleasePortWhenPortAddressedVcIsRemoved
-    private static final int PORT_BLOCK_ADD = 51100; // shouldStartServingAddedPortAddressedVcEndToEnd
-    private static final int PORT_BLOCK_BINDFAIL = 51200; // shouldSurfaceBindFailureAsReconfigureError...
-    private static final int PORT_BLOCK_REUSE = 51300; // shouldSupportPortReuseAcrossReconfigures
-    private static final int PORT_BLOCK_ADD_THEN_REMOVE = 51400; // shouldRemoveRuntimeAddedPortAddressedVc
-    private static final int PORT_BLOCK_MODIFY_SAME_PORT = 51500; // shouldModifyPortAddressedVcWithSamePort
-    private static final int PORT_BLOCK_MODIFY_DIFF_PORT = 51600; // shouldModifyPortAddressedVcWithDifferentPort
-    private static final int PORT_BLOCK_MODIFY_FAIL = 51700; // shouldSurfaceModifyFailureAsReconfigureError
 
     /**
      * Asserts the port is bindable from outside the proxy within 5s.

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -7,6 +7,7 @@ package io.kroxylicious.proxy;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -149,7 +150,7 @@ public final class KafkaProxy implements AutoCloseable {
     private final Configuration config;
     private final @Nullable ManagementConfiguration managementConfiguration;
     private final List<MicrometerDefinition> micrometerConfig;
-    private final List<VirtualClusterModel> virtualClusterModels;
+    private final Collection<VirtualClusterModel> virtualClusterModels;
     private final AtomicBoolean running = new AtomicBoolean();
     private final CompletableFuture<Void> shutdown = new CompletableFuture<>();
     private final NetworkBindingOperationProcessor bindingOperationProcessor = new DefaultNetworkBindingOperationProcessor();

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
@@ -52,7 +52,7 @@ public class VirtualClusterRegistry {
      */
     private record VirtualClusterEntry(VirtualClusterModel model, VirtualClusterLifecycle lifecycle) {}
 
-    private final Map<String, VirtualClusterEntry> entriesByCluster = new ConcurrentHashMap<>();;
+    private final Map<String, VirtualClusterEntry> entriesByCluster = new ConcurrentHashMap<>();
     private final BiConsumer<String, Optional<Throwable>> onVirtualClusterStopped;
 
     /**
@@ -319,21 +319,23 @@ public class VirtualClusterRegistry {
     public CompletableFuture<Void> addVirtualCluster(VirtualClusterModel newModel) {
         Objects.requireNonNull(newModel, "newModel must not be null");
         String name = newModel.getClusterName();
-        var existing = entriesByCluster.get(name);
-        if (existing != null) {
-            var state = existing.lifecycle().state();
-            if (!(state instanceof VirtualClusterLifecycleState.Stopped)) {
-                throw new IllegalStateException(
-                        "Cluster '" + name + "' already exists and its lifecycle is "
-                                + state.getClass().getSimpleName() + "; re-add is only permitted from Stopped");
+
+        entriesByCluster.compute(name, (key, existing) -> {
+            if (existing != null) {
+                var state = existing.lifecycle().state();
+                if (!(state instanceof VirtualClusterLifecycleState.Stopped)) {
+                    throw new IllegalStateException(
+                            "Cluster '" + name + "' already exists and its lifecycle is "
+                                    + state.getClass().getSimpleName() + "; re-add is only permitted from Stopped");
+                }
             }
-        }
-        LOGGER.atInfo()
-                .addKeyValue("virtualCluster", name)
-                .addKeyValue("operation", "addVirtualCluster")
-                .addKeyValue("replacingStoppedEntry", existing != null)
-                .log("reconfigure: created lifecycle in INITIALIZING; gateway registration is the orchestrator's responsibility");
-        entriesByCluster.put(name, new VirtualClusterEntry(newModel, new VirtualClusterLifecycle(name, newModel.drainTimeout())));
+            LOGGER.atInfo()
+                    .addKeyValue("virtualCluster", name)
+                    .addKeyValue("operation", "addVirtualCluster")
+                    .addKeyValue("replacingStoppedEntry", existing != null)
+                    .log("reconfigure: created lifecycle in INITIALIZING; gateway registration is the orchestrator's responsibility");
+            return new VirtualClusterEntry(newModel, new VirtualClusterLifecycle(name, newModel.drainTimeout()));
+        });
         return CompletableFuture.completedFuture(null);
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
@@ -6,13 +6,13 @@
 
 package io.kroxylicious.proxy.internal;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 
 import org.slf4j.Logger;
@@ -69,7 +69,7 @@ public class VirtualClusterRegistry {
                                   BiConsumer<String, Optional<Throwable>> onVirtualClusterStopped) {
         Objects.requireNonNull(virtualClusterModels, "virtualClusterModels must not be null");
         this.onVirtualClusterStopped = Objects.requireNonNull(onVirtualClusterStopped, "onVirtualClusterStopped must not be null");
-        this.entriesByCluster = new LinkedHashMap<>();
+        this.entriesByCluster = new ConcurrentHashMap<>();
         for (var vcm : virtualClusterModels) {
             var name = vcm.getClusterName();
             if (entriesByCluster.containsKey(name)) {
@@ -83,7 +83,10 @@ public class VirtualClusterRegistry {
      * Returns the currently-tracked virtual cluster models. The list reflects the constructor-
      * supplied models PLUS any added at runtime via {@link #addVirtualCluster(VirtualClusterModel)}.
      *
-     * @return snapshot of currently-tracked virtual cluster models (insertion order)
+     * <p>Iteration order is unspecified (the backing map is concurrent). Callers that need
+     * order-stable output should sort the result themselves.
+     *
+     * @return weakly-consistent snapshot of currently-tracked virtual cluster models
      */
     public List<VirtualClusterModel> virtualClusterModels() {
         return entriesByCluster.values().stream()
@@ -280,51 +283,37 @@ public class VirtualClusterRegistry {
     }
 
     /**
-     * Drives an existing virtual cluster through {@code SERVING → DRAINING → INITIALIZING → SERVING}
-     * with the supplied new model. Invoked by {@code ConfigurationReloadOrchestrator} for
-     * clusters whose configuration differs between the running and submitted configurations.
-     *
-     * <p>Named by its <em>intent</em> (apply {@code newModel} to the cluster identified by
-     * {@code clusterName}) rather than its implementation; a future iteration may implement
-     * replace more surgically (filter-chain swap on existing connections, rolling handoff)
-     * without changing the caller's interface.
-     *
-     * @param clusterName the virtual cluster to replace; must name an existing cluster
-     * @param newModel    the new model to apply
-     * @return a future that completes when the replacement is finished
-     */
-    public CompletableFuture<Void> replaceVirtualCluster(String clusterName, VirtualClusterModel newModel) {
-        // TODO: implement SERVING -> DRAINING -> [drain] -> [deregister] -> INITIALIZING ->
-        // [register] -> SERVING in the follow-up PR. See removeVirtualCluster Javadoc.
-        LOGGER.atWarn()
-                .addKeyValue("virtualCluster", clusterName)
-                .addKeyValue("operation", "replaceVirtualCluster")
-                .log("reconfigure: per-VC lifecycle transitions not yet implemented; no-op stub invoked");
-        return CompletableFuture.completedFuture(null);
-    }
-
-    /**
      * Creates a {@link VirtualClusterLifecycle} in {@code INITIALIZING} for
      * the given model. Endpoint binding and the transition to {@code SERVING} are the
      * orchestrator's responsibility — once gateway registration succeeds it calls
      * {@link #initializationSucceeded(String)}; on failure it calls
      * {@link #initializationFailed(String, Throwable)} and rolls back the gateway bindings.
      *
-     * @param newModel the model for the new cluster; must not name a cluster already present
+     * <p>If an entry already exists for this name AND its lifecycle is {@code Stopped}, the
+     * entry is replaced — this is how {@code ReplaceCluster}'s add half re-establishes the
+     * cluster after the remove half drove it to {@code Stopped}. The retained-{@code Stopped}-
+     * entry policy (see {@link #shutdownCluster}) interacts with re-add by name reuse, and
+     * "replace the dead entry" is the natural reconciliation.
+     *
+     * @param newModel the model for the new cluster
      * @return an already-completed future (the operation is synchronous; the
      *         {@link CompletableFuture} shape is preserved for caller symmetry with
      *         {@link #removeVirtualCluster})
-     * @throws IllegalArgumentException if a cluster with this name already exists
+     * @throws IllegalArgumentException if an entry already exists AND its lifecycle is in any
+     *         state OTHER than {@code Stopped} — re-adding an actively-serving (or initializing,
+     *         draining, or failed) cluster would be a contract violation.
      */
     public CompletableFuture<Void> addVirtualCluster(VirtualClusterModel newModel) {
         Objects.requireNonNull(newModel, "newModel must not be null");
         String name = newModel.getClusterName();
-        if (entriesByCluster.containsKey(name)) {
-            throw new IllegalArgumentException("Cluster already exists: " + name);
+        var existing = entriesByCluster.get(name);
+        if (existing != null && !(existing.lifecycle().state() instanceof VirtualClusterLifecycleState.Stopped)) {
+            throw new IllegalArgumentException("Cluster already exists and is not Stopped: " + name);
         }
         LOGGER.atInfo()
                 .addKeyValue("virtualCluster", name)
                 .addKeyValue("operation", "addVirtualCluster")
+                .addKeyValue("replacingStoppedEntry", existing != null)
                 .log("reconfigure: created lifecycle in INITIALIZING; gateway registration is the orchestrator's responsibility");
         entriesByCluster.put(name, new VirtualClusterEntry(newModel, new VirtualClusterLifecycle(name, newModel.drainTimeout())));
         return CompletableFuture.completedFuture(null);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.proxy.internal;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -80,7 +81,7 @@ public class VirtualClusterRegistry {
     }
 
     /**
-     * Returns the currently-tracked virtual cluster models. The list reflects the constructor-
+     * Returns the currently-tracked virtual cluster models. The collection reflects the constructor-
      * supplied models PLUS any added at runtime via {@link #addVirtualCluster(VirtualClusterModel)}.
      *
      * <p>Iteration order is unspecified (the backing map is concurrent). Callers that need
@@ -88,7 +89,7 @@ public class VirtualClusterRegistry {
      *
      * @return weakly-consistent snapshot of currently-tracked virtual cluster models
      */
-    public List<VirtualClusterModel> virtualClusterModels() {
+    public Collection<VirtualClusterModel> virtualClusterModels() {
         return entriesByCluster.values().stream()
                 .map(VirtualClusterEntry::model)
                 .toList();
@@ -311,16 +312,22 @@ public class VirtualClusterRegistry {
      * @return an already-completed future (the operation is synchronous; the
      *         {@link CompletableFuture} shape is preserved for caller symmetry with
      *         {@link #removeVirtualCluster})
-     * @throws IllegalArgumentException if an entry already exists AND its lifecycle is in any
+     * @throws IllegalStateException if an entry already exists AND its lifecycle is in any
      *         state OTHER than {@code Stopped} — re-adding an actively-serving (or initializing,
-     *         draining, or failed) cluster would be a contract violation.
+     *         draining, or failed) cluster would be a contract violation. The exception message
+     *         names the current state to aid diagnosis.
      */
     public CompletableFuture<Void> addVirtualCluster(VirtualClusterModel newModel) {
         Objects.requireNonNull(newModel, "newModel must not be null");
         String name = newModel.getClusterName();
         var existing = entriesByCluster.get(name);
-        if (existing != null && !(existing.lifecycle().state() instanceof VirtualClusterLifecycleState.Stopped)) {
-            throw new IllegalArgumentException("Cluster already exists and is not Stopped: " + name);
+        if (existing != null) {
+            var state = existing.lifecycle().state();
+            if (!(state instanceof VirtualClusterLifecycleState.Stopped)) {
+                throw new IllegalStateException(
+                        "Cluster '" + name + "' already exists and its lifecycle is "
+                                + state.getClass().getSimpleName() + "; re-add is only permitted from Stopped");
+            }
         }
         LOGGER.atInfo()
                 .addKeyValue("virtualCluster", name)

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
@@ -213,6 +213,18 @@ public class VirtualClusterRegistry {
     }
 
     /**
+     * Returns the model for the given virtual cluster name.
+     *
+     * @param clusterName the virtual cluster name
+     * @return the model, or {@code null} if no cluster with that name exists
+     */
+    @Nullable
+    public VirtualClusterModel modelFor(String clusterName) {
+        var entry = entriesByCluster.get(clusterName);
+        return entry == null ? null : entry.model();
+    }
+
+    /**
      * Attempts to register a new connection for {@code clusterName}.
      *
      * @return {@code true} iff the cluster is known to this registry AND its lifecycle is in a

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
@@ -52,7 +52,7 @@ public class VirtualClusterRegistry {
      */
     private record VirtualClusterEntry(VirtualClusterModel model, VirtualClusterLifecycle lifecycle) {}
 
-    private final Map<String, VirtualClusterEntry> entriesByCluster;
+    private final Map<String, VirtualClusterEntry> entriesByCluster = new ConcurrentHashMap<>();;
     private final BiConsumer<String, Optional<Throwable>> onVirtualClusterStopped;
 
     /**
@@ -70,7 +70,6 @@ public class VirtualClusterRegistry {
                                   BiConsumer<String, Optional<Throwable>> onVirtualClusterStopped) {
         Objects.requireNonNull(virtualClusterModels, "virtualClusterModels must not be null");
         this.onVirtualClusterStopped = Objects.requireNonNull(onVirtualClusterStopped, "onVirtualClusterStopped must not be null");
-        this.entriesByCluster = new ConcurrentHashMap<>();
         for (var vcm : virtualClusterModels) {
             var name = vcm.getClusterName();
             if (entriesByCluster.containsKey(name)) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ClusterOperation.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ClusterOperation.java
@@ -15,7 +15,7 @@ import io.kroxylicious.proxy.reload.ReconfigureError;
  * produce — adding a new operation type is a deliberate change that the compiler can flag
  * at every dispatch point.
  */
-sealed interface ClusterOperation permits AddCluster, RemoveCluster {
+sealed interface ClusterOperation permits AddCluster, RemoveCluster, ReplaceCluster {
 
     String clusterName();
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
@@ -47,8 +47,6 @@ import io.kroxylicious.proxy.tag.VisibleForTesting;
  *   <li><b>Commit</b> — advance {@code currentConfiguration} to the submitted value.</li>
  * </ul>
  *
- * <p>Modify operations are not yet supported and are rejected upfront with
- * {@link UnsupportedOperationException}.
  */
 public class ConfigurationReloadOrchestrator {
 
@@ -107,14 +105,12 @@ public class ConfigurationReloadOrchestrator {
      *           <li>successfully with an empty-errors {@link ReconfigureResult} on a no-op
      *               reconfigure ({@code currentConfiguration} still advances)</li>
      *           <li>successfully with a {@link ReconfigureResult} (possibly with per-cluster
-     *               errors) on any non-modify reconfigure ({@code currentConfiguration}
-     *               advances unconditionally — see {@link #commit} for rationale)</li>
+     *               errors) on any reconfigure ({@code currentConfiguration} advances
+     *               unconditionally — see {@link #commit} for rationale)</li>
      *           <li>exceptionally with {@link StaticConfigurationChangedException} on
      *               static-section diff</li>
      *           <li>exceptionally with {@link ConcurrentReconfigureException} on
      *               concurrent submission</li>
-     *           <li>exceptionally with {@link UnsupportedOperationException} when the
-     *               submission requires modify operations</li>
      *         </ul>
      */
     public CompletableFuture<ReconfigureResult> reconfigure(Configuration newConfig) {
@@ -152,7 +148,6 @@ public class ConfigurationReloadOrchestrator {
         if (changes.isEmpty()) {
             return commit(newConfig, List.of());
         }
-        rejectIfModifyRequested(changes);
 
         var errors = planner.plan(changes, newConfig).stream()
                 .map(ClusterOperation::apply)
@@ -172,15 +167,6 @@ public class ConfigurationReloadOrchestrator {
     private CompletableFuture<ReconfigureResult> commit(Configuration newConfig, List<ReconfigureError> errors) {
         this.currentConfiguration = newConfig;
         return CompletableFuture.completedFuture(ReconfigureResult.of(errors));
-    }
-
-    private void rejectIfModifyRequested(ChangeResult changes) {
-        if (!changes.clustersToModify().isEmpty()) {
-            throw new UnsupportedOperationException(
-                    "KafkaProxy.reconfigure() does not yet support modify operations. "
-                            + "This reconfigure was rejected because it would have required "
-                            + changes.clustersToModify().size() + " cluster modify operation(s).");
-        }
     }
 
     private ChangeResult aggregateChanges(Configuration oldConfig, Configuration newConfig) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/OperationsPlanner.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/OperationsPlanner.java
@@ -48,6 +48,11 @@ final class OperationsPlanner {
      * (the model that's already serving), adds resolve from {@code newConfig}, and modifies
      * resolve <em>both</em> — old from the registry, new from the submitted configuration.
      *
+     * <p>Registry-side resolution uses {@link VirtualClusterRegistry#modelFor(String)} —
+     * a direct name-keyed lookup to fetch the old existing model.
+     * The new-config side still requires a Map-build because
+     * {@code modelResolver} returns a list (it has no direct name-lookup affordance).
+     *
      * @throws IllegalStateException if any of {@code clustersToRemove}, {@code clustersToAdd},
      *         or {@code clustersToModify} names a cluster that can't be resolved on the side
      *         it's expected — all three indicate a {@code ChangeDetector} contract violation
@@ -56,27 +61,23 @@ final class OperationsPlanner {
     List<ClusterOperation> plan(ChangeResult changes, Configuration newConfig) {
         var ops = new ArrayList<ClusterOperation>();
 
-        // Resolve each model map at most once, and only when at least one phase needs it.
-        // A pure-remove plan doesn't pay for resolving newConfig (and vice versa). Modifies
-        // need both.
-        Map<String, VirtualClusterModel> registryModelsByName = (changes.clustersToRemove().isEmpty()
-                && changes.clustersToModify().isEmpty()) ? Map.of() : registryModelsByName();
+        // The new-config side needs a name → model lookup.
         Map<String, VirtualClusterModel> newModelsByName = (changes.clustersToAdd().isEmpty()
                 && changes.clustersToModify().isEmpty()) ? Map.of() : resolveByName(newConfig);
 
         for (String name : changes.clustersToRemove()) {
-            VirtualClusterModel model = registryModelsByName.get(name);
-            if (model == null) {
+            VirtualClusterModel oldModel = virtualClusterRegistry.modelFor(name);
+            if (oldModel == null) {
                 throw new IllegalStateException(
                         "OperationsPlanner: no model for removed cluster '" + name
                                 + "'; this indicates a ChangeDetector contract violation"
                                 + " (cluster reported as removed but absent from the registry)");
             }
-            ops.add(new RemoveCluster(model, virtualClusterRegistry, endpointRegistry));
+            ops.add(new RemoveCluster(oldModel, virtualClusterRegistry, endpointRegistry));
         }
 
         for (String name : changes.clustersToModify()) {
-            VirtualClusterModel oldModel = registryModelsByName.get(name);
+            VirtualClusterModel oldModel = virtualClusterRegistry.modelFor(name);
             if (oldModel == null) {
                 throw new IllegalStateException(
                         "OperationsPlanner: no old model for modified cluster '" + name
@@ -94,14 +95,14 @@ final class OperationsPlanner {
         }
 
         for (String name : changes.clustersToAdd()) {
-            VirtualClusterModel model = newModelsByName.get(name);
-            if (model == null) {
+            VirtualClusterModel newModel = newModelsByName.get(name);
+            if (newModel == null) {
                 throw new IllegalStateException(
                         "OperationsPlanner: no model for added cluster '" + name
                                 + "'; this indicates a ChangeDetector contract violation"
                                 + " (cluster reported as added but absent from the submitted configuration)");
             }
-            ops.add(new AddCluster(model, virtualClusterRegistry, endpointRegistry));
+            ops.add(new AddCluster(newModel, virtualClusterRegistry, endpointRegistry));
         }
 
         return List.copyOf(ops);
@@ -109,11 +110,6 @@ final class OperationsPlanner {
 
     private Map<String, VirtualClusterModel> resolveByName(Configuration newConfig) {
         return modelResolver.apply(newConfig).stream()
-                .collect(Collectors.toUnmodifiableMap(VirtualClusterModel::getClusterName, Function.identity()));
-    }
-
-    private Map<String, VirtualClusterModel> registryModelsByName() {
-        return virtualClusterRegistry.virtualClusterModels().stream()
                 .collect(Collectors.toUnmodifiableMap(VirtualClusterModel::getClusterName, Function.identity()));
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/OperationsPlanner.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/OperationsPlanner.java
@@ -22,7 +22,11 @@ import io.kroxylicious.proxy.model.VirtualClusterModel;
  * list of {@link ClusterOperation}s for the orchestrator to execute. Stateless — the
  * planner holds only its collaborators, no per-reconfigure state.
  *
- * <p>Ordering: removes before adds</p>
+ * <p><strong>Ordering:</strong> pure removes → modifies → pure adds. The "removes before
+ * adds" invariant is preserved globally, and each modify is a self-contained pair-wise
+ * remove-then-add inside its {@link ReplaceCluster} operation — so a same-port modify gets
+ * unbind-then-rebind sequenced tightly within one op, without intervening drains from
+ * unrelated clusters.</p>
  */
 final class OperationsPlanner {
 
@@ -39,42 +43,65 @@ final class OperationsPlanner {
     }
 
     /**
-     * Plan the operations for a reconfigure.
+     * Plan the operations for a reconfigure. Each phase resolves a {@link VirtualClusterModel}
+     * by name and hands it to the operation: removes resolve from the registry's current state
+     * (the model that's already serving), adds resolve from {@code newConfig}, and modifies
+     * resolve <em>both</em> — old from the registry, new from the submitted configuration.
      *
-     * @throws IllegalStateException if {@code changes.clustersToRemove()} names a cluster that
-     *         isn't registered, or {@code changes.clustersToAdd()} names a cluster that isn't
-     *         in {@code newConfig}'s resolved models — both indicate a {@code ChangeDetector}
-     *         contract violation (i.e. a framework bug).
+     * @throws IllegalStateException if any of {@code clustersToRemove}, {@code clustersToAdd},
+     *         or {@code clustersToModify} names a cluster that can't be resolved on the side
+     *         it's expected — all three indicate a {@code ChangeDetector} contract violation
+     *         (i.e. a framework bug).
      */
     List<ClusterOperation> plan(ChangeResult changes, Configuration newConfig) {
         var ops = new ArrayList<ClusterOperation>();
 
-        if (!changes.clustersToRemove().isEmpty()) {
-            Map<String, VirtualClusterModel> registryModelsByName = registryModelsByName();
-            for (String name : changes.clustersToRemove()) {
-                VirtualClusterModel model = registryModelsByName.get(name);
-                if (model == null) {
-                    throw new IllegalStateException(
-                            "OperationsPlanner: no model for removed cluster '" + name
-                                    + "'; this indicates a ChangeDetector contract violation"
-                                    + " (cluster reported as removed but absent from the registry)");
-                }
-                ops.add(new RemoveCluster(model, virtualClusterRegistry, endpointRegistry));
+        // Resolve each model map at most once, and only when at least one phase needs it.
+        // A pure-remove plan doesn't pay for resolving newConfig (and vice versa). Modifies
+        // need both.
+        Map<String, VirtualClusterModel> registryModelsByName = (changes.clustersToRemove().isEmpty()
+                && changes.clustersToModify().isEmpty()) ? Map.of() : registryModelsByName();
+        Map<String, VirtualClusterModel> newModelsByName = (changes.clustersToAdd().isEmpty()
+                && changes.clustersToModify().isEmpty()) ? Map.of() : resolveByName(newConfig);
+
+        for (String name : changes.clustersToRemove()) {
+            VirtualClusterModel model = registryModelsByName.get(name);
+            if (model == null) {
+                throw new IllegalStateException(
+                        "OperationsPlanner: no model for removed cluster '" + name
+                                + "'; this indicates a ChangeDetector contract violation"
+                                + " (cluster reported as removed but absent from the registry)");
             }
+            ops.add(new RemoveCluster(model, virtualClusterRegistry, endpointRegistry));
         }
 
-        if (!changes.clustersToAdd().isEmpty()) {
-            Map<String, VirtualClusterModel> newModelsByName = resolveByName(newConfig);
-            for (String name : changes.clustersToAdd()) {
-                VirtualClusterModel model = newModelsByName.get(name);
-                if (model == null) {
-                    throw new IllegalStateException(
-                            "OperationsPlanner: no model for added cluster '" + name
-                                    + "'; this indicates a ChangeDetector contract violation"
-                                    + " (cluster reported as added but absent from the submitted configuration)");
-                }
-                ops.add(new AddCluster(model, virtualClusterRegistry, endpointRegistry));
+        for (String name : changes.clustersToModify()) {
+            VirtualClusterModel oldModel = registryModelsByName.get(name);
+            if (oldModel == null) {
+                throw new IllegalStateException(
+                        "OperationsPlanner: no old model for modified cluster '" + name
+                                + "'; this indicates a ChangeDetector contract violation"
+                                + " (cluster reported as modified but absent from the registry)");
             }
+            VirtualClusterModel newModel = newModelsByName.get(name);
+            if (newModel == null) {
+                throw new IllegalStateException(
+                        "OperationsPlanner: no new model for modified cluster '" + name
+                                + "'; this indicates a ChangeDetector contract violation"
+                                + " (cluster reported as modified but absent from the submitted configuration)");
+            }
+            ops.add(new ReplaceCluster(oldModel, newModel, virtualClusterRegistry, endpointRegistry));
+        }
+
+        for (String name : changes.clustersToAdd()) {
+            VirtualClusterModel model = newModelsByName.get(name);
+            if (model == null) {
+                throw new IllegalStateException(
+                        "OperationsPlanner: no model for added cluster '" + name
+                                + "'; this indicates a ChangeDetector contract violation"
+                                + " (cluster reported as added but absent from the submitted configuration)");
+            }
+            ops.add(new AddCluster(model, virtualClusterRegistry, endpointRegistry));
         }
 
         return List.copyOf(ops);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ReplaceCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ReplaceCluster.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.reload;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import io.kroxylicious.proxy.internal.VirtualClusterRegistry;
+import io.kroxylicious.proxy.internal.net.EndpointRegistry;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
+import io.kroxylicious.proxy.reload.ReconfigureError;
+
+/**
+ * Apply a configuration change to an existing virtual cluster during a reconfigure.
+ *
+ * <h2>Remove then add</h2>
+ * Today's implementation is the simplest possible: drive {@link RemoveCluster} on {@code oldModel}
+ * to drain the existing serving cluster, then {@link AddCluster} on {@code newModel} to bring the
+ * new shape online. Composition rather than reimplementation: each sub-operation already owns its
+ * own failure semantics, rollback, and lifecycle transitions, so this class is just a sequencer.
+ *
+ * <h2>Failure semantics</h2>
+ * <ul>
+ *   <li><b>Remove half fails</b> ⇒ the add half is <em>skipped</em>. The cluster is left in
+ *       whatever terminal state the remove failure produced. The returned {@link ReconfigureError}
+ *       attributes the failure to a single phase, so the orchestrator surfaces one error per
+ *       failing cluster — not a remove-error plus a phantom add-error.</li>
+ *   <li><b>Add half fails after remove succeeds</b> ⇒ the cluster ends up offline (entry exists in
+ *       the registry but the lifecycle is {@code STOPPED}). The {@link ReconfigureError} carries
+ *       the bind cause from the add half. This is consistent with the failure shape of a pure
+ *       {@link AddCluster}, so operator-facing semantics are predictable.</li>
+ * </ul>
+ */
+final class ReplaceCluster implements ClusterOperation {
+
+    private final VirtualClusterModel oldModel;
+    private final VirtualClusterModel newModel;
+    private final VirtualClusterRegistry virtualClusterRegistry;
+    private final EndpointRegistry endpointRegistry;
+
+    ReplaceCluster(VirtualClusterModel oldModel,
+                   VirtualClusterModel newModel,
+                   VirtualClusterRegistry virtualClusterRegistry,
+                   EndpointRegistry endpointRegistry) {
+        this.oldModel = Objects.requireNonNull(oldModel, "oldModel");
+        this.newModel = Objects.requireNonNull(newModel, "newModel");
+        this.virtualClusterRegistry = Objects.requireNonNull(virtualClusterRegistry, "virtualClusterRegistry");
+        this.endpointRegistry = Objects.requireNonNull(endpointRegistry, "endpointRegistry");
+        // The ChangeDetector contract guarantees both sides share the cluster name; we guard it
+        // locally to catch a buggy planner / detector before it produces a corrupted reconfigure.
+        if (!oldModel.getClusterName().equals(newModel.getClusterName())) {
+            throw new IllegalArgumentException(
+                    "ReplaceCluster requires the same cluster name on both sides; got '"
+                            + oldModel.getClusterName() + "' (old) vs '" + newModel.getClusterName() + "' (new)");
+        }
+    }
+
+    @Override
+    public String clusterName() {
+        return newModel.getClusterName();
+    }
+
+    @Override
+    public Optional<ReconfigureError> apply() {
+        var removeError = new RemoveCluster(oldModel, virtualClusterRegistry, endpointRegistry).apply();
+        if (removeError.isPresent()) {
+            // Short-circuit: don't attempt the add half. We want one error per failing cluster,
+            // not a cascade where a stuck-on-remove cluster also produces a (likely unrelated) add
+            // failure. The cluster stays in the failure state RemoveCluster left it in.
+            return removeError;
+        }
+        return new AddCluster(newModel, virtualClusterRegistry, endpointRegistry).apply();
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
@@ -757,9 +757,6 @@ class VirtualClusterRegistryTest {
     @Test
     void addVirtualClusterRejectsDuplicateNameWhenExistingEntryIsActive() {
         // CLUSTER_A is in INITIALIZING after setUp — re-adding it is a contract violation.
-        // IllegalStateException because the argument is valid;
-        // it's the registry's state that doesn't permit the operation. The message names the
-        // existing lifecycle's state to aid diagnosis.
         var duplicate = mockModel(CLUSTER_A);
         assertThatThrownBy(() -> vcc.addVirtualCluster(duplicate))
                 .isInstanceOf(IllegalStateException.class)

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
@@ -757,13 +757,14 @@ class VirtualClusterRegistryTest {
     @Test
     void addVirtualClusterRejectsDuplicateNameWhenExistingEntryIsActive() {
         // CLUSTER_A is in INITIALIZING after setUp — re-adding it is a contract violation.
-        // The duplicate-name check is "no actively-tracked cluster with this name" rather
-        // than "no entry at all" (see the Stopped-replace path below).
+        // IllegalStateException because the argument is valid;
+        // it's the registry's state that doesn't permit the operation. The message names the
+        // existing lifecycle's state to aid diagnosis.
         var duplicate = mockModel(CLUSTER_A);
         assertThatThrownBy(() -> vcc.addVirtualCluster(duplicate))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(CLUSTER_A)
-                .hasMessageContaining("not Stopped");
+                .hasMessageContaining("Initializing");
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
@@ -100,8 +100,8 @@ class VirtualClusterRegistryTest {
         // when
         var models = multiVcm.virtualClusterModels();
 
-        // then
-        assertThat(models).containsExactly(modelA, modelB);
+        // then — order is unspecified (backing map is ConcurrentHashMap); only contents matter.
+        assertThat(models).containsExactlyInAnyOrder(modelA, modelB);
     }
 
     @SuppressWarnings("DataFlowIssue")
@@ -637,11 +637,8 @@ class VirtualClusterRegistryTest {
     }
 
     // -----------------------------------------------------------------------------------------
-    // Reconfigure operations. removeVirtualCluster is the first to be made real (step 1 of
-    // the hot-reload staircase); replaceVirtualCluster and addVirtualCluster remain no-op
-    // stubs until later steps land them. The stub tests below pin the contract: each stub
-    // completes its future immediately without mutating registry state, so the orchestrator
-    // can drive the full pipeline against this class while only some operations are real.
+    // Reconfigure operations: addVirtualCluster and removeVirtualCluster. Modify is delegated
+    // to ReplaceCluster which composes remove + add — there is no dedicated VCR method for it.
     // -----------------------------------------------------------------------------------------
 
     @Test
@@ -713,21 +710,6 @@ class VirtualClusterRegistryTest {
     }
 
     @Test
-    void replaceVirtualClusterStubReturnsCompletedFutureWithoutMutatingState() {
-        // given
-        vcc.initializationSucceeded(CLUSTER_A);
-        var lifecycleBefore = vcc.lifecycleFor(CLUSTER_A);
-        var newModel = mockModel(CLUSTER_A);
-
-        // when
-        var future = vcc.replaceVirtualCluster(CLUSTER_A, newModel);
-
-        // then
-        assertThat(future).isCompleted();
-        assertThat(vcc.lifecycleFor(CLUSTER_A)).isSameAs(lifecycleBefore);
-    }
-
-    @Test
     void addVirtualClusterCreatesLifecycleInInitializing() {
         // given
         var newModel = mockModel(CLUSTER_B);
@@ -745,12 +727,36 @@ class VirtualClusterRegistryTest {
     }
 
     @Test
-    void addVirtualClusterRejectsDuplicateName() {
-        // CLUSTER_A is already present from setUp
+    void addVirtualClusterRejectsDuplicateNameWhenExistingEntryIsActive() {
+        // CLUSTER_A is in INITIALIZING after setUp — re-adding it is a contract violation.
+        // The duplicate-name check is "no actively-tracked cluster with this name" rather
+        // than "no entry at all" (see the Stopped-replace path below).
         var duplicate = mockModel(CLUSTER_A);
         assertThatThrownBy(() -> vcc.addVirtualCluster(duplicate))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining(CLUSTER_A);
+                .hasMessageContaining(CLUSTER_A)
+                .hasMessageContaining("not Stopped");
+    }
+
+    @Test
+    void addVirtualClusterReplacesStoppedEntry() {
+        // ReplaceCluster's add half lands here: the remove half drove the cluster to Stopped
+        // (entry retained per shutdownCluster's append-only policy), and the add half then
+        // calls addVirtualCluster with the new model — which must succeed and replace the
+        // dead entry with a fresh INITIALIZING lifecycle.
+        vcc.removeVirtualCluster(CLUSTER_A).join();
+        var freshModel = mockModel(CLUSTER_A);
+
+        var future = vcc.addVirtualCluster(freshModel);
+
+        assertThat(future).isCompleted();
+        assertThat(vcc.lifecycleFor(CLUSTER_A)).isNotNull()
+                .extracting(VirtualClusterLifecycle::state)
+                .as("re-added cluster's lifecycle should be a fresh Initializing instance")
+                .isInstanceOf(VirtualClusterLifecycleState.Initializing.class);
+        assertThat(vcc.virtualClusterModels())
+                .as("virtualClusterModels reports the new model, not the stale one")
+                .containsExactly(freshModel);
     }
 
     @SuppressWarnings("DataFlowIssue")
@@ -762,20 +768,21 @@ class VirtualClusterRegistryTest {
 
     @Test
     void virtualClusterModelsReflectsRuntimeAddedModel() {
-        // Contract relied on by RemoveCluster#originalGateways: a model handed to
-        // addVirtualCluster appears in virtualClusterModels() so a subsequent reconfigure can
-        // resolve its gateways.
+        // Contract relied on by OperationsPlanner: a model handed to addVirtualCluster appears
+        // in virtualClusterModels() so a subsequent reconfigure can resolve it by name.
         var addedModel = mockModel(CLUSTER_B);
 
         vcc.addVirtualCluster(addedModel);
 
+        // Order is unspecified (backing map is ConcurrentHashMap); both the constructor-supplied
+        // model and the runtime-added one must be present.
         assertThat(vcc.virtualClusterModels())
-                .as("constructor-supplied CLUSTER_A then the runtime-added addedModel, in insertion order")
+                .as("models for both the constructor-supplied and runtime-added clusters are present")
                 .extracting(VirtualClusterModel::getClusterName)
-                .containsExactly(CLUSTER_A, CLUSTER_B);
+                .containsExactlyInAnyOrder(CLUSTER_A, CLUSTER_B);
         assertThat(vcc.virtualClusterModels())
                 .as("runtime-added model identity is preserved (same reference, not a copy)")
-                .last().isSameAs(addedModel);
+                .contains(addedModel);
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
@@ -91,6 +91,34 @@ class VirtualClusterRegistryTest {
     }
 
     @Test
+    void modelForReturnsRegisteredModel() {
+        // CLUSTER_A is in the registry via setUp.
+        assertThat(vcc.modelFor(CLUSTER_A))
+                .isNotNull()
+                .extracting(VirtualClusterModel::getClusterName).isEqualTo(CLUSTER_A);
+    }
+
+    @Test
+    void modelForReturnsNullForUnknownCluster() {
+        assertThat(vcc.modelFor("never-existed")).isNull();
+    }
+
+    @Test
+    void modelForFollowsRuntimeAddAndRemove() {
+        // After addVirtualCluster, modelFor returns the new model.
+        var added = mockModel(CLUSTER_B);
+        vcc.addVirtualCluster(added);
+        assertThat(vcc.modelFor(CLUSTER_B)).isSameAs(added);
+
+        // After removeVirtualCluster, the entry is retained (append-only policy) so modelFor
+        // continues to return the same model. The lifecycle's state distinguishes "Stopped"
+        // from "Serving" — callers that care about state should compose with lifecycleFor.
+        vcc.initializationSucceeded(CLUSTER_B);
+        vcc.removeVirtualCluster(CLUSTER_B).join();
+        assertThat(vcc.modelFor(CLUSTER_B)).isSameAs(added);
+    }
+
+    @Test
     void shouldExposeVirtualClusterModels() {
         // given
         var modelA = mockModel("cluster-a");

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
@@ -289,7 +289,7 @@ class ConfigurationReloadOrchestratorTest {
         var removeModel = mock(VirtualClusterModel.class);
         when(removeModel.getClusterName()).thenReturn("cluster-remove");
         when(removeModel.gateways()).thenReturn(Map.of("default", mock(EndpointGateway.class)));
-        when(registry.virtualClusterModels()).thenReturn(List.of(removeModel));
+        when(registry.modelFor("cluster-remove")).thenReturn(removeModel);
 
         var orchestrator = newOrchestrator(oldConfig, registry);
 
@@ -562,7 +562,8 @@ class ConfigurationReloadOrchestratorTest {
         var succeedsModel = mock(VirtualClusterModel.class);
         when(succeedsModel.getClusterName()).thenReturn("cluster-remove-succeeds");
         when(succeedsModel.gateways()).thenReturn(Map.of("default", mock(EndpointGateway.class)));
-        when(registry.virtualClusterModels()).thenReturn(List.of(failsModel, succeedsModel));
+        when(registry.modelFor("cluster-remove-fails")).thenReturn(failsModel);
+        when(registry.modelFor("cluster-remove-succeeds")).thenReturn(succeedsModel);
 
         var orchestrator = newOrchestrator(oldConfig, registry);
 
@@ -638,6 +639,12 @@ class ConfigurationReloadOrchestratorTest {
             return model;
         }).toList();
         when(registry.virtualClusterModels()).thenReturn(models);
+        // The planner uses modelFor(name) for registry-side resolution; stub each known name.
+        // Unknown names fall through to Mockito's default (null), which the planner surfaces
+        // as a phantom-remove/phantom-modify IllegalStateException.
+        for (var model : models) {
+            when(registry.modelFor(model.getClusterName())).thenReturn(model);
+        }
         return registry;
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
@@ -64,7 +64,6 @@ class ConfigurationReloadOrchestratorTest {
         assertThatThrownBy(future::join).cause().isInstanceOf(StaticConfigurationChangedException.class);
         // No registry interactions — pre-flight rejected before the pipeline ran.
         verify(registry, never()).removeVirtualCluster(anyString());
-        verify(registry, never()).replaceVirtualCluster(anyString(), any());
         verify(registry, never()).addVirtualCluster(any());
     }
 
@@ -84,7 +83,6 @@ class ConfigurationReloadOrchestratorTest {
         assertThat(future).isCompletedWithValueMatching(result -> !result.hasErrors());
         // No registry interactions — there was nothing to do.
         verify(registry, never()).removeVirtualCluster(anyString());
-        verify(registry, never()).replaceVirtualCluster(anyString(), any());
         verify(registry, never()).addVirtualCluster(any());
     }
 
@@ -120,7 +118,6 @@ class ConfigurationReloadOrchestratorTest {
 
         // Negative assertions: no remove/replace happened, no rollback deregister fired.
         verify(registry, never()).removeVirtualCluster(anyString());
-        verify(registry, never()).replaceVirtualCluster(anyString(), any());
         verify(registry, never()).initializationFailed(anyString(), any());
         verify(endpointRegistry, never()).deregisterVirtualCluster(any(EndpointGateway.class));
     }
@@ -214,7 +211,6 @@ class ConfigurationReloadOrchestratorTest {
         inOrder.verify(registry).removeVirtualCluster("cluster-remove");
         inOrder.verify(endpointRegistry).deregisterVirtualCluster(any(EndpointGateway.class));
         verify(registry, never()).addVirtualCluster(any());
-        verify(registry, never()).replaceVirtualCluster(anyString(), any());
     }
 
     @Test
@@ -248,26 +244,28 @@ class ConfigurationReloadOrchestratorTest {
 
     @Test
     void lockIsReleasedOnExceptionSoSubsequentCallsCanProceed() {
-        // After the first reconfigure throws UnsupportedOperationException, a second call
-        // must not be rejected with ConcurrentReconfigureException — the lock should be
-        // released even on exception via the finally block. Inject a detector that produces
-        // a modify (the only operation still unsupported under step 2) so the orchestrator
-        // reaches the placeholder UOE rather than the no-op early-return.
+        // After the first reconfigure throws (planner-level IllegalStateException, e.g.
+        // phantom-add from a buggy change detector), a second call must not be rejected with
+        // ConcurrentReconfigureException — the lock should be released even on exception via
+        // the finally block. We inject a detector that reports a phantom add for a cluster
+        // that's NOT present in the submitted configuration; the planner's guard fires with
+        // IllegalStateException, which propagates out of doReconfigure.
         var config = configWith(vc("cluster-a"));
-        var modifyDetector = mock(ChangeDetector.class);
-        when(modifyDetector.detect(any())).thenReturn(new ChangeResult(
-                Set.of(), Set.of(), Set.of("cluster-a")));
+        var phantomAddDetector = mock(ChangeDetector.class);
+        when(phantomAddDetector.detect(any())).thenReturn(new ChangeResult(
+                Set.of("phantom-cluster"), Set.of(), Set.of()));
         var orchestrator = new ConfigurationReloadOrchestrator(
-                config, stubbedRegistry(), endpointRegistry, mock(PluginFactoryRegistry.class), List.of(modifyDetector));
+                config, stubbedRegistry(), endpointRegistry, mock(PluginFactoryRegistry.class), List.of(phantomAddDetector));
 
         var first = orchestrator.reconfigure(config);
         assertThat(first).isCompletedExceptionally();
-        assertThatThrownBy(first::join).cause().isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(first::join).cause().isInstanceOf(IllegalStateException.class);
 
         var second = orchestrator.reconfigure(config);
         assertThat(second).isCompletedExceptionally();
-        // Second call should also throw UOE (not ConcurrentReconfigureException).
-        assertThatThrownBy(second::join).cause().isInstanceOf(UnsupportedOperationException.class);
+        // Second call should also throw the planner's IllegalStateException (not
+        // ConcurrentReconfigureException) — proving the lock was released between calls.
+        assertThatThrownBy(second::join).cause().isInstanceOf(IllegalStateException.class);
     }
 
     @Test
@@ -386,7 +384,6 @@ class ConfigurationReloadOrchestratorTest {
         // then — the orchestrator consulted the injected detector and acted on its verdict.
         verify(customDetector).detect(any());
         verify(registry).removeVirtualCluster("cluster-remove");
-        verify(registry, never()).replaceVirtualCluster(anyString(), any());
         verify(registry, never()).addVirtualCluster(any());
 
         // Pure-remove reconfigure: orchestrator completes successfully.
@@ -409,33 +406,66 @@ class ConfigurationReloadOrchestratorTest {
         var inOrder = inOrder(registry);
         inOrder.verify(registry).removeVirtualCluster("cluster-remove");
         inOrder.verify(registry).addVirtualCluster(argThat(m -> m.getClusterName().equals("cluster-add")));
-        verify(registry, never()).replaceVirtualCluster(anyString(), any());
     }
 
     @Test
-    void modifyOnlyReconfigureIsRejectedUpfront() {
-        // A modify-only reconfigure is still unsupported and rejected upfront with UOE
-        // before any per-VC work runs. We inject a detector that produces a clustersToModify
-        // entry because the production detectors require an actual filter/cluster change to
-        // surface a modify; this lets the test focus on the orchestrator's guard behaviour.
+    void modifyOnlyReconfigureExecutesViaReplaceCluster() {
+        // A modify-only reconfigure now runs a ReplaceCluster operation, which internally
+        // composes RemoveCluster + AddCluster. The orchestrator-visible behaviour is the same
+        // shape as add/remove: the future completes successfully, ReconfigureResult has no
+        // errors, and the registry sees remove + add for the same cluster name.
         var config = configWith(vc("cluster-a"));
-        var customDetector = mock(ChangeDetector.class);
-        when(customDetector.detect(any())).thenReturn(new ChangeResult(
-                Set.of(),
-                Set.of(),
-                Set.of("cluster-a")));
+        var modifyDetector = mock(ChangeDetector.class);
+        when(modifyDetector.detect(any())).thenReturn(new ChangeResult(
+                Set.of(), Set.of(), Set.of("cluster-a")));
 
-        var registry = stubbedRegistry();
+        var registry = stubbedRegistry("cluster-a");
         var orchestrator = new ConfigurationReloadOrchestrator(
-                config, registry, endpointRegistry, mock(PluginFactoryRegistry.class), List.of(customDetector));
+                config, registry, endpointRegistry, mock(PluginFactoryRegistry.class), List.of(modifyDetector));
 
         var future = orchestrator.reconfigure(config);
 
-        assertThat(future).isCompletedExceptionally();
-        assertThatThrownBy(future::join).cause().isInstanceOf(UnsupportedOperationException.class);
-        verify(registry, never()).removeVirtualCluster(anyString());
-        verify(registry, never()).addVirtualCluster(any());
-        verify(registry, never()).replaceVirtualCluster(anyString(), any());
+        assertThat(future).isCompletedWithValueMatching(r -> !r.hasErrors());
+        // Both halves of the replace executed on the registry side. Ordering is enforced by
+        // ReplaceCluster — the orchestrator just dispatches.
+        var inOrder = inOrder(registry);
+        inOrder.verify(registry).removeVirtualCluster("cluster-a");
+        inOrder.verify(registry).addVirtualCluster(argThat(m -> m.getClusterName().equals("cluster-a")));
+    }
+
+    @Test
+    void shouldExecuteAddRemoveAndModifyInSingleReconfigure() {
+        // End-to-end: a reconfigure that touches every bucket. Ordering invariant (pure
+        // removes → modifies → pure adds) is asserted via mockito's inOrder verification on
+        // the registry's per-name calls. The submitted configuration mentions both the
+        // modified cluster (so the planner can resolve newModel) and the pure-add cluster
+        // (so the planner can resolve its addModel); cluster-pure-remove is absent because
+        // it's being removed.
+        var config = configWith(vc("cluster-modify"), vc("cluster-pure-add"));
+        var multiBucketDetector = mock(ChangeDetector.class);
+        when(multiBucketDetector.detect(any())).thenReturn(new ChangeResult(
+                Set.of("cluster-pure-add"),
+                Set.of("cluster-pure-remove"),
+                Set.of("cluster-modify")));
+
+        var registry = stubbedRegistry("cluster-pure-remove", "cluster-modify");
+        var orchestrator = new ConfigurationReloadOrchestrator(
+                config, registry, endpointRegistry, mock(PluginFactoryRegistry.class), List.of(multiBucketDetector));
+
+        var future = orchestrator.reconfigure(config);
+
+        assertThat(future).isCompletedWithValueMatching(r -> !r.hasErrors());
+        var inOrder = inOrder(registry);
+        // Pure remove first.
+        inOrder.verify(registry).removeVirtualCluster("cluster-pure-remove");
+        // Then the modify pair (encapsulated inside ReplaceCluster — both calls happen).
+        inOrder.verify(registry).removeVirtualCluster("cluster-modify");
+        inOrder.verify(registry).addVirtualCluster(argThat(m -> m.getClusterName().equals("cluster-modify")));
+        // Then the pure add last.
+        inOrder.verify(registry).addVirtualCluster(argThat(m -> m.getClusterName().equals("cluster-pure-add")));
+        // We made two adds across the reconfigure (one for the modify, one for the pure-add).
+        verify(registry, times(2)).addVirtualCluster(any());
+        verify(registry, times(2)).removeVirtualCluster(anyString());
     }
 
     @Test
@@ -600,7 +630,6 @@ class ConfigurationReloadOrchestratorTest {
     private static VirtualClusterRegistry stubbedRegistry(String... clustersInOldConfig) {
         var registry = mock(VirtualClusterRegistry.class);
         when(registry.removeVirtualCluster(anyString())).thenReturn(CompletableFuture.completedFuture(null));
-        when(registry.replaceVirtualCluster(anyString(), any())).thenReturn(CompletableFuture.completedFuture(null));
         when(registry.addVirtualCluster(any())).thenReturn(CompletableFuture.completedFuture(null));
         var models = Arrays.stream(clustersInOldConfig).map(name -> {
             var model = mock(VirtualClusterModel.class);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/OperationsPlannerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/OperationsPlannerTest.java
@@ -51,6 +51,85 @@ class OperationsPlannerTest {
     }
 
     @Test
+    void shouldOrderPureRemovesThenModifiesThenPureAdds() {
+        // The full three-bucket ordering. A same-port modify wants its remove and add tight
+        // together — emitting one ReplaceCluster per modify achieves that structurally rather
+        // than by the planner remembering to pair them.
+        var pureRemoveModel = modelFor("cluster-pure-remove");
+        var oldModifyModel = modelFor("cluster-modify");
+        var newModifyModel = modelFor("cluster-modify");
+        var pureAddModel = modelFor("cluster-pure-add");
+        when(vcr.virtualClusterModels()).thenReturn(List.of(pureRemoveModel, oldModifyModel));
+        var planner = plannerWithModels(newModifyModel, pureAddModel);
+        var changes = new ChangeResult(
+                Set.of("cluster-pure-add"),
+                Set.of("cluster-pure-remove"),
+                Set.of("cluster-modify"));
+
+        var ops = planner.plan(changes, configWith("cluster-modify", "cluster-pure-add"));
+
+        assertThat(ops).hasSize(3);
+        assertThat(ops.get(0)).isInstanceOf(RemoveCluster.class);
+        assertThat(ops.get(0).clusterName()).isEqualTo("cluster-pure-remove");
+        assertThat(ops.get(1)).isInstanceOf(ReplaceCluster.class);
+        assertThat(ops.get(1).clusterName()).isEqualTo("cluster-modify");
+        assertThat(ops.get(2)).isInstanceOf(AddCluster.class);
+        assertThat(ops.get(2).clusterName()).isEqualTo("cluster-pure-add");
+    }
+
+    @Test
+    void shouldPlanModifyAsSingleReplaceClusterOp() {
+        // Modify produces ONE op, not two. The remove-then-add internals are encapsulated
+        // inside ReplaceCluster — the orchestrator sees a single intent.
+        var oldModel = modelFor("cluster-modify");
+        var newModel = modelFor("cluster-modify");
+        when(vcr.virtualClusterModels()).thenReturn(List.of(oldModel));
+        var planner = plannerWithModels(newModel);
+        var changes = new ChangeResult(Set.of(), Set.of(), Set.of("cluster-modify"));
+
+        var ops = planner.plan(changes, configWith("cluster-modify"));
+
+        assertThat(ops).singleElement()
+                .isInstanceOfSatisfying(ReplaceCluster.class,
+                        op -> assertThat(op.clusterName()).isEqualTo("cluster-modify"));
+    }
+
+    @Test
+    void shouldThrowIllegalStateWhenChangeDetectorReportsModifyForClusterNotInRegistry() {
+        // Phantom-modify, old-side variant. The change detector reported a modify for a name
+        // the registry doesn't have an entry for — the planner can't build a ReplaceCluster
+        // without both halves. Same shape of failure as phantom-add and phantom-remove.
+        var newModel = modelFor("cluster-modify");
+        when(vcr.virtualClusterModels()).thenReturn(List.of());
+        var planner = plannerWithModels(newModel);
+        var changes = new ChangeResult(Set.of(), Set.of(), Set.of("cluster-modify"));
+        var config = configWith("cluster-modify");
+
+        assertThatThrownBy(() -> planner.plan(changes, config))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("cluster-modify")
+                .hasMessageContaining("absent from the registry")
+                .hasMessageContaining("ChangeDetector contract violation");
+    }
+
+    @Test
+    void shouldThrowIllegalStateWhenChangeDetectorReportsModifyForClusterNotInNewConfig() {
+        // Phantom-modify, new-side variant. The registry has the old model but the submitted
+        // configuration doesn't include the cluster — internally inconsistent.
+        var oldModel = modelFor("cluster-modify");
+        when(vcr.virtualClusterModels()).thenReturn(List.of(oldModel));
+        var planner = plannerWithModels(); // resolver returns no models
+        var changes = new ChangeResult(Set.of(), Set.of(), Set.of("cluster-modify"));
+        var config = configWith("placeholder");
+
+        assertThatThrownBy(() -> planner.plan(changes, config))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("cluster-modify")
+                .hasMessageContaining("absent from the submitted configuration")
+                .hasMessageContaining("ChangeDetector contract violation");
+    }
+
+    @Test
     void shouldHandRemoveClusterTheRegistryOwnedModel() {
         // Reference-identity gotcha: EndpointRegistry's binding map is keyed on the
         // EndpointGateway reference itself. RemoveCluster must be given the *registry's*

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/OperationsPlannerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/OperationsPlannerTest.java
@@ -37,7 +37,7 @@ class OperationsPlannerTest {
     void shouldPlanRemovesBeforeAdds() {
         var removeModel = modelFor("cluster-remove");
         var addModel = modelFor("cluster-add");
-        when(vcr.virtualClusterModels()).thenReturn(List.of(removeModel));
+        when(vcr.modelFor("cluster-remove")).thenReturn(removeModel);
         var planner = plannerWithModels(addModel);
         var changes = new ChangeResult(Set.of("cluster-add"), Set.of("cluster-remove"), Set.of());
 
@@ -59,7 +59,8 @@ class OperationsPlannerTest {
         var oldModifyModel = modelFor("cluster-modify");
         var newModifyModel = modelFor("cluster-modify");
         var pureAddModel = modelFor("cluster-pure-add");
-        when(vcr.virtualClusterModels()).thenReturn(List.of(pureRemoveModel, oldModifyModel));
+        when(vcr.modelFor("cluster-pure-remove")).thenReturn(pureRemoveModel);
+        when(vcr.modelFor("cluster-modify")).thenReturn(oldModifyModel);
         var planner = plannerWithModels(newModifyModel, pureAddModel);
         var changes = new ChangeResult(
                 Set.of("cluster-pure-add"),
@@ -83,7 +84,7 @@ class OperationsPlannerTest {
         // inside ReplaceCluster — the orchestrator sees a single intent.
         var oldModel = modelFor("cluster-modify");
         var newModel = modelFor("cluster-modify");
-        when(vcr.virtualClusterModels()).thenReturn(List.of(oldModel));
+        when(vcr.modelFor("cluster-modify")).thenReturn(oldModel);
         var planner = plannerWithModels(newModel);
         var changes = new ChangeResult(Set.of(), Set.of(), Set.of("cluster-modify"));
 
@@ -99,8 +100,8 @@ class OperationsPlannerTest {
         // Phantom-modify, old-side variant. The change detector reported a modify for a name
         // the registry doesn't have an entry for — the planner can't build a ReplaceCluster
         // without both halves. Same shape of failure as phantom-add and phantom-remove.
+        // vcr.modelFor("cluster-modify") returns null by Mockito default — no stub needed.
         var newModel = modelFor("cluster-modify");
-        when(vcr.virtualClusterModels()).thenReturn(List.of());
         var planner = plannerWithModels(newModel);
         var changes = new ChangeResult(Set.of(), Set.of(), Set.of("cluster-modify"));
         var config = configWith("cluster-modify");
@@ -117,7 +118,7 @@ class OperationsPlannerTest {
         // Phantom-modify, new-side variant. The registry has the old model but the submitted
         // configuration doesn't include the cluster — internally inconsistent.
         var oldModel = modelFor("cluster-modify");
-        when(vcr.virtualClusterModels()).thenReturn(List.of(oldModel));
+        when(vcr.modelFor("cluster-modify")).thenReturn(oldModel);
         var planner = plannerWithModels(); // resolver returns no models
         var changes = new ChangeResult(Set.of(), Set.of(), Set.of("cluster-modify"));
         var config = configWith("placeholder");
@@ -136,9 +137,9 @@ class OperationsPlannerTest {
         // model, not a freshly-resolved one whose gateways have different identities, or
         // the deregister becomes a silent no-op and the binding leaks. We assert that the
         // model instance the planner hands to RemoveCluster is the one returned by
-        // vcr.virtualClusterModels().
+        // vcr.modelFor(name).
         var registryModel = modelFor("cluster-remove");
-        when(vcr.virtualClusterModels()).thenReturn(List.of(registryModel));
+        when(vcr.modelFor("cluster-remove")).thenReturn(registryModel);
         var planner = plannerWithModels(); // no adds; resolver returns nothing
         var changes = new ChangeResult(Set.of(), Set.of("cluster-remove"), Set.of());
 
@@ -160,11 +161,11 @@ class OperationsPlannerTest {
 
     @Test
     void shouldNotResolveModelsWhenOnlyRemovesArePresent() {
-        // Remove operations resolve their model from the registry (vcr.virtualClusterModels),
+        // Remove operations resolve their model from the registry (vcr.modelFor(name)),
         // not the submitted Configuration. The modelResolver (which builds models for the new
         // config) must not be invoked when there are no adds.
         var removeModel = modelFor("cluster-remove");
-        when(vcr.virtualClusterModels()).thenReturn(List.of(removeModel));
+        when(vcr.modelFor("cluster-remove")).thenReturn(removeModel);
         var resolverCalls = new int[1];
         Function<Configuration, List<VirtualClusterModel>> resolver = config -> {
             resolverCalls[0]++;
@@ -199,7 +200,7 @@ class OperationsPlannerTest {
         // named cluster, so the planner can't build a RemoveCluster for it. Surfacing this
         // at the framework layer (rather than deeper in RemoveCluster) keeps the operation
         // free of "couldn't resolve gateways" guards.
-        when(vcr.virtualClusterModels()).thenReturn(List.of());
+        // vcr.modelFor("phantom-cluster") returns null by Mockito default — no stub needed.
         var planner = plannerWithModels();
         var changes = new ChangeResult(Set.of(), Set.of("phantom-cluster"), Set.of());
         var config = configWith("placeholder");

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ReplaceClusterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ReplaceClusterTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.reload;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.internal.VirtualClusterRegistry;
+import io.kroxylicious.proxy.internal.net.EndpointGateway;
+import io.kroxylicious.proxy.internal.net.EndpointRegistry;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ReplaceClusterTest {
+
+    private static final String NAME = "cluster-modify";
+
+    private final VirtualClusterRegistry vcr = mock(VirtualClusterRegistry.class);
+    private final EndpointRegistry endpointRegistry = mock(EndpointRegistry.class);
+
+    @Test
+    void shouldDriveRemoveThenAddOnHappyPath() {
+        var oldGateway = mock(EndpointGateway.class);
+        var newGateway = mock(EndpointGateway.class);
+        var oldModel = modelWithGateway(NAME, oldGateway);
+        var newModel = modelWithGateway(NAME, newGateway);
+        stubRemoveSucceeds();
+        stubDeregisterSucceeds();
+        stubAddBookkeepingSucceeds();
+        stubRegisterSucceeds();
+
+        var result = new ReplaceCluster(oldModel, newModel, vcr, endpointRegistry).apply();
+
+        assertThat(result).isEmpty();
+        var inOrder = inOrder(vcr, endpointRegistry);
+        inOrder.verify(vcr).removeVirtualCluster(NAME);
+        inOrder.verify(endpointRegistry).deregisterVirtualCluster(oldGateway);
+        inOrder.verify(vcr).addVirtualCluster(newModel);
+        inOrder.verify(endpointRegistry).registerVirtualCluster(newGateway);
+        inOrder.verify(vcr).initializationSucceeded(NAME);
+    }
+
+    @Test
+    void shouldShortCircuitWhenRemoveFails() {
+        // If the remove half can't complete, we don't proceed to the add. One error per
+        // failing cluster — not a cascade.
+        var oldGateway = mock(EndpointGateway.class);
+        var newGateway = mock(EndpointGateway.class);
+        var oldModel = modelWithGateway(NAME, oldGateway);
+        var newModel = modelWithGateway(NAME, newGateway);
+        var removeCause = new IllegalStateException("simulated drain failure");
+        when(vcr.removeVirtualCluster(NAME)).thenReturn(CompletableFuture.failedFuture(removeCause));
+
+        var result = new ReplaceCluster(oldModel, newModel, vcr, endpointRegistry).apply();
+
+        assertThat(result).hasValueSatisfying(e -> {
+            assertThat(e.humanReadableIdentifier()).isEqualTo(NAME);
+            assertThat(e.cause()).isSameAs(removeCause);
+        });
+        verify(vcr, never()).addVirtualCluster(any(VirtualClusterModel.class));
+        verify(endpointRegistry, never()).registerVirtualCluster(any(EndpointGateway.class));
+    }
+
+    @Test
+    void shouldReportAddErrorWhenRemoveSucceedsButAddFails() {
+        // Remove half completes cleanly; bind on the new model fails. ReconfigureError carries
+        // the add cause (the cluster's offline because of the failed add, not anything in the
+        // remove). The cluster ends up in STOPPED — same shape as a pure-add bind failure.
+        var oldGateway = mock(EndpointGateway.class);
+        var newGateway = mock(EndpointGateway.class);
+        var oldModel = modelWithGateway(NAME, oldGateway);
+        var newModel = modelWithGateway(NAME, newGateway);
+        stubRemoveSucceeds();
+        stubDeregisterSucceeds();
+        stubAddBookkeepingSucceeds();
+        var bindCause = new IllegalStateException("simulated bind failure");
+        when(endpointRegistry.registerVirtualCluster(any(EndpointGateway.class)))
+                .thenReturn(CompletableFuture.failedStage(bindCause));
+        stubDeregisterSucceeds(); // for the AddCluster rollback path
+
+        var result = new ReplaceCluster(oldModel, newModel, vcr, endpointRegistry).apply();
+
+        assertThat(result).hasValueSatisfying(e -> {
+            assertThat(e.humanReadableIdentifier()).isEqualTo(NAME);
+            assertThat(e.cause()).isSameAs(bindCause);
+        });
+        verify(vcr).removeVirtualCluster(NAME);
+        verify(vcr).addVirtualCluster(newModel);
+        verify(vcr).initializationFailed(NAME, bindCause);
+    }
+
+    @Test
+    void clusterNameReflectsTheNewModel() {
+        // The remove half operates on oldModel but the operation's identity (its slot in the
+        // change-detection vocabulary) is the name shared by both — which both models report.
+        var oldModel = modelWithGateway(NAME, mock(EndpointGateway.class));
+        var newModel = modelWithGateway(NAME, mock(EndpointGateway.class));
+
+        assertThat(new ReplaceCluster(oldModel, newModel, vcr, endpointRegistry).clusterName())
+                .isEqualTo(NAME);
+    }
+
+    @Test
+    void constructorRejectsNameMismatch() {
+        // Defence in depth: the planner only emits ReplaceCluster pairs where both models share
+        // a name, but the operation guards against a buggy planner that violates that.
+        var oldModel = modelWithGateway("cluster-a", mock(EndpointGateway.class));
+        var newModel = modelWithGateway("cluster-b", mock(EndpointGateway.class));
+
+        assertThatThrownBy(() -> new ReplaceCluster(oldModel, newModel, vcr, endpointRegistry))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cluster-a")
+                .hasMessageContaining("cluster-b");
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void constructorRejectsNullArguments() {
+        var model = modelWithGateway(NAME, mock(EndpointGateway.class));
+        assertThatThrownBy(() -> new ReplaceCluster(null, model, vcr, endpointRegistry))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new ReplaceCluster(model, null, vcr, endpointRegistry))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new ReplaceCluster(model, model, null, endpointRegistry))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new ReplaceCluster(model, model, vcr, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    private void stubRemoveSucceeds() {
+        when(vcr.removeVirtualCluster(NAME)).thenReturn(CompletableFuture.completedFuture(null));
+    }
+
+    private void stubDeregisterSucceeds() {
+        when(endpointRegistry.deregisterVirtualCluster(any(EndpointGateway.class)))
+                .thenReturn(CompletableFuture.completedStage(null));
+    }
+
+    private void stubAddBookkeepingSucceeds() {
+        when(vcr.addVirtualCluster(any(VirtualClusterModel.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+    }
+
+    private void stubRegisterSucceeds() {
+        when(endpointRegistry.registerVirtualCluster(any(EndpointGateway.class)))
+                .thenReturn(CompletableFuture.completedStage(null));
+    }
+
+    private static VirtualClusterModel modelWithGateway(String name, EndpointGateway gateway) {
+        var model = mock(VirtualClusterModel.class);
+        when(model.getClusterName()).thenReturn(name);
+        var gateways = new LinkedHashMap<String, EndpointGateway>();
+        gateways.put("default", gateway);
+        when(model.gateways()).thenReturn((Map) gateways);
+        return model;
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As per the [discussed sequence](https://github.com/kroxylicious/kroxylicious/pull/3977#discussion_r3270313081), I have added a new `ReplaceCluster` operation which will handle reloading of a modified cluster.

### Additional Context

https://github.com/kroxylicious/kroxylicious/issues/4000

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
