### PR TITLE
chore(ci): remove unused workflow parameters from artifact downloads

### DIFF
--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -104,7 +104,6 @@ jobs:
       - name: Download release state artefact
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151
         with:
-          workflow: stage-release
           run_id: ${{ env.RELCAND_ID }}
           name: RELEASE_STATE.json
 

--- a/.github/workflows/run-system-tests.yaml
+++ b/.github/workflows/run-system-tests.yaml
@@ -99,26 +99,22 @@ jobs:
       - name: 'Download Kroxylicious Maven artifacts'
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151
         with:
-          workflow: build_artifacts
           name: kroxylicious-maven-artifacts
           path: /tmp/kroxylicious-artifacts
           run_id: ${{github.run_id}}
       - name: Download kroxylicious proxy container artifact
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151
         with:
-          workflow: build_kroxylicious_images
           name: kroxylicious-proxy
           run_id: ${{github.run_id}}
       - name: Download kroxylicious operator container artifact
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151
         with:
-          workflow: build_kroxylicious_images
           name: kroxylicious-operator
           run_id: ${{github.run_id}}
       - name: Download kroxylicious admission-webhook container artifact
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151
         with:
-          workflow: build_kroxylicious_images
           name: kroxylicious-admission-webhook
           run_id: ${{github.run_id}}
       - name: 'Extract Kroxylicious Maven artifacts'

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -28,7 +28,6 @@ jobs:
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151
         if: env.SONAR_TOKEN_SET == 'true'
         with:
-          workflow: Build
           run_id: ${{ github.event.workflow_run.id }}
           name: PR_NUMBER
       - name: Read PR_NUMBER.txt


### PR DESCRIPTION
## Summary
Removes dead code from GitHub Actions workflows - the `workflow` parameter in `dawidd6/action-download-artifact` action calls that is ignored when `run_id` is specified.

## Background
While investigating #4111, we discovered that several workflows specify the `workflow` parameter when downloading artifacts, but this parameter is completely ignored by the action when `run_id` is also specified. 

Looking at the [action's source code](https://github.com/dawidd6/action-download-artifact/blob/master/main.js#L133), the workflow search logic only executes when `run_id` is NOT specified. When `run_id` is present, the action directly downloads artifacts from that specific run.

The workflow parameter is documented as requiring a workflow filename, rather than a workflow title.  We had erroneously passed a workflow title in a few places. In some cases the title had rotted too.

## Changes
Removed the unused `workflow` parameter from:
- `.github/workflows/sonar.yaml` - removed `workflow: Build`
- `.github/workflows/run-system-tests.yaml` - removed 4 instances
- `.github/workflows/promote_release.yaml` - removed `workflow: stage-release`

## Impact
- **No behavioral change** - all workflows continue to function identically
- **Code clarity** - removes misleading dead code that suggested the action was searching by workflow name
- **Correctness** - the removed values were incorrect anyway (using titles/job names instead of filenames)

## Testing
- [x] Verified the action source code confirms this is dead code
- [x] All affected workflows have `run_id` specified, so behavior is unchanged
- [ ] CI will validate workflows still work correctly

Relates-to: #4111