### PR TITLE
fix(runtime): lazy VCM construction in OperationsPlanner

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/FilterChangeHotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/FilterChangeHotReloadIT.java
@@ -79,8 +79,8 @@ class FilterChangeHotReloadIT extends BaseIT {
 
     @AfterEach
     void afterEach() {
-        // Per-test isolation
-        InvocationCountingFilterFactory.resetCounts();
+        // Strict per-test hygiene: every initialise call must have a matching close.
+        InvocationCountingFilterFactory.assertAllClosedAndResetCounts();
     }
 
     @Test
@@ -160,13 +160,9 @@ class FilterChangeHotReloadIT extends BaseIT {
                 .addToVirtualClusters(startingConfig.virtualClusters().toArray(new VirtualCluster[0]));
         try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(testerBuilder).createDefaultKroxyliciousTester()) {
 
-            // Given: both VCs initialised at startup and serving traffic on their respective chains.
-            // Init counts use a lower-bound assertion because the planner over-initialises during
-            // reconfigure planning (see afterEach).
-            assertThat(InvocationCountingFilterFactory.initializationCountFor(vcAFilter1Id))
-                    .as("VC-A's old filter was initialised at startup").isGreaterThanOrEqualTo(1);
-            assertThat(InvocationCountingFilterFactory.initializationCountFor(vcBFilterId))
-                    .as("VC-B's filter was initialised at startup").isGreaterThanOrEqualTo(1);
+            // Given: both VCs initialised exactly once at startup and serving traffic on their chains.
+            InvocationCountingFilterFactory.assertInitializationCount(vcAFilter1Id, 1);
+            InvocationCountingFilterFactory.assertInitializationCount(vcBFilterId, 1);
             String topicA = tester.createTopic("vc-a");
             String topicB = tester.createTopic("vc-b");
             assertProduceConsumeRoundTrip(tester, "vc-a", topicA, "before-reconfigure-vc-a");
@@ -178,13 +174,16 @@ class FilterChangeHotReloadIT extends BaseIT {
                     .succeedsWithin(RECONFIGURE_TIMEOUT)
                     .satisfies(rr -> assertThat(rr.hasErrors()).isFalse());
 
-            // Then: VC-A's old filter is closed; VC-B's filter is untouched. (Asserted via close
-            // counts because init counts are inflated by planner pre-construction.)
+            // Then: VC-A's old filter is closed and its new filter is initialised exactly once.
             assertThat(InvocationCountingFilterFactory.closeCountFor(vcAFilter1Id))
                     .as("VC-A's old filter should have been closed exactly once during ReplaceCluster")
                     .isEqualTo(1);
+            InvocationCountingFilterFactory.assertInitializationCount(vcAFilter2Id, 1);
+
+            // Then: VC-B's filter is structurally untouched — same init count as at startup, no close.
+            InvocationCountingFilterFactory.assertInitializationCount(vcBFilterId, 1);
             assertThat(InvocationCountingFilterFactory.closeCountFor(vcBFilterId))
-                    .as("VC-B's filter must NOT have been closed by VC-A's reconfigure (per-VC isolation)")
+                    .as("VC-B's filter must NOT have been closed by VC-A's reconfigure")
                     .isZero();
 
             // Then: both VCs still serve traffic — VC-A on its new chain, VC-B unchanged.
@@ -194,14 +193,13 @@ class FilterChangeHotReloadIT extends BaseIT {
     }
 
     @Test
-    void shouldFailReconfigureExceptionallyWhenNewFilterChainHasInvalidConfig(@BrokerCluster KafkaCluster cluster) throws Exception {
-        // The orchestrator's OperationsPlanner pre-constructs VCMs for the entire new config
-        // as part of planning (so it can resolve cluster names to fully-built models for the
-        // Add/Replace operations). Filter init failures surface during this construction,
-        // BEFORE any operation's apply runs — so the reconfigure future fails exceptionally
-        // and no live cluster is mutated. The contract is therefore *more transactional* than
-        // the naive "non-transactional replace" reading would suggest: a doomed new config
-        // is rejected at the planning phase, leaving the live proxy state intact.
+    void shouldSurfaceFilterInitFailureAsReconfigureErrorAndLeaveVcStopped(@BrokerCluster KafkaCluster cluster) throws Exception {
+        // Per-cluster failure semantics under lazy VCM construction. A filter that throws
+        // on initialize causes the AddCluster half of ReplaceCluster to fail AFTER the
+        // RemoveCluster half has already torn down the old chain. The reconfigure future
+        // completes successfully — the failure surfaces in ReconfigureResult.errors() — but the
+        // affected VC ends up Stopped, and its old filter HAS been closed. Other clusters in the
+        // same reconfigure are unaffected.
         UUID goodFilterId = UUID.randomUUID();
 
         var goodFilterDef = invocationCounterDef("good-counter", goodFilterId);
@@ -225,21 +223,24 @@ class FilterChangeHotReloadIT extends BaseIT {
             assertProduceConsumeRoundTrip(tester, "vc-fail", topic, "before-reconfigure");
 
             // When: proxy reconfigured with a filter that fails on initialize.
-            LOGGER.info("Reconfiguring vc-fail with invalid filter chain (expected to fail at plan phase)");
+            LOGGER.info("Reconfiguring vc-fail with invalid filter chain");
             assertThat(tester.reconfigure(afterConfig))
-                    .as("reconfigure with a filter that throws on initialize should fail exceptionally")
-                    .failsWithin(RECONFIGURE_TIMEOUT)
-                    .withThrowableThat()
-                    .havingCause()
-                    .withMessageContaining("FailingInitFilterFactory");
+                    .as("reconfigure future completes successfully but carries an error for the failing cluster")
+                    .succeedsWithin(RECONFIGURE_TIMEOUT)
+                    .satisfies(rr -> {
+                        assertThat(rr.hasErrors())
+                                .as("ReconfigureResult should report the per-cluster failure")
+                                .isTrue();
+                        assertThat(rr.errors())
+                                .as("error should mention the failing cluster")
+                                .anySatisfy(e -> assertThat(e.toString()).contains("vc-fail"));
+                    });
 
-            // Then: the old filter is NOT closed — no operation ran, the live VC is unaffected.
+            // Then: the old filter HAS been closed — the RemoveCluster half of ReplaceCluster ran
+            // successfully before the AddCluster half tried (and failed) to build the new VCM.
             assertThat(InvocationCountingFilterFactory.closeCountFor(goodFilterId))
-                    .as("old filter must NOT be closed when the reconfigure fails at planning")
-                    .isZero();
-
-            // Then: traffic still flows on the original chain (proxy state was not mutated).
-            assertProduceConsumeRoundTrip(tester, "vc-fail", topic, "after-failed-reconfigure");
+                    .as("old filter is closed because RemoveCluster ran before the new chain's filter init failed")
+                    .isEqualTo(1);
         }
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/FilterChangeHotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/FilterChangeHotReloadIT.java
@@ -106,9 +106,7 @@ class FilterChangeHotReloadIT extends BaseIT {
                 .addToVirtualClusters(startingConfig.virtualClusters().toArray(new VirtualCluster[0]));
         try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(testerBuilder).createDefaultKroxyliciousTester()) {
 
-            // Given: only the old filter has been initialised, and real traffic flows on the old chain.
-            InvocationCountingFilterFactory.assertInitializationCount(oldFilterId, 1);
-            assertThat(InvocationCountingFilterFactory.closeCountFor(oldFilterId)).isZero();
+            // Given: VC referencing the old-counter filter, serving traffic.
             String topic = tester.createTopic("vc-filter-change");
             assertProduceConsumeRoundTrip(tester, "vc-filter-change", topic, "before-reconfigure");
 
@@ -160,13 +158,15 @@ class FilterChangeHotReloadIT extends BaseIT {
                 .addToVirtualClusters(startingConfig.virtualClusters().toArray(new VirtualCluster[0]));
         try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(testerBuilder).createDefaultKroxyliciousTester()) {
 
-            // Given: both VCs initialised exactly once at startup and serving traffic on their chains.
-            InvocationCountingFilterFactory.assertInitializationCount(vcAFilter1Id, 1);
-            InvocationCountingFilterFactory.assertInitializationCount(vcBFilterId, 1);
+            // Given: both VCs serving traffic on their respective chains. Capture VC-B's
+            // pre-reconfigure init/close counts so the Then can assert "unchanged" via delta —
+            // self-contained and independent of startup behaviour.
             String topicA = tester.createTopic("vc-a");
             String topicB = tester.createTopic("vc-b");
             assertProduceConsumeRoundTrip(tester, "vc-a", topicA, "before-reconfigure-vc-a");
             assertProduceConsumeRoundTrip(tester, "vc-b", topicB, "before-reconfigure-vc-b");
+            int vcBInitBefore = InvocationCountingFilterFactory.initializationCountFor(vcBFilterId);
+            int vcBCloseBefore = InvocationCountingFilterFactory.closeCountFor(vcBFilterId);
 
             // When: proxy reconfigured to change only VC-A's filter chain; VC-B's config is identical.
             LOGGER.info("Reconfiguring to change vc-a's filter chain only");
@@ -180,11 +180,15 @@ class FilterChangeHotReloadIT extends BaseIT {
                     .isEqualTo(1);
             InvocationCountingFilterFactory.assertInitializationCount(vcAFilter2Id, 1);
 
-            // Then: VC-B's filter is structurally untouched — same init count as at startup, no close.
-            InvocationCountingFilterFactory.assertInitializationCount(vcBFilterId, 1);
+            // Then: VC-B's filter counts match the pre-reconfigure snapshot — the load-bearing
+            // per-VC isolation assertion. The planner does not construct a VCM for VC-B during
+            // VC-A's reconfigure, so neither count moves.
+            assertThat(InvocationCountingFilterFactory.initializationCountFor(vcBFilterId))
+                    .as("VC-B's filter init count must not change during VC-A's reconfigure")
+                    .isEqualTo(vcBInitBefore);
             assertThat(InvocationCountingFilterFactory.closeCountFor(vcBFilterId))
-                    .as("VC-B's filter must NOT have been closed by VC-A's reconfigure")
-                    .isZero();
+                    .as("VC-B's filter close count must not change during VC-A's reconfigure")
+                    .isEqualTo(vcBCloseBefore);
 
             // Then: both VCs still serve traffic — VC-A on its new chain, VC-B unchanged.
             assertProduceConsumeRoundTrip(tester, "vc-a", topicA, "after-reconfigure-vc-a");
@@ -267,8 +271,9 @@ class FilterChangeHotReloadIT extends BaseIT {
                 .addToVirtualClusters(startingConfig.virtualClusters().toArray(new VirtualCluster[0]));
         try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(testerBuilder).createDefaultKroxyliciousTester()) {
 
-            // Given: only F1 initialised at startup.
-            InvocationCountingFilterFactory.assertInitializationCount(filter1Id, 1);
+            // Given: capture F1's pre-reconfigure init count so we can assert the reconfigure's
+            // delta rather than an absolute value that bakes in the startup contract.
+            int f1InitBefore = InvocationCountingFilterFactory.initializationCountFor(filter1Id);
 
             // When: proxy reconfigured to add F2 — chain [f1] -> [f1, f2].
             LOGGER.info("Reconfiguring vc-add-filter: [f1] -> [f1, f2]");
@@ -276,17 +281,17 @@ class FilterChangeHotReloadIT extends BaseIT {
                     .succeedsWithin(RECONFIGURE_TIMEOUT)
                     .satisfies(rr -> assertThat(rr.hasErrors()).isFalse());
 
-            // Then: F1 closed and re-initialised, F2 newly initialised — F1's init=2 is the
-            // load-bearing whole-FCF-replacement assertion.
+            // Then: F1's old initResult closed exactly once.
             assertThat(InvocationCountingFilterFactory.closeCountFor(filter1Id))
                     .as("F1's old initResult should have been closed during ReplaceCluster")
                     .isEqualTo(1);
+            // Then: F1 RE-INITIALISED for the new chain — the load-bearing whole-FCF-replacement
+            // assertion. Expressed as a delta against the pre-reconfigure snapshot.
             assertThat(InvocationCountingFilterFactory.initializationCountFor(filter1Id))
-                    .as("F1 should have been RE-INITIALISED for the new chain (whole-FCF replacement, no partial preservation)")
-                    .isEqualTo(2);
-            assertThat(InvocationCountingFilterFactory.initializationCountFor(filter2Id))
-                    .as("F2 should have been newly initialised when added to the chain")
-                    .isEqualTo(1);
+                    .as("F1 should have been re-initialised for the new chain (whole-FCF replacement, no partial preservation)")
+                    .isEqualTo(f1InitBefore + 1);
+            // Then: F2 newly initialised, not yet closed.
+            InvocationCountingFilterFactory.assertInitializationCount(filter2Id, 1);
             assertThat(InvocationCountingFilterFactory.closeCountFor(filter2Id))
                     .as("F2 is part of the live new chain, should not be closed yet")
                     .isZero();
@@ -320,9 +325,9 @@ class FilterChangeHotReloadIT extends BaseIT {
                 .addToVirtualClusters(startingConfig.virtualClusters().toArray(new VirtualCluster[0]));
         try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(testerBuilder).createDefaultKroxyliciousTester()) {
 
-            // Given: both F1 and F2 initialised at startup.
-            InvocationCountingFilterFactory.assertInitializationCount(filter1Id, 1);
-            InvocationCountingFilterFactory.assertInitializationCount(filter2Id, 1);
+            // Given: snapshot pre-reconfigure init counts for both filters.
+            int f1InitBefore = InvocationCountingFilterFactory.initializationCountFor(filter1Id);
+            int f2InitBefore = InvocationCountingFilterFactory.initializationCountFor(filter2Id);
 
             // When: proxy reconfigured to remove F2 — chain [f1, f2] -> [f1].
             LOGGER.info("Reconfiguring vc-remove-filter: [f1, f2] -> [f1]");
@@ -330,19 +335,20 @@ class FilterChangeHotReloadIT extends BaseIT {
                     .succeedsWithin(RECONFIGURE_TIMEOUT)
                     .satisfies(rr -> assertThat(rr.hasErrors()).isFalse());
 
-            // Then: both old initResults closed; F1 re-initialised, F2 not (it is gone from the new chain).
+            // Then: both old initResults closed.
             assertThat(InvocationCountingFilterFactory.closeCountFor(filter1Id))
                     .as("F1's old initResult should have been closed")
                     .isEqualTo(1);
             assertThat(InvocationCountingFilterFactory.closeCountFor(filter2Id))
                     .as("F2's initResult should have been closed (it was removed from the chain)")
                     .isEqualTo(1);
+            // Then: F1 was re-initialised for the new chain (delta +1); F2 was NOT re-initialised.
             assertThat(InvocationCountingFilterFactory.initializationCountFor(filter1Id))
                     .as("F1 should have been re-initialised for the new chain")
-                    .isEqualTo(2);
+                    .isEqualTo(f1InitBefore + 1);
             assertThat(InvocationCountingFilterFactory.initializationCountFor(filter2Id))
                     .as("F2 should NOT have been re-initialised — it's not in the new chain")
-                    .isEqualTo(1);
+                    .isEqualTo(f2InitBefore);
 
             // Then: traffic flows on the shortened chain.
             String topic = tester.createTopic("vc-remove-filter");
@@ -375,9 +381,9 @@ class FilterChangeHotReloadIT extends BaseIT {
                 .addToVirtualClusters(startingConfig.virtualClusters().toArray(new VirtualCluster[0]));
         try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(testerBuilder).createDefaultKroxyliciousTester()) {
 
-            // Given: both F1 and F2 initialised at startup.
-            InvocationCountingFilterFactory.assertInitializationCount(filter1Id, 1);
-            InvocationCountingFilterFactory.assertInitializationCount(filter2Id, 1);
+            // Given: snapshot pre-reconfigure init counts for both filters.
+            int f1InitBefore = InvocationCountingFilterFactory.initializationCountFor(filter1Id);
+            int f2InitBefore = InvocationCountingFilterFactory.initializationCountFor(filter2Id);
 
             // When: proxy reconfigured to reorder the chain — [f1, f2] -> [f2, f1].
             LOGGER.info("Reconfiguring vc-reorder: [f1, f2] -> [f2, f1]");
@@ -385,19 +391,20 @@ class FilterChangeHotReloadIT extends BaseIT {
                     .succeedsWithin(RECONFIGURE_TIMEOUT)
                     .satisfies(rr -> assertThat(rr.hasErrors()).isFalse());
 
-            // Then: reorder is treated as a full replace — both old initResults closed, both new initResults initialised.
+            // Then: reorder is treated as a full replace — both old initResults closed.
             assertThat(InvocationCountingFilterFactory.closeCountFor(filter1Id))
                     .as("F1's old initResult should have been closed")
                     .isEqualTo(1);
             assertThat(InvocationCountingFilterFactory.closeCountFor(filter2Id))
                     .as("F2's old initResult should have been closed")
                     .isEqualTo(1);
+            // Then: both filters re-initialised for the reordered chain (delta +1 each).
             assertThat(InvocationCountingFilterFactory.initializationCountFor(filter1Id))
                     .as("F1 should have been re-initialised for the reordered chain")
-                    .isEqualTo(2);
+                    .isEqualTo(f1InitBefore + 1);
             assertThat(InvocationCountingFilterFactory.initializationCountFor(filter2Id))
                     .as("F2 should have been re-initialised for the reordered chain")
-                    .isEqualTo(2);
+                    .isEqualTo(f2InitBefore + 1);
 
             // Then: traffic flows on the reordered chain.
             String topic = tester.createTopic("vc-reorder");
@@ -430,9 +437,7 @@ class FilterChangeHotReloadIT extends BaseIT {
                 .addToVirtualClusters(startingConfig.virtualClusters().toArray(new VirtualCluster[0]));
         try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(testerBuilder).createDefaultKroxyliciousTester()) {
 
-            // Given: filter initialised with config X.
-            InvocationCountingFilterFactory.assertInitializationCount(configX, 1);
-            assertThat(InvocationCountingFilterFactory.initializationCountFor(configY)).isZero();
+            // Given: proxy started with VC referencing filter 'f1' under config X.
 
             // When: proxy reconfigured to change the same filter name's config X -> Y.
             LOGGER.info("Reconfiguring vc-cfg-change: filter 'f1' config X -> Y");
@@ -488,12 +493,7 @@ class FilterChangeHotReloadIT extends BaseIT {
 
         try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(startingTesterBuilder).createDefaultKroxyliciousTester()) {
 
-            // Given: both VCs initialised via defaultFilters and serving traffic. Per-VC FCF
-            // scoping means each VC initialises its own copy of the shared defaultFilter, so
-            // the same UUID sees two init calls.
-            assertThat(InvocationCountingFilterFactory.initializationCountFor(oldFilterId))
-                    .as("Both VCs share the same defaultFilter config UUID — init fires once per VC")
-                    .isEqualTo(2);
+            // Given: both VCs serving traffic on their respective chains via defaultFilters.
             String topicA = tester.createTopic("vc-default-a");
             String topicB = tester.createTopic("vc-default-b");
             assertProduceConsumeRoundTrip(tester, "vc-default-a", topicA, "before-reconfigure-vc-a");

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/InvocationCountingFilterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/InvocationCountingFilterFactory.java
@@ -80,18 +80,6 @@ public class InvocationCountingFilterFactory implements FilterFactory<Invocation
         return counter == null ? 0 : counter.get();
     }
 
-    /**
-     * Clears initialise/close counters without assertion. Use in {@code @BeforeEach}/{@code @AfterEach}
-     * when the test's contract cannot rely on perfect init/close balance — e.g. hot-reload tests
-     * where {@code OperationsPlanner.resolveByName} pre-constructs VCMs for every cluster in the
-     * new configuration as part of planning, leaving orphan initialisations for unchanged
-     * clusters that never reach the registry and therefore never see a matching close.
-     */
-    public static void resetCounts() {
-        initializeCounts.clear();
-        closeCounts.clear();
-    }
-
     public static void assertAllClosedAndResetCounts() {
         // Everything that was initialised gets closed
         for (var entry : initializeCounts.entrySet()) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -180,9 +180,7 @@ public record Configuration(
     }
 
     public List<VirtualClusterModel> virtualClusterModel(PluginFactoryRegistry pfr) {
-        var filterDefinitionsByName = Optional.ofNullable(this.filterDefinitions()).orElse(List.of())
-                .stream()
-                .collect(Collectors.toMap(NamedFilterDefinition::name, Function.identity()));
+        var filterDefinitionsByName = buildFilterDefinitionsByName();
 
         return virtualClusters.stream()
                 .map(virtualCluster -> {
@@ -202,9 +200,7 @@ public record Configuration(
      * @throws IllegalArgumentException if no virtual cluster with that name exists in this configuration
      */
     public VirtualClusterModel virtualClusterModel(PluginFactoryRegistry pfr, String clusterName) {
-        var filterDefinitionsByName = Optional.ofNullable(this.filterDefinitions()).orElse(List.of())
-                .stream()
-                .collect(Collectors.toMap(NamedFilterDefinition::name, Function.identity()));
+        var filterDefinitionsByName = buildFilterDefinitionsByName();
 
         return virtualClusters.stream()
                 .filter(virtualCluster -> virtualCluster.name().equals(clusterName))
@@ -214,6 +210,12 @@ public record Configuration(
                     return toVirtualClusterModel(virtualCluster, filterDefinitions, pfr);
                 })
                 .orElseThrow(() -> new IllegalArgumentException("No virtual cluster named '" + clusterName + "' in this configuration"));
+    }
+
+    private Map<String, NamedFilterDefinition> buildFilterDefinitionsByName() {
+        return Optional.ofNullable(this.filterDefinitions()).orElse(List.of())
+                .stream()
+                .collect(Collectors.toMap(NamedFilterDefinition::name, Function.identity()));
     }
 
     private List<NamedFilterDefinition> namedFilterDefinitionsForCluster(Map<String, NamedFilterDefinition> filterDefinitionsByName,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -192,6 +192,30 @@ public record Configuration(
                 .toList();
     }
 
+    /**
+     * Builds the {@link VirtualClusterModel} for a single virtual cluster by name. Unlike
+     * {@link #virtualClusterModel(PluginFactoryRegistry)}, this avoids constructing models
+     * (and therefore avoids running each filter's {@code initialize()}) for any virtual cluster
+     * other than the one requested. Used by {@code OperationsPlanner} so a reconfigure that
+     * targets one cluster doesn't orphan-initialise the filters of unrelated clusters.
+     *
+     * @throws IllegalArgumentException if no virtual cluster with that name exists in this configuration
+     */
+    public VirtualClusterModel virtualClusterModel(PluginFactoryRegistry pfr, String clusterName) {
+        var filterDefinitionsByName = Optional.ofNullable(this.filterDefinitions()).orElse(List.of())
+                .stream()
+                .collect(Collectors.toMap(NamedFilterDefinition::name, Function.identity()));
+
+        return virtualClusters.stream()
+                .filter(virtualCluster -> virtualCluster.name().equals(clusterName))
+                .findFirst()
+                .map(virtualCluster -> {
+                    List<NamedFilterDefinition> filterDefinitions = namedFilterDefinitionsForCluster(filterDefinitionsByName, virtualCluster);
+                    return toVirtualClusterModel(virtualCluster, filterDefinitions, pfr);
+                })
+                .orElseThrow(() -> new IllegalArgumentException("No virtual cluster named '" + clusterName + "' in this configuration"));
+    }
+
     private List<NamedFilterDefinition> namedFilterDefinitionsForCluster(Map<String, NamedFilterDefinition> filterDefinitionsByName,
                                                                          VirtualCluster virtualCluster) {
         List<NamedFilterDefinition> filterDefinitions;

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/AddCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/AddCluster.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,25 +54,42 @@ final class AddCluster implements ClusterOperation {
     private static final String LOG_KEY_VIRTUAL_CLUSTER = "virtualCluster";
     private static final String LOG_KEY_ERROR = "error";
 
-    private final VirtualClusterModel model;
+    private final String clusterName;
+    private final Supplier<VirtualClusterModel> modelSupplier;
     private final VirtualClusterRegistry virtualClusterRegistry;
     private final EndpointRegistry endpointRegistry;
 
-    AddCluster(VirtualClusterModel model,
+    AddCluster(String clusterName,
+               Supplier<VirtualClusterModel> modelSupplier,
                VirtualClusterRegistry virtualClusterRegistry,
                EndpointRegistry endpointRegistry) {
-        this.model = Objects.requireNonNull(model, "model");
+        this.clusterName = Objects.requireNonNull(clusterName, "clusterName");
+        this.modelSupplier = Objects.requireNonNull(modelSupplier, "modelSupplier");
         this.virtualClusterRegistry = Objects.requireNonNull(virtualClusterRegistry, "virtualClusterRegistry");
         this.endpointRegistry = Objects.requireNonNull(endpointRegistry, "endpointRegistry");
     }
 
     @Override
     public String clusterName() {
-        return model.getClusterName();
+        return clusterName;
     }
 
     @Override
     public Optional<ReconfigureError> apply() {
+        // Construct the model lazily: the supplier closes over (Configuration, clusterName) and
+        // calling get() triggers VCM construction including each filter's initialize(). Failures
+        // here (e.g. PluginConfigurationException from a bad filter config) become a per-cluster
+        // ReconfigureError rather than failing the whole reconfigure exceptionally — other
+        // operations in the same plan can still succeed.
+        VirtualClusterModel model;
+        try {
+            model = modelSupplier.get();
+        }
+        catch (RuntimeException e) {
+            return Optional.of(reportFailure(CompletionExceptions.unwrap(e),
+                    "reconfigure: failed to construct virtual cluster model"));
+        }
+
         try {
             virtualClusterRegistry.addVirtualCluster(model).join();
         }
@@ -79,10 +97,10 @@ final class AddCluster implements ClusterOperation {
             return Optional.of(reportFailure(CompletionExceptions.unwrap(e),
                     "reconfigure: failed to create lifecycle for virtual cluster"));
         }
-        return bindGatewaysWithRollback();
+        return bindGatewaysWithRollback(model);
     }
 
-    private Optional<ReconfigureError> bindGatewaysWithRollback() {
+    private Optional<ReconfigureError> bindGatewaysWithRollback(VirtualClusterModel model) {
         List<EndpointGateway> gateways = List.copyOf(model.gateways().values());
         var bindFutures = gateways.stream()
                 .map(g -> endpointRegistry.registerVirtualCluster(g).toCompletableFuture())

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/AddCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/AddCluster.java
@@ -86,7 +86,7 @@ final class AddCluster implements ClusterOperation {
             model = modelSupplier.get();
         }
         catch (RuntimeException e) {
-            return Optional.of(reportFailure(CompletionExceptions.unwrap(e),
+            return Optional.of(reportFailure(e,
                     "reconfigure: failed to construct virtual cluster model"));
         }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
@@ -73,7 +73,7 @@ public class ConfigurationReloadOrchestrator {
                                            List<ChangeDetector> detectors) {
         this(initialConfiguration, detectors,
                 new OperationsPlanner(virtualClusterRegistry, endpointRegistry,
-                        config -> config.virtualClusterModel(pfr)));
+                        (config, clusterName) -> config.virtualClusterModel(pfr, clusterName)));
     }
 
     /**

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/OperationsPlanner.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/OperationsPlanner.java
@@ -7,10 +7,9 @@ package io.kroxylicious.proxy.internal.reload;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.internal.VirtualClusterRegistry;
@@ -32,38 +31,39 @@ final class OperationsPlanner {
 
     private final VirtualClusterRegistry virtualClusterRegistry;
     private final EndpointRegistry endpointRegistry;
-    private final Function<Configuration, List<VirtualClusterModel>> modelResolver;
+    private final BiFunction<Configuration, String, VirtualClusterModel> modelResolver;
 
     OperationsPlanner(VirtualClusterRegistry virtualClusterRegistry,
                       EndpointRegistry endpointRegistry,
-                      Function<Configuration, List<VirtualClusterModel>> modelResolver) {
+                      BiFunction<Configuration, String, VirtualClusterModel> modelResolver) {
         this.virtualClusterRegistry = Objects.requireNonNull(virtualClusterRegistry, "virtualClusterRegistry");
         this.endpointRegistry = Objects.requireNonNull(endpointRegistry, "endpointRegistry");
         this.modelResolver = Objects.requireNonNull(modelResolver, "modelResolver");
     }
 
     /**
-     * Plan the operations for a reconfigure. Each phase resolves a {@link VirtualClusterModel}
-     * by name and hands it to the operation: removes resolve from the registry's current state
-     * (the model that's already serving), adds resolve from {@code newConfig}, and modifies
-     * resolve <em>both</em> — old from the registry, new from the submitted configuration.
+     * Plan the operations for a reconfigure. Operations that need a model from the new
+     * configuration (adds, modifies) receive a lazy supplier rather than an eagerly-built
+     * {@link VirtualClusterModel}: the model is constructed inside the operation's
+     * {@code apply()} when needed, not during planning.
+     *
+     * <p>Lazy construction matters because building a VCM eagerly calls every filter's
+     * {@code initialize()}. Building VCMs for clusters that the planner doesn't touch
+     * leaks initialisations that are never matched by a {@code close()}.
+     * With lazy construction, only clusters that actually receive an Add or Replace
+     * operation are constructed.
      *
      * <p>Registry-side resolution uses {@link VirtualClusterRegistry#modelFor(String)} —
-     * a direct name-keyed lookup to fetch the old existing model.
-     * The new-config side still requires a Map-build because
-     * {@code modelResolver} returns a list (it has no direct name-lookup affordance).
+     * a direct name-keyed lookup to fetch the old existing model (used by removes and the
+     * old side of replaces).
      *
-     * @throws IllegalStateException if any of {@code clustersToRemove}, {@code clustersToAdd},
-     *         or {@code clustersToModify} names a cluster that can't be resolved on the side
-     *         it's expected — all three indicate a {@code ChangeDetector} contract violation
+     * @throws IllegalStateException if any of {@code clustersToRemove} or
+     *         {@code clustersToModify} names a cluster that can't be resolved against the
+     *         registry — both indicate a {@code ChangeDetector} contract violation
      *         (i.e. a framework bug).
      */
     List<ClusterOperation> plan(ChangeResult changes, Configuration newConfig) {
         var ops = new ArrayList<ClusterOperation>();
-
-        // The new-config side needs a name → model lookup.
-        Map<String, VirtualClusterModel> newModelsByName = (changes.clustersToAdd().isEmpty()
-                && changes.clustersToModify().isEmpty()) ? Map.of() : resolveByName(newConfig);
 
         for (String name : changes.clustersToRemove()) {
             VirtualClusterModel oldModel = virtualClusterRegistry.modelFor(name);
@@ -84,32 +84,36 @@ final class OperationsPlanner {
                                 + "'; this indicates a ChangeDetector contract violation"
                                 + " (cluster reported as modified but absent from the registry)");
             }
-            VirtualClusterModel newModel = newModelsByName.get(name);
-            if (newModel == null) {
-                throw new IllegalStateException(
-                        "OperationsPlanner: no new model for modified cluster '" + name
-                                + "'; this indicates a ChangeDetector contract violation"
-                                + " (cluster reported as modified but absent from the submitted configuration)");
-            }
-            ops.add(new ReplaceCluster(oldModel, newModel, virtualClusterRegistry, endpointRegistry));
+            requireClusterInConfig(newConfig, name, "modified");
+            ops.add(new ReplaceCluster(oldModel, name, supplierFor(newConfig, name), virtualClusterRegistry, endpointRegistry));
         }
 
         for (String name : changes.clustersToAdd()) {
-            VirtualClusterModel newModel = newModelsByName.get(name);
-            if (newModel == null) {
-                throw new IllegalStateException(
-                        "OperationsPlanner: no model for added cluster '" + name
-                                + "'; this indicates a ChangeDetector contract violation"
-                                + " (cluster reported as added but absent from the submitted configuration)");
-            }
-            ops.add(new AddCluster(newModel, virtualClusterRegistry, endpointRegistry));
+            requireClusterInConfig(newConfig, name, "added");
+            ops.add(new AddCluster(name, supplierFor(newConfig, name), virtualClusterRegistry, endpointRegistry));
         }
 
         return List.copyOf(ops);
     }
 
-    private Map<String, VirtualClusterModel> resolveByName(Configuration newConfig) {
-        return modelResolver.apply(newConfig).stream()
-                .collect(Collectors.toUnmodifiableMap(VirtualClusterModel::getClusterName, Function.identity()));
+    /**
+     * Eager phantom-cluster check. Verifies the named cluster exists in the submitted
+     * configuration without triggering VCM construction (and therefore without running any
+     * filter's {@code initialize()}). Preserves the "loud at framework layer" diagnostic for
+     * a buggy {@code ChangeDetector} that names a cluster absent from the submitted config.
+     */
+    private static void requireClusterInConfig(Configuration newConfig, String clusterName, String operation) {
+        boolean present = newConfig.virtualClusters().stream()
+                .anyMatch(vc -> vc.name().equals(clusterName));
+        if (!present) {
+            throw new IllegalStateException(
+                    "OperationsPlanner: no model for " + operation + " cluster '" + clusterName
+                            + "'; this indicates a ChangeDetector contract violation"
+                            + " (cluster reported as " + operation + " but absent from the submitted configuration)");
+        }
+    }
+
+    private Supplier<VirtualClusterModel> supplierFor(Configuration newConfig, String clusterName) {
+        return () -> modelResolver.apply(newConfig, clusterName);
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ReplaceCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ReplaceCluster.java
@@ -7,6 +7,7 @@ package io.kroxylicious.proxy.internal.reload;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import io.kroxylicious.proxy.internal.VirtualClusterRegistry;
 import io.kroxylicious.proxy.internal.net.EndpointRegistry;
@@ -37,30 +38,33 @@ import io.kroxylicious.proxy.reload.ReconfigureError;
 final class ReplaceCluster implements ClusterOperation {
 
     private final VirtualClusterModel oldModel;
-    private final VirtualClusterModel newModel;
+    private final String clusterName;
+    private final Supplier<VirtualClusterModel> newModelSupplier;
     private final VirtualClusterRegistry virtualClusterRegistry;
     private final EndpointRegistry endpointRegistry;
 
     ReplaceCluster(VirtualClusterModel oldModel,
-                   VirtualClusterModel newModel,
+                   String clusterName,
+                   Supplier<VirtualClusterModel> newModelSupplier,
                    VirtualClusterRegistry virtualClusterRegistry,
                    EndpointRegistry endpointRegistry) {
         this.oldModel = Objects.requireNonNull(oldModel, "oldModel");
-        this.newModel = Objects.requireNonNull(newModel, "newModel");
+        this.clusterName = Objects.requireNonNull(clusterName, "clusterName");
+        this.newModelSupplier = Objects.requireNonNull(newModelSupplier, "newModelSupplier");
         this.virtualClusterRegistry = Objects.requireNonNull(virtualClusterRegistry, "virtualClusterRegistry");
         this.endpointRegistry = Objects.requireNonNull(endpointRegistry, "endpointRegistry");
-        // The ChangeDetector contract guarantees both sides share the cluster name; we guard it
-        // locally to catch a buggy planner / detector before it produces a corrupted reconfigure.
-        if (!oldModel.getClusterName().equals(newModel.getClusterName())) {
+        // The ChangeDetector contract guarantees the old side's cluster name matches the planned
+        // cluster name; guard it locally to catch a buggy planner / detector early.
+        if (!oldModel.getClusterName().equals(clusterName)) {
             throw new IllegalArgumentException(
-                    "ReplaceCluster requires the same cluster name on both sides; got '"
-                            + oldModel.getClusterName() + "' (old) vs '" + newModel.getClusterName() + "' (new)");
+                    "ReplaceCluster: oldModel cluster name '" + oldModel.getClusterName()
+                            + "' does not match planned cluster name '" + clusterName + "'");
         }
     }
 
     @Override
     public String clusterName() {
-        return newModel.getClusterName();
+        return clusterName;
     }
 
     @Override
@@ -72,6 +76,6 @@ final class ReplaceCluster implements ClusterOperation {
             // failure. The cluster stays in the failure state RemoveCluster left it in.
             return removeError;
         }
-        return new AddCluster(newModel, virtualClusterRegistry, endpointRegistry).apply();
+        return new AddCluster(clusterName, newModelSupplier, virtualClusterRegistry, endpointRegistry).apply();
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -475,6 +475,91 @@ class ConfigParserTest {
     }
 
     @Test
+    void virtualClusterModelByNameReturnsTheRequestedCluster() {
+        // Given: two virtual clusters in the configuration.
+        Configuration config = configParser.parseConfiguration("""
+                virtualClusters:
+                  - name: vc-a
+                    targetCluster:
+                      bootstrapServers: kafka.example:1234
+                    gateways:
+                    - name: default
+                      portIdentifiesNode:
+                        bootstrapAddress: cluster1:9192
+                  - name: vc-b
+                    targetCluster:
+                      bootstrapServers: kafka.example:5678
+                    gateways:
+                    - name: default
+                      portIdentifiesNode:
+                        bootstrapAddress: cluster2:9292
+                """);
+
+        // When: the per-name builder is asked for vc-a.
+        var result = config.virtualClusterModel(null, "vc-a");
+
+        // Then: only vc-a's model is returned.
+        assertThat(result.getClusterName()).isEqualTo("vc-a");
+    }
+
+    @Test
+    void virtualClusterModelByNameThrowsForUnknownCluster() {
+        // Given: a configuration with one virtual cluster.
+        Configuration config = configParser.parseConfiguration("""
+                virtualClusters:
+                  - name: vc-a
+                    targetCluster:
+                      bootstrapServers: kafka.example:1234
+                    gateways:
+                    - name: default
+                      portIdentifiesNode:
+                        bootstrapAddress: cluster1:9192
+                """);
+
+        // When/Then: asking for a name not in the config surfaces the framework-layer diagnostic.
+        assertThatThrownBy(() -> config.virtualClusterModel(null, "never-existed"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("never-existed");
+    }
+
+    @Test
+    void virtualClusterModelByNameDoesNotBuildUnrelatedClusters() {
+        // Given: a configuration where vc-a is valid but vc-bad has invalid TLS that would
+        // cause its VCM construction to throw. The list-form builder iterates every cluster
+        // and would surface that failure; the per-name builder must not.
+        Configuration config = configParser.parseConfiguration("""
+                virtualClusters:
+                  - name: vc-a
+                    targetCluster:
+                      bootstrapServers: kafka.example:1234
+                    gateways:
+                    - name: default
+                      portIdentifiesNode:
+                        bootstrapAddress: cluster1:9192
+                  - name: vc-bad
+                    targetCluster:
+                      bootstrapServers: kafka.example:5678
+                    gateways:
+                    - name: default
+                      tls: {}
+                      portIdentifiesNode:
+                        bootstrapAddress: cluster2:9292
+                """);
+
+        // Sanity: building the full list throws because of vc-bad's missing TLS key.
+        assertThatThrownBy(() -> config.virtualClusterModel(null))
+                .as("list-form should surface vc-bad's configuration error")
+                .isInstanceOf(IllegalConfigurationException.class);
+
+        // When: the per-name builder is asked for vc-a (the valid one).
+        // Then: it returns vc-a's model and does NOT touch vc-bad. This is the load-bearing
+        // contract for issue #4091 — selective construction means orphan VCMs are not built
+        // for clusters the reconfigure isn't touching.
+        var result = config.virtualClusterModel(null, "vc-a");
+        assertThat(result.getClusterName()).isEqualTo("vc-a");
+    }
+
+    @Test
     void shouldRequireKeyIfDownstreamTlsObjectPresent() {
         // given
         Configuration configuration = configParser.parseConfiguration("""

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/AddClusterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/AddClusterTest.java
@@ -40,7 +40,7 @@ class AddClusterTest {
         stubBookkeepingSucceeds();
         stubBindSucceeds();
 
-        var result = new AddCluster(model, vcr, endpointRegistry).apply();
+        var result = new AddCluster(NAME, () -> model, vcr, endpointRegistry).apply();
 
         assertThat(result).isEmpty();
         var inOrder = inOrder(vcr, endpointRegistry);
@@ -57,7 +57,7 @@ class AddClusterTest {
         var cause = new IllegalStateException("bookkeeping failed");
         when(vcr.addVirtualCluster(model)).thenReturn(CompletableFuture.failedFuture(cause));
 
-        var result = new AddCluster(model, vcr, endpointRegistry).apply();
+        var result = new AddCluster(NAME, () -> model, vcr, endpointRegistry).apply();
 
         assertThat(result).hasValueSatisfying(e -> {
             assertThat(e.humanReadableIdentifier()).isEqualTo(NAME);
@@ -76,7 +76,7 @@ class AddClusterTest {
                 .thenReturn(CompletableFuture.failedStage(bindCause));
         stubDeregisterSucceeds();
 
-        var result = new AddCluster(model, vcr, endpointRegistry).apply();
+        var result = new AddCluster(NAME, () -> model, vcr, endpointRegistry).apply();
 
         assertThat(result).hasValueSatisfying(e -> {
             assertThat(e.humanReadableIdentifier()).isEqualTo(NAME);
@@ -98,7 +98,7 @@ class AddClusterTest {
         when(endpointRegistry.deregisterVirtualCluster(any(EndpointGateway.class)))
                 .thenReturn(CompletableFuture.failedStage(new IllegalStateException("rollback failure")));
 
-        var result = new AddCluster(model, vcr, endpointRegistry).apply();
+        var result = new AddCluster(NAME, () -> model, vcr, endpointRegistry).apply();
 
         assertThat(result).hasValueSatisfying(e -> assertThat(e.cause()).isSameAs(bindCause));
         verify(endpointRegistry).deregisterVirtualCluster(any(EndpointGateway.class));
@@ -117,7 +117,7 @@ class AddClusterTest {
         when(endpointRegistry.deregisterVirtualCluster(any(EndpointGateway.class)))
                 .thenReturn(pendingDeregister);
 
-        var applyFuture = CompletableFuture.supplyAsync(() -> new AddCluster(model, vcr, endpointRegistry).apply());
+        var applyFuture = CompletableFuture.supplyAsync(() -> new AddCluster(NAME, () -> model, vcr, endpointRegistry).apply());
 
         verify(endpointRegistry, timeout(2_000)).deregisterVirtualCluster(any(EndpointGateway.class));
         assertThat(applyFuture)

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/OperationsPlannerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/OperationsPlannerTest.java
@@ -7,9 +7,11 @@ package io.kroxylicious.proxy.internal.reload;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -167,9 +169,9 @@ class OperationsPlannerTest {
         var removeModel = modelFor("cluster-remove");
         when(vcr.modelFor("cluster-remove")).thenReturn(removeModel);
         var resolverCalls = new int[1];
-        Function<Configuration, List<VirtualClusterModel>> resolver = config -> {
+        BiFunction<Configuration, String, VirtualClusterModel> resolver = (config, clusterName) -> {
             resolverCalls[0]++;
-            return List.of();
+            throw new IllegalStateException("resolver should not be called for remove-only plans");
         };
         var planner = new OperationsPlanner(vcr, endpointRegistry, resolver);
 
@@ -212,7 +214,18 @@ class OperationsPlannerTest {
     }
 
     private OperationsPlanner plannerWithModels(VirtualClusterModel... resolvedModels) {
-        return new OperationsPlanner(vcr, endpointRegistry, config -> List.of(resolvedModels));
+        Map<String, VirtualClusterModel> byName = Arrays.stream(resolvedModels)
+                .collect(Collectors.toMap(VirtualClusterModel::getClusterName, m -> m));
+        return new OperationsPlanner(vcr, endpointRegistry, (config, clusterName) -> {
+            var resolved = byName.get(clusterName);
+            if (resolved == null) {
+                // Simulate the production behaviour where Configuration#virtualClusterModel(pfr, name)
+                // throws IllegalArgumentException for unknown clusters. Some tests rely on this
+                // behaviour to surface phantom-add bugs.
+                throw new IllegalArgumentException("No virtual cluster named '" + clusterName + "' in this configuration");
+            }
+            return resolved;
+        });
     }
 
     private static VirtualClusterModel modelFor(String name) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ReplaceClusterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ReplaceClusterTest.java
@@ -43,7 +43,7 @@ class ReplaceClusterTest {
         stubAddBookkeepingSucceeds();
         stubRegisterSucceeds();
 
-        var result = new ReplaceCluster(oldModel, newModel, vcr, endpointRegistry).apply();
+        var result = new ReplaceCluster(oldModel, NAME, () -> newModel, vcr, endpointRegistry).apply();
 
         assertThat(result).isEmpty();
         var inOrder = inOrder(vcr, endpointRegistry);
@@ -65,7 +65,7 @@ class ReplaceClusterTest {
         var removeCause = new IllegalStateException("simulated drain failure");
         when(vcr.removeVirtualCluster(NAME)).thenReturn(CompletableFuture.failedFuture(removeCause));
 
-        var result = new ReplaceCluster(oldModel, newModel, vcr, endpointRegistry).apply();
+        var result = new ReplaceCluster(oldModel, NAME, () -> newModel, vcr, endpointRegistry).apply();
 
         assertThat(result).hasValueSatisfying(e -> {
             assertThat(e.humanReadableIdentifier()).isEqualTo(NAME);
@@ -92,7 +92,7 @@ class ReplaceClusterTest {
                 .thenReturn(CompletableFuture.failedStage(bindCause));
         stubDeregisterSucceeds(); // for the AddCluster rollback path
 
-        var result = new ReplaceCluster(oldModel, newModel, vcr, endpointRegistry).apply();
+        var result = new ReplaceCluster(oldModel, NAME, () -> newModel, vcr, endpointRegistry).apply();
 
         assertThat(result).hasValueSatisfying(e -> {
             assertThat(e.humanReadableIdentifier()).isEqualTo(NAME);
@@ -110,18 +110,19 @@ class ReplaceClusterTest {
         var oldModel = modelWithGateway(NAME, mock(EndpointGateway.class));
         var newModel = modelWithGateway(NAME, mock(EndpointGateway.class));
 
-        assertThat(new ReplaceCluster(oldModel, newModel, vcr, endpointRegistry).clusterName())
+        assertThat(new ReplaceCluster(oldModel, NAME, () -> newModel, vcr, endpointRegistry).clusterName())
                 .isEqualTo(NAME);
     }
 
     @Test
-    void constructorRejectsNameMismatch() {
-        // Defence in depth: the planner only emits ReplaceCluster pairs where both models share
-        // a name, but the operation guards against a buggy planner that violates that.
+    void constructorRejectsNameMismatchBetweenOldModelAndPlannedName() {
+        // Defence in depth: the planner only emits ReplaceCluster where the old model's name
+        // matches the planned cluster name, but the operation guards against a buggy planner
+        // that violates that.
         var oldModel = modelWithGateway("cluster-a", mock(EndpointGateway.class));
         var newModel = modelWithGateway("cluster-b", mock(EndpointGateway.class));
 
-        assertThatThrownBy(() -> new ReplaceCluster(oldModel, newModel, vcr, endpointRegistry))
+        assertThatThrownBy(() -> new ReplaceCluster(oldModel, "cluster-b", () -> newModel, vcr, endpointRegistry))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("cluster-a")
                 .hasMessageContaining("cluster-b");
@@ -131,13 +132,15 @@ class ReplaceClusterTest {
     @Test
     void constructorRejectsNullArguments() {
         var model = modelWithGateway(NAME, mock(EndpointGateway.class));
-        assertThatThrownBy(() -> new ReplaceCluster(null, model, vcr, endpointRegistry))
+        assertThatThrownBy(() -> new ReplaceCluster(null, NAME, () -> model, vcr, endpointRegistry))
                 .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new ReplaceCluster(model, null, vcr, endpointRegistry))
+        assertThatThrownBy(() -> new ReplaceCluster(model, null, () -> model, vcr, endpointRegistry))
                 .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new ReplaceCluster(model, model, null, endpointRegistry))
+        assertThatThrownBy(() -> new ReplaceCluster(model, NAME, null, vcr, endpointRegistry))
                 .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new ReplaceCluster(model, model, vcr, null))
+        assertThatThrownBy(() -> new ReplaceCluster(model, NAME, () -> model, null, endpointRegistry))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new ReplaceCluster(model, NAME, () -> model, vcr, null))
                 .isInstanceOf(NullPointerException.class);
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

 Fixes - https://github.com/kroxylicious/kroxylicious/issues/4091 

  Before this change, `OperationsPlanner.plan()` called `resolveByName(newConfig)` whenever any cluster was added or modified. That call constructed a fresh `VirtualClusterModel` for every cluster in the new configuration — including clusters that were unchanged and would not be touched by any operation in the plan. Because the VCM constructor eagerly builds a `FilterChainFactory`, each unchanged cluster's filters had `initialize()` called during planning. The pre-built VCM for unchanged clusters was never registered, never used, and never closed — leaking one `initialize()` per unchanged cluster's filter chain per reconfigure.

 **Fix: lazy VCM construction**

 `OperationsPlanner` no longer pre-builds VCMs. Each operation that needs a model from the new configuration receives a `Supplier<VirtualClusterModel>` closed over `(newConfig, clusterName)`. The model is constructed inside the operation's `apply()` — only for clusters that actually receive an `AddCluster` or `ReplaceCluster` operation. Unchanged clusters are never constructed.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
