### PR TITLE
Draft: Repeat tests to provoke CI failures

### DIFF
--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/OperatorChangeDetectionST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/OperatorChangeDetectionST.java
@@ -18,8 +18,8 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,7 +103,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         kroxylicious.createOrUpdateResources();
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldUpdateDeploymentWhenKafkaProxyIngressChanges(String namespace) {
         // Given
         deployPortIdentifiesNodeWithNoFilters(namespace, kafkaClusterName);
@@ -121,7 +121,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUpdated(namespace, originalChecksum);
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldUpdateDeploymentWhenVirtualKafkaClusterChanges(String namespace) {
         // Given
         // @formatter:off
@@ -156,7 +156,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUpdated(namespace, originalChecksum);
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldUpdateDeploymentWhenDownstreamTlsCertUpdated(String namespace) {
         // Given
         var issuer = certManager.issuer(namespace);
@@ -182,7 +182,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUpdated(namespace, originalChecksum);
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldUpdateDeploymentWhenDownstreamTrustUpdated(String namespace) {
         // Given
         var issuer = certManager.issuer(namespace);
@@ -206,7 +206,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUpdated(namespace, originalChecksum);
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldUpdateWhenFilterConfigurationChanges(String namespace) {
         // Given
         // @formatter:off
@@ -233,7 +233,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUpdated(namespace, originalChecksum);
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldUpdateDeploymentWhenResourceRequirementsChange(String namespace) {
         // Given
         KubeClient kubeClient = kubeClient(namespace);
@@ -281,7 +281,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         });
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldNotUpdateDeploymentChecksumWhenKafkaProxyScaled(String namespace) {
         // Given
         KubeClient kubeClient = kubeClient(namespace);
@@ -302,7 +302,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUnchanged(namespace, originalChecksum, 2);
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldPreserveExternalSsaPatchOnProxyDeploymentAfterReconcile(String namespace) {
         // Given
         KubeClient kubeClient = kubeClient(namespace);
@@ -321,7 +321,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertEnvVarsStillPresent(namespace, kubeClient);
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldUpdateDeploymentWhenSecretChanges(String namespace) {
         // Given
         resourceManager.createOrUpdateResourceFromBuilderWithWait(


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Getting a baseline with the Operator change system tests set to repeat 20 times each to gauge if our fix branch has improved the situation.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
