### PR TITLE
docs(rules): clarify Given block constraints in testing rule

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -30,3 +30,26 @@ Numbered phase comments (`// Phase 1`, `// Phase 2`) tell you sequence but hide 
 "Phase 3: reconfigure swaps the filter chain" and "When: proxy reconfigured with new filter
 chain" carry the same information, but only the second tells you that reconfigure is the action
 being tested, not more setup.
+
+## Given — minimum state, no assertions
+
+**Given provides only the minimum state needed to make When testable — nothing more.**
+The confidence a test suite provides comes from two signals: the aggregate (many tests
+failing at once tells you something fundamental has snapped) and the individual (one test
+failing tells you precisely what is broken). A Given that does more than minimum setup
+corrupts both. It inflates the sea of red — tests that aren't about the broken thing start
+failing, making the aggregate harder to read. And it reduces the specificity of a single
+failure — you can no longer tell whether the precondition was wrong or the When produced
+the wrong outcome.
+
+**Given must not contain assertions.** An assertion in Given gives the test two reasons to
+fail: the precondition is wrong, or the When produced the wrong outcome. When the test
+fails you can't tell which. If a precondition is genuinely worth asserting, extract it to a
+dedicated test that owns that concern — then every test that depends on it can simply trust it.
+
+If you need to guard against a test running in an environment that can't support it,
+`assumeThat` is appropriate — for example, checking that `kubectl` is on the PATH or that
+EPOLL or io_uring can be enabled. These are deployment facts, not behavioral contracts. For
+behavioral preconditions (did my filter initialize? does this cluster exist?), `assumeThat`
+is the wrong tool — those imply a testable contract that either already has coverage elsewhere
+in the suite, or needs a dedicated test added. The right answer is never to silently skip.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -33,13 +33,16 @@ being tested, not more setup.
 
 ## Given — minimum state, no assertions
 
-**Given provides only the minimum state needed to make When testable — nothing more.**
+**Given establishes the side effects the When block depends on — nothing more.** Ask: what
+does the When need to act on? Given should establish exactly that. Anything beyond it is
+characterising system behaviour, not establishing state.
+
 The confidence a test suite provides comes from two signals: the aggregate (many tests
 failing at once tells you something fundamental has snapped) and the individual (one test
-failing tells you precisely what is broken). A Given that does more than minimum setup
-corrupts both. It inflates the sea of red — tests that aren't about the broken thing start
-failing, making the aggregate harder to read. And it reduces the specificity of a single
-failure — you can no longer tell whether the precondition was wrong or the When produced
+failing tells you precisely what is broken). A Given that does more than establish the When's
+dependencies corrupts both. It inflates the sea of red — tests that aren't about the broken
+thing start failing, making the aggregate harder to read. And it reduces the specificity of a
+single failure — you can no longer tell whether the precondition was wrong or the When produced
 the wrong outcome.
 
 **Given must not contain assertions.** An assertion in Given gives the test two reasons to


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Extends the existing Given/When/Then test structure rule to clarify what belongs in a Given block.

Reviewing recent integration tests surfaced a pattern worth making explicit: Given blocks that contain assertions or checks beyond the minimum state needed to make When testable. This corrupts two signals the test suite provides — the aggregate (many failures at once indicates something fundamental has broken) and the individual (a single failure points precisely at what is wrong). Assertions in Given give a test two reasons to fail, diluting both.

The addition covers:
- Given = minimum state only, and why that matters for suite-level signal
- Given must not contain assertions; if a precondition is worth asserting, it warrants a dedicated test
- The appropriate use of `assumeThat` for deployment/infrastructure preconditions (e.g. is `kubectl` on the PATH, can EPOLL or io_uring be enabled) vs behavioural preconditions, which imply a testable contract that should have dedicated coverage

### Additional Context

The existing rule introduced the Given/When/Then structure but didn't address the boundary of what Given should contain. This closes that gap.

### Checklist

- [x] New tests written (where applicable).
- [x] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).