### PR TITLE
refactor(runtime): Moving FCF lifecycle into virtual cluster model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#4073](https://github.com/kroxylicious/kroxylicious/pull/4073): refactor(runtime): move `FilterChainFactory` from a proxy-wide shared component to per-virtual-cluster ownership. Each virtual cluster now owns its filter chain — `FilterFactory.initialize()`/`close()` lifecycles are scoped per virtual cluster, with independent initialization data and configuration. This isolates filter resources between virtual clusters and enables safe hot-reload of filter chains (a virtual cluster's chain can be reconfigured without affecting other virtual clusters' filters). `FilterFactory.initialize()` and `close()` are now guaranteed to run on a non-Netty-event-loop thread, so blocking work (e.g. closing KMS/HTTP clients) is safe in either method
 * [#4070](https://github.com/kroxylicious/kroxylicious/pull/4070): fix(operator): KafkaService secondary→primary mappers no longer call the API server on every secondary event, preventing KafkaService from getting stuck when the API server is transiently unavailable
 * [#4064](https://github.com/kroxylicious/kroxylicious/pull/4064): fix(operator): VirtualKafkaCluster secondary→primary mappers no longer call the API server on every secondary event, preventing VKCs from getting stuck when the API server is transiently unavailable (follow-up to [#4044](https://github.com/kroxylicious/kroxylicious/pull/4044) by @Roshr2211)
 * [#4017](https://github.com/kroxylicious/kroxylicious/issues/4017): fix(operator): `KafkaProxy` secondary→primary mappers no longer call the API server on every secondary event, preventing `KafkaProxy` from getting stuck when the API server is transiently unavailable
@@ -14,6 +15,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ### Changes, deprecations and removals
 
+* [#4073](https://github.com/kroxylicious/kroxylicious/pull/4073): **Behaviour change for plugin authors** — `FilterChainFactory` is now scoped per virtual cluster rather than shared across the whole proxy. A filter type used by N virtual clusters now sees N independent `FilterFactory.initialize()`/`close()` lifecycles — one per virtual cluster, each with its own initialization data. The threading model is also tightened: `close()` is now invoked on a non-Netty-event-loop thread (previously on the proxy shutdown caller's thread) after all connections to the virtual cluster have drained, so blocking work (e.g. closing KMS/HTTP clients) is safe in `close()`. Plugins that maintained cross-virtual-cluster state in a single `FilterFactory` instance, or relied on `close()` running on a specific thread, should be reviewed.
 * [#3913](https://github.com/kroxylicious/kroxylicious/pull/3913): The operator now sets a `DeprecationWarning` status condition on `KafkaProxy` resources that have no `spec` field, complementing the existing log warning. Users should add an empty `spec: {}` to any `KafkaProxy` resource that lacks one. Support for spec-less `KafkaProxy` resources will be removed in a future release.
 
 ## 0.21.0

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
@@ -17,12 +17,22 @@ import edu.umd.cs.findbugs.annotations.UnknownNullness;
  * <li>called by the proxy runtime to {@linkplain #createFilter(FilterFactoryContext, Object) create} filter instances</li>
  * </ul>
  *
- * <p>The proxy runtime guarantees that:</p>
+ * <h2>Lifecycle scope</h2>
+ * <p>{@code FilterFactory} instances are scoped <strong>per virtual cluster</strong>: each virtual
+ * cluster that references a filter definition gets its own {@code FilterFactory} instance with its
+ * own {@link #initialize(FilterFactoryContext, Object) initialize}/{@link #close(Object) close}
+ * pair. The same filter type used by two virtual clusters produces two independent instances with
+ * independent initialization data — there is no cross-virtual-cluster sharing. Within a single
+ * virtual cluster, a filter definition referenced multiple times in the chain (e.g. an audit filter
+ * applied before and after a transformation) is initialized once and its initialization data is
+ * shared across all positions in that virtual cluster's chain.</p>
+ *
+ * <p>Per virtual cluster, the proxy runtime guarantees that:</p>
  * <ol>
  *     <li>instances will be {@linkplain  #initialize(FilterFactoryContext, Object) initialized} before any attempt to {@linkplain  #createFilter(FilterFactoryContext, Object) create} filter instances,</li>
  *     <li>instances will eventually be {@linkplain #close(Object)} closed} if and only if they were successfully initialized,</li>
  *     <li>no attempts to create filter instances will be made once a {@code FilterFactory} instance is closed,</li>
- *     <li>instances will be initialized and closed on the same thread.</li>
+ *     <li>{@code close} may run on a thread different from {@code initialize} (e.g. a Netty event loop on shutdown).</li>
  * </ol>
  * <p>Filter instance creation can happen on a different thread than initialization or cleanup.
  * It is suggested to pass state using via the return value from {@link #createFilter(FilterFactoryContext, Object)} rather than
@@ -36,10 +46,16 @@ public interface FilterFactory<C, I> {
     /**
      * <p>Initializes the factory with the specified configuration.</p>
      *
-     * <p>This method is guaranteed to be called at most once for each filter configuration and before any call to
-     * {@link #createFilter(FilterFactoryContext, Object)}.
-     * This method may provide extra semantic validation of the config,
-     * and returns some object (which may be the config, or some other object) which will be passed to {@link #createFilter(FilterFactoryContext, Object)}.
+     * <p>This method is guaranteed to be called at most once <em>per virtual cluster</em> for each
+     * filter definition referenced by that virtual cluster, and before any call to
+     * {@link #createFilter(FilterFactoryContext, Object)} on that virtual cluster. Note that
+     * because {@code FilterFactory} instances are per-virtual-cluster (see the class javadoc),
+     * the same filter type used by multiple virtual clusters will see one {@code initialize} call
+     * per virtual cluster — each on a different {@code FilterFactory} instance with its own
+     * initialization data.</p>
+     *
+     * <p>This method may provide extra semantic validation of the config,
+     * and returns some object (which may be the config, or some other object) which will be passed to {@link #createFilter(FilterFactoryContext, Object)}.</p>
      *
      * @param context context
      * @param config configuration

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
@@ -32,7 +32,7 @@ import edu.umd.cs.findbugs.annotations.UnknownNullness;
  *     <li>instances will be {@linkplain  #initialize(FilterFactoryContext, Object) initialized} before any attempt to {@linkplain  #createFilter(FilterFactoryContext, Object) create} filter instances,</li>
  *     <li>instances will eventually be {@linkplain #close(Object)} closed} if and only if they were successfully initialized,</li>
  *     <li>no attempts to create filter instances will be made once a {@code FilterFactory} instance is closed,</li>
- *     <li>{@code close} may run on a thread different from {@code initialize} (e.g. a Netty event loop on shutdown).</li>
+ *     <li>{@code initialize} and {@code close} are never invoked on a Netty event loop thread — blocking work (e.g. closing an HTTP/KMS client) is safe in either method.</li>
  * </ol>
  * <p>Filter instance creation can happen on a different thread than initialization or cleanup.
  * It is suggested to pass state using via the return value from {@link #createFilter(FilterFactoryContext, Object)} rather than

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -46,7 +46,6 @@ import io.netty.channel.uring.IoUringIoHandler;
 import io.netty.channel.uring.IoUringServerSocketChannel;
 import io.netty.util.concurrent.Future;
 
-import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.IllegalConfigurationException;
 import io.kroxylicious.proxy.config.MicrometerDefinition;
@@ -69,6 +68,7 @@ import io.kroxylicious.proxy.internal.net.NetworkBindingOperationProcessor;
 import io.kroxylicious.proxy.internal.reload.ConfigurationReloadOrchestrator;
 import io.kroxylicious.proxy.internal.util.Metrics;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
+import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 import io.kroxylicious.proxy.reload.ReconfigureResult;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
@@ -157,7 +157,6 @@ public final class KafkaProxy implements AutoCloseable {
     private final PluginFactoryRegistry pfr;
     private final VirtualClusterRegistry virtualClusterRegistry;
     private @Nullable MeterRegistries meterRegistries;
-    private @Nullable FilterChainFactory filterChainFactory;
 
     private @Nullable ConfigurationReloadOrchestrator reconfigureOrchestrator;
     private @Nullable EventGroupConfig managementEventGroup;
@@ -178,7 +177,18 @@ public final class KafkaProxy implements AutoCloseable {
     }
 
     private static VirtualClusterRegistry defaultRegistry(Configuration config, PluginFactoryRegistry pfr) {
-        var models = config.virtualClusterModel(pfr);
+        // VCM construction triggers per-VC FilterChainFactory construction, which calls each
+        // filter factory's initialize(). A filter init failure surfaces here as a
+        // PluginConfigurationException — wrap it as a LifecycleException so callers that go
+        // through startup-failure handling still see the same exception type they did before
+        // FCF construction moved into the VCM constructor.
+        final List<VirtualClusterModel> models;
+        try {
+            models = config.virtualClusterModel(pfr);
+        }
+        catch (PluginConfigurationException e) {
+            throw new LifecycleException("Startup completed exceptionally", e);
+        }
         return new VirtualClusterRegistry(models, (clusterName, cause) -> {
             if (cause.isPresent()) {
                 STARTUP_SHUTDOWN_LOGGER.atWarn()
@@ -266,7 +276,7 @@ public final class KafkaProxy implements AutoCloseable {
 
             var overrideMap = getApiKeyMaxVersionOverride(config);
             ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl(overrideMap);
-            this.filterChainFactory = new FilterChainFactory(pfr, config.filterDefinitions());
+
             this.reconfigureOrchestrator = new ConfigurationReloadOrchestrator(
                     config, virtualClusterRegistry, endpointRegistry, pfr,
                     ConfigurationReloadOrchestrator.defaultDetectors());
@@ -274,10 +284,10 @@ public final class KafkaProxy implements AutoCloseable {
             Optional<NettySettings> proxyNettySettings = getNettySettings(config, NetworkDefinition::proxy);
             var proxyProtocolMode = config.proxyProtocolMode();
             var tlsServerBootstrap = buildServerBootstrap(proxyEventGroup,
-                    new KafkaProxyInitializer(filterChainFactory, pfr, true, endpointRegistry, endpointRegistry, proxyProtocolMode,
+                    new KafkaProxyInitializer(pfr, true, endpointRegistry, endpointRegistry, proxyProtocolMode,
                             apiVersionsService, proxyNettySettings, virtualClusterRegistry));
             var plainServerBootstrap = buildServerBootstrap(proxyEventGroup,
-                    new KafkaProxyInitializer(filterChainFactory, pfr, false, endpointRegistry, endpointRegistry, proxyProtocolMode,
+                    new KafkaProxyInitializer(pfr, false, endpointRegistry, endpointRegistry, proxyProtocolMode,
                             apiVersionsService, proxyNettySettings, virtualClusterRegistry));
 
             bindingOperationProcessor.start(plainServerBootstrap, tlsServerBootstrap);
@@ -469,20 +479,18 @@ public final class KafkaProxy implements AutoCloseable {
             }
             closeFutures.forEach(Future::syncUninterruptibly);
 
-            if (filterChainFactory != null) {
-                filterChainFactory.close();
-            }
             if (meterRegistries != null) {
                 meterRegistries.close();
             }
         }
         finally {
-            // Close virtual cluster models to release TLS credential supplier resources
-            virtualClusterModels.forEach(VirtualClusterModel::close);
+            // No explicit forEach close on virtualClusterModels — the registry's
+            // shutdownAllClusters() above drives each lifecycle to Stopped and closes its
+            // model along the way (see VirtualClusterRegistry#closeModel). The registry is
+            // the single source of truth for per-VC resource lifecycle.
             managementEventGroup = null;
             proxyEventGroup = null;
             meterRegistries = null;
-            filterChainFactory = null;
             reconfigureOrchestrator = null;
             shutdown.complete(null);
             LOGGER.atInfo()

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -283,11 +283,12 @@ public final class KafkaProxy implements AutoCloseable {
 
             Optional<NettySettings> proxyNettySettings = getNettySettings(config, NetworkDefinition::proxy);
             var proxyProtocolMode = config.proxyProtocolMode();
+            var endpointServices = new KafkaProxyInitializer.EndpointServices(endpointRegistry, endpointRegistry);
             var tlsServerBootstrap = buildServerBootstrap(proxyEventGroup,
-                    new KafkaProxyInitializer(pfr, true, endpointRegistry, endpointRegistry, proxyProtocolMode,
+                    new KafkaProxyInitializer(pfr, true, endpointServices, proxyProtocolMode,
                             apiVersionsService, proxyNettySettings, virtualClusterRegistry));
             var plainServerBootstrap = buildServerBootstrap(proxyEventGroup,
-                    new KafkaProxyInitializer(pfr, false, endpointRegistry, endpointRegistry, proxyProtocolMode,
+                    new KafkaProxyInitializer(pfr, false, endpointServices, proxyProtocolMode,
                             apiVersionsService, proxyNettySettings, virtualClusterRegistry));
 
             bindingOperationProcessor.start(plainServerBootstrap, tlsServerBootstrap);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -7,7 +7,6 @@ package io.kroxylicious.proxy;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -68,7 +67,6 @@ import io.kroxylicious.proxy.internal.net.EndpointRegistry;
 import io.kroxylicious.proxy.internal.net.NetworkBindingOperationProcessor;
 import io.kroxylicious.proxy.internal.reload.ConfigurationReloadOrchestrator;
 import io.kroxylicious.proxy.internal.util.Metrics;
-import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 import io.kroxylicious.proxy.reload.ReconfigureResult;
 import io.kroxylicious.proxy.service.HostPort;
@@ -150,7 +148,6 @@ public final class KafkaProxy implements AutoCloseable {
     private final Configuration config;
     private final @Nullable ManagementConfiguration managementConfiguration;
     private final List<MicrometerDefinition> micrometerConfig;
-    private final Collection<VirtualClusterModel> virtualClusterModels;
     private final AtomicBoolean running = new AtomicBoolean();
     private final CompletableFuture<Void> shutdown = new CompletableFuture<>();
     private final NetworkBindingOperationProcessor bindingOperationProcessor = new DefaultNetworkBindingOperationProcessor();
@@ -172,7 +169,6 @@ public final class KafkaProxy implements AutoCloseable {
         this.pfr = requireNonNull(pfr);
         this.config = validate(requireNonNull(config), requireNonNull(features));
         this.virtualClusterRegistry = requireNonNull(virtualClusterRegistry);
-        this.virtualClusterModels = virtualClusterRegistry.virtualClusterModels();
         this.managementConfiguration = config.management();
         this.micrometerConfig = config.getMicrometer();
     }
@@ -183,26 +179,25 @@ public final class KafkaProxy implements AutoCloseable {
         // PluginConfigurationException — wrap it as a LifecycleException so callers that go
         // through startup-failure handling still see the same exception type they did before
         // FCF construction moved into the VCM constructor.
-        final List<VirtualClusterModel> models;
         try {
-            models = config.virtualClusterModel(pfr);
+            var models = config.virtualClusterModel(pfr);
+            return new VirtualClusterRegistry(models, (clusterName, cause) -> {
+                if (cause.isPresent()) {
+                    STARTUP_SHUTDOWN_LOGGER.atWarn()
+                            .addKeyValue("virtualCluster", clusterName)
+                            .addKeyValue("error", cause.get().getMessage())
+                            .log("Virtual cluster reached terminal stopped state due to failure, proxy shutdown required");
+                }
+                else {
+                    STARTUP_SHUTDOWN_LOGGER.atInfo()
+                            .addKeyValue("virtualCluster", clusterName)
+                            .log("Virtual cluster stopped");
+                }
+            });
         }
         catch (PluginConfigurationException e) {
             throw new LifecycleException("Startup completed exceptionally", e);
         }
-        return new VirtualClusterRegistry(models, (clusterName, cause) -> {
-            if (cause.isPresent()) {
-                STARTUP_SHUTDOWN_LOGGER.atWarn()
-                        .addKeyValue("virtualCluster", clusterName)
-                        .addKeyValue("error", cause.get().getMessage())
-                        .log("Virtual cluster reached terminal stopped state due to failure, proxy shutdown required");
-            }
-            else {
-                STARTUP_SHUTDOWN_LOGGER.atInfo()
-                        .addKeyValue("virtualCluster", clusterName)
-                        .log("Virtual cluster stopped");
-            }
-        });
     }
 
     @VisibleForTesting
@@ -239,6 +234,10 @@ public final class KafkaProxy implements AutoCloseable {
         if (running.getAndSet(true)) {
             throw new IllegalStateException("This proxy is already running");
         }
+        // Read the current model set fresh from the registry rather than from a field captured at
+        // construction time — keeps startup() consistent with the registry-as-source-of-truth
+        // invariant used by shutdown().
+        var virtualClusterModels = virtualClusterRegistry.virtualClusterModels();
         try {
             if (!TESTED_JRE_VERSIONS.contains(JRE_FEATURE_VERSION)) {
                 String versionStatus = "untested";
@@ -284,12 +283,11 @@ public final class KafkaProxy implements AutoCloseable {
 
             Optional<NettySettings> proxyNettySettings = getNettySettings(config, NetworkDefinition::proxy);
             var proxyProtocolMode = config.proxyProtocolMode();
-            var endpointServices = new KafkaProxyInitializer.EndpointServices(endpointRegistry, endpointRegistry);
             var tlsServerBootstrap = buildServerBootstrap(proxyEventGroup,
-                    new KafkaProxyInitializer(pfr, true, endpointServices, proxyProtocolMode,
+                    new KafkaProxyInitializer(pfr, true, endpointRegistry, endpointRegistry, proxyProtocolMode,
                             apiVersionsService, proxyNettySettings, virtualClusterRegistry));
             var plainServerBootstrap = buildServerBootstrap(proxyEventGroup,
-                    new KafkaProxyInitializer(pfr, false, endpointServices, proxyProtocolMode,
+                    new KafkaProxyInitializer(pfr, false, endpointRegistry, endpointRegistry, proxyProtocolMode,
                             apiVersionsService, proxyNettySettings, virtualClusterRegistry));
 
             bindingOperationProcessor.start(plainServerBootstrap, tlsServerBootstrap);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -36,9 +37,32 @@ import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
- * Abstracts the creation of a chain of filter instances, hiding the configuration
- * required for instantiation at the point at which instances are created.
- * New instances are created during initialization of a downstream channel.
+ * Builds per-connection filter instances for a single virtual cluster's filter chain.
+ *
+ * <h2>Scope</h2>
+ * A {@code FilterChainFactory} is scoped to <em>one</em> {@link io.kroxylicious.proxy.model.VirtualClusterModel}.
+ * Its lifetime is bound to that VCM — constructed when the VCM is built, closed when the VCM
+ * is closed (driven by {@code VirtualClusterRegistry} when the lifecycle reaches
+ * {@code Stopped}).
+ *
+ * <h2>What it holds</h2>
+ * <ul>
+ *   <li>An ordered list of {@link NamedFilterDefinition}s — the VC's filter chain, as
+ *       resolved from {@code VirtualCluster.filters()} (or {@code defaultFilters} when the
+ *       cluster opts in to the proxy-wide default chain).</li>
+ *   <li>A per-name map of initialized {@link Wrapper}s. Each {@code Wrapper} owns the
+ *       expensive {@code initResult} (KMS clients, caches, rule files, etc.) produced by
+ *       {@code FilterFactory.initialize}. Wrappers are deduped by name — a chain that
+ *       references {@code audit} twice (e.g. before-and-after positions) initializes the
+ *       {@code audit} factory once and reuses the {@code initResult} across both positions.</li>
+ * </ul>
+ *
+ * <h2>What it does</h2>
+ * {@link #createFilters(FilterFactoryContext)} returns a fresh list of {@link Filter}
+ * instances for one downstream channel. The chain order is the order this factory was
+ * constructed with; instances are fresh per-call, but the underlying {@code initResult}
+ * is shared across all calls to this factory (i.e. across all connections to the same VC).
+ *
  */
 public class FilterChainFactory implements AutoCloseable {
     private static final Logger LOGGER = LoggerFactory.getLogger(FilterChainFactory.class);
@@ -146,16 +170,35 @@ public class FilterChainFactory implements AutoCloseable {
 
     }
 
+    /**
+     * The VC's filter chain in invocation order. May contain duplicate names (e.g. an audit
+     * filter applied before and after a transformation). Stored as the source of truth for
+     * {@link #createFilters(FilterFactoryContext)} — every call iterates this list.
+     */
+    private final List<NamedFilterDefinition> filterChain;
+
+    /**
+     * Wrappers keyed by filter-definition name. Each wrapper owns one expensive
+     * {@code initResult}; the map is deduped on name so a chain that references the same
+     * definition twice initializes the factory once and shares the {@code initResult} across
+     * both positions in the chain.
+     */
     private final Map<String, Wrapper> initialized;
 
-    public FilterChainFactory(PluginFactoryRegistry pfr, @Nullable List<NamedFilterDefinition> filterDefinitions) {
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        Class<FilterFactory<? super Object, ? super Object>> type = (Class) FilterFactory.class;
-        PluginFactory<FilterFactory<? super Object, ? super Object>> pluginFactory = pfr.pluginFactory(type);
-        if (filterDefinitions == null || filterDefinitions.isEmpty()) {
+    public FilterChainFactory(@Nullable PluginFactoryRegistry pfr, @Nullable List<NamedFilterDefinition> filterChain) {
+        if (filterChain == null || filterChain.isEmpty()) {
+            // Empty chain — no plugin lookups needed, so a null pfr is tolerated. Empty
+            // FCFs arise from VCs that opt out of the default filter chain (filters == [])
+            // and from test-only VirtualClusterModel constructors that don't supply a pfr.
+            this.filterChain = List.of();
             this.initialized = Map.of();
         }
         else {
+            Objects.requireNonNull(pfr, "PluginFactoryRegistry must not be null when filterChain is non-empty");
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            Class<FilterFactory<? super Object, ? super Object>> type = (Class) FilterFactory.class;
+            PluginFactory<FilterFactory<? super Object, ? super Object>> pluginFactory = pfr.pluginFactory(type);
+            this.filterChain = List.copyOf(filterChain);
             FilterFactoryContext context = new FilterFactoryContext() {
 
                 @Override
@@ -173,9 +216,15 @@ public class FilterChainFactory implements AutoCloseable {
                     return pfr.pluginFactory(pluginClass).registeredInstanceNames();
                 }
             };
-            this.initialized = new LinkedHashMap<>(filterDefinitions.size());
+            this.initialized = new LinkedHashMap<>(this.filterChain.size());
             try {
-                for (var fd : filterDefinitions) {
+                for (var fd : this.filterChain) {
+                    // A chain may reference the same definition twice (e.g. audit before/after).
+                    // Initialize each unique definition only once — the duplicate-position case
+                    // reuses the same Wrapper and its initResult.
+                    if (this.initialized.containsKey(fd.name())) {
+                        continue;
+                    }
                     FilterFactory<? super Object, ? super Object> filterFactory = pluginFactory.pluginInstance(fd.type());
                     Class<?> configType = pluginFactory.configType(fd.type());
                     if (fd.config() == null || configType.isInstance(fd.config())) {
@@ -221,15 +270,16 @@ public class FilterChainFactory implements AutoCloseable {
     }
 
     /**
-     * Creates and returns a new chain of filter instances.
+     * Creates a fresh list of {@link Filter} instances for the chain this factory was built
+     * with. Returned instances are <strong>per-call</strong> — every connection gets its own
+     * filter instances — but the underlying {@code initResult} is shared across all
+     * connections through the {@link Wrapper}s held by this factory.
      *
-     * @return the new chain.
+     * @param context the filter factory context (typically per-connection)
+     * @return the new chain, in the order the factory was constructed with; empty if this
+     *         factory was constructed with a null or empty chain
      */
-    public List<FilterAndInvoker> createFilters(FilterFactoryContext context,
-                                                @Nullable List<NamedFilterDefinition> filterChain) {
-        if (filterChain == null) {
-            return List.of();
-        }
+    public List<FilterAndInvoker> createFilters(FilterFactoryContext context) {
         return filterChain
                 .stream()
                 .flatMap(filterDefinition -> FilterAndInvoker.build(

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -38,8 +38,6 @@ import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.IdleStateHandler;
 
 import io.kroxylicious.proxy.authentication.TransportSubjectBuilder;
-import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
-import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.NettySettings;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
@@ -75,8 +73,6 @@ public class KafkaProxyFrontendHandler
     private final DelegatingDecodePredicate dp;
     private final ClientConnectionStateMachine clientConnectionStateMachine;
     private final PluginFactoryRegistry pfr;
-    private final FilterChainFactory filterChainFactory;
-    private final List<NamedFilterDefinition> namedFilterDefinitions;
     private final ApiVersionsIntersectFilter apiVersionsIntersectFilter;
     private final ApiVersionsDowngradeFilter apiVersionsDowngradeFilter;
 
@@ -109,8 +105,6 @@ public class KafkaProxyFrontendHandler
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     KafkaProxyFrontendHandler(
                               PluginFactoryRegistry pfr,
-                              FilterChainFactory filterChainFactory,
-                              List<NamedFilterDefinition> namedFilterDefinitions,
                               EndpointReconciler endpointReconciler,
                               ApiVersionsServiceImpl apiVersionsService,
                               DelegatingDecodePredicate dp,
@@ -118,8 +112,6 @@ public class KafkaProxyFrontendHandler
                               ClientConnectionStateMachine clientConnectionStateMachine,
                               Optional<NettySettings> proxyNettySettings) {
         this.pfr = pfr;
-        this.filterChainFactory = filterChainFactory;
-        this.namedFilterDefinitions = namedFilterDefinitions;
         this.endpointReconciler = endpointReconciler;
         this.apiVersionsIntersectFilter = new ApiVersionsIntersectFilter(apiVersionsService);
         this.apiVersionsDowngradeFilter = new ApiVersionsDowngradeFilter(apiVersionsService);
@@ -274,7 +266,10 @@ public class KafkaProxyFrontendHandler
         filterAndInvokers.addAll(FilterAndInvoker.build("ApiVersionsDowngrade (internal)", apiVersionsDowngradeFilter));
 
         NettyFilterContext filterContext = new NettyFilterContext(clientCtx().channel().eventLoop(), pfr);
-        List<FilterAndInvoker> filterChain = filterChainFactory.createFilters(filterContext, this.namedFilterDefinitions);
+
+        List<FilterAndInvoker> filterChain = clientConnectionStateMachine.virtualCluster()
+                .filterChainFactory()
+                .createFilters(filterContext);
         filterAndInvokers.addAll(filterChain);
 
         if (clientConnectionStateMachine.endpointBinding().restrictUpstreamToMetadataDiscovery()) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -27,7 +27,6 @@ import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.concurrent.Future;
 
 import io.kroxylicious.proxy.authentication.TransportSubjectBuilder;
-import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
 import io.kroxylicious.proxy.config.NettySettings;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.config.ProxyProtocolMode;
@@ -60,7 +59,6 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
     private final EndpointBindingResolver bindingResolver;
     private final EndpointReconciler endpointReconciler;
     private final PluginFactoryRegistry pfr;
-    private final FilterChainFactory filterChainFactory;
     private final ApiVersionsServiceImpl apiVersionsService;
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private final Optional<NettySettings> proxyNettySettings;
@@ -70,8 +68,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
     private final VirtualClusterRegistry virtualClusterRegistry;
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    public KafkaProxyInitializer(FilterChainFactory filterChainFactory,
-                                 PluginFactoryRegistry pfr,
+    public KafkaProxyInitializer(PluginFactoryRegistry pfr,
                                  boolean tls,
                                  EndpointBindingResolver bindingResolver,
                                  EndpointReconciler endpointReconciler,
@@ -84,7 +81,6 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
         this.proxyProtocolMode = proxyProtocolMode;
         this.tls = tls;
         this.bindingResolver = bindingResolver;
-        this.filterChainFactory = Objects.requireNonNull(filterChainFactory, "filterChainFactory");
         this.apiVersionsService = apiVersionsService;
         this.proxyNettySettings = proxyNettySettings;
         this.clientToProxyErrorCounter = Metrics.clientToProxyErrorCounter("", null).withTags();
@@ -246,8 +242,6 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
         }
         var frontendHandler = new KafkaProxyFrontendHandler(
                 pfr,
-                filterChainFactory,
-                virtualCluster.getFilters(),
                 endpointReconciler,
                 apiVersionsService,
                 dp,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -67,30 +67,20 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
     private final Long unauthenticatedIdleMillis;
     private final VirtualClusterRegistry virtualClusterRegistry;
 
-    /**
-     * Endpoint plumbing services used by the initializer: resolving inbound connections to
-     * an {@link EndpointBinding} and reconciling endpoint state with the registry.
-     */
-    public record EndpointServices(EndpointBindingResolver bindingResolver, EndpointReconciler endpointReconciler) {
-        public EndpointServices {
-            Objects.requireNonNull(bindingResolver);
-            Objects.requireNonNull(endpointReconciler);
-        }
-    }
-
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    @SuppressWarnings({ "OptionalUsedAsFieldOrParameterType", "java:S107" })
     public KafkaProxyInitializer(PluginFactoryRegistry pfr,
                                  boolean tls,
-                                 EndpointServices endpointServices,
+                                 EndpointBindingResolver bindingResolver,
+                                 EndpointReconciler endpointReconciler,
                                  ProxyProtocolMode proxyProtocolMode,
                                  ApiVersionsServiceImpl apiVersionsService,
                                  Optional<NettySettings> proxyNettySettings,
                                  VirtualClusterRegistry virtualClusterRegistry) {
         this.pfr = pfr;
-        this.endpointReconciler = endpointServices.endpointReconciler();
+        this.endpointReconciler = endpointReconciler;
         this.proxyProtocolMode = proxyProtocolMode;
         this.tls = tls;
-        this.bindingResolver = endpointServices.bindingResolver();
+        this.bindingResolver = bindingResolver;
         this.apiVersionsService = apiVersionsService;
         this.proxyNettySettings = proxyNettySettings;
         this.clientToProxyErrorCounter = Metrics.clientToProxyErrorCounter("", null).withTags();

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -67,20 +67,30 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
     private final Long unauthenticatedIdleMillis;
     private final VirtualClusterRegistry virtualClusterRegistry;
 
+    /**
+     * Endpoint plumbing services used by the initializer: resolving inbound connections to
+     * an {@link EndpointBinding} and reconciling endpoint state with the registry.
+     */
+    public record EndpointServices(EndpointBindingResolver bindingResolver, EndpointReconciler endpointReconciler) {
+        public EndpointServices {
+            Objects.requireNonNull(bindingResolver);
+            Objects.requireNonNull(endpointReconciler);
+        }
+    }
+
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public KafkaProxyInitializer(PluginFactoryRegistry pfr,
                                  boolean tls,
-                                 EndpointBindingResolver bindingResolver,
-                                 EndpointReconciler endpointReconciler,
+                                 EndpointServices endpointServices,
                                  ProxyProtocolMode proxyProtocolMode,
                                  ApiVersionsServiceImpl apiVersionsService,
                                  Optional<NettySettings> proxyNettySettings,
                                  VirtualClusterRegistry virtualClusterRegistry) {
         this.pfr = pfr;
-        this.endpointReconciler = endpointReconciler;
+        this.endpointReconciler = endpointServices.endpointReconciler();
         this.proxyProtocolMode = proxyProtocolMode;
         this.tls = tls;
-        this.bindingResolver = bindingResolver;
+        this.bindingResolver = endpointServices.bindingResolver();
         this.apiVersionsService = apiVersionsService;
         this.proxyNettySettings = proxyNettySettings;
         this.clientToProxyErrorCounter = Metrics.clientToProxyErrorCounter("", null).withTags();

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
@@ -169,6 +169,7 @@ public class VirtualClusterRegistry {
             return lifecycle.startDraining()
                     .thenRun(() -> {
                         lifecycle.drainComplete();
+                        closeModel(clusterName);
                         onVirtualClusterStopped.accept(clusterName, Optional.empty());
                     });
         }
@@ -178,23 +179,53 @@ public class VirtualClusterRegistry {
             return lifecycle.drainFuture()
                     .thenRun(() -> {
                         lifecycle.drainComplete();
+                        closeModel(clusterName);
                         onVirtualClusterStopped.accept(clusterName, Optional.empty());
                     });
         }
         else if (state instanceof VirtualClusterLifecycleState.Failed failed) {
             lifecycle.stop();
+            closeModel(clusterName);
             onVirtualClusterStopped.accept(clusterName, Optional.of(failed.cause()));
             return CompletableFuture.completedFuture(null);
         }
         else if (state instanceof VirtualClusterLifecycleState.Stopped) {
-            // Already dead, let sleeping dogs lie.
+            // Already stopped, no need to close() again
             return CompletableFuture.completedFuture(null);
         }
         else {
             // Initializing — transition to Stopped via the dedicated stop() method.
             lifecycle.stop();
+            closeModel(clusterName);
             onVirtualClusterStopped.accept(clusterName, Optional.empty());
             return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    /**
+     * Closes per-VC resources (FilterChainFactory, TLS credential supplier manager) at the
+     * moment the lifecycle transitions into {@code Stopped}. Called from every transition-
+     * into-Stopped branch of {@link #shutdownCluster}
+     *
+     * <p>If the model close throws, the failure is logged at WARN and swallowed — we don't
+     * want a noisy filter cleanup to stop us from firing {@link #onVirtualClusterStopped}
+     * or completing the shutdown future. The exception is recorded against the cluster name
+     * so operators can diagnose stuck cleanups.
+     */
+    private void closeModel(String clusterName) {
+        var entry = entriesByCluster.get(clusterName);
+        if (entry == null) {
+            return;
+        }
+        try {
+            entry.model().close();
+        }
+        catch (RuntimeException e) {
+            LOGGER.atWarn()
+                    .setCause(e)
+                    .addKeyValue("virtualCluster", clusterName)
+                    .addKeyValue("error", e.getMessage())
+                    .log("Failed to close virtual cluster resources on lifecycle transition to Stopped");
         }
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.BiConsumer;
 
 import org.slf4j.Logger;
@@ -169,22 +170,26 @@ public class VirtualClusterRegistry {
     private CompletableFuture<Void> shutdownCluster(String clusterName, VirtualClusterLifecycle lifecycle) {
         var state = lifecycle.state();
         if (state instanceof VirtualClusterLifecycleState.Serving) {
+            // Dispatch the close + callback to a non-event-loop executor: a connection's drain
+            // future completes on its Netty event loop, and a default thenRun would inherit that
+            // thread. FilterFactory.close() is allowed to block (closing KMS/HTTP clients), so it
+            // must not run on an event loop.
             return lifecycle.startDraining()
-                    .thenRun(() -> {
+                    .thenRunAsync(() -> {
                         lifecycle.drainComplete();
                         closeModel(clusterName);
                         onVirtualClusterStopped.accept(clusterName, Optional.empty());
-                    });
+                    }, ForkJoinPool.commonPool());
         }
         else if (state instanceof VirtualClusterLifecycleState.Draining) {
             // Pre-existing drain (e.g. concurrent shutdown or hot-reload) — join it rather
-            // than starting a new one.
+            // than starting a new one. Same non-event-loop dispatch as the Serving path above.
             return lifecycle.drainFuture()
-                    .thenRun(() -> {
+                    .thenRunAsync(() -> {
                         lifecycle.drainComplete();
                         closeModel(clusterName);
                         onVirtualClusterStopped.accept(clusterName, Optional.empty());
-                    });
+                    }, ForkJoinPool.commonPool());
         }
         else if (state instanceof VirtualClusterLifecycleState.Failed failed) {
             lifecycle.stop();

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -31,6 +31,7 @@ import io.netty.handler.ssl.SslContextBuilder;
 
 import io.kroxylicious.proxy.authentication.TransportSubjectBuilder;
 import io.kroxylicious.proxy.authentication.TransportSubjectBuilderService;
+import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
 import io.kroxylicious.proxy.bootstrap.TlsCredentialSupplierManager;
 import io.kroxylicious.proxy.config.CacheConfiguration;
 import io.kroxylicious.proxy.config.IllegalConfigurationException;
@@ -58,8 +59,28 @@ import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Runtime representation of a virtual cluster: its name, target Kafka cluster, gateways,
+ * TLS configuration, and the components whose lifecycle is bound to this VC.
+ *
+ * <h2>Owned resources</h2>
+ * The VCM owns and is responsible for closing two per-VC components:
+ * <ul>
+ *   <li>{@link FilterChainFactory} — the filter chain factory for <em>this</em> VC. Each VCM
+ *       has its own FCF.</li>
+ *   <li>{@link TlsCredentialSupplierManager} — the TLS credential supplier for this VC.</li>
+ * </ul>
+ *
+ * <h2>Lifecycle</h2>
+ * The VCM is created when the VC is configured (or reconfigured via hot-reload), and closed
+ * via {@link #close()} when the VC's lifecycle reaches {@code Stopped}. The
+ * {@code VirtualClusterRegistry} drives the close.
+ *
+ * <p>{@link #close()} is idempotent: the underlying components guard against double-close,
+ * so accidental redundant close calls are safe.
+ */
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-public class VirtualClusterModel {
+public class VirtualClusterModel implements AutoCloseable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(VirtualClusterModel.class);
     public static final int DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES = 104857600;
@@ -85,6 +106,13 @@ public class VirtualClusterModel {
     private TopicNameCacheFilter topicNameCacheFilter = null;
 
     private final TlsCredentialSupplierManager tlsCredentialSupplierManager;
+
+    /**
+     * The filter chain factory for <em>this</em> virtual cluster. Owned by the VCM — its
+     * lifetime is tied to this VCM's lifetime, closed when {@link #close()} is called by
+     * {@code VirtualClusterRegistry} on transition into {@code Stopped}.
+     */
+    private final FilterChainFactory filterChainFactory;
 
     @VisibleForTesting
     public VirtualClusterModel(String clusterName,
@@ -129,13 +157,29 @@ public class VirtualClusterModel {
                     .flatMap(tls -> Optional.ofNullable(tls.credentialSupplier()))
                     .orElse(null);
             this.tlsCredentialSupplierManager = new TlsCredentialSupplierManager(pluginFactoryRegistry, definition);
+            this.filterChainFactory = new FilterChainFactory(pluginFactoryRegistry, filters);
         }
         else {
             this.tlsCredentialSupplierManager = TlsCredentialSupplierManager.unconfigured();
+            // Test-only constructors take this branch. They always pass an empty/null filter
+            // list, so an empty FCF is the right shape — FilterChainFactory tolerates a null
+            // pfr when the chain is empty, which spares tests from building a real
+            // PluginFactoryRegistry.
+            this.filterChainFactory = new FilterChainFactory(null, List.of());
         }
 
         // TODO: https://github.com/kroxylicious/kroxylicious/issues/104 be prepared to reload the SslContext at runtime.
         this.upstreamSslContext = buildUpstreamSslContext();
+    }
+
+    /**
+     * Returns this VC's filter chain factory. The returned factory is alive for the lifetime
+     * of this VCM; closing the VCM (via {@link #close()}, driven by
+     * {@code VirtualClusterRegistry} on transition into {@code Stopped}) also closes the FCF.
+     * Callers should not retain the reference past the VC's lifetime.
+     */
+    public FilterChainFactory filterChainFactory() {
+        return filterChainFactory;
     }
 
     public Duration drainTimeout() {
@@ -234,11 +278,37 @@ public class VirtualClusterModel {
     }
 
     /**
-     * Closes resources associated with this virtual cluster.
-     * Currently closes the TLS credential supplier manager.
+     * Closes resources associated with this virtual cluster — the TLS credential supplier
+     * manager and the {@link FilterChainFactory}. Called by {@code VirtualClusterRegistry}
+     * on lifecycle transition into {@code Stopped}. Safe to call multiple times — the FCF's
+     * underlying {@code Wrapper.close} is idempotent via an internal {@code AtomicBoolean},
+     * and {@code TlsCredentialSupplierManager.close} tolerates re-entry.
      */
+    @Override
     public void close() {
-        tlsCredentialSupplierManager.close();
+        // Suppress exceptions from FCF close so the TLS close still runs; surface the first
+        // failure at the end so callers see something rather than nothing.
+        RuntimeException firstFailure = null;
+        try {
+            filterChainFactory.close();
+        }
+        catch (RuntimeException e) {
+            firstFailure = e;
+        }
+        try {
+            tlsCredentialSupplierManager.close();
+        }
+        catch (RuntimeException e) {
+            if (firstFailure == null) {
+                firstFailure = e;
+            }
+            else {
+                firstFailure.addSuppressed(e);
+            }
+        }
+        if (firstFailure != null) {
+            throw firstFailure;
+        }
     }
 
     /**

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyLifecycleTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyLifecycleTest.java
@@ -136,8 +136,9 @@ class KafkaProxyLifecycleTest {
                    defaultFilters:
                    - filter1
                 """;
+        var parsedConfig = configParser.parseConfiguration(config);
 
-        assertThatThrownBy(() -> new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures()))
+        assertThatThrownBy(() -> new KafkaProxy(configParser, parsedConfig, Features.defaultFeatures()))
                 .isInstanceOf(LifecycleException.class)
                 .cause()
                 .isInstanceOf(PluginConfigurationException.class);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyLifecycleTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyLifecycleTest.java
@@ -137,8 +137,9 @@ class KafkaProxyLifecycleTest {
                    - filter1
                 """;
         var parsedConfig = configParser.parseConfiguration(config);
+        var features = Features.defaultFeatures();
 
-        assertThatThrownBy(() -> new KafkaProxy(configParser, parsedConfig, Features.defaultFeatures()))
+        assertThatThrownBy(() -> new KafkaProxy(configParser, parsedConfig, features))
                 .isInstanceOf(LifecycleException.class)
                 .cause()
                 .isInstanceOf(PluginConfigurationException.class);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyLifecycleTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyLifecycleTest.java
@@ -114,8 +114,13 @@ class KafkaProxyLifecycleTest {
     }
 
     @Test
-    void shouldTransitionToStoppedOnStartupFailure() throws Exception {
-        // given
+    void shouldFailConstructionWhenFilterInitializationFails() {
+        // The FCF-per-VC refactor moved filter init into VirtualClusterModel construction (run from
+        // KafkaProxy's constructor via defaultRegistry), so a bad filter config now surfaces from the
+        // constructor — wrapped as LifecycleException by defaultRegistry — rather than from startup().
+        // The proxy object never exists when its construction throws, so the previously-observed
+        // post-failure transition to Stopped is no longer reachable; the exception-type contract is the
+        // observable contract that remains.
         var config = """
                    virtualClusters:
                      - name: demo1
@@ -132,20 +137,9 @@ class KafkaProxyLifecycleTest {
                    - filter1
                 """;
 
-        try (var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures())) {
-            // when
-            assertThatThrownBy(proxy::startup)
-                    .isInstanceOf(LifecycleException.class)
-                    .cause()
-                    .isInstanceOf(PluginConfigurationException.class);
-
-            // then
-            var manager = proxy.lifecycleFor("demo1");
-            assertThat(manager).isNotNull();
-            assertThat(manager.state())
-                    .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.type(Stopped.class))
-                    .extracting(Stopped::priorFailureCause)
-                    .isInstanceOf(PluginConfigurationException.class);
-        }
+        assertThatThrownBy(() -> new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures()))
+                .isInstanceOf(LifecycleException.class)
+                .cause()
+                .isInstanceOf(PluginConfigurationException.class);
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyLifecycleTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyLifecycleTest.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -88,7 +90,7 @@ class KafkaProxyLifecycleTest {
     }
 
     @Test
-    void shouldTransitionToStoppedAfterShutdown() {
+    void shouldTransitionToStoppedAfterShutdown() throws Exception {
         // given
         var config = """
                    virtualClusters:
@@ -101,16 +103,73 @@ class KafkaProxyLifecycleTest {
                            bootstrapAddress: localhost:9192
                 """;
 
-        var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures());
-        proxy.startup();
-        var manager = proxy.lifecycleFor("demo1");
+        try (var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures())) {
+            proxy.startup();
+            var manager = proxy.lifecycleFor("demo1");
 
-        // when
-        proxy.shutdown();
+            // when
+            proxy.shutdown();
 
-        // then
-        assertThat(manager).isNotNull();
-        assertThat(manager.state()).isInstanceOf(Stopped.class);
+            // then
+            assertThat(manager).isNotNull();
+            assertThat(manager.state()).isInstanceOf(Stopped.class);
+        }
+    }
+
+    @Test
+    void shutdownAfterReloadDrivesNewlyAddedVcToStopped() throws Exception {
+        // Regression test for #4066: KafkaProxy.shutdown() must drive VCs added via reload to
+        // Stopped, not just the ones present at proxy construction time. Prior to the FCF-per-VC
+        // refactor, shutdown iterated a stale snapshot of virtualClusterModels captured at
+        // construction time — any VC added via the reload API was invisible to shutdown.
+        var initial = """
+                   virtualClusters:
+                     - name: vc-a
+                       targetCluster:
+                         bootstrapServers: kafka.example:1234
+                       gateways:
+                       - name: default
+                         portIdentifiesNode:
+                           bootstrapAddress: localhost:9492
+                """;
+        var afterReload = """
+                   virtualClusters:
+                     - name: vc-a
+                       targetCluster:
+                         bootstrapServers: kafka.example:1234
+                       gateways:
+                       - name: default
+                         portIdentifiesNode:
+                           bootstrapAddress: localhost:9492
+                     - name: vc-b
+                       targetCluster:
+                         bootstrapServers: kafka.example:5678
+                       gateways:
+                       - name: default
+                         portIdentifiesNode:
+                           bootstrapAddress: localhost:9592
+                """;
+
+        try (var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(initial), Features.defaultFeatures())) {
+            proxy.startup();
+            proxy.reconfigure(configParser.parseConfiguration(afterReload)).get(5, TimeUnit.SECONDS);
+
+            var lifecycleA = proxy.lifecycleFor("vc-a");
+            var lifecycleB = proxy.lifecycleFor("vc-b");
+            assertThat(lifecycleB).as("vc-b should be tracked after reload").isNotNull();
+            assertThat(lifecycleB.state()).as("vc-b should reach Serving after reload").isInstanceOf(Serving.class);
+
+            // when
+            proxy.shutdown();
+
+            // then — BOTH the originally-configured vc-a AND the runtime-added vc-b must reach Stopped.
+            assertThat(lifecycleA.state())
+                    .as("originally-configured vc-a should reach Stopped on shutdown")
+                    .isInstanceOf(Stopped.class);
+            assertThat(lifecycleB.state())
+                    .as("runtime-added vc-b should also reach Stopped on shutdown (regression test for #4066)")
+                    .isInstanceOf(Stopped.class);
+        }
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -58,7 +58,11 @@ class KafkaProxyTest {
     }
 
     @Test
-    void shouldFailToStartIfRequireFilterConfigIsMissing() throws Exception {
+    void shouldFailToStartIfRequireFilterConfigIsMissing() {
+        // Filter init runs during VCM construction (per the FCF-per-VC refactor), so a bad filter
+        // config now surfaces from the KafkaProxy constructor rather than from startup(). The
+        // wrap-as-LifecycleException in KafkaProxy.defaultRegistry preserves the exception type
+        // and cause that callers of the legacy startup() path had previously relied on.
         var config = """
                    virtualClusters:
                      - name: demo1
@@ -74,13 +78,11 @@ class KafkaProxyTest {
                    defaultFilters:
                    - filter1
                 """;
-        try (var kafkaProxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures())) {
-            assertThatThrownBy(kafkaProxy::startup)
-                    .isInstanceOf(LifecycleException.class)
-                    .cause()
-                    .isInstanceOf(PluginConfigurationException.class)
-                    .hasMessageContaining("Exception initializing filter factory filter1 with config null");
-        }
+        assertThatThrownBy(() -> new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures()))
+                .isInstanceOf(LifecycleException.class)
+                .cause()
+                .isInstanceOf(PluginConfigurationException.class)
+                .hasMessageContaining("Exception initializing filter factory filter1 with config null");
     }
 
     static Stream<Arguments> detectsConflictingPorts() {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -79,7 +79,8 @@ class KafkaProxyTest {
                    - filter1
                 """;
         var parsedConfig = configParser.parseConfiguration(config);
-        assertThatThrownBy(() -> new KafkaProxy(configParser, parsedConfig, Features.defaultFeatures()))
+        var features = Features.defaultFeatures();
+        assertThatThrownBy(() -> new KafkaProxy(configParser, parsedConfig, features))
                 .isInstanceOf(LifecycleException.class)
                 .cause()
                 .isInstanceOf(PluginConfigurationException.class)

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -78,7 +78,8 @@ class KafkaProxyTest {
                    defaultFilters:
                    - filter1
                 """;
-        assertThatThrownBy(() -> new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures()))
+        var parsedConfig = configParser.parseConfiguration(config);
+        assertThatThrownBy(() -> new KafkaProxy(configParser, parsedConfig, Features.defaultFeatures()))
                 .isInstanceOf(LifecycleException.class)
                 .cause()
                 .isInstanceOf(PluginConfigurationException.class)

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -114,7 +114,7 @@ class FilterChainFactoryTest {
     @Test
     void testNullFiltersInConfigResultsInEmptyList() {
         FilterChainFactory filterChainFactory = new FilterChainFactory(pfr, null);
-        List<FilterAndInvoker> filters = filterChainFactory.createFilters(new NettyFilterContext(eventLoop, pfr), null);
+        List<FilterAndInvoker> filters = filterChainFactory.createFilters(new NettyFilterContext(eventLoop, pfr));
         assertThat(filters)
                 .isNotNull()
                 .isEmpty();
@@ -143,7 +143,7 @@ class FilterChainFactoryTest {
         var nameFilterDefinitions = List.of(new NamedFilterDefinition("myFilterDef", DeprecatedMethodsFilterFactory.class.getName(), null));
         try (var filterChainFactory = new FilterChainFactory(pfr, nameFilterDefinitions)) {
             var context = new NettyFilterContext(eventLoop, pfr);
-            filterChainFactory.createFilters(context, nameFilterDefinitions);
+            filterChainFactory.createFilters(context);
             assertThat(logCaptor.getLogEvents())
                     .hasSize(2)
                     .allSatisfy(logEvent -> {
@@ -290,7 +290,7 @@ class FilterChainFactoryTest {
     private ListAssert<FilterAndInvoker> assertFiltersCreated(List<NamedFilterDefinition> nameFilterDefinitions) {
         try (FilterChainFactory filterChainFactory = new FilterChainFactory(pfr, nameFilterDefinitions)) {
             NettyFilterContext context = new NettyFilterContext(eventLoop, pfr);
-            List<FilterAndInvoker> filters = filterChainFactory.createFilters(context, nameFilterDefinitions);
+            List<FilterAndInvoker> filters = filterChainFactory.createFilters(context);
             return assertThat(filters).hasSameSizeAs(nameFilterDefinitions);
         }
     }
@@ -352,7 +352,7 @@ class FilterChainFactoryTest {
             // When
 
             // Then
-            assertThatThrownBy(() -> fcf.createFilters(context, list))
+            assertThatThrownBy(() -> fcf.createFilters(context))
                     .isExactlyInstanceOf(PluginConfigurationException.class)
                     .cause()
                     .isExactlyInstanceOf(RuntimeException.class)
@@ -368,6 +368,68 @@ class FilterChainFactoryTest {
         assertThat(onInitialize2.count).isEqualTo(1);
         assertThat(onClose2.count).isEqualTo(1);
 
+    }
+
+    @Test
+    void shouldInitializeAndCloseDedupedFilterOnce() {
+        // A chain may reference the same filter definition multiple times (e.g. audit before-and-after a
+        // transformation). initialize and close must run once per unique name, but createFilters must
+        // still honour every chain position.
+        var onAuditInit = new Counter();
+        var onAuditClose = new Counter();
+        var onTransformInit = new Counter();
+        var onTransformClose = new Counter();
+        List<FlakyConfig> initializeOrder = new ArrayList<>();
+        List<FlakyConfig> closeOrder = new ArrayList<>();
+        var auditConfig = new FlakyConfig(null, null, null,
+                ((Consumer<FlakyConfig>) onAuditInit::increment).andThen(initializeOrder::add),
+                ((Consumer<FlakyConfig>) onAuditClose::increment).andThen(closeOrder::add));
+        var transformConfig = new FlakyConfig(null, null, null,
+                ((Consumer<FlakyConfig>) onTransformInit::increment).andThen(initializeOrder::add),
+                ((Consumer<FlakyConfig>) onTransformClose::increment).andThen(closeOrder::add));
+        var auditDef = new NamedFilterDefinition("audit", FlakyFactory.class.getName(), auditConfig);
+        var transformDef = new NamedFilterDefinition("transform", FlakyFactory.class.getName(), transformConfig);
+        var chain = List.of(auditDef, transformDef, auditDef);
+
+        try (var fcf = new FilterChainFactory(pfr, chain)) {
+            assertThat(onAuditInit.count).isEqualTo(1);
+            assertThat(onTransformInit.count).isEqualTo(1);
+            assertThat(initializeOrder).isEqualTo(List.of(auditConfig, transformConfig));
+
+            var filters = fcf.createFilters(new NettyFilterContext(eventLoop, pfr));
+            assertThat(filters).hasSize(3);
+        }
+
+        assertThat(onAuditClose.count).isEqualTo(1);
+        assertThat(onTransformClose.count).isEqualTo(1);
+        assertThat(closeOrder).isEqualTo(List.of(transformConfig, auditConfig));
+    }
+
+    @Test
+    void shouldNotCloseAnotherFilterChainFactorysWrappersOnClose() {
+        // Two FCFs (one per virtual cluster) using the same filter type with independent configs.
+        // Closing one must not invoke close on the other's wrappers — initResult sharing is intra-FCF only.
+        var onInitA = new Counter();
+        var onCloseA = new Counter();
+        var onInitB = new Counter();
+        var onCloseB = new Counter();
+        var configA = new FlakyConfig(null, null, null, onInitA::increment, onCloseA::increment);
+        var configB = new FlakyConfig(null, null, null, onInitB::increment, onCloseB::increment);
+        var chainA = List.of(new NamedFilterDefinition("flaky", FlakyFactory.class.getName(), configA));
+        var chainB = List.of(new NamedFilterDefinition("flaky", FlakyFactory.class.getName(), configB));
+
+        try (var fcfA = new FilterChainFactory(pfr, chainA);
+                var fcfB = new FilterChainFactory(pfr, chainB)) {
+            assertThat(onInitA.count).isEqualTo(1);
+            assertThat(onInitB.count).isEqualTo(1);
+
+            fcfA.close();
+            assertThat(onCloseA.count).isEqualTo(1);
+            assertThat(onCloseB.count).isZero();
+        }
+
+        assertThat(onCloseA.count).isEqualTo(1);
+        assertThat(onCloseB.count).isEqualTo(1);
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -28,6 +28,7 @@ import io.netty.channel.EventLoop;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.PluginFactory;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterDispatchExecutor;
 import io.kroxylicious.proxy.filter.FilterFactory;
 import io.kroxylicious.proxy.internal.filter.DeprecatedMethodsFilterFactory;
@@ -430,6 +431,64 @@ class FilterChainFactoryTest {
 
         assertThat(onCloseA.count).isEqualTo(1);
         assertThat(onCloseB.count).isEqualTo(1);
+    }
+
+    @Test
+    void shouldCallInitializeOnceRegardlessOfConnectionCount() {
+        // Given
+        var onInit = new Counter();
+        var flakyConfig = new FlakyConfig(null, null, null, onInit::increment, c -> {
+        });
+        var chain = List.of(new NamedFilterDefinition("f", FlakyFactory.class.getName(), flakyConfig));
+        try (var fcf = new FilterChainFactory(pfr, chain)) {
+            var context = new NettyFilterContext(eventLoop, pfr);
+            fcf.createFilters(context);
+            fcf.createFilters(context);
+
+            // When
+            fcf.createFilters(context);
+
+            // Then
+            assertThat(onInit.count).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void shouldCreateNewFilterInstancePerConnection() {
+        // Given
+        var chain = List.of(new NamedFilterDefinition("f", TestFilterFactory.class.getName(), config));
+        try (var fcf = new FilterChainFactory(pfr, chain)) {
+            var context = new NettyFilterContext(eventLoop, pfr);
+
+            // When
+            var conn1 = fcf.createFilters(context);
+            var conn2 = fcf.createFilters(context);
+
+            // Then
+            Filter conn1Filter = conn1.get(0).filter();
+            Filter conn2Filter = conn2.get(0).filter();
+            assertThat(conn1Filter).isNotSameAs(conn2Filter);
+        }
+    }
+
+    @Test
+    void shouldCreateNewInstanceWhenDefinitionIsDuplicated() {
+        // Given
+        var auditDef = new NamedFilterDefinition("audit", TestFilterFactory.class.getName(), config);
+        var transformDef = new NamedFilterDefinition("transform", TestFilterFactory.class.getName(), new ExampleConfig());
+        var chain = List.of(auditDef, transformDef, auditDef);
+        try (var fcf = new FilterChainFactory(pfr, chain)) {
+            var context = new NettyFilterContext(eventLoop, pfr);
+
+            // When
+            var filters = fcf.createFilters(context);
+
+            // Then
+            assertThat(filters).hasSize(3);
+            Filter inboundAudit = filters.get(0).filter();
+            Filter outboundAudit = filters.get(2).filter();
+            assertThat(inboundAudit).isNotSameAs(outboundAudit);
+        }
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
@@ -55,7 +55,6 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 
-import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
 import io.kroxylicious.proxy.config.CacheConfiguration;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
@@ -483,8 +482,6 @@ class ClientConnectionStateMachineEndToEndTest {
                                               DelegatingDecodePredicate dp) {
         var pfr = mock(PluginFactoryRegistry.class);
         return new KafkaProxyFrontendHandler(pfr,
-                new FilterChainFactory(pfr, List.of()),
-                List.of(),
                 mock(EndpointReconciler.class),
                 new ApiVersionsServiceImpl(),
                 dp,
@@ -501,6 +498,9 @@ class ClientConnectionStateMachineEndToEndTest {
         when(virtualClusterModel.getClusterName()).thenReturn("cluster");
         TopicNameCacheFilter topicNameCacheFilter = new TopicNameCacheFilter(CacheConfiguration.DEFAULT, "cluster");
         when(virtualClusterModel.getTopicNameCacheFilter()).thenReturn(topicNameCacheFilter);
+        // FCF is now resolved per-connection from the VC (see #4055). An empty FCF here is
+        // sufficient — these tests don't exercise filter behavior, just connection flow.
+        when(virtualClusterModel.filterChainFactory()).thenReturn(new io.kroxylicious.proxy.bootstrap.FilterChainFactory(null, java.util.List.of()));
         EndpointBinding endpointBinding = mock(EndpointBinding.class);
         EndpointGateway endpointGateway = mock(EndpointGateway.class);
         when(endpointGateway.virtualCluster()).thenReturn(virtualClusterModel);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerMockCollaboratorsTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerMockCollaboratorsTest.java
@@ -100,6 +100,7 @@ class KafkaProxyFrontendHandlerMockCollaboratorsTest {
     @BeforeEach
     void setUp() {
         when(virtualCluster.getClusterName()).thenReturn(CLUSTER_NAME);
+        when(virtualCluster.filterChainFactory()).thenReturn(new FilterChainFactory(null, List.of()));
         when(endpointGateway.virtualCluster()).thenReturn(virtualCluster);
         when(endpointBinding.endpointGateway()).thenReturn(endpointGateway);
         when(clientConnectionStateMachine.endpointBinding()).thenReturn(endpointBinding);
@@ -114,8 +115,6 @@ class KafkaProxyFrontendHandlerMockCollaboratorsTest {
 
         handler = new KafkaProxyFrontendHandler(
                 pfr,
-                filterChainFactory,
-                virtualCluster.getFilters(),
                 endpointReconciler,
                 new ApiVersionsServiceImpl(),
                 DELEGATING_PREDICATE,
@@ -249,8 +248,6 @@ class KafkaProxyFrontendHandlerMockCollaboratorsTest {
         // Given
         handler = new KafkaProxyFrontendHandler(
                 mock(PluginFactoryRegistry.class),
-                mock(FilterChainFactory.class),
-                List.of(),
                 endpointReconciler,
                 mock(ApiVersionsServiceImpl.class),
                 DELEGATING_PREDICATE,
@@ -279,8 +276,6 @@ class KafkaProxyFrontendHandlerMockCollaboratorsTest {
         // Given
         handler = new KafkaProxyFrontendHandler(
                 mock(PluginFactoryRegistry.class),
-                mock(FilterChainFactory.class),
-                List.of(),
                 endpointReconciler,
                 mock(ApiVersionsServiceImpl.class),
                 DELEGATING_PREDICATE,
@@ -311,8 +306,6 @@ class KafkaProxyFrontendHandlerMockCollaboratorsTest {
         var ccsm = new ClientConnectionStateMachine(endpointBinding, subjectBuilder, session);
         handler = new KafkaProxyFrontendHandler(
                 pfr,
-                filterChainFactory,
-                virtualCluster.getFilters(),
                 endpointReconciler,
                 new ApiVersionsServiceImpl(),
                 DELEGATING_PREDICATE,
@@ -336,8 +329,6 @@ class KafkaProxyFrontendHandlerMockCollaboratorsTest {
         var ccsm = new ClientConnectionStateMachine(endpointBinding, subjectBuilder, session);
         handler = new KafkaProxyFrontendHandler(
                 pfr,
-                filterChainFactory,
-                virtualCluster.getFilters(),
                 endpointReconciler,
                 new ApiVersionsServiceImpl(),
                 DELEGATING_PREDICATE,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -41,7 +41,6 @@ import io.netty.handler.ssl.SslContextBuilder;
 
 import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
 import io.kroxylicious.proxy.config.CacheConfiguration;
-import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.frame.DecodedFrame;
@@ -244,11 +243,14 @@ class KafkaProxyFrontendHandlerTest {
         assertStateIsClosed(clientConnectionStateMachine);
     }
 
-    private static VirtualClusterModel mockVirtualClusterModel(String cluster) {
+    private VirtualClusterModel mockVirtualClusterModel(String cluster) {
         VirtualClusterModel virtualClusterModel = mock(VirtualClusterModel.class);
         when(virtualClusterModel.getClusterName()).thenReturn(cluster);
         TopicNameCacheFilter topicNameCacheFilter = new TopicNameCacheFilter(CacheConfiguration.DEFAULT, cluster);
         when(virtualClusterModel.getTopicNameCacheFilter()).thenReturn(topicNameCacheFilter);
+        // FCF is now resolved per-connection from the VC (see #4055). Wire the test's fcf
+        // mock through the VC so verify(fcf).createFilters(...) still works.
+        when(virtualClusterModel.filterChainFactory()).thenReturn(fcf);
         return virtualClusterModel;
     }
 
@@ -338,10 +340,7 @@ class KafkaProxyFrontendHandlerTest {
     }
 
     KafkaProxyFrontendHandler handler(DelegatingDecodePredicate dp, ClientConnectionStateMachine clientConnectionStateMachine) {
-        var namedFilterDefs = List.<NamedFilterDefinition> of();
         return new KafkaProxyFrontendHandler(pfr,
-                fcf,
-                namedFilterDefs,
                 mock(EndpointReconciler.class),
                 new ApiVersionsServiceImpl(),
                 dp,
@@ -511,7 +510,7 @@ class KafkaProxyFrontendHandlerTest {
         assertTrue(inboundChannel.config().isAutoRead(),
                 "Expect inbound autoRead=true, since outbound now active");
         assertThat(clientConnectionStateMachine.state()).isExactlyInstanceOf(ClientConnectionState.Forwarding.class);
-        verify(fcf).createFilters(any(FilterFactoryContext.class), any(List.class));
+        verify(fcf).createFilters(any(FilterFactoryContext.class));
     }
 
     private List<String> outboundClientSoftwareNames() {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -421,7 +421,8 @@ class KafkaProxyInitializerTest {
                                                               VirtualClusterRegistry vcc) {
         return new KafkaProxyInitializer(pfr,
                 tls,
-                new KafkaProxyInitializer.EndpointServices(bindingResolver, (virtualCluster, upstreamNodes) -> null),
+                bindingResolver,
+                (virtualCluster, upstreamNodes) -> null,
                 proxyProtocolMode,
                 new ApiVersionsServiceImpl(),
                 Optional.ofNullable(proxyNettySettings),

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -422,8 +422,7 @@ class KafkaProxyInitializerTest {
                                                               ProxyProtocolMode proxyProtocolMode,
                                                               EndpointBindingResolver bindingResolver,
                                                               VirtualClusterRegistry vcc) {
-        return new KafkaProxyInitializer(filterChainFactory,
-                pfr,
+        return new KafkaProxyInitializer(pfr,
                 tls,
                 bindingResolver,
                 (virtualCluster, upstreamNodes) -> null,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -48,7 +48,6 @@ import io.netty.handler.ssl.SniHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.internal.StringUtil;
 
-import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
 import io.kroxylicious.proxy.config.CacheConfiguration;
 import io.kroxylicious.proxy.config.NettySettings;
 import io.kroxylicious.proxy.config.ProxyProtocolMode;
@@ -105,7 +104,6 @@ class KafkaProxyInitializerTest {
     private KafkaProxyInitializer kafkaProxyInitializer;
     private CompletionStage<EndpointBinding> bindingStage;
     private VirtualClusterModel virtualClusterModel;
-    private FilterChainFactory filterChainFactory;
     private NettySettings proxyNettySettings;
 
     @BeforeEach
@@ -113,7 +111,6 @@ class KafkaProxyInitializerTest {
         virtualClusterModel = buildVirtualCluster(false, false);
         pfr = new ServiceBasedPluginFactoryRegistry();
         bindingStage = CompletableFuture.completedStage(endpointBinding);
-        filterChainFactory = new FilterChainFactory(pfr, List.of());
         proxyNettySettings = null; // use defaults
         final InetSocketAddress localhost = new InetSocketAddress(0);
         ChannelId channelId = DefaultChannelId.newInstance();
@@ -424,8 +421,7 @@ class KafkaProxyInitializerTest {
                                                               VirtualClusterRegistry vcc) {
         return new KafkaProxyInitializer(pfr,
                 tls,
-                bindingResolver,
-                (virtualCluster, upstreamNodes) -> null,
+                new KafkaProxyInitializer.EndpointServices(bindingResolver, (virtualCluster, upstreamNodes) -> null),
                 proxyProtocolMode,
                 new ApiVersionsServiceImpl(),
                 Optional.ofNullable(proxyNettySettings),

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
@@ -25,7 +25,10 @@ import io.kroxylicious.proxy.model.VirtualClusterModel;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -792,6 +795,116 @@ class VirtualClusterRegistryTest {
                 .as("constructor-supplied model should remain queryable after removeVirtualCluster")
                 .extracting(VirtualClusterModel::getClusterName)
                 .containsExactly(CLUSTER_A);
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // closeModel hook — pins the per-VC resource cleanup contract added by the FCF-per-VC
+    // refactor. Each of the four transition-into-Stopped branches in shutdownCluster must
+    // invoke model.close(); the Stopped→Stopped no-op must not. Close failure must not stall
+    // the shutdown future or block the onVirtualClusterStopped callback.
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    void shouldCloseModelWhenServingClusterIsRemoved() {
+        var model = mockModel(CLUSTER_A);
+        var registry = new VirtualClusterRegistry(List.of(model), noOpCallback);
+        registry.initializationSucceeded(CLUSTER_A);
+
+        registry.removeVirtualCluster(CLUSTER_A).join();
+
+        verify(model).close();
+    }
+
+    @Test
+    void shouldCloseModelWhenInitializingClusterIsShutDown() {
+        // Initializing state — the cluster never reached Serving but still owns FCF/TLS resources.
+        var model = mockModel(CLUSTER_A);
+        var registry = new VirtualClusterRegistry(List.of(model), noOpCallback);
+
+        registry.shutdownAllClusters();
+
+        verify(model).close();
+    }
+
+    @Test
+    void shouldCloseModelWhenFailedClusterIsShutDown() {
+        // Drive directly to Failed via the lifecycle, bypassing the registry's auto-stop, so the
+        // shutdownAllClusters call exercises the Failed→Stopped close branch.
+        var model = mockModel(CLUSTER_A);
+        var registry = new VirtualClusterRegistry(List.of(model), noOpCallback);
+        var failureCause = new RuntimeException("init failed");
+        var lifecycle = registry.lifecycleFor(CLUSTER_A);
+        Assumptions.assumeThat(lifecycle).isNotNull();
+        lifecycle.initializationFailed(failureCause);
+
+        registry.shutdownAllClusters();
+
+        verify(model).close();
+    }
+
+    @Test
+    void shouldCloseModelWhenDrainingClusterCompletesDrain() {
+        // Close must fire only after the drain completes — not at drain start. Mocks the connection's
+        // drain future so we can hold the cluster in Draining and assert close has not yet fired.
+        var model = mockModel(CLUSTER_A);
+        var registry = new VirtualClusterRegistry(List.of(model), noOpCallback);
+        registry.initializationSucceeded(CLUSTER_A);
+
+        var pendingDrain = new CompletableFuture<Void>();
+        var ccsm = mock(ClientConnectionStateMachine.class);
+        when(ccsm.drain(any())).thenReturn(pendingDrain);
+        registry.registerConnection(CLUSTER_A, ccsm);
+
+        var shutdown = CompletableFuture.runAsync(registry::shutdownAllClusters);
+
+        Awaitility.await("drain should be initiated while cluster is Draining")
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(ccsm).drain(any()));
+
+        // While still Draining, close must not have fired yet
+        verify(model, never()).close();
+
+        // Complete the drain — close should now fire on the Draining→Stopped transition
+        pendingDrain.complete(null);
+
+        assertThat(shutdown).succeedsWithin(5, TimeUnit.SECONDS);
+        verify(model).close();
+    }
+
+    @Test
+    void shouldNotCloseAlreadyStoppedModelOnRedundantShutdown() {
+        // The Stopped→Stopped no-op branch must not invoke close again. Without this guarantee,
+        // the FCF's per-Wrapper AtomicBoolean would absorb the double-close, but the
+        // TlsCredentialSupplierManager might not, and a future close-handler addition could
+        // throw on double-invocation.
+        var model = mockModel(CLUSTER_A);
+        var registry = new VirtualClusterRegistry(List.of(model), noOpCallback);
+        registry.initializationSucceeded(CLUSTER_A);
+
+        registry.removeVirtualCluster(CLUSTER_A).join();
+        verify(model, times(1)).close();
+
+        registry.removeVirtualCluster(CLUSTER_A).join();
+
+        verify(model, times(1)).close();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldFireStoppedCallbackEvenWhenModelCloseThrows() {
+        // The swallow-and-log policy in closeModel means filter/TLS close failures cannot stall
+        // the shutdown future or block the onVirtualClusterStopped callback.
+        var model = mockModel(CLUSTER_A);
+        doThrow(new RuntimeException("KMS shutdown failed")).when(model).close();
+        BiConsumer<String, Optional<Throwable>> callback = mock(BiConsumer.class);
+        var registry = new VirtualClusterRegistry(List.of(model), callback);
+        registry.initializationSucceeded(CLUSTER_A);
+
+        var shutdown = registry.removeVirtualCluster(CLUSTER_A);
+
+        assertThat(shutdown).succeedsWithin(5, TimeUnit.SECONDS);
+        verify(model).close();
+        verify(callback).accept(CLUSTER_A, Optional.empty());
     }
 
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
@@ -185,9 +185,10 @@ class VirtualClusterModelTest {
         var filters = List.<NamedFilterDefinition> of(new NamedFilterDefinition("bad-filter", FlakyFactory.class.getName(), flakyConfig));
         var targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
         var pfr = combinedPluginFactoryRegistry();
+        var drainTimeout = Duration.ofSeconds(10);
 
         assertThatThrownBy(() -> new VirtualClusterModel("vc1", targetCluster, false, false, filters,
-                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), pfr))
+                CacheConfiguration.DEFAULT, null, drainTimeout, pfr))
                 .isExactlyInstanceOf(PluginConfigurationException.class)
                 .hasMessageContaining("Exception initializing filter factory bad-filter")
                 .cause()

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
@@ -184,9 +184,10 @@ class VirtualClusterModelTest {
         });
         var filters = List.<NamedFilterDefinition> of(new NamedFilterDefinition("bad-filter", FlakyFactory.class.getName(), flakyConfig));
         var targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
+        var pfr = combinedPluginFactoryRegistry();
 
         assertThatThrownBy(() -> new VirtualClusterModel("vc1", targetCluster, false, false, filters,
-                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), combinedPluginFactoryRegistry()))
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), pfr))
                 .isExactlyInstanceOf(PluginConfigurationException.class)
                 .hasMessageContaining("Exception initializing filter factory bad-filter")
                 .cause()

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
@@ -11,6 +11,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.net.ssl.SSLContext;
 
@@ -30,6 +31,9 @@ import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.config.tls.TlsClientAuth;
 import io.kroxylicious.proxy.config.tls.TlsCredentialSupplierConfig;
 import io.kroxylicious.proxy.config.tls.TrustStore;
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.internal.filter.FlakyConfig;
+import io.kroxylicious.proxy.internal.filter.FlakyFactory;
 import io.kroxylicious.proxy.internal.tls.TlsTestConstants;
 import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
@@ -142,6 +146,55 @@ class VirtualClusterModelTest {
     }
 
     @Test
+    void closeClosesBothFilterChainFactoryAndTlsCredentialSupplierManager() {
+        // The merged close at VCM.close() must invoke close on both the FilterChainFactory and the
+        // TlsCredentialSupplierManager. Observed via FlakyConfig.onClose for the filter leg and via
+        // TlsCredentialSupplierManager.getSupplier throwing IllegalStateException post-close for the TLS leg.
+        var onFilterClose = new AtomicInteger();
+        var flakyConfig = new FlakyConfig(null, null, null, c -> {
+        }, c -> onFilterClose.incrementAndGet());
+        var filters = List.<NamedFilterDefinition> of(new NamedFilterDefinition("flaky", FlakyFactory.class.getName(), flakyConfig));
+
+        var credentialSupplierConfig = new TlsCredentialSupplierConfig("TestSupplierFactory", new TestSupplierConfig("test"));
+        var targetCluster = new TargetCluster("bootstrap:9092", Optional.of(new Tls(null, null, null, null, credentialSupplierConfig)));
+        var model = new VirtualClusterModel("vc1", targetCluster, false, false, filters,
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), combinedPluginFactoryRegistry());
+
+        var tlsManager = model.getTlsCredentialSupplierManager();
+        assertThat(tlsManager.isConfigured()).isTrue();
+        assertThat(tlsManager.getSupplier()).isNotNull();
+        assertThat(onFilterClose.get()).isZero();
+
+        model.close();
+
+        assertThat(onFilterClose.get()).as("FilterChainFactory close should fire").isEqualTo(1);
+        assertThatThrownBy(tlsManager::getSupplier)
+                .as("TlsCredentialSupplierManager close should fire — post-close getSupplier throws")
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void constructorPropagatesFilterInitializeFailureAsPluginConfigurationException() {
+        // The contract that KafkaProxy.defaultRegistry's try-catch depends on: any filter init failure
+        // during VCM construction surfaces as PluginConfigurationException, which defaultRegistry then
+        // wraps as LifecycleException. If this exception type drifts, the wrap silently stops working
+        // and startup error reporting regresses (the AuthzFailsClosedIT path).
+        var flakyConfig = new FlakyConfig("init kaboom", null, null, c -> {
+        }, c -> {
+        });
+        var filters = List.<NamedFilterDefinition> of(new NamedFilterDefinition("bad-filter", FlakyFactory.class.getName(), flakyConfig));
+        var targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
+
+        assertThatThrownBy(() -> new VirtualClusterModel("vc1", targetCluster, false, false, filters,
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), combinedPluginFactoryRegistry()))
+                .isExactlyInstanceOf(PluginConfigurationException.class)
+                .hasMessageContaining("Exception initializing filter factory bad-filter")
+                .cause()
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessage("init kaboom");
+    }
+
+    @Test
     void shouldNotAllowUpstreamToProvideTlsServerOptions() {
         // Given
         final Optional<Tls> downstreamTls = Optional
@@ -153,6 +206,54 @@ class VirtualClusterModelTest {
                 CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10)))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("Cannot apply trust options");
+    }
+
+    /**
+     * PFR that dispatches on plugin class — FilterFactory routes to FlakyFactory; everything else
+     * (in practice, ServerTlsCredentialSupplierFactory) routes to TestSupplierFactory. Used by tests
+     * that exercise both filter and TLS legs simultaneously.
+     */
+    private static PluginFactoryRegistry combinedPluginFactoryRegistry() {
+        return new PluginFactoryRegistry() {
+            @SuppressWarnings({ "rawtypes", "unchecked" })
+            @Override
+            public <P> PluginFactory<P> pluginFactory(Class<P> pluginClass) {
+                if (pluginClass == FilterFactory.class) {
+                    return new PluginFactory() {
+                        @Override
+                        public Object pluginInstance(String instanceName) {
+                            return new FlakyFactory();
+                        }
+
+                        @Override
+                        public Class<?> configType(String instanceName) {
+                            return FlakyConfig.class;
+                        }
+
+                        @Override
+                        public Set<String> registeredInstanceNames() {
+                            return Set.of(FlakyFactory.class.getSimpleName());
+                        }
+                    };
+                }
+                return new PluginFactory() {
+                    @Override
+                    public Object pluginInstance(String instanceName) {
+                        return new TestSupplierFactory();
+                    }
+
+                    @Override
+                    public Class<?> configType(String instanceName) {
+                        return TestSupplierConfig.class;
+                    }
+
+                    @Override
+                    public Set<String> registeredInstanceNames() {
+                        return Set.of("TestSupplierFactory");
+                    }
+                };
+            }
+        };
     }
 
     private static PluginFactoryRegistry pluginFactoryRegistry() {


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Currently, the FilterChainFactory acts as a "shared" provider for multiple virtual clusters. If a common filter is used across multiple VC's, FCF would help by creating a single instance in order to optimize for memory.
This complexity causes a problem during Hot reload as when a configuration change affects only one VC's filters, we still need to update the FCF. The naive approach — build a new FCF and atomically swap the reference — is safe at the swap step (old connections keep their already-built filter chains). The harm comes at the close step: the old FCF's initResult objects are still in use by live filters on unchanged VCs. Closing the old factory tears down those initResults — silent breakage with no exception at the proxy level.

The proxy is slowly moving towards the state where VirtualClusters are individual block of units, and we would like to control the blast radius at a VC level.

As per the discussions, it is decided to let go of this memory optimization in favor of simplicity, and move the FCF lifecycle inside the virtual cluster model.
Virtual cluster model now owns its own FCF (rather than being shared proxy-wide).


### Additional Context

https://github.com/kroxylicious/kroxylicious/issues/4055

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
