### PR TITLE
fix(operator): KafkaProxy secondary→primary mappers read from primary cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format `<github issue/pr number>: <short description>`.
 ## SNAPSHOT
 
 * [#4064](https://github.com/kroxylicious/kroxylicious/pull/4064): fix(operator): VirtualKafkaCluster secondary→primary mappers no longer call the API server on every secondary event, preventing VKCs from getting stuck when the API server is transiently unavailable (follow-up to [#4044](https://github.com/kroxylicious/kroxylicious/pull/4044) by @Roshr2211)
+* [#4017](https://github.com/kroxylicious/kroxylicious/issues/4017): fix(operator): `KafkaProxy` secondary→primary mappers no longer call the API server on every secondary event, preventing `KafkaProxy` from getting stuck when the API server is transiently unavailable
 * [#3913](https://github.com/kroxylicious/kroxylicious/pull/3913): feat(operator): report `DeprecationWarning` status condition on `KafkaProxy` resources with absent `spec`
 
 ### Changes, deprecations and removals

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -418,6 +418,21 @@ public class ResourcesUtil {
         });
     }
 
+    /**
+     * Returns the {@link ResourceID}s of all primaries in the same namespace as the given referent, regardless of
+     * whether the primary refers to the referent. This is useful for secondary&rarr;primary mappers where the secondary
+     * has no direct reference to the primary and therefore all primaries in the same namespace must be considered
+     * (e.g. filter-to-proxy mapping). See {@link #findKnownPrimariesOf(EventSourceContext, HasMetadata, Function)} for
+     * the rationale and preconditions.
+     * @param context The event source context
+     * @param referent A resource bearing the namespace we wish to search
+     * @return The ids of all known primaries in the same namespace as the referent.
+     * @param <P> The type of the primary
+     */
+    public static <P extends HasMetadata> Set<ResourceID> findAllKnownPrimariesInNamespace(EventSourceContext<P> context, HasMetadata referent) {
+        return filteredPrimaryIdsInSameNamespace(context, referent, ignored -> true);
+    }
+
     private static <P extends HasMetadata> Set<ResourceID> filteredPrimaryIdsInSameNamespace(EventSourceContext<P> context,
                                                                                              HasMetadata referent,
                                                                                              Predicate<P> predicate) {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProtocolFilterSecondaryToKafkaProxyPrimaryMapper.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProtocolFilterSecondaryToKafkaProxyPrimaryMapper.java
@@ -19,6 +19,8 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProtocolFilter;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.findAllKnownPrimariesInNamespace;
+
 class KafkaProtocolFilterSecondaryToKafkaProxyPrimaryMapper implements SecondaryToPrimaryMapper<KafkaProtocolFilter> {
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProtocolFilterSecondaryToKafkaProxyPrimaryMapper.class);
 
@@ -39,7 +41,7 @@ class KafkaProtocolFilterSecondaryToKafkaProxyPrimaryMapper implements Secondary
         }
         // filters don't point to a proxy, but must be in the same namespace as the proxy/proxies which reference the,
         // so when a filter changes we reconcile all the proxies in the same namespace
-        Set<ResourceID> proxiesInFilterNamespace = ResourcesUtil.filteredResourceIdsInSameNamespace(context, filter, KafkaProxy.class, proxy -> true);
+        Set<ResourceID> proxiesInFilterNamespace = findAllKnownPrimariesInNamespace(context, filter);
         LOGGER.atDebug()
                 .addKeyValue("proxyIds", proxiesInFilterNamespace)
                 .log("Event source SecondaryToPrimaryMapper");

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyIngressSecondaryToKafkaProxyPrimaryMapper.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyIngressSecondaryToKafkaProxyPrimaryMapper.java
@@ -19,6 +19,8 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.findAllKnownPrimariesInNamespace;
+
 class KafkaProxyIngressSecondaryToKafkaProxyPrimaryMapper implements SecondaryToPrimaryMapper<KafkaProxyIngress> {
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyIngressSecondaryToKafkaProxyPrimaryMapper.class);
 
@@ -39,7 +41,7 @@ class KafkaProxyIngressSecondaryToKafkaProxyPrimaryMapper implements SecondaryTo
         }
         // we need to reconcile all proxies when a kafka proxy ingress changes in case the proxyRef is updated, we need to update
         // the previously referenced proxy too.
-        Set<ResourceID> proxyIds = ResourcesUtil.filteredResourceIdsInSameNamespace(context, ingress, KafkaProxy.class, proxy -> true);
+        Set<ResourceID> proxyIds = findAllKnownPrimariesInNamespace(context, ingress);
         LOGGER.atDebug()
                 .addKeyValue("proxyIds", proxyIds)
                 .log("Event source KafkaProxyIngress SecondaryToPrimaryMapper");

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaServiceSecondaryToKafkaProxyPrimaryMapper.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaServiceSecondaryToKafkaProxyPrimaryMapper.java
@@ -7,7 +7,6 @@
 package io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy;
 
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,14 +15,11 @@ import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
 
-import io.kroxylicious.kubernetes.api.common.LocalRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
-import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
-import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterSpec;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 
-import static io.kroxylicious.kubernetes.operator.ResourcesUtil.toLocalRef;
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.findAllKnownPrimariesInNamespace;
 
 class KafkaServiceSecondaryToKafkaProxyPrimaryMapper implements SecondaryToPrimaryMapper<KafkaService> {
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaServiceSecondaryToKafkaProxyPrimaryMapper.class);
@@ -43,16 +39,9 @@ class KafkaServiceSecondaryToKafkaProxyPrimaryMapper implements SecondaryToPrima
                     .log("Ignoring event from KafkaService with stale status");
             return Set.of();
         }
-        // find all virtual clusters that reference this kafkaServiceRef
-
-        Set<? extends LocalRef<KafkaProxy>> proxyRefs = ResourcesUtil.resourcesInSameNamespace(context, kafkaService, VirtualKafkaCluster.class)
-                .filter(vkc -> vkc.getSpec().getTargetKafkaServiceRef().equals(ResourcesUtil.toLocalRef(kafkaService)))
-                .map(VirtualKafkaCluster::getSpec)
-                .map(VirtualKafkaClusterSpec::getProxyRef)
-                .collect(Collectors.toSet());
-
-        Set<ResourceID> proxyIds = ResourcesUtil.filteredResourceIdsInSameNamespace(context, kafkaService, KafkaProxy.class,
-                proxy -> proxyRefs.contains(toLocalRef(proxy)));
+        // reconcile all proxies in the namespace; the extra reconciliations for proxies that don't reference this
+        // KafkaService are harmless no-ops, and this avoids API-server calls that can fail transiently (#4017)
+        Set<ResourceID> proxyIds = findAllKnownPrimariesInNamespace(context, kafkaService);
         LOGGER.atDebug()
                 .addKeyValue("proxyIds", proxyIds)
                 .log("Event source KafkaService SecondaryToPrimaryMapper");

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/VirtualKafkaClusterSecondaryToKafkaProxyPrimaryMapper.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/VirtualKafkaClusterSecondaryToKafkaProxyPrimaryMapper.java
@@ -19,6 +19,8 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.findAllKnownPrimariesInNamespace;
+
 public class VirtualKafkaClusterSecondaryToKafkaProxyPrimaryMapper implements SecondaryToPrimaryMapper<VirtualKafkaCluster> {
     private static final Logger LOGGER = LoggerFactory.getLogger(VirtualKafkaClusterSecondaryToKafkaProxyPrimaryMapper.class);
 
@@ -39,7 +41,7 @@ public class VirtualKafkaClusterSecondaryToKafkaProxyPrimaryMapper implements Se
         }
         // we need to reconcile all proxies when a virtual kafka cluster changes in case the proxyRef is updated, we need to update
         // the previously referenced proxy too.
-        Set<ResourceID> proxyIds = ResourcesUtil.filteredResourceIdsInSameNamespace(context, cluster, KafkaProxy.class, proxy -> true);
+        Set<ResourceID> proxyIds = findAllKnownPrimariesInNamespace(context, cluster);
         LOGGER.atDebug()
                 .addKeyValue("proxyIds", proxyIds)
                 .log("Event source VirtualKafkaCluster SecondaryToPrimaryMapper");

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProtocolFilterSecondaryToKafkaProxyPrimaryMapperTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProtocolFilterSecondaryToKafkaProxyPrimaryMapperTest.java
@@ -6,15 +6,10 @@
 
 package io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy;
 
-import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
@@ -24,59 +19,44 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProtocolFilterBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 class KafkaProtocolFilterSecondaryToKafkaProxyPrimaryMapperTest {
+
     @Test
     void filterToProxyMapper() {
-        EventSourceContext<KafkaProxy> eventSourceContext = mock();
-        KubernetesClient client = mock();
-        when(eventSourceContext.getClient()).thenReturn(client);
-        MixedOperation<KafkaProxy, KubernetesResourceList<KafkaProxy>, Resource<KafkaProxy>> mockOperation = mock();
-        when(client.resources(KafkaProxy.class)).thenReturn(mockOperation);
-        KubernetesResourceList<KafkaProxy> mockList = mock();
-        when(mockOperation.list()).thenReturn(mockList);
-        when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
+        // given
         KafkaProxy proxy = MapperTestSupport.buildProxy("proxy");
-        when(mockList.getItems()).thenReturn(List.of(proxy));
+        EventSourceContext<KafkaProxy> eventSourceContext = MapperTestSupport.mockContextContaining(proxy);
         SecondaryToPrimaryMapper<KafkaProtocolFilter> mapper = new KafkaProtocolFilterSecondaryToKafkaProxyPrimaryMapper(eventSourceContext);
-        String namespace = "test";
-        KafkaProtocolFilter filter = new KafkaProtocolFilterBuilder().withNewMetadata().withName("filter").withNamespace(namespace).endMetadata().build();
+        KafkaProtocolFilter filter = new KafkaProtocolFilterBuilder().withNewMetadata().withName("filter").withNamespace("test").endMetadata().build();
+
+        // when
         Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(filter);
+
+        // then
         assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(proxy));
-        verify(mockOperation).inNamespace(namespace);
     }
 
     @Test
     void filterToProxyMapperIgnoresFilterWithStaleStatus() {
         // given
-        EventSourceContext<KafkaProxy> eventSourceContext = mock();
-        KubernetesClient client = mock();
-        when(eventSourceContext.getClient()).thenReturn(client);
-        MixedOperation<KafkaProxy, KubernetesResourceList<KafkaProxy>, Resource<KafkaProxy>> mockOperation = mock();
-        when(client.resources(KafkaProxy.class)).thenReturn(mockOperation);
-        KubernetesResourceList<KafkaProxy> mockList = mock();
-        when(mockOperation.list()).thenReturn(mockList);
-        when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
         KafkaProxy proxy = MapperTestSupport.buildProxy("proxy");
-        when(mockList.getItems()).thenReturn(List.of(proxy));
+        EventSourceContext<KafkaProxy> eventSourceContext = MapperTestSupport.mockContextContaining(proxy);
         SecondaryToPrimaryMapper<KafkaProtocolFilter> mapper = new KafkaProtocolFilterSecondaryToKafkaProxyPrimaryMapper(eventSourceContext);
-        String namespace = "test";
         // @formatter:off
         KafkaProtocolFilter filter = new KafkaProtocolFilterBuilder()
                 .withNewMetadata()
                 .withGeneration(4L)
                 .withName("filter")
-                .withNamespace(namespace)
+                .withNamespace("test")
                 .endMetadata()
                 .withNewStatus()
                 .withObservedGeneration(1L)
                 .endStatus()
                 .build();
         // @formatter:on
+
         // when
         Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(filter);
 
@@ -84,4 +64,20 @@ class KafkaProtocolFilterSecondaryToKafkaProxyPrimaryMapperTest {
         assertThat(primaryResourceIDs).isEmpty();
     }
 
+    @Test
+    void shouldReturnIdsWhenApiServerUnavailable() {
+        // given
+        KafkaProxy proxy = MapperTestSupport.buildProxy("proxy");
+        EventSourceContext<KafkaProxy> context = mock();
+        MapperTestSupport.stubFailingListOperationClient(context);
+        MapperTestSupport.stubPrimaryCache(context, proxy);
+        SecondaryToPrimaryMapper<KafkaProtocolFilter> mapper = new KafkaProtocolFilterSecondaryToKafkaProxyPrimaryMapper(context);
+        KafkaProtocolFilter filter = new KafkaProtocolFilterBuilder().withNewMetadata().withName("filter").withNamespace("test").endMetadata().build();
+
+        // when
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(filter);
+
+        // then
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(proxy));
+    }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyIngressSecondaryToKafkaProxyPrimaryMapperTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyIngressSecondaryToKafkaProxyPrimaryMapperTest.java
@@ -6,51 +6,35 @@
 
 package io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy;
 
-import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class KafkaProxyIngressSecondaryToKafkaProxyPrimaryMapperTest {
 
     @Test
     void ingressToProxyMapper() {
         // given
-        EventSourceContext<KafkaProxy> eventSourceContext = mock();
-        KubernetesClient client = mock();
-        when(eventSourceContext.getClient()).thenReturn(client);
-        MixedOperation<KafkaProxy, KubernetesResourceList<KafkaProxy>, Resource<KafkaProxy>> mockOperation = mock();
-        when(client.resources(KafkaProxy.class)).thenReturn(mockOperation);
-        KubernetesResourceList<KafkaProxy> mockList = mock();
-        when(mockOperation.list()).thenReturn(mockList);
-        when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
-        KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("proxy").endMetadata().build();
-        when(mockList.getItems()).thenReturn(List.of(proxy));
+        KafkaProxy proxy = MapperTestSupport.buildProxy("proxy");
+        EventSourceContext<KafkaProxy> eventSourceContext = MapperTestSupport.mockContextContaining(proxy);
         SecondaryToPrimaryMapper<KafkaProxyIngress> mapper = new KafkaProxyIngressSecondaryToKafkaProxyPrimaryMapper(eventSourceContext);
-        KafkaProxyIngress cluster = new KafkaProxyIngressBuilder().withNewMetadata().withName("ingress").endMetadata().withNewSpec().withNewProxyRef()
+        KafkaProxyIngress ingress = new KafkaProxyIngressBuilder().withNewMetadata().withName("ingress").endMetadata().withNewSpec().withNewProxyRef()
                 .withName("proxy")
                 .endProxyRef().endSpec().build();
 
         // when
-        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(cluster);
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(ingress);
 
         // then
         assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(proxy));
@@ -59,16 +43,8 @@ class KafkaProxyIngressSecondaryToKafkaProxyPrimaryMapperTest {
     @Test
     void ingressToProxyMapperIgnoresIngressWithStaleStatus() {
         // given
-        EventSourceContext<KafkaProxy> eventSourceContext = mock();
-        KubernetesClient client = mock();
-        when(eventSourceContext.getClient()).thenReturn(client);
-        MixedOperation<KafkaProxy, KubernetesResourceList<KafkaProxy>, Resource<KafkaProxy>> mockOperation = mock();
-        when(client.resources(KafkaProxy.class)).thenReturn(mockOperation);
-        KubernetesResourceList<KafkaProxy> mockList = mock();
-        when(mockOperation.list()).thenReturn(mockList);
-        when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
-        KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("proxy").endMetadata().build();
-        when(mockList.getItems()).thenReturn(List.of(proxy));
+        KafkaProxy proxy = MapperTestSupport.buildProxy("proxy");
+        EventSourceContext<KafkaProxy> eventSourceContext = MapperTestSupport.mockContextContaining(proxy);
         SecondaryToPrimaryMapper<KafkaProxyIngress> mapper = new KafkaProxyIngressSecondaryToKafkaProxyPrimaryMapper(eventSourceContext);
         // @formatter:off
         KafkaProxyIngress ingress = new KafkaProxyIngressBuilder()
@@ -94,4 +70,22 @@ class KafkaProxyIngressSecondaryToKafkaProxyPrimaryMapperTest {
         assertThat(primaryResourceIDs).isEmpty();
     }
 
+    @Test
+    void shouldReturnIdsWhenApiServerUnavailable() {
+        // given
+        KafkaProxy proxy = MapperTestSupport.buildProxy("proxy");
+        EventSourceContext<KafkaProxy> context = mock();
+        MapperTestSupport.stubFailingListOperationClient(context);
+        MapperTestSupport.stubPrimaryCache(context, proxy);
+        SecondaryToPrimaryMapper<KafkaProxyIngress> mapper = new KafkaProxyIngressSecondaryToKafkaProxyPrimaryMapper(context);
+        KafkaProxyIngress ingress = new KafkaProxyIngressBuilder().withNewMetadata().withName("ingress").endMetadata().withNewSpec().withNewProxyRef()
+                .withName("proxy")
+                .endProxyRef().endSpec().build();
+
+        // when
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(ingress);
+
+        // then
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(proxy));
+    }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaServiceSecondaryToKafkaProxyPrimaryMapperTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaServiceSecondaryToKafkaProxyPrimaryMapperTest.java
@@ -6,119 +6,82 @@
 
 package io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy;
 
-import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
-import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class KafkaServiceSecondaryToKafkaProxyPrimaryMapperTest {
 
     @Test
     void kafkaServiceToProxyMapper() {
-        EventSourceContext<KafkaProxy> eventSourceContext = mock();
-        KubernetesClient client = mock();
-        when(eventSourceContext.getClient()).thenReturn(client);
-
-        KafkaService kafkaServiceRef = MapperTestSupport.buildKafkaService("ref", 1L, 1L);
+        // given
         KafkaProxy proxy = MapperTestSupport.buildProxy("proxy");
-        VirtualKafkaCluster cluster = MapperTestSupport.buildVirtualKafkaCluster(proxy, "cluster", kafkaServiceRef);
-
-        KubernetesResourceList<KafkaProxy> mockProxyList = MapperTestSupport.mockKafkaProxyListOperation(client);
-        when(mockProxyList.getItems()).thenReturn(List.of(proxy));
-
-        KubernetesResourceList<VirtualKafkaCluster> mockClusterList = MapperTestSupport.mockVirtualKafkaClusterListOperation(client);
-        when(mockClusterList.getItems()).thenReturn(List.of(cluster));
-
+        EventSourceContext<KafkaProxy> eventSourceContext = MapperTestSupport.mockContextContaining(proxy);
+        KafkaService kafkaService = MapperTestSupport.buildKafkaService("ref", 1L, 1L);
         SecondaryToPrimaryMapper<KafkaService> mapper = new KafkaServiceSecondaryToKafkaProxyPrimaryMapper(eventSourceContext);
 
-        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(kafkaServiceRef);
+        // when
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(kafkaService);
+
+        // then
         assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(proxy));
     }
 
     @Test
     void kafkaServiceToProxyMapperIgnoresServiceWithStaleStatus() {
         // given
-        EventSourceContext<KafkaProxy> eventSourceContext = mock();
-        KubernetesClient client = mock();
-        when(eventSourceContext.getClient()).thenReturn(client);
-
-        KafkaService kafkaServiceRef = MapperTestSupport.buildKafkaService("ref", 5L, 3L);
         KafkaProxy proxy = MapperTestSupport.buildProxy("proxy");
-        VirtualKafkaCluster cluster = MapperTestSupport.buildVirtualKafkaCluster(proxy, "cluster", kafkaServiceRef);
-
-        KubernetesResourceList<KafkaProxy> mockProxyList = MapperTestSupport.mockKafkaProxyListOperation(client);
-        when(mockProxyList.getItems()).thenReturn(List.of(proxy));
-
-        KubernetesResourceList<VirtualKafkaCluster> mockClusterList = MapperTestSupport.mockVirtualKafkaClusterListOperation(client);
-        when(mockClusterList.getItems()).thenReturn(List.of(cluster));
-
+        EventSourceContext<KafkaProxy> eventSourceContext = MapperTestSupport.mockContextContaining(proxy);
+        KafkaService kafkaService = MapperTestSupport.buildKafkaService("ref", 5L, 3L);
         SecondaryToPrimaryMapper<KafkaService> mapper = new KafkaServiceSecondaryToKafkaProxyPrimaryMapper(eventSourceContext);
 
         // when
-        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(kafkaServiceRef);
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(kafkaService);
 
         // then
         assertThat(primaryResourceIDs).isEmpty();
     }
 
     @Test
-    void kafkaServiceToProxyMapperHandlesSharedKafkaService() {
-        EventSourceContext<KafkaProxy> eventSourceContext = mock();
-        KubernetesClient client = mock();
-        when(eventSourceContext.getClient()).thenReturn(client);
-
-        KafkaService kafkaServiceRef = MapperTestSupport.buildKafkaService("ref", 1L, 1L);
+    void kafkaServiceToProxyMapperReturnsAllProxiesInNamespace() {
+        // given — the mapper no longer filters by VKC reference, so all proxies in the namespace are returned
         KafkaProxy proxy1 = MapperTestSupport.buildProxy("proxy1");
         KafkaProxy proxy2 = MapperTestSupport.buildProxy("proxy2");
-        VirtualKafkaCluster proxy1cluster = MapperTestSupport.buildVirtualKafkaCluster(proxy1, "proxy1cluster", kafkaServiceRef);
-        VirtualKafkaCluster proxy2cluster = MapperTestSupport.buildVirtualKafkaCluster(proxy2, "proxy2cluster", kafkaServiceRef);
-
-        KubernetesResourceList<KafkaProxy> mockProxyList = MapperTestSupport.mockKafkaProxyListOperation(client);
-        when(mockProxyList.getItems()).thenReturn(List.of(proxy1, proxy2));
-
-        KubernetesResourceList<VirtualKafkaCluster> mockClusterList = MapperTestSupport.mockVirtualKafkaClusterListOperation(client);
-        when(mockClusterList.getItems()).thenReturn(List.of(proxy1cluster, proxy2cluster));
-
+        EventSourceContext<KafkaProxy> eventSourceContext = MapperTestSupport.mockContextContaining(proxy1, proxy2);
+        KafkaService kafkaService = MapperTestSupport.buildKafkaService("ref", 1L, 1L);
         SecondaryToPrimaryMapper<KafkaService> mapper = new KafkaServiceSecondaryToKafkaProxyPrimaryMapper(eventSourceContext);
 
-        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(kafkaServiceRef);
-        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(proxy1), ResourceID.fromResource(proxy2));
+        // when
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(kafkaService);
+
+        // then
+        assertThat(primaryResourceIDs).containsExactlyInAnyOrder(ResourceID.fromResource(proxy1), ResourceID.fromResource(proxy2));
     }
 
     @Test
-    void kafkaServiceToProxyMapperHandlesOrphanKafkaService() {
-        EventSourceContext<KafkaProxy> eventSourceContext = mock();
-        KubernetesClient client = mock();
-        when(eventSourceContext.getClient()).thenReturn(client);
-
-        KafkaService orphanKafkaClusterRed = MapperTestSupport.buildKafkaService("orphan", 1L, 1L);
+    void shouldReturnIdsWhenApiServerUnavailable() {
+        // given
         KafkaProxy proxy = MapperTestSupport.buildProxy("proxy");
-        VirtualKafkaCluster cluster = MapperTestSupport.buildVirtualKafkaCluster(proxy, "cluster", MapperTestSupport.buildKafkaService("ref", 1L, 1L));
+        EventSourceContext<KafkaProxy> context = mock();
+        MapperTestSupport.stubFailingListOperationClient(context);
+        MapperTestSupport.stubPrimaryCache(context, proxy);
+        KafkaService kafkaService = MapperTestSupport.buildKafkaService("ref", 1L, 1L);
+        SecondaryToPrimaryMapper<KafkaService> mapper = new KafkaServiceSecondaryToKafkaProxyPrimaryMapper(context);
 
-        KubernetesResourceList<KafkaProxy> mockProxyList = MapperTestSupport.mockKafkaProxyListOperation(client);
-        when(mockProxyList.getItems()).thenReturn(List.of(proxy));
+        // when
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(kafkaService);
 
-        KubernetesResourceList<VirtualKafkaCluster> mockClusterList = MapperTestSupport.mockVirtualKafkaClusterListOperation(client);
-        when(mockClusterList.getItems()).thenReturn(List.of(cluster));
-
-        SecondaryToPrimaryMapper<KafkaService> mapper = new KafkaServiceSecondaryToKafkaProxyPrimaryMapper(eventSourceContext);
-
-        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(orphanKafkaClusterRed);
-        assertThat(primaryResourceIDs).isEmpty();
+        // then
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(proxy));
     }
-
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/MapperTestSupport.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/MapperTestSupport.java
@@ -6,10 +6,16 @@
 
 package io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy;
 
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
+import io.javaoperatorsdk.operator.processing.event.source.IndexerResourceCache;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
@@ -24,6 +30,31 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class MapperTestSupport {
+
+    public static void stubPrimaryCache(EventSourceContext<KafkaProxy> context, KafkaProxy... proxies) {
+        IndexerResourceCache<KafkaProxy> primaryCache = mock();
+        when(primaryCache.list(any(), any())).thenAnswer(invocation -> {
+            Predicate<KafkaProxy> predicate = invocation.getArgument(1);
+            return Stream.of(proxies).filter(predicate);
+        });
+        when(context.getPrimaryCache()).thenReturn(primaryCache);
+    }
+
+    public static void stubFailingListOperationClient(EventSourceContext<KafkaProxy> context) {
+        KubernetesClient client = mock();
+        when(context.getClient()).thenReturn(client);
+        MixedOperation<KafkaProxy, KubernetesResourceList<KafkaProxy>, Resource<KafkaProxy>> mockOperation = mock();
+        when(client.resources(KafkaProxy.class)).thenReturn(mockOperation);
+        when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
+        when(mockOperation.list()).thenThrow(new KubernetesClientException("transient API server failure"));
+    }
+
+    public static EventSourceContext<KafkaProxy> mockContextContaining(KafkaProxy... proxies) {
+        EventSourceContext<KafkaProxy> context = mock();
+        stubPrimaryCache(context, proxies);
+        return context;
+    }
+
     public static KafkaProxy buildProxy(String name) {
         return proxyBuilder(name).build();
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/VirtualKafkaClusterToKafkaProxySecondaryToPrimaryMapperTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/VirtualKafkaClusterToKafkaProxySecondaryToPrimaryMapperTest.java
@@ -6,15 +6,10 @@
 
 package io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy;
 
-import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
@@ -23,25 +18,15 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class VirtualKafkaClusterToKafkaProxySecondaryToPrimaryMapperTest {
 
     @Test
     void clusterToProxyMapper() {
         // given
-        EventSourceContext<KafkaProxy> eventSourceContext = mock();
-        KubernetesClient client = mock();
-        when(eventSourceContext.getClient()).thenReturn(client);
-        MixedOperation<KafkaProxy, KubernetesResourceList<KafkaProxy>, Resource<KafkaProxy>> mockOperation = mock();
-        when(client.resources(KafkaProxy.class)).thenReturn(mockOperation);
-        KubernetesResourceList<KafkaProxy> mockList = mock();
-        when(mockOperation.list()).thenReturn(mockList);
-        when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
         KafkaProxy proxy = MapperTestSupport.buildProxy("proxy");
-        when(mockList.getItems()).thenReturn(List.of(proxy));
+        EventSourceContext<KafkaProxy> eventSourceContext = MapperTestSupport.mockContextContaining(proxy);
         SecondaryToPrimaryMapper<VirtualKafkaCluster> mapper = new VirtualKafkaClusterSecondaryToKafkaProxyPrimaryMapper(eventSourceContext);
 
         // when
@@ -55,16 +40,8 @@ class VirtualKafkaClusterToKafkaProxySecondaryToPrimaryMapperTest {
     @Test
     void clusterToProxyMapperIgnoresClusterWithStaleStatus() {
         // given
-        EventSourceContext<KafkaProxy> eventSourceContext = mock();
-        KubernetesClient client = mock();
-        when(eventSourceContext.getClient()).thenReturn(client);
-        MixedOperation<KafkaProxy, KubernetesResourceList<KafkaProxy>, Resource<KafkaProxy>> mockOperation = mock();
-        when(client.resources(KafkaProxy.class)).thenReturn(mockOperation);
-        KubernetesResourceList<KafkaProxy> mockList = mock();
-        when(mockOperation.list()).thenReturn(mockList);
-        when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
         KafkaProxy proxy = MapperTestSupport.buildProxy("proxy");
-        when(mockList.getItems()).thenReturn(List.of(proxy));
+        EventSourceContext<KafkaProxy> eventSourceContext = MapperTestSupport.mockContextContaining(proxy);
         SecondaryToPrimaryMapper<VirtualKafkaCluster> mapper = new VirtualKafkaClusterSecondaryToKafkaProxyPrimaryMapper(eventSourceContext);
 
         // when
@@ -75,4 +52,20 @@ class VirtualKafkaClusterToKafkaProxySecondaryToPrimaryMapperTest {
         assertThat(primaryResourceIDs).isEmpty();
     }
 
+    @Test
+    void shouldReturnIdsWhenApiServerUnavailable() {
+        // given
+        KafkaProxy proxy = MapperTestSupport.buildProxy("proxy");
+        EventSourceContext<KafkaProxy> context = mock();
+        MapperTestSupport.stubFailingListOperationClient(context);
+        MapperTestSupport.stubPrimaryCache(context, proxy);
+        SecondaryToPrimaryMapper<VirtualKafkaCluster> mapper = new VirtualKafkaClusterSecondaryToKafkaProxyPrimaryMapper(context);
+
+        // when
+        VirtualKafkaCluster cluster = MapperTestSupport.baseVirtualKafkaClusterBuilder(proxy, "cluster", 1L, 1L).build();
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(cluster);
+
+        // then
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(proxy));
+    }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

All four secondary→primary mappers in the KafkaProxy reconciler were calling
`ResourcesUtil.filteredResourceIdsInSameNamespace`, which issues a live `list`
against the API server on every secondary event. JOSDK silently drops events when
an exception is thrown inside the informer's event-dispatch path, so a transient
`KubernetesClientException` would leave KafkaProxy stuck with stale status and no retry.

This PR replaces all four calls with `ResourcesUtil.findAllKnownPrimariesInNamespace`,
a new cache-based helper (wrapping the private `filteredPrimaryIdsInSameNamespace`)
that reads from the controller's in-memory primary cache
(`EventSourceContext#getPrimaryCache()`) instead.

Mappers fixed:
- `VirtualKafkaClusterSecondaryToKafkaProxyPrimaryMapper`
- `KafkaProxyIngressSecondaryToKafkaProxyPrimaryMapper`
- `KafkaProtocolFilterSecondaryToKafkaProxyPrimaryMapper`
- `KafkaServiceSecondaryToKafkaProxyPrimaryMapper`

Each mapper has a `shouldReturnIdsWhenApiServerUnavailable` regression test that
stubs the API server to throw and verifies correct IDs are still returned via the
primary cache. Shared `MapperTestSupport` helpers (`stubPrimaryCache`,
`stubFailingListOperationClient`, `mockContextContaining`) mirror the pattern
established in the KafkaService reconciler tests.

**Note on `KafkaServiceSecondaryToKafkaProxyPrimaryMapper`:** the previous
implementation made two API-server calls — first listing `VirtualKafkaCluster`
resources to find those referencing the changed `KafkaService`, then listing
`KafkaProxy` resources to find those referenced by those VKCs. Because
`EventSourceContext<KafkaProxy>` only caches `KafkaProxy` objects (not VKCs),
the VKC lookup cannot be replicated from cache. The mapper is therefore simplified
to return all `KafkaProxy` resources in the namespace — consistent with the other
three mappers. The extra reconciliations for proxies not referencing the changed
`KafkaService` are harmless no-ops.

### Additional Context

Companion fix to #4064 (VKC reconciler) and #4070 (KafkaService reconciler). Part
of closing #4017 for the KafkaProxy primary type.

### Checklist

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [x] For user facing changes, update CHANGELOG.md.