### PR TITLE
fix(operator): force reschedule to guard against missed generation updates

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconciler.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.kubernetes.operator.reconciler.kafkaprotocolfilter;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -60,6 +61,8 @@ public class KafkaProtocolFilterReconciler implements
         Reconciler<KafkaProtocolFilter> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProtocolFilterReconciler.class);
+    // Workaround for https://github.com/operator-framework/java-operator-sdk/issues/3398
+    static final Duration FORCE_RECONCILE_INTERVAL = Duration.ofSeconds(1);
     private static final String SECRETS = "secrets";
     private static final String CONFIG_MAPS = "configmaps";
     private final KafkaProtocolFilterStatusFactory statusFactory;
@@ -253,7 +256,13 @@ public class KafkaProtocolFilterReconciler implements
                     .addKeyValue(OperatorLoggingKeys.NAME, name(filter))
                     .log("Completed reconciliation");
         }
-        return UpdateControl.patchResourceAndStatus(patch);
+        // Workaround for https://github.com/operator-framework/java-operator-sdk/issues/3398
+        // JOSDK can miss generation updates that arrive during our SSA patch.
+        var updateControl = UpdateControl.<KafkaProtocolFilter> patchResourceAndStatus(patch);
+        if (!ResourcesUtil.isStatusFresh(filter)) {
+            updateControl.rescheduleAfter(FORCE_RECONCILE_INTERVAL);
+        }
+        return updateControl;
     }
 
     @Override

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconciler.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.kubernetes.operator.reconciler.kafkaproxyingress;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -54,6 +55,8 @@ public class KafkaProxyIngressReconciler implements
         Reconciler<KafkaProxyIngress> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyIngressReconciler.class);
+    // Workaround for https://github.com/operator-framework/java-operator-sdk/issues/3398
+    static final Duration FORCE_RECONCILE_INTERVAL = Duration.ofSeconds(1);
     public static final String PROXY_EVENT_SOURCE_NAME = "proxy";
     private final KafkaProxyIngressStatusFactory statusFactory;
 
@@ -106,6 +109,11 @@ public class KafkaProxyIngressReconciler implements
         }
         else {
             updateControl = UpdateControl.patchStatus(update);
+        }
+        // Workaround for https://github.com/operator-framework/java-operator-sdk/issues/3398
+        // JOSDK can miss generation updates that arrive during our SSA patch.
+        if (!ResourcesUtil.isStatusFresh(ingress)) {
+            updateControl.rescheduleAfter(FORCE_RECONCILE_INTERVAL);
         }
 
         if (LOGGER.isInfoEnabled()) {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceReconciler.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.kubernetes.operator.reconciler.kafkaservice;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -65,6 +66,8 @@ public final class KafkaServiceReconciler implements
         io.javaoperatorsdk.operator.api.reconciler.Reconciler<KafkaService> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaServiceReconciler.class);
+    // Workaround for https://github.com/operator-framework/java-operator-sdk/issues/3398
+    static final Duration FORCE_RECONCILE_INTERVAL = Duration.ofSeconds(1);
 
     public static final String SECRETS_EVENT_SOURCE_NAME = "secrets";
     public static final String CONFIG_MAPS_TRUST_ANCHOR_REF_EVENT_SOURCE_NAME = "configmapsTrustAnchorRef";
@@ -398,7 +401,13 @@ public final class KafkaServiceReconciler implements
                     .addKeyValue(OperatorLoggingKeys.NAME, name(service))
                     .log("Completed reconciliation");
         }
-        return UpdateControl.patchResourceAndStatus(updated);
+        // Workaround for https://github.com/operator-framework/java-operator-sdk/issues/3398
+        // JOSDK can miss generation updates that arrive during our SSA patch.
+        var updateControl = UpdateControl.<KafkaService> patchResourceAndStatus(updated);
+        if (!ResourcesUtil.isStatusFresh(service)) {
+            updateControl.rescheduleAfter(FORCE_RECONCILE_INTERVAL);
+        }
+        return updateControl;
     }
 
     @Override

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconciler.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.kubernetes.operator.reconciler.virtualkafkacluster;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -91,6 +92,8 @@ public final class VirtualKafkaClusterReconciler implements
         Reconciler<VirtualKafkaCluster> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(VirtualKafkaClusterReconciler.class);
+    // Workaround for https://github.com/operator-framework/java-operator-sdk/issues/3398
+    static final Duration FORCE_RECONCILE_INTERVAL = Duration.ofSeconds(1);
     static final String PROXY_EVENT_SOURCE_NAME = "proxy";
     static final String PROXY_CONFIG_STATE_SOURCE_NAME = "proxy-config-state";
     static final String SERVICES_EVENT_SOURCE_NAME = "services";
@@ -150,6 +153,11 @@ public final class VirtualKafkaClusterReconciler implements
                     .addKeyValue(OperatorLoggingKeys.NAMESPACE, namespace(cluster))
                     .addKeyValue(OperatorLoggingKeys.NAME, name(cluster))
                     .log("Completed reconciliation");
+        }
+        // Workaround for https://github.com/operator-framework/java-operator-sdk/issues/3398
+        // JOSDK can miss generation updates that arrive during our SSA patch.
+        if (!ResourcesUtil.isStatusFresh(cluster)) {
+            reconciliationResult.rescheduleAfter(FORCE_RECONCILE_INTERVAL);
         }
         return reconciliationResult;
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerTest.java
@@ -274,6 +274,41 @@ class KafkaProtocolFilterReconcilerTest {
     }
 
     @Test
+    void shouldRescheduleWhenObservedGenerationBehind() {
+        // given
+        Context<KafkaProtocolFilter> context = mockContext();
+        when(context.getSecondaryResourcesAsStream(Secret.class)).thenReturn(Stream.of(SECRET));
+        when(context.getSecondaryResourcesAsStream(ConfigMap.class)).thenReturn(Stream.of(CONFIG_MAP));
+        var reconciler = new KafkaProtocolFilterReconciler(TEST_CLOCK, SecureConfigInterpolator.DEFAULT_INTERPOLATOR, mock(SharedInformerManager.class));
+
+        // when (FILTER has no status, so observedGeneration is null — behind metadata.generation)
+        var update = reconciler.reconcile(FILTER, context);
+
+        // then
+        assertThat(update.getScheduleDelay()).hasValue(KafkaProtocolFilterReconciler.FORCE_RECONCILE_INTERVAL.toMillis());
+    }
+
+    @Test
+    void shouldNotRescheduleWhenObservedGenerationCurrent() {
+        // given
+        Context<KafkaProtocolFilter> context = mockContext();
+        when(context.getSecondaryResourcesAsStream(Secret.class)).thenReturn(Stream.of(SECRET));
+        when(context.getSecondaryResourcesAsStream(ConfigMap.class)).thenReturn(Stream.of(CONFIG_MAP));
+        var reconciler = new KafkaProtocolFilterReconciler(TEST_CLOCK, SecureConfigInterpolator.DEFAULT_INTERPOLATOR, mock(SharedInformerManager.class));
+        var freshFilter = FILTER.edit()
+                .editOrNewStatus()
+                .withObservedGeneration(FILTER.getMetadata().getGeneration())
+                .endStatus()
+                .build();
+
+        // when
+        var update = reconciler.reconcile(freshFilter, context);
+
+        // then
+        assertThat(update.getScheduleDelay()).isEmpty();
+    }
+
+    @Test
     void shouldSetResolvedRefsToUnknown() {
         // given
         var reconciler = new KafkaProtocolFilterReconciler(TEST_CLOCK, SecureConfigInterpolator.DEFAULT_INTERPOLATOR, mock(SharedInformerManager.class));

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconcilerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconcilerTest.java
@@ -208,6 +208,37 @@ class KafkaProxyIngressReconcilerTest {
     }
 
     @Test
+    void shouldRescheduleWhenObservedGenerationBehind() throws Exception {
+        // given
+        var reconciler = new KafkaProxyIngressReconciler(TEST_CLOCK);
+        when(context.getSecondaryResource(KafkaProxy.class, KafkaProxyIngressReconciler.PROXY_EVENT_SOURCE_NAME)).thenReturn(Optional.of(PROXY));
+
+        // when (INGRESS has no status, so observedGeneration is null — behind metadata.generation)
+        var update = reconciler.reconcile(INGRESS, context);
+
+        // then
+        assertThat(update.getScheduleDelay()).hasValue(KafkaProxyIngressReconciler.FORCE_RECONCILE_INTERVAL.toMillis());
+    }
+
+    @Test
+    void shouldNotRescheduleWhenObservedGenerationCurrent() throws Exception {
+        // given
+        var reconciler = new KafkaProxyIngressReconciler(TEST_CLOCK);
+        when(context.getSecondaryResource(KafkaProxy.class, KafkaProxyIngressReconciler.PROXY_EVENT_SOURCE_NAME)).thenReturn(Optional.of(PROXY));
+        var freshIngress = INGRESS.edit()
+                .editOrNewStatus()
+                .withObservedGeneration(INGRESS.getMetadata().getGeneration())
+                .endStatus()
+                .build();
+
+        // when
+        var update = reconciler.reconcile(freshIngress, context);
+
+        // then
+        assertThat(update.getScheduleDelay()).isEmpty();
+    }
+
+    @Test
     void shouldNotPatchResourceWhenResolvedRefsFalse() throws Exception {
         // given
         var reconciler = new KafkaProxyIngressReconciler(TEST_CLOCK);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceReconcilerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceReconcilerTest.java
@@ -635,6 +635,37 @@ class KafkaServiceReconcilerTest {
     }
 
     @Test
+    void shouldRescheduleWhenObservedGenerationBehind() {
+        // given
+        Context<KafkaService> context = mockContext();
+        var service = new KafkaServiceBuilder(SERVICE).editSpec().withStrimziKafkaRef(null).withTls(null).endSpec().build();
+
+        // when (SERVICE has no status, so observedGeneration is null — behind metadata.generation)
+        var update = kafkaServiceReconciler.reconcile(service, context);
+
+        // then
+        assertThat(update.getScheduleDelay()).hasValue(KafkaServiceReconciler.FORCE_RECONCILE_INTERVAL.toMillis());
+    }
+
+    @Test
+    void shouldNotRescheduleWhenObservedGenerationCurrent() {
+        // given
+        Context<KafkaService> context = mockContext();
+        var freshService = new KafkaServiceBuilder(SERVICE)
+                .editSpec().withStrimziKafkaRef(null).withTls(null).endSpec()
+                .editOrNewStatus()
+                .withObservedGeneration(SERVICE.getMetadata().getGeneration())
+                .endStatus()
+                .build();
+
+        // when
+        var update = kafkaServiceReconciler.reconcile(freshService, context);
+
+        // then
+        assertThat(update.getScheduleDelay()).isEmpty();
+    }
+
+    @Test
     void shouldSetReferentAnnotationWhenCertificateRefSecretPresent() {
         Context<KafkaService> context = mockContext();
         mockGetSecret(context, Optional.of(TLS_SECRET));

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerTest.java
@@ -750,6 +750,35 @@ class VirtualKafkaClusterReconcilerTest {
     }
 
     @Test
+    void shouldRescheduleWhenObservedGenerationBehind() {
+        // given
+        Context<VirtualKafkaCluster> context = mockReconcilerContext(PROXY, CLUSTERIP_INGRESS, SERVICE, null, Set.of());
+
+        // when (CLUSTER_NO_FILTERS has no status, so observedGeneration is null — behind metadata.generation)
+        var update = virtualKafkaClusterReconciler.reconcile(CLUSTER_NO_FILTERS, context);
+
+        // then
+        assertThat(update.getScheduleDelay()).hasValue(VirtualKafkaClusterReconciler.FORCE_RECONCILE_INTERVAL.toMillis());
+    }
+
+    @Test
+    void shouldNotRescheduleWhenObservedGenerationCurrent() {
+        // given
+        Context<VirtualKafkaCluster> context = mockReconcilerContext(PROXY, CLUSTERIP_INGRESS, SERVICE, null, Set.of());
+        var freshCluster = new VirtualKafkaClusterBuilder(CLUSTER_NO_FILTERS)
+                .editOrNewStatus()
+                .withObservedGeneration(CLUSTER_NO_FILTERS.getMetadata().getGeneration())
+                .endStatus()
+                .build();
+
+        // when
+        var update = virtualKafkaClusterReconciler.reconcile(freshCluster, context);
+
+        // then
+        assertThat(update.getScheduleDelay()).isEmpty();
+    }
+
+    @Test
     void shouldSetResolvedRefsToUnknown() {
         // given
         var reconciler = new VirtualKafkaClusterReconciler(TEST_CLOCK, DependencyResolver.create(), mock(SharedInformerManager.class));

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/OperatorChangeDetectionST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/OperatorChangeDetectionST.java
@@ -18,8 +18,8 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,7 +103,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         kroxylicious.createOrUpdateResources();
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldUpdateDeploymentWhenKafkaProxyIngressChanges(String namespace) {
         // Given
         deployPortIdentifiesNodeWithNoFilters(namespace, kafkaClusterName);
@@ -121,7 +121,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUpdated(namespace, originalChecksum);
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldUpdateDeploymentWhenVirtualKafkaClusterChanges(String namespace) {
         // Given
         // @formatter:off
@@ -156,7 +156,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUpdated(namespace, originalChecksum);
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldUpdateDeploymentWhenDownstreamTlsCertUpdated(String namespace) {
         // Given
         var issuer = certManager.issuer(namespace);
@@ -182,7 +182,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUpdated(namespace, originalChecksum);
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldUpdateDeploymentWhenDownstreamTrustUpdated(String namespace) {
         // Given
         var issuer = certManager.issuer(namespace);
@@ -206,7 +206,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUpdated(namespace, originalChecksum);
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldUpdateWhenFilterConfigurationChanges(String namespace) {
         // Given
         // @formatter:off
@@ -233,7 +233,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUpdated(namespace, originalChecksum);
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldUpdateDeploymentWhenResourceRequirementsChange(String namespace) {
         // Given
         KubeClient kubeClient = kubeClient(namespace);
@@ -281,7 +281,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         });
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldNotUpdateDeploymentChecksumWhenKafkaProxyScaled(String namespace) {
         // Given
         KubeClient kubeClient = kubeClient(namespace);
@@ -302,7 +302,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUnchanged(namespace, originalChecksum, 2);
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldPreserveExternalSsaPatchOnProxyDeploymentAfterReconcile(String namespace) {
         // Given
         KubeClient kubeClient = kubeClient(namespace);
@@ -321,7 +321,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertEnvVarsStillPresent(namespace, kubeClient);
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldUpdateDeploymentWhenSecretChanges(String namespace) {
         // Given
         resourceManager.createOrUpdateResourceFromBuilderWithWait(


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

JOSDK's TemporaryResourceCache can drop informer events for generation changes that arrive during an SSA patch. When a resource's spec is modified by a third party while the reconciler is patching, the SSA patch result inherits a higher resourceVersion than the spec change event. The TemporaryResourceCache treats the spec change as obsolete and never delivers it to the EventProcessor, permanently missing that generation.

This adds an immediate reschedule (Duration.ZERO) whenever the resource's status.observedGeneration doesn't match metadata.generation at reconciliation time. The reschedule is self-terminating: once observedGeneration catches up, no further reschedules are queued.

Applied to all four reconcilers: KafkaProxyIngress, VirtualKafkaCluster, KafkaService, and KafkaProtocolFilter.

Workaround for https://github.com/operator-framework/java-operator-sdk/issues/3398

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>


### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
