### PR TITLE
Downgrade JOSDK from 5.3.4 to 5.2.3

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-admission-api/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-admission-api/pom.xml
@@ -27,7 +27,7 @@
     </description>
 
     <properties>
-        <josdk.version>5.3.4</josdk.version>
+        <josdk.version>5.2.3</josdk.version>
         <log4j.version>2.20.0</log4j.version>
         <fabric8-client.version>7.4.0</fabric8-client.version>
         <lombok.version>1.18.44</lombok.version>

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-api/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-api/pom.xml
@@ -27,7 +27,7 @@
     </description>
 
     <properties>
-        <josdk.version>5.3.4</josdk.version>
+        <josdk.version>5.2.3</josdk.version>
         <log4j.version>2.20.0</log4j.version>
         <fabric8-client.version>7.4.0</fabric8-client.version>
         <lombok.version>1.18.44</lombok.version>

--- a/kroxylicious-kubernetes/kroxylicious-operator/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/pom.xml
@@ -21,7 +21,7 @@
     <description>An operator for running the Kroxylicious Proxy on Kubernetes</description>
 
     <properties>
-        <josdk.version>5.3.4</josdk.version>
+        <josdk.version>5.2.3</josdk.version>
         <prometheus-metrics.version>1.6.1</prometheus-metrics.version>
         <io.kroxylicious.operator.image.name>quay.io/kroxylicious/operator:${project.version}</io.kroxylicious.operator.image.name>
         <io.kroxylicious.operator.image.archive>target/kroxylicious-operator.img.tar.gz</io.kroxylicious.operator.image.archive>
@@ -269,7 +269,7 @@
         </dependency>
         <dependency>
             <groupId>io.javaoperatorsdk</groupId>
-            <artifactId>operator-framework-junit</artifactId>
+            <artifactId>operator-framework-junit-5</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

JOSDK 5.3.x has an open issue 
https://github.com/operator-framework/java-operator-sdk/issues/3398 where concurrent updates to resources while they are having SSA updates applied by the operator can lead to generations of the resource not being reconciled. Which is causing test instability #4040, though this is a real issue that could affect users if we released it.

We also want the bugfix in 5.2.4 but I'm not sure the artifacts are in [a good state](https://github.com/operator-framework/java-operator-sdk/issues/3402), I suspect they're released off main and contain the same bug, waiting for upstream feedback.

So if we merge this we should create a blocker Issue to upgrade to the next JOSDK version, we want the fix for https://github.com/operator-framework/java-operator-sdk/issues/2978 as we have also observed the same behaviour.

Closes #4040

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
