### PR TITLE
refactor: replace anonymous class override with ServerConnectionFacto…

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -198,10 +198,10 @@ public class ClientConnectionStateMachine {
     public ClientConnectionStateMachine(EndpointBinding endpointBinding,
                                         TransportSubjectBuilder transportSubjectBuilder,
                                         KafkaSession kafkaSession) {
-        this(endpointBinding, transportSubjectBuilder, kafkaSession,
-                (remote, ccsm, vc, cn, ni) -> new ServerConnectionStateMachine(remote, ccsm, vc, cn, ni));
+        this(endpointBinding, transportSubjectBuilder, kafkaSession, ServerConnectionStateMachine::new);
     }
 
+    @VisibleForTesting
     ClientConnectionStateMachine(EndpointBinding endpointBinding,
                                  TransportSubjectBuilder transportSubjectBuilder,
                                  KafkaSession kafkaSession,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -149,6 +149,7 @@ public class ClientConnectionStateMachine {
     @VisibleForTesting
     @Nullable
     Timer.Sample clientToProxyBackpressureTimer;
+    private final ServerConnectionFactory serverConnectionFactory;
 
     private final EndpointBinding endpointBinding;
 
@@ -197,9 +198,18 @@ public class ClientConnectionStateMachine {
     public ClientConnectionStateMachine(EndpointBinding endpointBinding,
                                         TransportSubjectBuilder transportSubjectBuilder,
                                         KafkaSession kafkaSession) {
+        this(endpointBinding, transportSubjectBuilder, kafkaSession,
+                (remote, ccsm, vc, cn, ni) -> new ServerConnectionStateMachine(remote, ccsm, vc, cn, ni));
+    }
+
+    ClientConnectionStateMachine(EndpointBinding endpointBinding,
+                                 TransportSubjectBuilder transportSubjectBuilder,
+                                 KafkaSession kafkaSession,
+                                 ServerConnectionFactory serverConnectionFactory) {
         this.endpointBinding = endpointBinding;
         this.transportSubjectBuilder = transportSubjectBuilder;
         this.kafkaSession = kafkaSession;
+        this.serverConnectionFactory = serverConnectionFactory;
         var virtualCluster = endpointBinding.endpointGateway().virtualCluster();
 
         var nodeId = endpointBinding.nodeId();
@@ -784,14 +794,17 @@ public class ClientConnectionStateMachine {
                 .log("Upstream connection initiated for client");
     }
 
-    @VisibleForTesting
+    @FunctionalInterface
+    interface ServerConnectionFactory {
+        ServerConnectionStateMachine create(HostPort remote,
+                                            ClientConnectionStateMachine ccsm,
+                                            VirtualClusterModel virtualCluster,
+                                            String clusterName,
+                                            @Nullable Integer nodeId);
+    }
+
     ServerConnectionStateMachine createServerConnection(HostPort remote) {
-        return new ServerConnectionStateMachine(
-                remote,
-                this,
-                virtualCluster(),
-                clusterName(),
-                nodeId());
+        return serverConnectionFactory.create(remote, this, virtualCluster(), clusterName(), nodeId());
     }
 
     /**

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
@@ -108,15 +108,8 @@ class ClientConnectionStateMachineEndToEndTest {
     ClientConnectionStateMachine clientConnectionStateMachine(EndpointBinding binding) {
         var kafkaSession = new KafkaSession(KafkaSessionState.ESTABLISHING);
         // Override createServerConnection to substitute EmbeddedChannels for real TCP connections
-        return new ClientConnectionStateMachine(binding, new DefaultSubjectBuilder(List.of()), kafkaSession) {
-            @Override
-            ServerConnectionStateMachine createServerConnection(HostPort remote) {
-                return new ServerConnectionStateMachine(
-                        remote,
-                        this,
-                        virtualCluster(),
-                        clusterName(),
-                        nodeId()) {
+        return new ClientConnectionStateMachine(binding, new DefaultSubjectBuilder(List.of()), kafkaSession,
+                (remote, ccsm, vc, cn, ni) -> new ServerConnectionStateMachine(remote, ccsm, vc, cn, ni) {
                     @Override
                     Bootstrap configureBootstrap(
                                                  KafkaProxyBackendHandler capturedBackendHandler,
@@ -145,9 +138,7 @@ class ClientConnectionStateMachineEndToEndTest {
                         }
                         return outboundChannel.newPromise();
                     }
-                };
-            }
-        };
+                });
     }
 
     @AfterEach

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
@@ -115,12 +115,8 @@ class ClientConnectionStateMachineTest {
         when(endpointBinding.endpointGateway()).thenReturn(endpointGateway);
         when(endpointGateway.virtualCluster()).thenReturn(VIRTUAL_CLUSTER_MODEL);
         clientConnectionStateMachine = new ClientConnectionStateMachine(endpointBinding, new DefaultSubjectBuilder(List.of()),
-                new KafkaSession(KafkaSessionState.ESTABLISHING)) {
-            @Override
-            ServerConnectionStateMachine createServerConnection(HostPort remote) {
-                return serverConnectionStateMachine;
-            }
-        };
+                new KafkaSession(KafkaSessionState.ESTABLISHING),
+                (remote, ccsm, vc, cn, ni) -> serverConnectionStateMachine);
         when(frontendHandler.channelId()).thenReturn(DefaultChannelId.newInstance());
         when(frontendHandler.remoteHost()).thenReturn("testhost.example.com");
         when(frontendHandler.remotePort()).thenReturn(9476);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -82,15 +82,8 @@ class KafkaProxyFrontendHandlerTest {
 
     ClientConnectionStateMachine clientConnectionStateMachine(EndpointBinding endpointBinding) {
         var kafkaSession = new KafkaSession(KafkaSessionState.ESTABLISHING);
-        return new ClientConnectionStateMachine(Objects.requireNonNull(endpointBinding), new DefaultSubjectBuilder(List.of()), kafkaSession) {
-            @Override
-            ServerConnectionStateMachine createServerConnection(HostPort remote) {
-                return new ServerConnectionStateMachine(
-                        remote,
-                        this,
-                        virtualCluster(),
-                        clusterName(),
-                        nodeId()) {
+        return new ClientConnectionStateMachine(Objects.requireNonNull(endpointBinding), new DefaultSubjectBuilder(List.of()), kafkaSession,
+                (remote, ccsm, vc, cn, ni) -> new ServerConnectionStateMachine(remote, ccsm, vc, cn, ni) {
                     @Override
                     Bootstrap configureBootstrap(
                                                  KafkaProxyBackendHandler capturedBackendHandler,
@@ -115,9 +108,7 @@ class KafkaProxyFrontendHandlerTest {
                         outboundChannel.pipeline().fireChannelRegistered();
                         return outboundChannel.newPromise();
                     }
-                };
-            }
-        };
+                });
     }
 
     private PluginFactoryRegistry pfr;


### PR DESCRIPTION
…ry composition

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
x Refactoring
- Documentation

### Description

Extracted `ServerConnectionFactory` functional interface inside `ClientConnectionStateMachine` 
to remove the anonymous class override pattern in tests.

- Added package-private constructor accepting `ServerConnectionFactory`
- Public constructor delegates to it with the default `ServerConnectionStateMachine` instantiation
- Removed `@VisibleForTesting` from `createServerConnection()`
- Updated test `setUp()` to use a lambda instead of an anonymous subclass override

### Additional Context

Fixes #4046

The existing test used an anonymous subclass of `ClientConnectionStateMachine` to override 
`createServerConnection()` and inject a mock `ServerConnectionStateMachine`. This is the 
"smelly override" pattern noted in the issue. Composition via a factory interface is cleaner 
and removes the need for a `@VisibleForTesting` override point.

Note: `forceState()` is still present as it is used extensively across the test class. 
Happy to investigate removing it in a follow-up if that's desirable.


### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
