### PR TITLE
fix(operator): KafkaService secondary→primary mappers read from primary cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
-* [#4017](https://github.com/kroxylicious/kroxylicious/issues/4017): fix(operator): KafkaService secondary→primary mappers no longer call the API server on every secondary event, preventing KafkaService from getting stuck when the API server is transiently unavailable
+* [#4070](https://github.com/kroxylicious/kroxylicious/pull/4070): fix(operator): KafkaService secondary→primary mappers no longer call the API server on every secondary event, preventing KafkaService from getting stuck when the API server is transiently unavailable
 * [#4064](https://github.com/kroxylicious/kroxylicious/pull/4064): fix(operator): VirtualKafkaCluster secondary→primary mappers no longer call the API server on every secondary event, preventing VKCs from getting stuck when the API server is transiently unavailable (follow-up to [#4044](https://github.com/kroxylicious/kroxylicious/pull/4044) by @Roshr2211)
 * [#3913](https://github.com/kroxylicious/kroxylicious/pull/3913): feat(operator): report `DeprecationWarning` status condition on `KafkaProxy` resources with absent `spec`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#4017](https://github.com/kroxylicious/kroxylicious/issues/4017): fix(operator): KafkaService secondary→primary mappers no longer call the API server on every secondary event, preventing KafkaService from getting stuck when the API server is transiently unavailable
 * [#4064](https://github.com/kroxylicious/kroxylicious/pull/4064): fix(operator): VirtualKafkaCluster secondary→primary mappers no longer call the API server on every secondary event, preventing VKCs from getting stuck when the API server is transiently unavailable (follow-up to [#4044](https://github.com/kroxylicious/kroxylicious/pull/4044) by @Roshr2211)
 * [#3913](https://github.com/kroxylicious/kroxylicious/pull/3913): feat(operator): report `DeprecationWarning` status condition on `KafkaProxy` resources with absent `spec`
 

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/ConfigMapSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/ConfigMapSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper.java
@@ -29,9 +29,8 @@ class ConfigMapSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper imp
 
     @Override
     public Set<ResourceID> toPrimaryResourceIDs(ConfigMap configMap) {
-        return ResourcesUtil.findReferrers(context,
+        return ResourcesUtil.findKnownPrimariesOf(context,
                 configMap,
-                KafkaService.class,
                 service -> Optional.ofNullable(service.getSpec())
                         .map(KafkaServiceSpec::getTls)
                         .map(Tls::getTrustAnchorRef)

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/SecretSecondaryJoinedOnTlsCertificateRefMapperToKafkaServicePrimaryMapper.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/SecretSecondaryJoinedOnTlsCertificateRefMapperToKafkaServicePrimaryMapper.java
@@ -28,9 +28,8 @@ class SecretSecondaryJoinedOnTlsCertificateRefMapperToKafkaServicePrimaryMapper 
 
     @Override
     public Set<ResourceID> toPrimaryResourceIDs(Secret secret) {
-        return ResourcesUtil.findReferrers(context,
+        return ResourcesUtil.findKnownPrimariesOf(context,
                 secret,
-                KafkaService.class,
                 service -> Optional.ofNullable(service.getSpec())
                         .map(KafkaServiceSpec::getTls)
                         .map(Tls::getCertificateRef));

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/SecretSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/SecretSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper.java
@@ -29,9 +29,8 @@ class SecretSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper implem
 
     @Override
     public Set<ResourceID> toPrimaryResourceIDs(Secret secret) {
-        return ResourcesUtil.findReferrers(context,
+        return ResourcesUtil.findKnownPrimariesOf(context,
                 secret,
-                KafkaService.class,
                 service -> Optional.ofNullable(service.getSpec())
                         .map(KafkaServiceSpec::getTls)
                         .map(Tls::getTrustAnchorRef)

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/StrimziCaCertificateSecondaryToKafkaServicePrimaryMapper.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/StrimziCaCertificateSecondaryToKafkaServicePrimaryMapper.java
@@ -29,9 +29,8 @@ class StrimziCaCertificateSecondaryToKafkaServicePrimaryMapper implements Second
 
     @Override
     public Set<ResourceID> toPrimaryResourceIDs(Secret secret) {
-        return ResourcesUtil.findReferrers(context,
+        return ResourcesUtil.findKnownPrimariesOf(context,
                 secret,
-                KafkaService.class,
                 service -> Optional.ofNullable(service.getSpec())
                         .map(KafkaServiceSpec::getStrimziKafkaRef)
                         .filter(StrimziKafkaRef::getTrustStrimziCaCertificate)

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/StrimziKafkaSecondaryToKafkaServicePrimaryMapper.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/StrimziKafkaSecondaryToKafkaServicePrimaryMapper.java
@@ -28,9 +28,8 @@ class StrimziKafkaSecondaryToKafkaServicePrimaryMapper implements SecondaryToPri
 
     @Override
     public Set<ResourceID> toPrimaryResourceIDs(Kafka kafka) {
-        return ResourcesUtil.findReferrers(context,
+        return ResourcesUtil.findKnownPrimariesOf(context,
                 kafka,
-                KafkaService.class,
                 service -> Optional.ofNullable(service.getSpec())
                         .map(KafkaServiceSpec::getStrimziKafkaRef)
                         .map(StrimziKafkaRef::getRef));

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/ConfigMapSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapperTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/ConfigMapSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapperTest.java
@@ -6,7 +6,7 @@
 
 package io.kroxylicious.kubernetes.operator.reconciler.kafkaservice;
 
-import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -15,8 +15,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
@@ -24,27 +22,36 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
 
 import static io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.MapperTestSupport.SERVICE;
-import static io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.MapperTestSupport.mockKafkaServiceListOperation;
+import static io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.MapperTestSupport.TRUST_ANCHOR_PEM_CONFIG_MAP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class ConfigMapSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapperTest {
 
     @Test
     void canMapFromConfigMapTrustAnchorRefToKafkaService() {
         // Given
-        EventSourceContext<KafkaService> eventSourceContext = mock();
-        KubernetesClient client = mock();
-        when(eventSourceContext.getClient()).thenReturn(client);
-
-        KubernetesResourceList<KafkaService> mockList = mockKafkaServiceListOperation(client);
-        when(mockList.getItems()).thenReturn(List.of(SERVICE));
-
-        var mapper = new ConfigMapSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper(eventSourceContext);
+        EventSourceContext<KafkaService> context = MapperTestSupport.mockContextContaining(SERVICE);
+        var mapper = new ConfigMapSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper(context);
 
         // When
-        var primaryResourceIDs = mapper.toPrimaryResourceIDs(MapperTestSupport.TRUST_ANCHOR_PEM_CONFIG_MAP);
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(TRUST_ANCHOR_PEM_CONFIG_MAP);
+
+        // Then
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(SERVICE));
+    }
+
+    @Test
+    void shouldReturnIdsWhenApiServerUnavailable() {
+        // Given
+        EventSourceContext<KafkaService> context = mock();
+        MapperTestSupport.stubFailingListOperationClient(context);
+        MapperTestSupport.stubPrimaryCache(context, SERVICE);
+
+        var mapper = new ConfigMapSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper(context);
+
+        // When
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(TRUST_ANCHOR_PEM_CONFIG_MAP);
 
         // Then
         assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(SERVICE));
@@ -61,18 +68,13 @@ class ConfigMapSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapperTest
     @MethodSource
     void mappingToConfigMapToleratesKafkaServicesWithoutTls(KafkaService service) {
         // Given
-        EventSourceContext<KafkaService> eventSourceContext = mock();
-        KubernetesClient client = mock();
-        when(eventSourceContext.getClient()).thenReturn(client);
-
-        KubernetesResourceList<KafkaService> mockList = mockKafkaServiceListOperation(client);
-        when(mockList.getItems()).thenReturn(List.of(service));
+        EventSourceContext<KafkaService> context = MapperTestSupport.mockContextContaining(service);
+        var mapper = new ConfigMapSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper(context);
 
         // When
-        var mapper = new ConfigMapSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper(eventSourceContext);
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(new ConfigMapBuilder().withNewMetadata().withName("cm").endMetadata().build());
 
         // Then
-        var primaryResourceIDs = mapper.toPrimaryResourceIDs(new ConfigMapBuilder().withNewMetadata().withName("cm").endMetadata().build());
         assertThat(primaryResourceIDs).isEmpty();
     }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/MapperTestSupport.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/MapperTestSupport.java
@@ -7,6 +7,8 @@
 package io.kroxylicious.kubernetes.operator.reconciler.kafkaservice;
 
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
@@ -14,8 +16,11 @@ import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
+import io.javaoperatorsdk.operator.processing.event.source.IndexerResourceCache;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
@@ -172,5 +177,29 @@ class MapperTestSupport {
         when(mockOperation.list()).thenReturn(mockList);
         when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
         return mockList;
+    }
+
+    public static void stubPrimaryCache(EventSourceContext<KafkaService> context, KafkaService... services) {
+        IndexerResourceCache<KafkaService> primaryCache = mock();
+        when(primaryCache.list(any(), any())).thenAnswer(invocation -> {
+            Predicate<KafkaService> predicate = invocation.getArgument(1);
+            return Stream.of(services).filter(predicate);
+        });
+        when(context.getPrimaryCache()).thenReturn(primaryCache);
+    }
+
+    public static void stubFailingListOperationClient(EventSourceContext<KafkaService> context) {
+        KubernetesClient client = mock();
+        when(context.getClient()).thenReturn(client);
+        MixedOperation<KafkaService, KubernetesResourceList<KafkaService>, Resource<KafkaService>> mockOperation = mock();
+        when(client.resources(KafkaService.class)).thenReturn(mockOperation);
+        when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
+        when(mockOperation.list()).thenThrow(new KubernetesClientException("transient API server failure"));
+    }
+
+    public static EventSourceContext<KafkaService> mockContextContaining(KafkaService... services) {
+        EventSourceContext<KafkaService> context = mock();
+        stubPrimaryCache(context, services);
+        return context;
     }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/SecretSecondaryJoinedOnTlsCertificateRefMapperToKafkaServicePrimaryMapperTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/SecretSecondaryJoinedOnTlsCertificateRefMapperToKafkaServicePrimaryMapperTest.java
@@ -6,25 +6,25 @@
 
 package io.kroxylicious.kubernetes.operator.reconciler.kafkaservice;
 
-import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
 
 import static io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.MapperTestSupport.SERVICE;
+import static io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.MapperTestSupport.TLS_SECRET;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class SecretSecondaryJoinedOnTlsCertificateRefMapperToKafkaServicePrimaryMapperTest {
 
@@ -35,22 +35,46 @@ class SecretSecondaryJoinedOnTlsCertificateRefMapperToKafkaServicePrimaryMapperT
                         new KafkaServiceBuilder(SERVICE).editSpec().editTls().withCertificateRef(null).endTls().endSpec().build()));
     }
 
+    @Test
+    void canMapFromTlsCertificateRefToKafkaService() {
+        // Given
+        EventSourceContext<KafkaService> context = MapperTestSupport.mockContextContaining(SERVICE);
+        var mapper = new SecretSecondaryJoinedOnTlsCertificateRefMapperToKafkaServicePrimaryMapper(context);
+
+        // When
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(TLS_SECRET);
+
+        // Then
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(SERVICE));
+    }
+
+    @Test
+    void shouldReturnIdsWhenApiServerUnavailable() {
+        // Given
+        EventSourceContext<KafkaService> context = mock();
+        MapperTestSupport.stubFailingListOperationClient(context);
+        MapperTestSupport.stubPrimaryCache(context, SERVICE);
+
+        var mapper = new SecretSecondaryJoinedOnTlsCertificateRefMapperToKafkaServicePrimaryMapper(context);
+
+        // When
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(TLS_SECRET);
+
+        // Then
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(SERVICE));
+    }
+
     @ParameterizedTest
     @MethodSource
     void mappingToSecretToleratesKafkaServicesWithoutTls(KafkaService service) {
         // Given
-        EventSourceContext<KafkaService> eventSourceContext = mock();
-        KubernetesClient client = mock();
-        when(eventSourceContext.getClient()).thenReturn(client);
-
-        KubernetesResourceList<KafkaService> mockList = MapperTestSupport.mockKafkaServiceListOperation(client);
-        when(mockList.getItems()).thenReturn(List.of(service));
+        EventSourceContext<KafkaService> context = MapperTestSupport.mockContextContaining(service);
+        var mapper = new SecretSecondaryJoinedOnTlsCertificateRefMapperToKafkaServicePrimaryMapper(context);
 
         // When
-        var mapper = new SecretSecondaryJoinedOnTlsCertificateRefMapperToKafkaServicePrimaryMapper(eventSourceContext);
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(new SecretBuilder().withNewMetadata().withName("secret").endMetadata().build());
 
         // Then
-        var primaryResourceIDs = mapper.toPrimaryResourceIDs(new SecretBuilder().withNewMetadata().withName("secret").endMetadata().build());
         assertThat(primaryResourceIDs).isEmpty();
     }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/SecretSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapperTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/SecretSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapperTest.java
@@ -6,7 +6,7 @@
 
 package io.kroxylicious.kubernetes.operator.reconciler.kafkaservice;
 
-import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -14,9 +14,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
@@ -25,27 +23,36 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
 
 import static io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.MapperTestSupport.SERVICE;
 import static io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.MapperTestSupport.SERVICE_SECRET_TRUST_ANCHOR;
-import static io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.MapperTestSupport.mockKafkaServiceListOperation;
+import static io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.MapperTestSupport.TRUST_ANCHOR_PEM_SECRET;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class SecretSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapperTest {
 
     @Test
     void canMapFromSecretTrustAnchorRefToKafkaService() {
         // Given
-        EventSourceContext<KafkaService> eventSourceContext = mock();
-        KubernetesClient client = mock();
-        when(eventSourceContext.getClient()).thenReturn(client);
-
-        KubernetesResourceList<KafkaService> mockList = mockKafkaServiceListOperation(client);
-        when(mockList.getItems()).thenReturn(List.of(SERVICE_SECRET_TRUST_ANCHOR));
-
-        var mapper = new SecretSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper(eventSourceContext);
+        EventSourceContext<KafkaService> context = MapperTestSupport.mockContextContaining(SERVICE_SECRET_TRUST_ANCHOR);
+        var mapper = new SecretSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper(context);
 
         // When
-        var primaryResourceIDs = mapper.toPrimaryResourceIDs(MapperTestSupport.TRUST_ANCHOR_PEM_SECRET);
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(TRUST_ANCHOR_PEM_SECRET);
+
+        // Then
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(SERVICE_SECRET_TRUST_ANCHOR));
+    }
+
+    @Test
+    void shouldReturnIdsWhenApiServerUnavailable() {
+        // Given
+        EventSourceContext<KafkaService> context = mock();
+        MapperTestSupport.stubFailingListOperationClient(context);
+        MapperTestSupport.stubPrimaryCache(context, SERVICE_SECRET_TRUST_ANCHOR);
+
+        var mapper = new SecretSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper(context);
+
+        // When
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(TRUST_ANCHOR_PEM_SECRET);
 
         // Then
         assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(SERVICE_SECRET_TRUST_ANCHOR));
@@ -62,18 +69,13 @@ class SecretSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapperTest {
     @MethodSource
     void mappingToSecretToleratesKafkaServicesWithoutTls(KafkaService service) {
         // Given
-        EventSourceContext<KafkaService> eventSourceContext = mock();
-        KubernetesClient client = mock();
-        when(eventSourceContext.getClient()).thenReturn(client);
-
-        KubernetesResourceList<KafkaService> mockList = mockKafkaServiceListOperation(client);
-        when(mockList.getItems()).thenReturn(List.of(service));
+        EventSourceContext<KafkaService> context = MapperTestSupport.mockContextContaining(service);
+        var mapper = new SecretSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper(context);
 
         // When
-        var mapper = new SecretSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper(eventSourceContext);
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(new SecretBuilder().withNewMetadata().withName("secret").endMetadata().build());
 
         // Then
-        var primaryResourceIDs = mapper.toPrimaryResourceIDs(new SecretBuilder().withNewMetadata().withName("secret").endMetadata().build());
         assertThat(primaryResourceIDs).isEmpty();
     }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/StrimziCaCertificateSecondaryToKafkaServicePrimaryMapperTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/StrimziCaCertificateSecondaryToKafkaServicePrimaryMapperTest.java
@@ -6,39 +6,46 @@
 
 package io.kroxylicious.kubernetes.operator.reconciler.kafkaservice;
 
-import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 
 import static io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.MapperTestSupport.SERVICE_WITH_TLS;
+import static io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.MapperTestSupport.STRIMZI_PEM_SECRET;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class StrimziCaCertificateSecondaryToKafkaServicePrimaryMapperTest {
 
     @Test
     void canMapFromStrimziCaCertificateToKafkaService() {
         // Given
-        EventSourceContext<KafkaService> eventSourceContext = mock();
-        KubernetesClient client = mock();
-        when(eventSourceContext.getClient()).thenReturn(client);
-
-        KubernetesResourceList<KafkaService> mockList = MapperTestSupport.mockKafkaServiceListOperation(client);
-        when(mockList.getItems()).thenReturn(List.of(SERVICE_WITH_TLS));
-
-        var mapper = new StrimziCaCertificateSecondaryToKafkaServicePrimaryMapper(eventSourceContext);
+        EventSourceContext<KafkaService> context = MapperTestSupport.mockContextContaining(SERVICE_WITH_TLS);
+        var mapper = new StrimziCaCertificateSecondaryToKafkaServicePrimaryMapper(context);
 
         // When
-        var primaryResourceIDs = mapper.toPrimaryResourceIDs(new SecretBuilder().withNewMetadata().withName("my-cluster-cluster-ca-cert").endMetadata().build());
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(STRIMZI_PEM_SECRET);
+
+        // Then
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(SERVICE_WITH_TLS));
+    }
+
+    @Test
+    void shouldReturnIdsWhenApiServerUnavailable() {
+        // Given
+        EventSourceContext<KafkaService> context = mock();
+        MapperTestSupport.stubFailingListOperationClient(context);
+        MapperTestSupport.stubPrimaryCache(context, SERVICE_WITH_TLS);
+
+        var mapper = new StrimziCaCertificateSecondaryToKafkaServicePrimaryMapper(context);
+
+        // When
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(STRIMZI_PEM_SECRET);
 
         // Then
         assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(SERVICE_WITH_TLS));

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/StrimziKafkaSecondaryToKafkaServicePrimaryMapperTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/StrimziKafkaSecondaryToKafkaServicePrimaryMapperTest.java
@@ -6,12 +6,10 @@
 
 package io.kroxylicious.kubernetes.operator.reconciler.kafkaservice;
 
-import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
@@ -21,24 +19,33 @@ import static io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.Mapper
 import static io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.MapperTestSupport.SERVICE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class StrimziKafkaSecondaryToKafkaServicePrimaryMapperTest {
 
     @Test
     void canMapFromStrimziKafkaToKafkaService() {
         // Given
-        EventSourceContext<KafkaService> eventSourceContext = mock();
-        KubernetesClient client = mock();
-        when(eventSourceContext.getClient()).thenReturn(client);
-
-        KubernetesResourceList<KafkaService> mockList = MapperTestSupport.mockKafkaServiceListOperation(client);
-        when(mockList.getItems()).thenReturn(List.of(SERVICE));
-
-        var mapper = new StrimziKafkaSecondaryToKafkaServicePrimaryMapper(eventSourceContext);
+        EventSourceContext<KafkaService> context = MapperTestSupport.mockContextContaining(SERVICE);
+        var mapper = new StrimziKafkaSecondaryToKafkaServicePrimaryMapper(context);
 
         // When
-        var primaryResourceIDs = mapper.toPrimaryResourceIDs(KAFKA);
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(KAFKA);
+
+        // Then
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(SERVICE));
+    }
+
+    @Test
+    void shouldReturnIdsWhenApiServerUnavailable() {
+        // Given
+        EventSourceContext<KafkaService> context = mock();
+        MapperTestSupport.stubFailingListOperationClient(context);
+        MapperTestSupport.stubPrimaryCache(context, SERVICE);
+
+        var mapper = new StrimziKafkaSecondaryToKafkaServicePrimaryMapper(context);
+
+        // When
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(KAFKA);
 
         // Then
         assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(SERVICE));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

All five secondary→primary mappers in the KafkaService reconciler were calling
`ResourcesUtil.findReferrers`, which issues a live `list` against the API server
on every secondary event. JOSDK silently drops events when an exception is thrown
inside the informer's event-dispatch path, so a transient `KubernetesClientException`
would leave KafkaService stuck with stale status and no retry.

This PR replaces all five `findReferrers` calls with `findKnownPrimariesOf`, which
reads from the controller's in-memory primary cache (`EventSourceContext#getPrimaryCache()`)
instead.

Mappers fixed:
- `StrimziKafkaSecondaryToKafkaServicePrimaryMapper`
- `SecretSecondaryJoinedOnTlsCertificateRefMapperToKafkaServicePrimaryMapper`
- `StrimziCaCertificateSecondaryToKafkaServicePrimaryMapper`
- `SecretSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper`
- `ConfigMapSecondaryJoinedOnTlsTrustAnchorRefToKafkaServicePrimaryMapper`

Each mapper has a `shouldReturnIdsWhenApiServerUnavailable` regression test that
stubs the API server to throw and verifies correct IDs are still returned via the
primary cache. The shared `MapperTestSupport` helpers (`stubPrimaryCache`,
`stubFailingListOperationClient`, `mockContextContaining`) mirror the pattern
established in the VKC reconciler tests.

### Additional Context

Companion fix to #4064 (VKC reconciler). Part of closing #4017 for the KafkaService
primary type. Depends on `findKnownPrimariesOf` introduced in #4064.

### Checklist

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).