### PR TITLE
fix(operator): extend primary-cache mapper fix to all VKC secondary→primary mappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#4064](https://github.com/kroxylicious/kroxylicious/pull/4064): fix(operator): VirtualKafkaCluster secondary→primary mappers no longer call the API server on every secondary event, preventing VKCs from getting stuck when the API server is transiently unavailable (follow-up to [#4044](https://github.com/kroxylicious/kroxylicious/pull/4044) by @Roshr2211)
 * [#3913](https://github.com/kroxylicious/kroxylicious/pull/3913): feat(operator): report `DeprecationWarning` status condition on `KafkaProxy` resources with absent `spec`
 
 ### Changes, deprecations and removals

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -366,18 +366,17 @@ public class ResourcesUtil {
      * @param <P> The type of the primary (reference owner)
      * @param <R> The type of the referent
      */
-    public static <P extends HasMetadata, R extends HasMetadata> Set<ResourceID> findReferringPrimaries(EventSourceContext<P> context,
-                                                                                                        R referent,
-                                                                                                        Function<P, Optional<LocalRef<R>>> refAccessor) {
-        return filteredPrimaryIdsInSameNamespace(context,
-                referent,
-                primary -> refAccessor.apply(primary).map(lr -> ResourcesUtil.isReferent(lr, referent)).orElse(false));
+    public static <P extends HasMetadata, R extends HasMetadata> Set<ResourceID> findKnownPrimariesOf(EventSourceContext<P> context,
+                                                                                                      R referent,
+                                                                                                      Function<P, Optional<LocalRef<R>>> refAccessor) {
+        return filteredPrimaryIdsInSameNamespace(context, referent,
+                primary -> refAccessor.apply(primary).map(lr -> isReferent(lr, referent)).orElse(false));
     }
 
     /**
      * Like {@link #findReferrers(EventSourceContext, OwnerReference, HasMetadata, Class, Function)} but resolves the
      * referring resources from the controller's primary cache rather than issuing a live {@code list}. See
-     * {@link #findReferringPrimaries(EventSourceContext, HasMetadata, Function)} for the rationale and preconditions.
+     * {@link #findKnownPrimariesOf(EventSourceContext, HasMetadata, Function)} for the rationale and preconditions.
      * @param context The event source context
      * @param referent The referent OwnerReference
      * @param hasNamespace A resource bearing the namespace we wish to search
@@ -386,19 +385,20 @@ public class ResourcesUtil {
      * @param <P> The type of the primary (reference owner)
      * @param <R> The type of the referent
      */
-    public static <P extends HasMetadata, R extends HasMetadata> Set<ResourceID> findReferringPrimaries(EventSourceContext<P> context,
-                                                                                                        OwnerReference referent,
-                                                                                                        HasMetadata hasNamespace,
-                                                                                                        Function<P, Optional<LocalRef<R>>> refAccessor) {
-        return filteredPrimaryIdsInSameNamespace(context,
-                hasNamespace,
-                primary -> refAccessor.apply(primary).map(lr -> referent.getName().equals(lr.getName()) && referent.getKind().equals(lr.getKind())).orElse(false));
+    public static <P extends HasMetadata, R extends HasMetadata> Set<ResourceID> findKnownPrimariesOf(EventSourceContext<P> context,
+                                                                                                      OwnerReference referent,
+                                                                                                      HasMetadata hasNamespace,
+                                                                                                      Function<P, Optional<LocalRef<R>>> refAccessor) {
+        return filteredPrimaryIdsInSameNamespace(context, hasNamespace,
+                primary -> refAccessor.apply(primary)
+                        .map(lr -> referent.getName().equals(lr.getName()) && referent.getKind().equals(lr.getKind()))
+                        .orElse(false));
     }
 
     /**
      * Like {@link #findReferrersMulti(EventSourceContext, HasMetadata, Class, Function)} but resolves the referring
      * resources from the controller's primary cache rather than issuing a live {@code list}. See
-     * {@link #findReferringPrimaries(EventSourceContext, HasMetadata, Function)} for the rationale and preconditions.
+     * {@link #findKnownPrimariesOf(EventSourceContext, HasMetadata, Function)} for the rationale and preconditions.
      * @param context The event source context
      * @param referent The potential referent
      * @param refAccessor A function which returns the references from a given primary.
@@ -406,18 +406,16 @@ public class ResourcesUtil {
      * @param <P> The type of the primary (reference owner)
      * @param <R> The type of the referent
      */
-    public static <P extends HasMetadata, R extends HasMetadata> Set<ResourceID> findReferringPrimariesMulti(EventSourceContext<P> context,
-                                                                                                             R referent,
-                                                                                                             Function<P, Collection<? extends LocalRef<R>>> refAccessor) {
-        return filteredPrimaryIdsInSameNamespace(context,
-                referent,
-                primary -> {
-                    Collection<? extends LocalRef<R>> refs = refAccessor.apply(primary);
-                    if (refs == null) {
-                        return false;
-                    }
-                    return refs.stream().anyMatch(ref -> ResourcesUtil.isReferent(ref, referent));
-                });
+    public static <P extends HasMetadata, R extends HasMetadata> Set<ResourceID> findKnownPrimariesOfEach(EventSourceContext<P> context,
+                                                                                                          R referent,
+                                                                                                          Function<P, Collection<? extends LocalRef<R>>> refAccessor) {
+        return filteredPrimaryIdsInSameNamespace(context, referent, primary -> {
+            Collection<? extends LocalRef<R>> refs = refAccessor.apply(primary);
+            if (refs == null) {
+                return false;
+            }
+            return refs.stream().anyMatch(ref -> isReferent(ref, referent));
+        });
     }
 
     private static <P extends HasMetadata> Set<ResourceID> filteredPrimaryIdsInSameNamespace(EventSourceContext<P> context,

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KafkaProtocolFilterSecondaryToVirtualKafkaClusterPrimaryMapper.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KafkaProtocolFilterSecondaryToVirtualKafkaClusterPrimaryMapper.java
@@ -29,7 +29,7 @@ class KafkaProtocolFilterSecondaryToVirtualKafkaClusterPrimaryMapper implements 
             VirtualKafkaClusterReconciler.logIgnoredEvent(filter);
             return Set.of();
         }
-        return ResourcesUtil.findReferringPrimariesMulti(context,
+        return ResourcesUtil.findKnownPrimariesOfEach(context,
                 filter,
                 cluster -> cluster.getSpec().getFilterRefs());
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KafkaProxyIngressSecondaryToVirtualKafkaClusterPrimaryMapper.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KafkaProxyIngressSecondaryToVirtualKafkaClusterPrimaryMapper.java
@@ -30,7 +30,7 @@ class KafkaProxyIngressSecondaryToVirtualKafkaClusterPrimaryMapper implements Se
             VirtualKafkaClusterReconciler.logIgnoredEvent(ingress);
             return Set.of();
         }
-        return ResourcesUtil.findReferringPrimariesMulti(context,
+        return ResourcesUtil.findKnownPrimariesOfEach(context,
                 ingress,
                 cluster -> cluster.getSpec().getIngresses().stream().map(Ingresses::getIngressRef).toList());
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KafkaServiceSecondaryToVirtualKafkaClusterPrimaryMapper.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KafkaServiceSecondaryToVirtualKafkaClusterPrimaryMapper.java
@@ -30,7 +30,7 @@ class KafkaServiceSecondaryToVirtualKafkaClusterPrimaryMapper implements Seconda
             VirtualKafkaClusterReconciler.logIgnoredEvent(service);
             return Set.of();
         }
-        return ResourcesUtil.findReferringPrimaries(context,
+        return ResourcesUtil.findKnownPrimariesOf(context,
                 service,
                 cluster -> Optional.of(cluster.getSpec().getTargetKafkaServiceRef()));
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KubernetesServicesSecondaryToVirtualKafkaClusterPrimaryMapper.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KubernetesServicesSecondaryToVirtualKafkaClusterPrimaryMapper.java
@@ -37,7 +37,7 @@ class KubernetesServicesSecondaryToVirtualKafkaClusterPrimaryMapper implements S
         Optional<OwnerReference> proxyOwner = extractOwnerRefFromKubernetesService(kubernetesService,
                 VirtualKafkaClusterReconciler.KAFKA_PROXY_KIND);
         if (proxyOwner.isPresent()) {
-            return ResourcesUtil.findReferringPrimaries(context, proxyOwner.get(), kubernetesService,
+            return ResourcesUtil.findKnownPrimariesOf(context, proxyOwner.get(), kubernetesService,
                     cluster -> Optional.of(cluster.getSpec().getProxyRef()));
         }
         else {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/ResourceSecondaryJoinedOnIngressTrustAnchorRefToVirtualKafkaClusterPrimaryMapper.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/ResourceSecondaryJoinedOnIngressTrustAnchorRefToVirtualKafkaClusterPrimaryMapper.java
@@ -30,7 +30,7 @@ class ResourceSecondaryJoinedOnIngressTrustAnchorRefToVirtualKafkaClusterPrimary
 
     @Override
     public Set<ResourceID> toPrimaryResourceIDs(T resource) {
-        return ResourcesUtil.findReferringPrimariesMulti(context,
+        return ResourcesUtil.findKnownPrimariesOfEach(context,
                 resource,
                 cluster -> cluster.getSpec().getIngresses().stream()
                         .flatMap(ingress -> Optional.ofNullable(ingress.getTls()).stream())

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/SecretSecondaryJoinedOnIngressCertificateRefToVirtualKafkaClusterPrimaryMapper.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/SecretSecondaryJoinedOnIngressCertificateRefToVirtualKafkaClusterPrimaryMapper.java
@@ -28,7 +28,7 @@ class SecretSecondaryJoinedOnIngressCertificateRefToVirtualKafkaClusterPrimaryMa
 
     @Override
     public Set<ResourceID> toPrimaryResourceIDs(Secret secret) {
-        return ResourcesUtil.findReferringPrimariesMulti(context,
+        return ResourcesUtil.findKnownPrimariesOfEach(context,
                 secret,
                 cluster -> cluster.getSpec().getIngresses().stream()
                         .flatMap(ingress -> Optional.ofNullable(ingress.getTls()).stream())

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconciler.java
@@ -399,7 +399,7 @@ public final class VirtualKafkaClusterReconciler implements
                 VirtualKafkaCluster.class)
                 .withName(PROXY_EVENT_SOURCE_NAME)
                 .withPrimaryToSecondaryMapper((VirtualKafkaCluster cluster) -> ResourcesUtil.localRefAsResourceId(cluster, cluster.getSpec().getProxyRef()))
-                .withSecondaryToPrimaryMapper(proxy -> ResourcesUtil.findReferringPrimaries(context,
+                .withSecondaryToPrimaryMapper(proxy -> ResourcesUtil.findKnownPrimariesOf(context,
                         proxy,
                         cluster -> Optional.of(cluster.getSpec().getProxyRef())))
                 .build();
@@ -410,7 +410,7 @@ public final class VirtualKafkaClusterReconciler implements
                 PROXY_CONFIG_STATE_SOURCE_NAME,
                 sharedConfigMapInformer,
                 VirtualKafkaClusterReconciler::toConfigStateResourceName,
-                configMap -> ResourcesUtil.findReferringPrimaries(context,
+                configMap -> ResourcesUtil.findKnownPrimariesOf(context,
                         configMap,
                         cluster -> Optional.of(new AnyLocalRefBuilder().withGroup("").withKind("ConfigMap")
                                 .withName(cluster.getSpec().getProxyRef().getName() + CONFIG_STATE_CONFIG_MAP_SUFFIX)

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/ConfigMapSecondaryJoinedOnIngressTrustAnchorRefToVirtualKafkaClusterPrimaryMapperTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/ConfigMapSecondaryJoinedOnIngressTrustAnchorRefToVirtualKafkaClusterPrimaryMapperTest.java
@@ -14,8 +14,24 @@ import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class ConfigMapSecondaryJoinedOnIngressTrustAnchorRefToVirtualKafkaClusterPrimaryMapperTest {
+    @Test
+    void shouldReturnIdsWhenApiServerUnavailable() {
+        // Regression for #4017. The mapper previously called client.list() on every secondary event.
+        // JOSDK catches exceptions in the informer's event-dispatch path and silently drops the event
+        // with no retry — a transient KubernetesClientException therefore left the VKC stuck.
+        EventSourceContext<VirtualKafkaCluster> context = mock();
+        MapperTestSupport.stubFailingListOperationClient(context);
+        MapperTestSupport.stubPrimaryCache(context, MapperTestSupport.CLUSTER_TLS_NO_FILTERS_WITH_CONFIGMAP_TRUST_ANCHOR);
+
+        var mapper = new ResourceSecondaryJoinedOnIngressTrustAnchorRefToVirtualKafkaClusterPrimaryMapper<>(context);
+        var primaryResourceIDs = mapper.toPrimaryResourceIDs(MapperTestSupport.PEM_CONFIG_MAP);
+
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(MapperTestSupport.CLUSTER_TLS_NO_FILTERS_WITH_CONFIGMAP_TRUST_ANCHOR));
+    }
+
     @Test
     void canMapFromConfigMapToVirtualKafkaClusterWithTls() {
         // Given

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KafkaProtocolFilterSecondaryToVirtualKafkaClusterPrimaryMapperTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KafkaProtocolFilterSecondaryToVirtualKafkaClusterPrimaryMapperTest.java
@@ -21,8 +21,29 @@ import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class KafkaProtocolFilterSecondaryToVirtualKafkaClusterPrimaryMapperTest {
+
+    @Test
+    void shouldReturnIdsWhenApiServerUnavailable() {
+        // Regression for #4017. The mapper previously called client.list() on every secondary event.
+        // JOSDK catches exceptions in the informer's event-dispatch path and silently drops the event
+        // with no retry — a transient KubernetesClientException therefore left the VKC stuck.
+        VirtualKafkaCluster cluster = new VirtualKafkaClusterBuilder().withNewMetadata().withName("cluster").endMetadata().withNewSpec()
+                .withFilterRefs(new FilterRefBuilder().withName("filter").build()).endSpec().build();
+
+        EventSourceContext<VirtualKafkaCluster> context = mock();
+        MapperTestSupport.stubFailingListOperationClient(context);
+        MapperTestSupport.stubPrimaryCache(context, cluster);
+
+        SecondaryToPrimaryMapper<KafkaProtocolFilter> mapper = new KafkaProtocolFilterSecondaryToVirtualKafkaClusterPrimaryMapper(context);
+        KafkaProtocolFilter filter = new KafkaProtocolFilterBuilder().withNewMetadata().withName("filter").endMetadata().withNewSpec().endSpec().build();
+
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(filter);
+
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(cluster));
+    }
 
     @Test
     void filterSecondaryToPrimaryMapper() {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KafkaProxyIngressSecondaryToVirtualKafkaClusterPrimaryMapperTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KafkaProxyIngressSecondaryToVirtualKafkaClusterPrimaryMapperTest.java
@@ -21,8 +21,31 @@ import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressesBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class KafkaProxyIngressSecondaryToVirtualKafkaClusterPrimaryMapperTest {
+
+    @Test
+    void shouldReturnIdsWhenApiServerUnavailable() {
+        // Regression for #4017. The mapper previously called client.list() on every secondary event.
+        // JOSDK catches exceptions in the informer's event-dispatch path and silently drops the event
+        // with no retry — a transient KubernetesClientException therefore left the VKC stuck.
+        VirtualKafkaCluster cluster = new VirtualKafkaClusterBuilder().withNewMetadata().withName("cluster").endMetadata().withNewSpec()
+                .withIngresses(new IngressesBuilder().withNewIngressRef().withName("ingress").endIngressRef().build())
+                .endSpec().build();
+
+        EventSourceContext<VirtualKafkaCluster> context = mock();
+        MapperTestSupport.stubFailingListOperationClient(context);
+        MapperTestSupport.stubPrimaryCache(context, cluster);
+
+        SecondaryToPrimaryMapper<KafkaProxyIngress> mapper = new KafkaProxyIngressSecondaryToVirtualKafkaClusterPrimaryMapper(context);
+        KafkaProxyIngress ingress = new KafkaProxyIngressBuilder().withNewMetadata().withName("ingress").endMetadata()
+                .withNewSpec().withNewProxyRef().withName("proxy").endProxyRef().endSpec().build();
+
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(ingress);
+
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(cluster));
+    }
 
     @Test
     void ingressSecondaryToPrimaryMapper() {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KafkaServiceSecondarytoVirtualKafkaClusterPrimaryMapperTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KafkaServiceSecondarytoVirtualKafkaClusterPrimaryMapperTest.java
@@ -12,6 +12,11 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.IndexerResourceCache;
@@ -73,6 +78,49 @@ class KafkaServiceSecondarytoVirtualKafkaClusterPrimaryMapperTest {
         // The live list (context.getClient()...) was the source of the transient failures that dropped events in #4017.
         assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(cluster));
         verify(eventSourceContext, never()).getClient();
+    }
+
+    @Test
+    void shouldReturnIdsWhenApiServerUnavailable() {
+        // Regression test for #4017. The mapper previously called client.list() on every secondary
+        // event. JOSDK catches exceptions thrown from within the informer's event-dispatch path and
+        // silently drops the triggering event with no retry — a transient KubernetesClientException
+        // on the list therefore left the VirtualKafkaCluster stuck with no ingress status.
+
+        // Given
+        VirtualKafkaCluster cluster = new VirtualKafkaClusterBuilder().withNewMetadata().withName("cluster").endMetadata().withNewSpec()
+                .withTargetKafkaServiceRef(new KafkaServiceRefBuilder().withName("target-kafka").build()).endSpec().build();
+
+        EventSourceContext<VirtualKafkaCluster> context = mock();
+        stubFailingListOperationClient(context);
+        stubPrimaryCache(cluster, context);
+
+        SecondaryToPrimaryMapper<KafkaService> mapper = new KafkaServiceSecondaryToVirtualKafkaClusterPrimaryMapper(context);
+        KafkaService service = new KafkaServiceBuilder().withNewMetadata().withName("target-kafka").endMetadata().withNewSpec().endSpec().build();
+
+        // When
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(service);
+
+        // Then
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(cluster));
+    }
+
+    private static void stubPrimaryCache(VirtualKafkaCluster cluster, EventSourceContext<VirtualKafkaCluster> context) {
+        IndexerResourceCache<VirtualKafkaCluster> primaryCache = mock();
+        when(primaryCache.list(any(), any())).thenAnswer(invocation -> {
+            Predicate<VirtualKafkaCluster> predicate = invocation.getArgument(1);
+            return Stream.of(cluster).filter(predicate);
+        });
+        when(context.getPrimaryCache()).thenReturn(primaryCache);
+    }
+
+    private static void stubFailingListOperationClient(EventSourceContext<VirtualKafkaCluster> context) {
+        KubernetesClient client = mock();
+        when(context.getClient()).thenReturn(client);
+        MixedOperation<VirtualKafkaCluster, KubernetesResourceList<VirtualKafkaCluster>, Resource<VirtualKafkaCluster>> mockOperation = mock();
+        when(client.resources(VirtualKafkaCluster.class)).thenReturn(mockOperation);
+        when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
+        when(mockOperation.list()).thenThrow(new KubernetesClientException("transient API server failure"));
     }
 
     @Test

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KafkaServiceSecondarytoVirtualKafkaClusterPrimaryMapperTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KafkaServiceSecondarytoVirtualKafkaClusterPrimaryMapperTest.java
@@ -7,19 +7,11 @@
 package io.kroxylicious.kubernetes.operator.reconciler.virtualkafkacluster;
 
 import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
-import io.javaoperatorsdk.operator.processing.event.source.IndexerResourceCache;
 import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
 
 import io.kroxylicious.kubernetes.api.common.KafkaServiceRefBuilder;
@@ -29,11 +21,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 class KafkaServiceSecondarytoVirtualKafkaClusterPrimaryMapperTest {
 
@@ -55,32 +43,6 @@ class KafkaServiceSecondarytoVirtualKafkaClusterPrimaryMapperTest {
     }
 
     @Test
-    void resolvesReferrersFromPrimaryCacheWithoutQueryingApiServer() {
-        // given a primary cache containing a referring cluster
-        VirtualKafkaCluster cluster = new VirtualKafkaClusterBuilder().withNewMetadata().withName("cluster").endMetadata().withNewSpec()
-                .withTargetKafkaServiceRef(new KafkaServiceRefBuilder().withName("target-kafka").build()).endSpec().build();
-
-        EventSourceContext<VirtualKafkaCluster> eventSourceContext = mock();
-        IndexerResourceCache<VirtualKafkaCluster> primaryCache = mock();
-        when(eventSourceContext.getPrimaryCache()).thenReturn(primaryCache);
-        when(primaryCache.list(any(), any())).thenAnswer(invocation -> {
-            Predicate<VirtualKafkaCluster> predicate = invocation.getArgument(1);
-            return Stream.of(cluster).filter(predicate);
-        });
-
-        SecondaryToPrimaryMapper<KafkaService> mapper = new KafkaServiceSecondaryToVirtualKafkaClusterPrimaryMapper(eventSourceContext);
-        KafkaService service = new KafkaServiceBuilder().withNewMetadata().withName("target-kafka").endMetadata().withNewSpec().endSpec().build();
-
-        // when
-        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(service);
-
-        // then the referrer is resolved from the cache, and no live list is issued against the API server.
-        // The live list (context.getClient()...) was the source of the transient failures that dropped events in #4017.
-        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(cluster));
-        verify(eventSourceContext, never()).getClient();
-    }
-
-    @Test
     void shouldReturnIdsWhenApiServerUnavailable() {
         // Regression test for #4017. The mapper previously called client.list() on every secondary
         // event. JOSDK catches exceptions thrown from within the informer's event-dispatch path and
@@ -92,8 +54,8 @@ class KafkaServiceSecondarytoVirtualKafkaClusterPrimaryMapperTest {
                 .withTargetKafkaServiceRef(new KafkaServiceRefBuilder().withName("target-kafka").build()).endSpec().build();
 
         EventSourceContext<VirtualKafkaCluster> context = mock();
-        stubFailingListOperationClient(context);
-        stubPrimaryCache(cluster, context);
+        MapperTestSupport.stubFailingListOperationClient(context);
+        MapperTestSupport.stubPrimaryCache(context, cluster);
 
         SecondaryToPrimaryMapper<KafkaService> mapper = new KafkaServiceSecondaryToVirtualKafkaClusterPrimaryMapper(context);
         KafkaService service = new KafkaServiceBuilder().withNewMetadata().withName("target-kafka").endMetadata().withNewSpec().endSpec().build();
@@ -103,24 +65,6 @@ class KafkaServiceSecondarytoVirtualKafkaClusterPrimaryMapperTest {
 
         // Then
         assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(cluster));
-    }
-
-    private static void stubPrimaryCache(VirtualKafkaCluster cluster, EventSourceContext<VirtualKafkaCluster> context) {
-        IndexerResourceCache<VirtualKafkaCluster> primaryCache = mock();
-        when(primaryCache.list(any(), any())).thenAnswer(invocation -> {
-            Predicate<VirtualKafkaCluster> predicate = invocation.getArgument(1);
-            return Stream.of(cluster).filter(predicate);
-        });
-        when(context.getPrimaryCache()).thenReturn(primaryCache);
-    }
-
-    private static void stubFailingListOperationClient(EventSourceContext<VirtualKafkaCluster> context) {
-        KubernetesClient client = mock();
-        when(context.getClient()).thenReturn(client);
-        MixedOperation<VirtualKafkaCluster, KubernetesResourceList<VirtualKafkaCluster>, Resource<VirtualKafkaCluster>> mockOperation = mock();
-        when(client.resources(VirtualKafkaCluster.class)).thenReturn(mockOperation);
-        when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
-        when(mockOperation.list()).thenThrow(new KubernetesClientException("transient API server failure"));
     }
 
     @Test

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KubernetesServicesSecondaryToVirtualKafkaClusterPrimaryMapperTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/KubernetesServicesSecondaryToVirtualKafkaClusterPrimaryMapperTest.java
@@ -30,6 +30,30 @@ import static org.mockito.Mockito.mock;
 class KubernetesServicesSecondaryToVirtualKafkaClusterPrimaryMapperTest {
 
     @Test
+    void shouldReturnIdsWhenApiServerUnavailable() {
+        // Regression for #4017. The mapper previously called client.list() on every secondary event.
+        // JOSDK catches exceptions in the informer's event-dispatch path and silently drops the event
+        // with no retry — a transient KubernetesClientException therefore left the VKC stuck.
+        KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("proxy").endMetadata().build();
+        VirtualKafkaCluster cluster = new VirtualKafkaClusterBuilder().withNewMetadata().withName("cluster").endMetadata().withNewSpec()
+                .withIngresses(new IngressesBuilder().withNewIngressRef().withName("ingress").endIngressRef().build())
+                .withNewProxyRef().withName("proxy").endProxyRef()
+                .endSpec().build();
+
+        EventSourceContext<VirtualKafkaCluster> context = mock();
+        MapperTestSupport.stubFailingListOperationClient(context);
+        MapperTestSupport.stubPrimaryCache(context, cluster);
+
+        SecondaryToPrimaryMapper<Service> mapper = new KubernetesServicesSecondaryToVirtualKafkaClusterPrimaryMapper(context);
+        OwnerReference proxyOwner = ResourcesUtil.newOwnerReferenceTo(proxy);
+        Service service = new ServiceBuilder().withNewMetadata().withOwnerReferences(proxyOwner).endMetadata().build();
+
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(service);
+
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(cluster));
+    }
+
+    @Test
     void kubernetesServicesSecondaryToPrimaryMapperServiceOwnedByProxy() {
         // given
         KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("proxy").endMetadata().build();

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/MapperTestSupport.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/MapperTestSupport.java
@@ -177,12 +177,7 @@ class MapperTestSupport {
      */
     public static EventSourceContext<VirtualKafkaCluster> mockContextContaining(VirtualKafkaCluster... clusters) {
         EventSourceContext<VirtualKafkaCluster> eventSourceContext = mock();
-        IndexerResourceCache<VirtualKafkaCluster> primaryCache = mock();
-        when(eventSourceContext.getPrimaryCache()).thenReturn(primaryCache);
-        when(primaryCache.list(any(), any())).thenAnswer(invocation -> {
-            Predicate<VirtualKafkaCluster> predicate = invocation.getArgument(1);
-            return Stream.of(clusters).filter(predicate);
-        });
+        stubPrimaryCache(eventSourceContext, clusters);
         return eventSourceContext;
     }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/MapperTestSupport.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/MapperTestSupport.java
@@ -12,8 +12,13 @@ import java.util.stream.Stream;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.processing.event.source.IndexerResourceCache;
 
@@ -135,10 +140,40 @@ class MapperTestSupport {
     // @formatter:on
 
     /**
+     * Stubs the primary cache on {@code context} so that {@code clusters} are returned from
+     * {@link IndexerResourceCache#list} filtered by the caller's predicate.
+     * Use together with {@link #stubFailingListOperationClient} to write contract-based regression
+     * tests that assert correct IDs are returned even when the API server is unavailable.
+     */
+    public static void stubPrimaryCache(EventSourceContext<VirtualKafkaCluster> context, VirtualKafkaCluster... clusters) {
+        IndexerResourceCache<VirtualKafkaCluster> primaryCache = mock();
+        when(primaryCache.list(any(), any())).thenAnswer(invocation -> {
+            Predicate<VirtualKafkaCluster> predicate = invocation.getArgument(1);
+            return Stream.of(clusters).filter(predicate);
+        });
+        when(context.getPrimaryCache()).thenReturn(primaryCache);
+    }
+
+    /**
+     * Stubs the Kubernetes client on {@code context} so that any attempt to list
+     * {@link VirtualKafkaCluster} resources throws a {@link KubernetesClientException}.
+     * Simulates a transient API server failure. Use together with {@link #stubPrimaryCache}
+     * to verify that secondary→primary mappers use the primary cache and not the live API.
+     */
+    public static void stubFailingListOperationClient(EventSourceContext<VirtualKafkaCluster> context) {
+        KubernetesClient client = mock();
+        when(context.getClient()).thenReturn(client);
+        MixedOperation<VirtualKafkaCluster, KubernetesResourceList<VirtualKafkaCluster>, Resource<VirtualKafkaCluster>> mockOperation = mock();
+        when(client.resources(VirtualKafkaCluster.class)).thenReturn(mockOperation);
+        when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
+        when(mockOperation.list()).thenThrow(new KubernetesClientException("transient API server failure"));
+    }
+
+    /**
      * Mocks an {@link EventSourceContext} whose primary cache contains the given clusters. Secondary&rarr;primary
-     * mappers resolve referrers from this cache (via {@code findReferringPrimaries}) rather than issuing a live
-     * {@code list} against the API server, so the mock stubs {@link EventSourceContext#getPrimaryCache()} and applies
-     * the caller's predicate to the supplied clusters.
+     * mappers resolve referrers from this cache (via {@link io.kroxylicious.kubernetes.operator.ResourcesUtil#findKnownPrimariesOf})
+     * rather than issuing a live {@code list} against the API server, so the mock stubs
+     * {@link EventSourceContext#getPrimaryCache()} and applies the caller's predicate to the supplied clusters.
      */
     public static EventSourceContext<VirtualKafkaCluster> mockContextContaining(VirtualKafkaCluster... clusters) {
         EventSourceContext<VirtualKafkaCluster> eventSourceContext = mock();

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/SecretSecondaryJoinedOnIngressCertificateRefToVirtualKafkaClusterPrimaryMapperTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/SecretSecondaryJoinedOnIngressCertificateRefToVirtualKafkaClusterPrimaryMapperTest.java
@@ -14,8 +14,24 @@ import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class SecretSecondaryJoinedOnIngressCertificateRefToVirtualKafkaClusterPrimaryMapperTest {
+    @Test
+    void shouldReturnIdsWhenApiServerUnavailable() {
+        // Regression for #4017. The mapper previously called client.list() on every secondary event.
+        // JOSDK catches exceptions in the informer's event-dispatch path and silently drops the event
+        // with no retry — a transient KubernetesClientException therefore left the VKC stuck.
+        EventSourceContext<VirtualKafkaCluster> context = mock();
+        MapperTestSupport.stubFailingListOperationClient(context);
+        MapperTestSupport.stubPrimaryCache(context, MapperTestSupport.CLUSTER_TLS_NO_FILTERS);
+
+        var mapper = new SecretSecondaryJoinedOnIngressCertificateRefToVirtualKafkaClusterPrimaryMapper(context);
+        var primaryResourceIDs = mapper.toPrimaryResourceIDs(MapperTestSupport.KUBE_TLS_CERT_SECRET);
+
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(MapperTestSupport.CLUSTER_TLS_NO_FILTERS));
+    }
+
     @Test
     void canMapFromSecretToVirtualKafkaClusterWithTls() {
         // Given

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/SecretSecondaryJoinedOnIngressTrustAnchorRefToVirtualKafkaClusterPrimaryMapperTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/SecretSecondaryJoinedOnIngressTrustAnchorRefToVirtualKafkaClusterPrimaryMapperTest.java
@@ -14,8 +14,24 @@ import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class SecretSecondaryJoinedOnIngressTrustAnchorRefToVirtualKafkaClusterPrimaryMapperTest {
+
+    @Test
+    void shouldReturnIdsWhenApiServerUnavailable() {
+        // Regression for #4017. The mapper previously called client.list() on every secondary event.
+        // JOSDK catches exceptions in the informer's event-dispatch path and silently drops the event
+        // with no retry — a transient KubernetesClientException therefore left the VKC stuck.
+        EventSourceContext<VirtualKafkaCluster> context = mock();
+        MapperTestSupport.stubFailingListOperationClient(context);
+        MapperTestSupport.stubPrimaryCache(context, MapperTestSupport.CLUSTER_TLS_NO_FILTERS_WITH_SECRET_TRUST_ANCHOR);
+
+        var mapper = new ResourceSecondaryJoinedOnIngressTrustAnchorRefToVirtualKafkaClusterPrimaryMapper<>(context);
+        var primaryResourceIDs = mapper.toPrimaryResourceIDs(MapperTestSupport.TRUST_ANCHOR_PEM_SECRET);
+
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(MapperTestSupport.CLUSTER_TLS_NO_FILTERS_WITH_SECRET_TRUST_ANCHOR));
+    }
 
     @Test
     void canMapFromSecretTrustAnchorRefToVirtualKafkaClusterWithTls() {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Follow-up to #4044, which fixed `KafkaServiceSecondaryToVirtualKafkaClusterPrimaryMapper`
to use `context.getPrimaryCache()` instead of calling the API server on every secondary
event. This PR applies the same fix to all remaining VKC secondary→primary mappers:

- `KafkaProtocolFilterSecondaryToVirtualKafkaClusterPrimaryMapper`
- `KafkaProxyIngressSecondaryToVirtualKafkaClusterPrimaryMapper`
- `KubernetesServicesSecondaryToVirtualKafkaClusterPrimaryMapper`
- `ResourceSecondaryJoinedOnIngressTrustAnchorRefToVirtualKafkaClusterPrimaryMapper`
- `SecretSecondaryJoinedOnIngressCertificateRefToVirtualKafkaClusterPrimaryMapper`

Two inline secondary→primary lambdas in `VirtualKafkaClusterReconciler` are also fixed.

`ResourcesUtil` gains `findReferringPrimaries` / `findReferringPrimariesMulti`, which
mirror the existing `findReferrers` / `findReferrersMulti` but read from the primary
cache instead of the live API server.

### Additional Context

Fixes #4017. A transient `KubernetesClientException` in JOSDK's informer event-dispatch
path is silently dropped with no retry, leaving the VKC stuck. Using the primary cache
(which is fully synced before any secondary informer starts) avoids the API server
entirely for the secondary→primary mapping step.

### Checklist

- [x] New tests written (where applicable).
- [x] Existing unit/integration/system tests passing.
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.