### PR TITLE
docs(rules): add Given/When/Then test structure convention to Claude rules

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "**/*Test.java"
+  - "**/*IT.java"
+---
+
+# Test Structure Conventions
+
+## Given / When / Then
+
+Structure test bodies using three labelled sections:
+
+- **Given** — the state required for the action to be meaningful. This is setup: initialising
+  the system, producing precondition traffic, seeding counters. It exists only to make the
+  `When` testable.
+- **When** — the single action whose side effects the test is trying to observe. There should be
+  exactly one. The same `When` action may appear across multiple tests — each test applies it
+  to a different `Given` state, or asserts a different property of the outcome.
+- **Then** — assertions that tell you what the action changed. A test has one reason to fail:
+  the `When` did not produce the expected outcome. That single reason may require multiple
+  assertions to fully characterise — asserting several properties of the post-`When` state is
+  fine, as long as they all fail for the same underlying reason.
+
+The value of this separation is that it makes the system under test legible from the test
+body alone, combined with the test name. A reader should be able to identify the `When`
+and immediately know what is being tested without reading the class Javadoc or surrounding
+context.
+
+Numbered phase comments (`// Phase 1`, `// Phase 2`) tell you sequence but hide intent:
+"Phase 3: reconfigure swaps the filter chain" and "When: proxy reconfigured with new filter
+chain" carry the same information, but only the second tells you that reconfigure is the action
+being tested, not more setup.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ When writing code, follow these prescriptive rules:
 - [Logging](.claude/rules/logging.md) - Logging conventions
 - [Documentation](.claude/rules/documentation-requirements.md) - When to write docs
 - [Pull Requests](.claude/rules/pull-requests.md) - PR checklist requirements
+- [Testing](.claude/rules/testing.md) - Test structure conventions
 
 ## Commit Conventions
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Adds `.claude/rules/testing.md` with a Given/When/Then test structure convention for Claude Code to follow when writing Java tests.

The rule captures the key distinction between the three sections:
- **Given** — precondition state; exists only to make the When meaningful
- **When** — the single action under test; the same When may appear across multiple tests applied to different Given states
- **Then** — assertions on the observable consequences; a test has one reason to fail, which may require multiple assertions to fully characterise

Also registers the rule in `CLAUDE.md` so Claude Code loads it when working in test files.

### Additional Context

Surfaced during review of #4088, where a reviewer noted that numbered phase comments (`// Phase 1`, `// Phase 2`) hide which step is the action under test versus setup. Given/When/Then makes that explicit from the test body alone (combined with the test name).

### Checklist

- [x] New tests written (where applicable). — N/A, docs-only change
- [x] Existing unit/integration/system tests passing. — no code changed
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer — included