### PR TITLE
chore(deps): upgrade JOSDK to 5.2.5

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-admission-api/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-admission-api/pom.xml
@@ -27,7 +27,6 @@
     </description>
 
     <properties>
-        <josdk.version>5.2.3</josdk.version>
         <log4j.version>2.20.0</log4j.version>
         <fabric8-client.version>7.4.0</fabric8-client.version>
         <lombok.version>1.18.44</lombok.version>
@@ -36,14 +35,7 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- note, we're inheriting the jackson & micrometer BOMs from our parent pom -->
-            <dependency>
-                <groupId>io.javaoperatorsdk</groupId>
-                <artifactId>operator-framework-bom</artifactId>
-                <version>${josdk.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
+            <!-- note, we're inheriting the jackson, micrometer & JOSDK BOMs from our parent pom -->
             <dependency>
                 <groupId>io.fabric8</groupId>
                 <artifactId>kubernetes-client-bom</artifactId>

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-api/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-api/pom.xml
@@ -27,7 +27,6 @@
     </description>
 
     <properties>
-        <josdk.version>5.2.3</josdk.version>
         <log4j.version>2.20.0</log4j.version>
         <fabric8-client.version>7.4.0</fabric8-client.version>
         <lombok.version>1.18.44</lombok.version>
@@ -36,14 +35,7 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- note, we're inheriting the jackson & micrometer BOMs from our parent pom -->
-            <dependency>
-                <groupId>io.javaoperatorsdk</groupId>
-                <artifactId>operator-framework-bom</artifactId>
-                <version>${josdk.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
+            <!-- note, we're inheriting the jackson, micrometer & JOSDK BOMs from our parent pom -->
             <dependency>
                 <groupId>io.fabric8</groupId>
                 <artifactId>kubernetes-client-bom</artifactId>

--- a/kroxylicious-kubernetes/kroxylicious-operator/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/pom.xml
@@ -21,7 +21,6 @@
     <description>An operator for running the Kroxylicious Proxy on Kubernetes</description>
 
     <properties>
-        <josdk.version>5.2.3</josdk.version>
         <prometheus-metrics.version>1.6.1</prometheus-metrics.version>
         <io.kroxylicious.operator.image.name>quay.io/kroxylicious/operator:${project.version}</io.kroxylicious.operator.image.name>
         <io.kroxylicious.operator.image.archive>target/kroxylicious-operator.img.tar.gz</io.kroxylicious.operator.image.archive>
@@ -33,15 +32,7 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- note, we're inheriting the jackson & micrometer BOMs from our parent pom -->
-
-            <dependency>
-                <groupId>io.javaoperatorsdk</groupId>
-                <artifactId>operator-framework-bom</artifactId>
-                <version>${josdk.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
+            <!-- note, we're inheriting the jackson, micrometer & JOSDK BOMs from our parent pom -->
             <dependency>
                 <groupId>io.fabric8</groupId>
                 <artifactId>kubernetes-client-bom</artifactId>

--- a/kroxylicious-kubernetes/pom.xml
+++ b/kroxylicious-kubernetes/pom.xml
@@ -21,6 +21,10 @@
     <description>Kubernetes components</description>
     <packaging>pom</packaging>
 
+    <properties>
+        <josdk.version>5.2.3</josdk.version>
+    </properties>
+
     <modules>
         <module>kroxylicious-kubernetes-api</module>
         <module>kroxylicious-operator</module>
@@ -30,6 +34,18 @@
         <module>kroxylicious-admission</module>
         <module>kroxylicious-admission-dist</module>
     </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.javaoperatorsdk</groupId>
+                <artifactId>operator-framework-bom</artifactId>
+                <version>${josdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>

--- a/kroxylicious-kubernetes/pom.xml
+++ b/kroxylicious-kubernetes/pom.xml
@@ -22,7 +22,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <josdk.version>5.2.3</josdk.version>
+        <josdk.version>5.2.5</josdk.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Closes #4083

Have pulled the JOSDK dependency up into the kubernetes parent pom as it spans operator and admission webhook. We could also consider lofting it up into the top parent pom with everything else, but maybe it's a good precedent to have some established way to configure kubernetes only dependencies scoped to that level. WDYT?

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
