### PR TITLE
test(operator): poll for referent checksum annotation in KafkaProtocolFilterReconcilerIT

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
@@ -185,10 +185,22 @@ class KafkaProtocolFilterReconcilerIT {
                 .build());
 
         // then
-        assertAllConditionsTrue(filterOne);
-        String newChecksum = testActor.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
-                .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
-        assertThat(newChecksum).isNotEqualTo(checksum);
+        // Editing the referent doesn't change the filter's metadata.generation, so an observedGeneration check
+        // alone is satisfied by the pre-edit state. Poll until the referent checksum changes (the reliable signal
+        // that the referent-triggered reconciliation completed) while confirming the conditions still hold (see #4018).
+        AWAIT.alias("referent checksum updated and conditions still true").untilAsserted(() -> {
+            var kpf = testActor.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne));
+            assertThat(kpf.getStatus()).isNotNull();
+            KafkaProtocolFilterStatusAssert
+                    .assertThat(kpf.getStatus())
+                    .hasObservedGenerationInSyncWithMetadataOf(kpf)
+                    .conditionList()
+                    .singleElement()
+                    .isResolvedRefsTrue(kpf);
+            String newChecksum = kpf.getMetadata().getAnnotations()
+                    .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
+            assertThat(newChecksum).isNotEqualTo(checksum);
+        });
     }
 
     @Test
@@ -204,10 +216,22 @@ class KafkaProtocolFilterReconcilerIT {
                 .build());
 
         // then
-        assertAllConditionsTrue(filterOne);
-        String newChecksum = testActor.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
-                .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
-        assertThat(newChecksum).isNotEqualTo(checksum);
+        // Editing the referent doesn't change the filter's metadata.generation, so an observedGeneration check
+        // alone is satisfied by the pre-edit state. Poll until the referent checksum changes (the reliable signal
+        // that the referent-triggered reconciliation completed) while confirming the conditions still hold (see #4018).
+        AWAIT.alias("referent checksum updated and conditions still true").untilAsserted(() -> {
+            var kpf = testActor.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne));
+            assertThat(kpf.getStatus()).isNotNull();
+            KafkaProtocolFilterStatusAssert
+                    .assertThat(kpf.getStatus())
+                    .hasObservedGenerationInSyncWithMetadataOf(kpf)
+                    .conditionList()
+                    .singleElement()
+                    .isResolvedRefsTrue(kpf);
+            String newChecksum = kpf.getMetadata().getAnnotations()
+                    .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
+            assertThat(newChecksum).isNotEqualTo(checksum);
+        });
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes the flaky `KafkaProtocolFilterReconcilerIT.shouldUpdateReferentAnnotationOnSecretModify` and `shouldUpdateReferentAnnotationOnConfigMapModify`.

Both tests modified a referenced Secret/ConfigMap and then asserted the filter's referent-checksum annotation had changed — but they read the annotation from a **single snapshot** taken immediately after the conditions became `true`. The referent checksum is recomputed in a *later* reconciliation than the one that sets the conditions, so the assertion could run before the annotation updated, intermittently failing with `Expecting actual: "X" not to be equal to: "X"`.

The fix wraps the "checksum changed" assertion in the existing `AWAIT` poller so it waits for the annotation to actually change, rather than asserting on one snapshot. Test-only change.

### Additional Context

Per the maintainer's conclusion in the issue (comment 4), the `403 Forbidden` watch errors are a **separate** issue affecting `KafkaProxyReconcilerIT` and explicitly **not** the cause of these failures, so they are out of scope here.

Validated by running the operator integration-test suite on a fork — `KafkaProtocolFilterReconcilerIT` ran green (`Tests run: 10, Failures: 0, Errors: 0`).

### Checklist

- [ ] New tests written (where applicable). — N/A, reliability fix to existing tests.
- [ ] If making a user-facing change, documentation is provided... — N/A, test-only.
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed.
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer. — omitted at the contributor's request.
- [ ] For user facing changes, update CHANGELOG.md. — N/A, test-only.

Closes #4018
