### PR TITLE
fix: downgrade JOSDK to 5.2.4

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-admission-api/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-admission-api/pom.xml
@@ -27,7 +27,8 @@
     </description>
 
     <properties>
-        <josdk.version>5.3.4</josdk.version>
+        <!-- do not upgrade JOSDK until https://github.com/operator-framework/java-operator-sdk/issues/3398 is resolved-->
+        <josdk.version>5.2.4</josdk.version>
         <log4j.version>2.20.0</log4j.version>
         <fabric8-client.version>7.4.0</fabric8-client.version>
         <lombok.version>1.18.44</lombok.version>

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-api/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-api/pom.xml
@@ -27,7 +27,8 @@
     </description>
 
     <properties>
-        <josdk.version>5.3.4</josdk.version>
+        <!-- do not upgrade JOSDK until https://github.com/operator-framework/java-operator-sdk/issues/3398 is resolved-->
+        <josdk.version>5.2.4</josdk.version>
         <log4j.version>2.20.0</log4j.version>
         <fabric8-client.version>7.4.0</fabric8-client.version>
         <lombok.version>1.18.44</lombok.version>

--- a/kroxylicious-kubernetes/kroxylicious-operator/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/pom.xml
@@ -21,7 +21,8 @@
     <description>An operator for running the Kroxylicious Proxy on Kubernetes</description>
 
     <properties>
-        <josdk.version>5.3.4</josdk.version>
+        <!-- do not upgrade JOSDK until https://github.com/operator-framework/java-operator-sdk/issues/3398 is resolved-->
+        <josdk.version>5.2.4</josdk.version>
         <prometheus-metrics.version>1.6.1</prometheus-metrics.version>
         <io.kroxylicious.operator.image.name>quay.io/kroxylicious/operator:${project.version}</io.kroxylicious.operator.image.name>
         <io.kroxylicious.operator.image.archive>target/kroxylicious-operator.img.tar.gz</io.kroxylicious.operator.image.archive>


### PR DESCRIPTION
### Type of change

- Bugfix (workaround)

### Description

Why: we have been suffering from intermittent system tests failures where a KafkaProxyIngress is updated, but this never results in a new generation of the KafkaProxy deployment being applied.

Looking upstream there is a JOSDK issue dealing with missing reconciliation events when the operator updates the resource while third parties are concurrently updating that same resource, which is what I observed with DEBUG logging on, that no reconciliation was triggered for some generations when there was a concurrent status update being applied by the Operator, while test code was also updating the resource spec.

This is not just a test issue, it could manifest in production, so we should downgrade in the meanwhile.

https://github.com/operator-framework/java-operator-sdk/issues/3398

Closes #4040

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
