### PR TITLE
chore(ci): make Sonar operator scan adaptive to branch module structure

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -122,9 +122,13 @@ jobs:
       - name: SonarCloud scan on PR for the Operator
         if: env.SONAR_TOKEN_SET == 'true'
         run: |
+          PROJECTS=':kroxylicious-operator,:kroxylicious-parent,:kroxylicious-operator-dist'
+          if [ -f "kroxylicious-kubernetes/pom.xml" ]; then
+            PROJECTS=":kroxylicious-operator,:kroxylicious-kubernetes-parent,:kroxylicious-parent,:kroxylicious-operator-dist"
+          fi
           mvn --batch-mode \
             --activate-profiles 'ci,!qa' \
-            --projects ':kroxylicious-operator,:kroxylicious-kubernetes-parent,:kroxylicious-parent,:kroxylicious-operator-dist' \
+            --projects "$PROJECTS" \
             -Derrorprone.skip=true \
             -DskipITs=true \
             -Djapicmp.skip=true \


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

x Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

The Sonar workflow hardcodes `:kroxylicious-kubernetes-parent` in the operator 
scan projects list. This module doesn't exist on older release branches (e.g. 
`release/v0.20`), causing the Maven build to fail silently and leaving PRs with 
a perpetually pending SonarCloud status check.

Fix: detect whether `kroxylicious-kubernetes/pom.xml` exists in the checked-out 
branch before building the project list, so the workflow adapts automatically to 
the branch's module structure.

### Additional Context

Fixes #4113

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
