### PR TITLE
test(integration): enable SO_REUSEADDR on test sockets in HotReloadIT

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -466,6 +466,7 @@ class HotReloadIT extends BaseIT {
                 .pollInterval(Duration.ofMillis(100))
                 .untilAsserted(() -> {
                     try (var s = new ServerSocket()) {
+                        s.setReuseAddress(true);
                         s.bind(new InetSocketAddress((InetAddress) null, port));
                     }
                 });
@@ -479,6 +480,7 @@ class HotReloadIT extends BaseIT {
         ServerSocket s = null;
         try {
             s = new ServerSocket();
+            s.setReuseAddress(true);
             s.bind(new InetSocketAddress((InetAddress) null, port));
             return s;
         }


### PR DESCRIPTION
## Description

Fixes flaky `HotReloadIT` tests that fail with "Address already in use" errors in CI.

## Root Cause

The test methods `openSocketOnPort()` and `assertPortIsBindable()` create `ServerSocket` instances without enabling `SO_REUSEADDR`. When tests run in rapid succession:

1. Test binds to port (e.g., 51000), closes socket → enters TIME_WAIT (30-120s)
2. Next test tries to bind to same port while in TIME_WAIT → fails with `BindException: Address already in use`

This causes intermittent failures depending on test execution timing and CI environment behavior.

## Solution

Enable `SO_REUSEADDR` before binding in both methods:
- `openSocketOnPort()` - used to hold ports externally to test bind failure scenarios
- `assertPortIsBindable()` - used to verify ports are released after reconfiguration

This is standard practice for test code that needs to bind/unbind ports repeatedly.

## Testing

- [x] Existing tests pass (HotReloadIT)
- [x] No functional changes to production code
- [x] Fix is isolated to test infrastructure

Fixes #4065

---
**Checklist**
- [x] Commits follow project conventions
- [x] Added `Assisted-by:` trailer
- [x] References issue number