### PR TITLE
Implement static/passthrough routing

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/config/BuilderConfig.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/config/BuilderConfig.java
@@ -14,6 +14,9 @@ import io.sundr.builder.annotations.ExternalBuildables;
 @ExternalBuildables(editableEnabled = false, generateBuilderPackage = true, builderPackage = BuilderConfig.TARGET_CONFIG_PACKAGE, value = {
         "io.kroxylicious.proxy.config.Configuration",
         "io.kroxylicious.proxy.config.TargetCluster",
+        "io.kroxylicious.proxy.config.TargetClusterDefinition",
+        "io.kroxylicious.proxy.config.RouterDefinition",
+        "io.kroxylicious.proxy.config.RouteDefinition",
         "io.kroxylicious.proxy.config.VirtualCluster",
         "io.kroxylicious.proxy.config.VirtualClusterGateway",
         "io.kroxylicious.proxy.config.PortIdentifiesNodeIdentificationStrategy",

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/config/BuilderConfig.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/config/BuilderConfig.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.ExternalBuildables;
 @ExternalBuildables(editableEnabled = false, generateBuilderPackage = true, builderPackage = BuilderConfig.TARGET_CONFIG_PACKAGE, value = {
         "io.kroxylicious.proxy.config.Configuration",
         "io.kroxylicious.proxy.config.TargetCluster",
-        "io.kroxylicious.proxy.config.TargetClusterDefinition",
+        "io.kroxylicious.proxy.config.ClusterDefinition",
         "io.kroxylicious.proxy.config.RouterDefinition",
         "io.kroxylicious.proxy.config.RouteDefinition",
         "io.kroxylicious.proxy.config.VirtualCluster",

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/config/ConfigurationTest.java
@@ -590,7 +590,17 @@ class ConfigurationTest {
                 new NamedFilterDefinition("foo", "", ""));
         Optional<Map<String, Object>> development = Optional.empty();
         var virtualCluster = List.of(VIRTUAL_CLUSTER);
-        assertThatThrownBy(() -> new Configuration(null, null, filterDefinitions, null, null, virtualCluster, null, false, development, null, null))
+        assertThatThrownBy(() -> new Configuration(null,
+                null,
+                filterDefinitions,
+                null,
+                null,
+                virtualCluster,
+                null,
+                false,
+                development,
+                null,
+                null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("'filterDefinitions' contains multiple items with the same names: [foo]");
     }
@@ -601,7 +611,17 @@ class ConfigurationTest {
         List<NamedFilterDefinition> filterDefinitions = List.of();
         List<String> defaultFilters = List.of("missing");
         var virtualCluster = List.of(VIRTUAL_CLUSTER);
-        assertThatThrownBy(() -> new Configuration(null, null, filterDefinitions, defaultFilters, null, virtualCluster, null, false, development, null, null))
+        assertThatThrownBy(() -> new Configuration(null,
+                null,
+                filterDefinitions,
+                defaultFilters,
+                null,
+                virtualCluster,
+                null,
+                false,
+                development,
+                null,
+                null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("'defaultFilters' references filters not defined in 'filterDefinitions': [missing]");
     }
@@ -614,7 +634,17 @@ class ConfigurationTest {
         TargetCluster targetCluster = new TargetCluster("unused:9082", Optional.empty());
         List<VirtualCluster> virtualClusters = List
                 .of(new VirtualCluster("vc1", targetCluster, defaultGateway, false, false, List.of("missing")));
-        assertThatThrownBy(() -> new Configuration(null, null, filterDefinitions, null, null, virtualClusters, null, false, development, null, null))
+        assertThatThrownBy(() -> new Configuration(
+                null,
+                null,
+                filterDefinitions,
+                null,
+                null,
+                virtualClusters,
+                null, false,
+                development,
+                null,
+                null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("'virtualClusters.vc1.filters' references filters not defined in 'filterDefinitions': [missing]");
     }
@@ -633,7 +663,17 @@ class ConfigurationTest {
         List<VirtualClusterGateway> defaultGateway = List.of(VIRTUAL_CLUSTER_GATEWAY);
         TargetCluster targetCluster = new TargetCluster("unused:9082", Optional.empty());
         List<VirtualCluster> virtualClusters = List.of(new VirtualCluster("vc1", targetCluster, defaultGateway, false, false, List.of("used2")));
-        assertThatThrownBy(() -> new Configuration(null, null, filterDefinitions, defaultFilters, null, virtualClusters, null, false, development, null, null))
+        assertThatThrownBy(() -> new Configuration(null,
+                null,
+                filterDefinitions,
+                defaultFilters,
+                null,
+                virtualClusters,
+                null,
+                false,
+                development,
+                null,
+                null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage(
                         "'filterDefinitions' defines filters which are not used in 'defaultFilters', in any virtual cluster's 'filters', or in any route's 'filters': [unused]");
@@ -649,8 +689,18 @@ class ConfigurationTest {
         VirtualCluster direct = buildVirtualCluster("direct", "y:9092", List.of("foo")); // filters defined on cluster
         VirtualCluster defaulted = buildVirtualCluster("defaulted", "x:9092", null); // filters not defined => should default to the top level
 
-        Configuration configuration = new Configuration(null, null, filterDefinitions, List.of("bar"), null, List.of(direct, defaulted), null, false, Optional.empty(),
-                null, null);
+        Configuration configuration = new Configuration(
+                null,
+                null,
+                filterDefinitions,
+                List.of("bar"),
+                null,
+                List.of(direct, defaulted),
+                null,
+                false,
+                Optional.empty(),
+                null,
+                null);
 
         // When
         var model = configuration.virtualClusterModel(null);
@@ -666,29 +716,37 @@ class ConfigurationTest {
 
     @Test
     void proxyProtocolModeShouldReturnRequiredWhenRequired() {
-        Configuration configuration = new Configuration(null, null, null, null, null, List.of(buildVirtualCluster("vc", "x:9092", null)), null, false, Optional.empty(),
-                null, new ProxyProtocolConfig(ProxyProtocolMode.REQUIRED));
+        Configuration configuration = new Configuration(null, null, null, null, null,
+                List.of(buildVirtualCluster("vc", "x:9092", null)),
+                null, false, Optional.empty(), null,
+                new ProxyProtocolConfig(ProxyProtocolMode.REQUIRED));
         assertThat(configuration.proxyProtocolMode()).isEqualTo(ProxyProtocolMode.REQUIRED);
     }
 
     @Test
     void proxyProtocolModeShouldReturnAllowedWhenAllowed() {
-        Configuration configuration = new Configuration(null, null, null, null, null, List.of(buildVirtualCluster("vc", "x:9092", null)), null, false, Optional.empty(),
-                null, new ProxyProtocolConfig(ProxyProtocolMode.ALLOWED));
+        Configuration configuration = new Configuration(null, null, null, null, null,
+                List.of(buildVirtualCluster("vc", "x:9092", null)),
+                null, false, Optional.empty(), null,
+                new ProxyProtocolConfig(ProxyProtocolMode.ALLOWED));
         assertThat(configuration.proxyProtocolMode()).isEqualTo(ProxyProtocolMode.ALLOWED);
     }
 
     @Test
     void proxyProtocolModeShouldReturnDisabledWhenDisabled() {
-        Configuration configuration = new Configuration(null, null, null, null, null, List.of(buildVirtualCluster("vc", "x:9092", null)), null, false, Optional.empty(),
-                null, new ProxyProtocolConfig(ProxyProtocolMode.DISABLED));
+        Configuration configuration = new Configuration(null, null, null, null, null,
+                List.of(buildVirtualCluster("vc", "x:9092", null)),
+                null, false, Optional.empty(), null,
+                new ProxyProtocolConfig(ProxyProtocolMode.DISABLED));
         assertThat(configuration.proxyProtocolMode()).isEqualTo(ProxyProtocolMode.DISABLED);
     }
 
     @Test
     void proxyProtocolDefaultsToDisabledWhenNull() {
-        Configuration configuration = new Configuration(null, null, null, null, null, List.of(buildVirtualCluster("vc", "x:9092", null)), null, false, Optional.empty(),
-                null, null);
+        Configuration configuration = new Configuration(null, null, null, null, null,
+                List.of(buildVirtualCluster("vc", "x:9092", null)),
+                null, false, Optional.empty(), null,
+                null);
         assertThat(configuration.proxyProtocolMode()).isEqualTo(ProxyProtocolMode.DISABLED);
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/AbstractFilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/AbstractFilterIT.java
@@ -68,7 +68,6 @@ import io.kroxylicious.testing.integration.Request;
 import io.kroxylicious.testing.integration.Response;
 import io.kroxylicious.testing.integration.ResponsePayload;
 import io.kroxylicious.testing.integration.config.NamedFilterDefinitionBuilder;
-import io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 import io.kroxylicious.testing.kafka.junit5ext.Topic;
@@ -76,7 +75,6 @@ import io.kroxylicious.testing.kafka.junit5ext.Topic;
 import static io.kroxylicious.it.UnknownTaggedFields.unknownTaggedFieldsToStrings;
 import static io.kroxylicious.it.testplugins.RequestResponseMarkingFilter.FILTER_NAME_TAG;
 import static io.kroxylicious.it.testplugins.TopicIdToNameResponseStamper.topicNameMapping;
-import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.proxy;
 import static io.kroxylicious.testing.integration.tester.KroxyliciousTesters.kroxyliciousTester;
 import static io.kroxylicious.testing.integration.tester.KroxyliciousTesters.mockKafkaKroxyliciousTester;
 import static io.kroxylicious.testing.integration.tester.MockServerKroxyliciousTester.zeroAckProduceRequestMatcher;
@@ -98,7 +96,9 @@ import static org.awaitility.Awaitility.await;
 
 @ExtendWith(KafkaClusterExtension.class)
 @ExtendWith(NettyLeakDetectorExtension.class)
-class FilterIT {
+abstract class AbstractFilterIT {
+
+    protected abstract ConfigurationBuilder proxyConfig(String bootstrapServers);
 
     private static final String PLAINTEXT = "Hello, world!";
     private static final NamedFilterDefinitionBuilder REJECTING_CREATE_TOPIC_FILTER = new NamedFilterDefinitionBuilder(RejectingCreateTopicFilterFactory.class.getName(),
@@ -120,7 +120,7 @@ class FilterIT {
         NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(TOPIC_ID_LOOKUP_FILTER_NAME,
                 TopicIdToNameResponseStamper.class.getName())
                 .build();
-        var config = proxy(cluster)
+        var config = proxyConfig(cluster.getBootstrapServers())
                 .addToFilterDefinitions(namedFilterDefinition)
                 .addToDefaultFilters(namedFilterDefinition.name());
 
@@ -141,7 +141,7 @@ class FilterIT {
                 TopicIdToNameResponseStamper.class.getName())
                 .withConfig("asyncTopicNameLookup", true)
                 .build();
-        var config = proxy(cluster)
+        var config = proxyConfig(cluster.getBootstrapServers())
                 .addToFilterDefinitions(namedFilterDefinition)
                 .addToDefaultFilters(namedFilterDefinition.name());
 
@@ -163,7 +163,7 @@ class FilterIT {
         NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(TOPIC_ID_LOOKUP_FILTER_NAME,
                 TopicIdToNameResponseStamper.class.getName())
                 .build();
-        var config = proxy(cluster)
+        var config = proxyConfig(cluster.getBootstrapServers())
                 .addToFilterDefinitions(namedFilterDefinition)
                 .addToDefaultFilters(namedFilterDefinition.name());
 
@@ -184,7 +184,7 @@ class FilterIT {
                 TopicIdToNameResponseStamper.class.getName())
                 .build();
         try (var tester = mockKafkaKroxyliciousTester(bootstrap -> {
-            ConfigurationBuilder proxy = proxy(bootstrap);
+            ConfigurationBuilder proxy = proxyConfig(bootstrap);
             proxy.addToFilterDefinitions(namedFilterDefinition)
                     .addToDefaultFilters(namedFilterDefinition.name());
             return proxy;
@@ -224,7 +224,7 @@ class FilterIT {
                 TopicIdToNameResponseStamper.class.getName())
                 .build();
         try (var tester = mockKafkaKroxyliciousTester(bootstrap -> {
-            ConfigurationBuilder proxy = proxy(bootstrap);
+            ConfigurationBuilder proxy = proxyConfig(bootstrap);
             proxy.addToFilterDefinitions(namedFilterDefinition)
                     .addToDefaultFilters(namedFilterDefinition.name());
             return proxy;
@@ -278,7 +278,7 @@ class FilterIT {
         NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(TOPIC_ID_LOOKUP_FILTER_NAME,
                 TopicIdToNameResponseStamper.class.getName())
                 .build();
-        var config = proxy(cluster)
+        var config = proxyConfig(cluster.getBootstrapServers())
                 .addToFilterDefinitions(namedFilterDefinition)
                 .addToDefaultFilters(namedFilterDefinition.name());
 
@@ -302,7 +302,7 @@ class FilterIT {
         NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(TOPIC_ID_LOOKUP_FILTER_NAME,
                 TopicIdToNameResponseStamper.class.getName())
                 .build();
-        var config = proxy(cluster)
+        var config = proxyConfig(cluster.getBootstrapServers())
                 .addToFilterDefinitions(namedFilterDefinition)
                 .addToDefaultFilters(namedFilterDefinition.name());
 
@@ -333,8 +333,8 @@ class FilterIT {
         assertTopicStampingFilterObservesTopicNames(cluster, topic1, topic2, filterOrder, topic1.name(), topic2.name());
     }
 
-    private static void assertTopicStampingFilterObservesTopicNames(KafkaCluster cluster, Topic topic1, Topic topic2, String[] filterOrder, String expectedNameForTopic1,
-                                                                    String expectedNameForTopic2) {
+    private void assertTopicStampingFilterObservesTopicNames(KafkaCluster cluster, Topic topic1, Topic topic2, String[] filterOrder, String expectedNameForTopic1,
+                                                             String expectedNameForTopic2) {
         Uuid topic1Id = topic1.topicId().orElseThrow();
         Uuid topic2Id = topic2.topicId().orElseThrow();
 
@@ -344,7 +344,7 @@ class FilterIT {
         NamedFilterDefinition topicNamePrefixer = new NamedFilterDefinitionBuilder(TOPIC_NAME_PREFIXER_FILTER_NAME,
                 TopicNameMetadataPrefixer.class.getName())
                 .build();
-        var config = proxy(cluster)
+        var config = proxyConfig(cluster.getBootstrapServers())
                 .addToFilterDefinitions(namedFilterDefinition)
                 .addToFilterDefinitions(topicNamePrefixer)
                 .addToDefaultFilters(filterOrder);
@@ -417,7 +417,7 @@ class FilterIT {
     @Test
     void shouldPassThroughRecordUnchanged(KafkaCluster cluster, Topic topic) throws Exception {
 
-        try (var tester = kroxyliciousTester(proxy(cluster));
+        try (var tester = kroxyliciousTester(proxyConfig(cluster.getBootstrapServers()));
                 var producer = tester.producer(Map.of(CLIENT_ID_CONFIG, "shouldPassThroughRecordUnchanged", DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
                 var consumer = tester.consumer()) {
             producer.send(new ProducerRecord<>(topic.name(), "my-key", "Hello, world!")).get();
@@ -438,7 +438,7 @@ class FilterIT {
     void bootstrapServersToleratesWhitespace(KafkaCluster cluster, Topic topic) throws Exception {
         String bootstrapServers = cluster.getBootstrapServers();
         String bootstrapServersContainingWhitespace = Arrays.stream(bootstrapServers.split(",")).collect(Collectors.joining("  ,  ", "  ", "  "));
-        ConfigurationBuilder configBuilder = KroxyliciousConfigUtils.proxy(bootstrapServersContainingWhitespace);
+        ConfigurationBuilder configBuilder = proxyConfig(bootstrapServersContainingWhitespace);
         try (var tester = kroxyliciousTester(configBuilder);
                 var producer = tester.producer(Map.of(CLIENT_ID_CONFIG, "shouldPassThroughRecordUnchanged", DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
                 var consumer = tester.consumer()) {
@@ -460,7 +460,7 @@ class FilterIT {
     @SuppressWarnings("java:S5841")
     // java:S5841 warns that doesNotContain passes for the empty case. Which is what we want here.
     void requestFiltersCanRespondWithoutProxying(KafkaCluster cluster, Admin admin) throws Exception {
-        var config = proxy(cluster)
+        var config = proxyConfig(cluster.getBootstrapServers())
                 .addToFilterDefinitions(REJECTING_CREATE_TOPIC_FILTER.build())
                 .addToDefaultFilters(REJECTING_CREATE_TOPIC_FILTER.name());
 
@@ -477,7 +477,7 @@ class FilterIT {
 
     @Test
     void filtersCanImplementGenericRequestFilterAndSpecificResponseFilter() {
-        try (var tester = mockKafkaKroxyliciousTester(mockBootstrap -> proxy(mockBootstrap)
+        try (var tester = mockKafkaKroxyliciousTester(mockBootstrap -> proxyConfig(mockBootstrap)
                 .addToFilterDefinitions(GENERIC_REQUEST_SPECIFIC_RESPONSE.build())
                 .addToDefaultFilters(GENERIC_REQUEST_SPECIFIC_RESPONSE.name()));
                 var simpleTestClient = tester.simpleTestClient()) {
@@ -497,7 +497,7 @@ class FilterIT {
 
     @Test
     void filtersCanImplementGenericResponseFilterAndSpecificRequestFilter() {
-        try (var tester = mockKafkaKroxyliciousTester(mockBootstrap -> proxy(mockBootstrap)
+        try (var tester = mockKafkaKroxyliciousTester(mockBootstrap -> proxyConfig(mockBootstrap)
                 .addToFilterDefinitions(GENERIC_RESPONSE_SPECIFIC_REQUEST.build())
                 .addToDefaultFilters(GENERIC_RESPONSE_SPECIFIC_REQUEST.name()));
                 var simpleTestClient = tester.simpleTestClient()) {
@@ -530,7 +530,7 @@ class FilterIT {
                 .withConfig("withCloseConnection", withCloseConnection,
                         "forwardingStyle", forwardingStyle)
                 .build();
-        try (var tester = mockKafkaKroxyliciousTester(mockBootstrap -> proxy(mockBootstrap)
+        try (var tester = mockKafkaKroxyliciousTester(mockBootstrap -> proxyConfig(mockBootstrap)
                 .addToFilterDefinitions(rejectFilter)
                 .addToDefaultFilters(REJECTING_CREATE_TOPIC_FILTER.name()));
                 var requestClient = tester.simpleTestClient()) {
@@ -604,7 +604,7 @@ class FilterIT {
                         "name", name,
                         "forwardingStyle", forwardingStyle)
                 .build();
-        try (var tester = mockKafkaKroxyliciousTester(mockBootstrap -> proxy(mockBootstrap)
+        try (var tester = mockKafkaKroxyliciousTester(mockBootstrap -> proxyConfig(mockBootstrap)
                 .addToFilterDefinitions(markingFilter)
                 .addToDefaultFilters(name));
                 var kafkaClient = tester.simpleTestClient()) {
@@ -639,7 +639,7 @@ class FilterIT {
     @SuppressWarnings("java:S5841")
     // java:S5841 warns that doesNotContain passes for the empty case. Which is what we want here.
     void requestFiltersCanRespondWithoutProxyingDoesntLeakBuffers(KafkaCluster cluster, Admin admin) throws Exception {
-        var config = proxy(cluster)
+        var config = proxyConfig(cluster.getBootstrapServers())
                 .addToFilterDefinitions(REJECTING_CREATE_TOPIC_FILTER.build())
                 .addToDefaultFilters(REJECTING_CREATE_TOPIC_FILTER.name());
 
@@ -679,7 +679,7 @@ class FilterIT {
         NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(ProduceRequestTransformation.class.getName(),
                 ProduceRequestTransformation.class.getName())
                 .withConfig("transformation", TestEncoderFactory.class.getName()).build();
-        var config = proxy(cluster)
+        var config = proxyConfig(cluster.getBootstrapServers())
                 .addToFilterDefinitions(namedFilterDefinition)
                 .addToDefaultFilters(namedFilterDefinition.name());
 
@@ -711,7 +711,7 @@ class FilterIT {
     void requestFiltersCanRespondWithoutProxyingRespondsInCorrectOrder() throws Exception {
 
         try (var tester = mockKafkaKroxyliciousTester(
-                s -> proxy(s).addToFilterDefinitions(REJECTING_CREATE_TOPIC_FILTER.build())
+                s -> proxyConfig(s).addToFilterDefinitions(REJECTING_CREATE_TOPIC_FILTER.build())
                         .addToDefaultFilters(REJECTING_CREATE_TOPIC_FILTER.name()));
                 var client = tester.simpleTestClient()) {
             tester.addMockResponseForApiKey(new ResponsePayload(METADATA, METADATA.latestVersion(), new MetadataResponseData()));
@@ -734,7 +734,7 @@ class FilterIT {
     void clientsCanSendMultipleMessagesImmediately() {
 
         try (var tester = mockKafkaKroxyliciousTester(
-                s -> proxy(s).addToFilterDefinitions(REJECTING_CREATE_TOPIC_FILTER.build())
+                s -> proxyConfig(s).addToFilterDefinitions(REJECTING_CREATE_TOPIC_FILTER.build())
                         .addToDefaultFilters(REJECTING_CREATE_TOPIC_FILTER.name()));
                 var client = tester.simpleTestClient()) {
             tester.addMockResponseForApiKey(new ResponsePayload(METADATA, METADATA.latestVersion(), new MetadataResponseData()));
@@ -752,7 +752,7 @@ class FilterIT {
     void zeroAckProduceRequestsDoNotInterfereWithResponseReorderingLogic() throws Exception {
 
         try (var tester = mockKafkaKroxyliciousTester(
-                s -> proxy(s).addToFilterDefinitions(REJECTING_CREATE_TOPIC_FILTER.build())
+                s -> proxyConfig(s).addToFilterDefinitions(REJECTING_CREATE_TOPIC_FILTER.build())
                         .addToDefaultFilters(REJECTING_CREATE_TOPIC_FILTER.name()));
                 var client = tester.simpleTestClient()) {
             tester.addMockResponseForApiKey(new ResponsePayload(METADATA, METADATA.latestVersion(), new MetadataResponseData()));
@@ -779,7 +779,7 @@ class FilterIT {
     @Test
     void shouldModifyZeroAckProduceMessage(KafkaCluster cluster, Topic topic) throws Exception {
         String className = ProduceRequestTransformation.class.getName();
-        var config = proxy(cluster)
+        var config = proxyConfig(cluster.getBootstrapServers())
                 .addToFilterDefinitions(new NamedFilterDefinitionBuilder(className, className)
                         .withConfig("transformation", TestEncoderFactory.class.getName()).build())
                 .addToDefaultFilters(className);
@@ -807,7 +807,7 @@ class FilterIT {
     @Test
     void shouldForwardUnfilteredZeroAckProduceMessage(KafkaCluster cluster, Topic topic) throws Exception {
 
-        var config = proxy(cluster);
+        var config = proxyConfig(cluster.getBootstrapServers());
 
         try (var tester = kroxyliciousTester(config);
                 var producer = tester.producer(Map.of(CLIENT_ID_CONFIG, "shouldModifyProduceMessage", DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000, ACKS_CONFIG, "0"));
@@ -835,7 +835,7 @@ class FilterIT {
         var encoded2 = encode(topic2.name(), ByteBuffer.wrap(bytes)).array();
 
         NamedFilterDefinitionBuilder filterDefinitionBuilder = new NamedFilterDefinitionBuilder("filter-1", FetchResponseTransformation.class.getName());
-        var config = proxy(cluster)
+        var config = proxyConfig(cluster.getBootstrapServers())
                 .addToFilterDefinitions(filterDefinitionBuilder
                         .withConfig("transformation", TestDecoderFactory.class.getName()).build())
                 .addToDefaultFilters(filterDefinitionBuilder.name());

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/FilterDirectIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/FilterDirectIT.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.it;
+
+import io.kroxylicious.proxy.config.ConfigurationBuilder;
+import io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils;
+
+class FilterDirectIT extends AbstractFilterIT {
+
+    @Override
+    protected ConfigurationBuilder proxyConfig(String bootstrapServers) {
+        return KroxyliciousConfigUtils.proxy(bootstrapServers);
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/FilterRoutedIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/FilterRoutedIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.it;
+
+import java.util.List;
+
+import io.kroxylicious.it.testplugins.PassThroughRouterFactory;
+import io.kroxylicious.proxy.config.ClusterDefinition;
+import io.kroxylicious.proxy.config.ConfigurationBuilder;
+import io.kroxylicious.proxy.config.RouteDefinition;
+import io.kroxylicious.proxy.config.RouteTarget;
+import io.kroxylicious.proxy.config.RouterDefinition;
+import io.kroxylicious.proxy.config.VirtualClusterBuilder;
+
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.baseConfigurationBuilder;
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
+
+/**
+ * Ensures that basic Virtual-cluster Filter interactions work in combination with a simple
+ * passthrough Router.
+ */
+class FilterRoutedIT extends AbstractFilterIT {
+
+    private static final String ROUTE_NAME = "default-route";
+    private static final String ROUTER_NAME = "pass-through";
+    private static final String CLUSTER_NAME = "backing";
+
+    @Override
+    protected ConfigurationBuilder proxyConfig(String bootstrapServers) {
+        var clusterDef = new ClusterDefinition(CLUSTER_NAME, bootstrapServers, null);
+        var route = new RouteDefinition(ROUTE_NAME, 0, List.of(), new RouteTarget(CLUSTER_NAME, null));
+        var routerConfig = new PassThroughRouterFactory.Config(ROUTE_NAME);
+        var routerDef = new RouterDefinition(ROUTER_NAME,
+                PassThroughRouterFactory.class.getName(), routerConfig, List.of(route));
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, ROUTER_NAME))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder("localhost:9192").build())
+                .build();
+        return baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDef)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingPassThroughIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingPassThroughIT.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.it;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
+
+import io.kroxylicious.it.testplugins.PassThroughRouterFactory;
+import io.kroxylicious.proxy.config.ClusterDefinition;
+import io.kroxylicious.proxy.config.ConfigurationBuilder;
+import io.kroxylicious.proxy.config.RouteDefinition;
+import io.kroxylicious.proxy.config.RouteTarget;
+import io.kroxylicious.proxy.config.RouterDefinition;
+import io.kroxylicious.proxy.config.VirtualClusterBuilder;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+import io.kroxylicious.testing.kafka.junit5ext.Topic;
+
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.baseConfigurationBuilder;
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
+import static io.kroxylicious.testing.integration.tester.KroxyliciousTesters.kroxyliciousTester;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests verifying that routing via a pass-through router
+ * works identically to the direct target-cluster path.
+ */
+@ExtendWith(KafkaClusterExtension.class)
+@ExtendWith(NettyLeakDetectorExtension.class)
+class RoutingPassThroughIT {
+
+    private static final String ROUTE_NAME = "default-route";
+    private static final String ROUTER_NAME = "pass-through";
+    private static final String TARGET_CLUSTER_NAME = "backing";
+
+    private ConfigurationBuilder routingConfig(KafkaCluster cluster) {
+        var targetCluster = new ClusterDefinition(TARGET_CLUSTER_NAME,
+                cluster.getBootstrapServers(), null);
+
+        var route = new RouteDefinition(ROUTE_NAME, 0, List.of(), new RouteTarget(TARGET_CLUSTER_NAME, null));
+
+        var routerConfig = new PassThroughRouterFactory.Config(ROUTE_NAME);
+        var routerDef = new RouterDefinition(ROUTER_NAME,
+                PassThroughRouterFactory.class.getName(), routerConfig, List.of(route));
+
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, ROUTER_NAME))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder("localhost:9192").build())
+                .build();
+
+        return baseConfigurationBuilder()
+                .addToClusterDefinitions(targetCluster)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
+    }
+
+    @Test
+    void shouldProduceAndConsumeViaPassThroughRouter(KafkaCluster cluster, Topic topic) throws Exception {
+        var config = routingConfig(cluster);
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer();
+                var consumer = tester.consumer(
+                        Map.of(ConsumerConfig.GROUP_ID_CONFIG, "routing-test",
+                                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+
+            producer.send(new ProducerRecord<>(topic.name(), "key", "value"))
+                    .get(10, TimeUnit.SECONDS);
+
+            consumer.subscribe(Set.of(topic.name()));
+            var records = consumer.poll(Duration.ofSeconds(10));
+            assertThat(records).hasSize(1);
+            var record = records.iterator().next();
+            assertThat(record.key()).isEqualTo("key");
+            assertThat(record.value()).isEqualTo("value");
+        }
+    }
+
+    @Test
+    void shouldListTopicsViaPassThroughRouter(KafkaCluster cluster, Topic topic) throws Exception {
+        var config = routingConfig(cluster);
+
+        try (var tester = kroxyliciousTester(config);
+                var admin = tester.admin()) {
+
+            var topics = admin.listTopics().names().get(10, TimeUnit.SECONDS);
+            assertThat(topics).contains(topic.name());
+        }
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingPassThroughIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingPassThroughIT.java
@@ -9,12 +9,16 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
 
@@ -26,6 +30,7 @@ import io.kroxylicious.proxy.config.RouteTarget;
 import io.kroxylicious.proxy.config.RouterDefinition;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.clients.CloseableAdmin;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 import io.kroxylicious.testing.kafka.junit5ext.Topic;
 
@@ -99,6 +104,67 @@ class RoutingPassThroughIT {
 
             var topics = admin.listTopics().names().get(10, TimeUnit.SECONDS);
             assertThat(topics).contains(topic.name());
+        }
+    }
+
+    @ParameterizedTest(name = "route to {0}")
+    @CsvSource({ "route-a", "route-b" })
+    void shouldRouteToSelectedClusterWhenMultipleRoutesDefined(String selectedRoute, KafkaCluster clusterA, KafkaCluster clusterB) throws Exception {
+        // Given: two clusters, two routes, router statically maps all keys to the selected route
+        var clusterDefA = new ClusterDefinition("cluster-a", clusterA.getBootstrapServers(), null);
+        var clusterDefB = new ClusterDefinition("cluster-b", clusterB.getBootstrapServers(), null);
+
+        var routeA = new RouteDefinition("route-a", 0, List.of(), new RouteTarget("cluster-a", null));
+        var routeB = new RouteDefinition("route-b", 1, List.of(), new RouteTarget("cluster-b", null));
+
+        var routerConfig = new PassThroughRouterFactory.Config(selectedRoute);
+        var routerDef = new RouterDefinition("multi-route-router",
+                PassThroughRouterFactory.class.getName(), routerConfig, List.of(routeA, routeB));
+
+        var vc = new VirtualClusterBuilder()
+                .withName("multi-route")
+                .withTarget(new RouteTarget(null, "multi-route-router"))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder("localhost:9192").build())
+                .build();
+
+        var config = baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDefA)
+                .addToClusterDefinitions(clusterDefB)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
+
+        KafkaCluster expectedCluster = selectedRoute.equals("route-a") ? clusterA : clusterB;
+        KafkaCluster unexpectedCluster = selectedRoute.equals("route-a") ? clusterB : clusterA;
+        var topicName = "route-selection-test-" + UUID.randomUUID();
+
+        // When: produce and consume through the proxy
+        try (var tester = kroxyliciousTester(config);
+                var admin = tester.admin();
+                var producer = tester.producer();
+                var consumer = tester.consumer(
+                        Map.of(ConsumerConfig.GROUP_ID_CONFIG, "route-select-test",
+                                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+
+            admin.createTopics(List.of(new NewTopic(topicName, 1, (short) 1)))
+                    .all().get(10, TimeUnit.SECONDS);
+
+            producer.send(new ProducerRecord<>(topicName, "key", "routed-value"))
+                    .get(10, TimeUnit.SECONDS);
+
+            consumer.subscribe(Set.of(topicName));
+            var records = consumer.poll(Duration.ofSeconds(10));
+            assertThat(records).hasSize(1);
+            assertThat(records.iterator().next().value()).isEqualTo("routed-value");
+        }
+
+        // Then: data should exist on the selected cluster, not on the other
+        try (var expectedAdmin = CloseableAdmin.create(expectedCluster.getKafkaClientConfiguration());
+                var unexpectedAdmin = CloseableAdmin.create(unexpectedCluster.getKafkaClientConfiguration())) {
+            var expectedTopics = expectedAdmin.listTopics().names().get(10, TimeUnit.SECONDS);
+            assertThat(expectedTopics).contains(topicName);
+
+            var unexpectedTopics = unexpectedAdmin.listTopics().names().get(10, TimeUnit.SECONDS);
+            assertThat(unexpectedTopics).isEmpty();
         }
     }
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/TestDecoderFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/TestDecoderFactory.java
@@ -30,7 +30,7 @@ public class TestDecoderFactory implements ByteBufferTransformationFactory<Void>
 
         @Override
         public ByteBuffer transform(String topicName, ByteBuffer in) {
-            return FilterIT.decode(topicName, in);
+            return AbstractFilterIT.decode(topicName, in);
         }
     }
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/TestEncoderFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/TestEncoderFactory.java
@@ -30,7 +30,7 @@ public class TestEncoderFactory implements ByteBufferTransformationFactory<Void>
 
         @Override
         public ByteBuffer transform(String topicName, ByteBuffer in) {
-            return FilterIT.encode(topicName, in);
+            return AbstractFilterIT.encode(topicName, in);
         }
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/PassThroughRouterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/PassThroughRouterFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.it.testplugins;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.router.RouterContext;
+import io.kroxylicious.proxy.router.RouterFactory;
+import io.kroxylicious.proxy.router.RouterFactoryContext;
+import io.kroxylicious.proxy.router.RouterResult;
+
+/**
+ * A router that forwards every request to a single named route, delivering
+ * the response back to the client unchanged.
+ */
+@Plugin(configType = PassThroughRouterFactory.Config.class)
+public class PassThroughRouterFactory implements RouterFactory<PassThroughRouterFactory.Config, PassThroughRouterFactory.Config> {
+
+    public record Config(String route) {}
+
+    @Override
+    public Config initialize(RouterFactoryContext context, Config config) {
+        return config;
+    }
+
+    @Override
+    public Router createRouter(RouterFactoryContext context, Config config) {
+        String route = config.route();
+        Map<ApiKeys, String> allStatic = Arrays.stream(ApiKeys.values())
+                .collect(Collectors.toUnmodifiableMap(k -> k, k -> route));
+        return new Router() {
+            @Override
+            public CompletionStage<RouterResult> onRequest(
+                                                           short apiVersion,
+                                                           ApiKeys apiKey,
+                                                           RequestHeaderData header,
+                                                           ApiMessage request,
+                                                           RouterContext routerContext) {
+                throw new IllegalStateException("Dynamic routing is not supported");
+            }
+
+            @Override
+            public Map<ApiKeys, String> staticRoutes() {
+                return allStatic;
+            }
+        };
+    }
+}

--- a/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.router.RouterFactory
+++ b/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.router.RouterFactory
@@ -1,0 +1,1 @@
+io.kroxylicious.it.testplugins.PassThroughRouterFactory

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGenerator.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGenerator.java
@@ -127,7 +127,18 @@ class ProxyConfigGenerator {
                 ? filterDefs.stream().map(NamedFilterDefinition::name).toList()
                 : null;
 
-        var configuration = new Configuration(management, null, filterDefs, defaultFilters, null, List.of(virtualCluster), null, false, Optional.empty(), null, null);
+        var configuration = new Configuration(
+                management,
+                null,
+                filterDefs,
+                defaultFilters,
+                null,
+                List.of(virtualCluster),
+                null,
+                false,
+                Optional.empty(),
+                null,
+                null);
 
         return toYaml(configuration);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/assertj/OperatorAssertionsTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/assertj/OperatorAssertionsTest.java
@@ -91,15 +91,25 @@ class OperatorAssertionsTest {
     @Test
     void shouldReturnConfigurationAssert() {
         // Given
-        var configurations = new Configuration(null, null, List.of(), List.of(), null, List.of(new VirtualCluster("Bob",
-                new TargetCluster("", Optional.empty()),
-                List.of(new VirtualClusterGateway("gateway",
-                        new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9090), null, null, List.of()),
-                        null,
-                        Optional.empty())),
+        var configurations = new Configuration(null,
+                null,
+                List.of(),
+                List.of(),
+                null,
+                List.of(new VirtualCluster("Bob",
+                        new TargetCluster("", Optional.empty()),
+                        List.of(new VirtualClusterGateway("gateway",
+                                new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9090), null, null, List.of()),
+                                null,
+                                Optional.empty())),
+                        false,
+                        false,
+                        List.of())),
+                List.of(),
                 false,
-                false,
-                List.of())), List.of(), false, Optional.empty(), null, null);
+                Optional.empty(),
+                null,
+                null);
 
         // When
         Assert<?, ?> actualAssertion = OperatorAssertions.assertThat(configurations);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconciler.java
@@ -215,8 +215,18 @@ public class KafkaProxyReconciler implements
                 .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(VolumeMount::getMountPath).reversed())));
 
         return new ConfigurationFragment<>(
-                new Configuration(new ManagementConfiguration(null, null, new EndpointsConfiguration(new PrometheusMetricsConfig())), null, referencedFilters, null, null,
-                        virtualClusters.stream().map(ConfigurationFragment::fragment).toList(), List.of(), false, Optional.empty(), NetworkDefinitionBuilder.build(proxy),
+                new Configuration(
+                        new ManagementConfiguration(null, null, new EndpointsConfiguration(new PrometheusMetricsConfig())),
+                        null, // no named target clusters
+                        referencedFilters,
+                        null, // no defaultFilters <= each of the virtualClusters specifies its own
+                        null, // no router definitions
+                        virtualClusters.stream().map(ConfigurationFragment::fragment).toList(),
+                        List.of(),
+                        false,
+                        // micrometer
+                        Optional.empty(),
+                        NetworkDefinitionBuilder.build(proxy),
                         null),
                 allVolumes,
                 allMounts);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -46,6 +46,7 @@ import io.netty.channel.uring.IoUringIoHandler;
 import io.netty.channel.uring.IoUringServerSocketChannel;
 import io.netty.util.concurrent.Future;
 
+import io.kroxylicious.proxy.bootstrap.RouterChainFactory;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.IllegalConfigurationException;
 import io.kroxylicious.proxy.config.MicrometerDefinition;
@@ -155,6 +156,7 @@ public final class KafkaProxy implements AutoCloseable {
     private final PluginFactoryRegistry pfr;
     private final VirtualClusterRegistry virtualClusterRegistry;
     private @Nullable MeterRegistries meterRegistries;
+    private @Nullable RouterChainFactory routerChainFactory;
 
     private @Nullable ConfigurationReloadOrchestrator reconfigureOrchestrator;
     private @Nullable EventGroupConfig managementEventGroup;
@@ -279,7 +281,7 @@ public final class KafkaProxy implements AutoCloseable {
 
             var overrideMap = getApiKeyMaxVersionOverride(config);
             ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl(overrideMap);
-
+            this.routerChainFactory = new RouterChainFactory(pfr, config.routerDefinitions());
             this.reconfigureOrchestrator = new ConfigurationReloadOrchestrator(
                     config, virtualClusterRegistry, endpointRegistry,
                     ConfigurationReloadOrchestrator.defaultDetectors());
@@ -287,11 +289,15 @@ public final class KafkaProxy implements AutoCloseable {
             Optional<NettySettings> proxyNettySettings = getNettySettings(config, NetworkDefinition::proxy);
             var proxyProtocolMode = config.proxyProtocolMode();
             var tlsServerBootstrap = buildServerBootstrap(proxyEventGroup,
-                    new KafkaProxyInitializer(pfr, true, endpointRegistry, endpointRegistry, proxyProtocolMode,
-                            apiVersionsService, proxyNettySettings, virtualClusterRegistry));
+                    new KafkaProxyInitializer(routerChainFactory,
+                            pfr, true, endpointRegistry, endpointRegistry,
+                            proxyProtocolMode, apiVersionsService,
+                            proxyNettySettings, virtualClusterRegistry));
             var plainServerBootstrap = buildServerBootstrap(proxyEventGroup,
-                    new KafkaProxyInitializer(pfr, false, endpointRegistry, endpointRegistry, proxyProtocolMode,
-                            apiVersionsService, proxyNettySettings, virtualClusterRegistry));
+                    new KafkaProxyInitializer(routerChainFactory,
+                            pfr, false, endpointRegistry, endpointRegistry,
+                            proxyProtocolMode, apiVersionsService,
+                            proxyNettySettings, virtualClusterRegistry));
 
             bindingOperationProcessor.start(plainServerBootstrap, tlsServerBootstrap);
 
@@ -482,6 +488,9 @@ public final class KafkaProxy implements AutoCloseable {
             }
             closeFutures.forEach(Future::syncUninterruptibly);
 
+            if (routerChainFactory != null) {
+                routerChainFactory.close();
+            }
             if (meterRegistries != null) {
                 meterRegistries.close();
             }
@@ -497,6 +506,7 @@ public final class KafkaProxy implements AutoCloseable {
             managementEventGroup = null;
             proxyEventGroup = null;
             meterRegistries = null;
+            routerChainFactory = null;
             reconfigureOrchestrator = null;
             shutdown.complete(null);
             LOGGER.atInfo()

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/RouterChainFactory.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/RouterChainFactory.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.bootstrap;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.kroxylicious.proxy.config.PluginFactory;
+import io.kroxylicious.proxy.config.PluginFactoryRegistry;
+import io.kroxylicious.proxy.config.RouterDefinition;
+import io.kroxylicious.proxy.plugin.PluginConfigurationException;
+import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.router.RouterFactory;
+import io.kroxylicious.proxy.router.RouterFactoryContext;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Abstracts the creation of router instances, hiding the configuration
+ * required for instantiation at the point at which instances are created.
+ */
+public class RouterChainFactory implements AutoCloseable {
+
+    private static final class Wrapper {
+
+        private final RouterFactory<? super Object, ? super Object> routerFactory;
+        private final RouterDefinition routerDefinition;
+        private final Object initResult;
+        private final AtomicBoolean closed = new AtomicBoolean(false);
+
+        private Wrapper(RouterFactoryContext context,
+                        RouterDefinition routerDefinition,
+                        RouterFactory<? super Object, ? super Object> routerFactory) {
+            this.routerFactory = routerFactory;
+            this.routerDefinition = routerDefinition;
+            Object config = routerDefinition.config();
+            try {
+                initResult = routerFactory.initialize(context, config);
+            }
+            catch (Exception e) {
+                throw new PluginConfigurationException(
+                        "Exception initializing router factory " + routerDefinition.name()
+                                + " with config " + config + ": " + e.getMessage(),
+                        e);
+            }
+        }
+
+        private Router create(RouterFactoryContext context) {
+            if (closed.get()) {
+                throw new IllegalStateException("Router factory " + routerDefinition.name() + " is closed");
+            }
+            try {
+                return routerFactory.createRouter(context, initResult);
+            }
+            catch (Exception e) {
+                throw new PluginConfigurationException(
+                        "Exception instantiating router " + routerDefinition.name()
+                                + " using factory " + routerFactory,
+                        e);
+            }
+        }
+
+        private void close() {
+            if (!this.closed.getAndSet(true)) {
+                routerFactory.close(initResult);
+            }
+        }
+    }
+
+    private final Map<String, Wrapper> initialized;
+
+    public RouterChainFactory(PluginFactoryRegistry pfr,
+                              @Nullable List<RouterDefinition> routerDefinitions) {
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        Class<RouterFactory<? super Object, ? super Object>> type = (Class) RouterFactory.class;
+        PluginFactory<RouterFactory<? super Object, ? super Object>> pluginFactory = pfr.pluginFactory(type);
+        if (routerDefinitions == null || routerDefinitions.isEmpty()) {
+            this.initialized = Map.of();
+        }
+        else {
+            this.initialized = new LinkedHashMap<>(routerDefinitions.size());
+            try {
+                for (var rd : routerDefinitions) {
+                    RouterFactoryContext context = new RouterFactoryContext() {
+                        @Override
+                        public String virtualClusterName() {
+                            return "";
+                        }
+
+                        @Override
+                        public String routerName() {
+                            return rd.name();
+                        }
+
+                        @Override
+                        public <P> P pluginInstance(Class<P> pluginClass, String implementationName) {
+                            return pfr.pluginFactory(pluginClass).pluginInstance(implementationName);
+                        }
+
+                        @Override
+                        public <P> Set<String> pluginImplementationNames(Class<P> pluginClass) {
+                            return pfr.pluginFactory(pluginClass).registeredInstanceNames();
+                        }
+                    };
+                    RouterFactory<? super Object, ? super Object> factory = pluginFactory.pluginInstance(rd.type());
+                    Class<?> configType = pluginFactory.configType(rd.type());
+                    if (rd.config() == null || configType.isInstance(rd.config())) {
+                        Wrapper wrapper = new Wrapper(context, rd, factory);
+                        this.initialized.put(rd.name(), wrapper);
+                    }
+                    else {
+                        throw new PluginConfigurationException(
+                                "Router " + rd.name() + " accepts config of type "
+                                        + configType.getName() + " but provided with config of type "
+                                        + rd.config().getClass().getName());
+                    }
+                }
+            }
+            catch (Exception e) {
+                close();
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Creates a new router instance for the given router name.
+     *
+     * @param routerName the name of the router definition
+     * @param context the factory context for creating the router
+     * @return the created router instance
+     */
+    public Router createRouter(String routerName,
+                               RouterFactoryContext context) {
+        Wrapper wrapper = initialized.get(routerName);
+        if (wrapper == null) {
+            throw new IllegalArgumentException("No router definition found for name: " + routerName);
+        }
+        return wrapper.create(context);
+    }
+
+    @Override
+    public void close() {
+        RuntimeException firstThrown = null;
+        var list = new ArrayList<>(initialized.values());
+        for (int i = list.size() - 1; i >= 0; i--) {
+            Wrapper wrapper = list.get(i);
+            try {
+                wrapper.close();
+            }
+            catch (RuntimeException e) {
+                if (firstThrown == null) {
+                    firstThrown = e;
+                }
+                else {
+                    firstThrown.addSuppressed(e);
+                }
+            }
+        }
+        if (firstThrown != null) {
+            throw firstThrown;
+        }
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import io.kroxylicious.proxy.config.admin.ManagementConfiguration;
+import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -246,8 +247,11 @@ public record Configuration(
 
     private VirtualClusterModel toVirtualClusterModel(VirtualCluster virtualCluster,
                                                       List<NamedFilterDefinition> filterDefinitions,
+                                                      Map<String, NamedFilterDefinition> filterDefinitionsByName,
                                                       PluginFactoryRegistry pfr) {
         TargetCluster resolvedTargetCluster = resolveTargetCluster(virtualCluster);
+        Map<String, RouteDescriptor> routeDescriptors = resolveRouteDescriptors(
+                virtualCluster, filterDefinitionsByName);
 
         VirtualClusterModel virtualClusterModel = new VirtualClusterModel(virtualCluster.name(),
                 resolvedTargetCluster,
@@ -257,7 +261,9 @@ public record Configuration(
                 virtualCluster.topicNameCacheConfig(),
                 virtualCluster.subjectBuilder(),
                 virtualCluster.effectiveDrainTimeout(),
-                pfr);
+                pfr,
+                virtualCluster.router(),
+                routeDescriptors);
 
         addGateways(virtualCluster.gateways(), virtualClusterModel);
         virtualClusterModel.logVirtualClusterSummary();
@@ -265,24 +271,76 @@ public record Configuration(
         return virtualClusterModel;
     }
 
+    @Nullable
     private TargetCluster resolveTargetCluster(VirtualCluster virtualCluster) {
         if (virtualCluster.targetCluster() != null) {
             return virtualCluster.targetCluster();
         }
         if (virtualCluster.namedTargetCluster() != null) {
-            return resolveNamedTargetCluster(virtualCluster.namedTargetCluster(), virtualCluster.name());
+            return Optional.ofNullable(clusterDefinitions).orElse(List.of()).stream()
+                    .filter(tc -> tc.name().equals(virtualCluster.namedTargetCluster()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalConfigurationException(
+                            "Virtual cluster '" + virtualCluster.name() + "' references unknown target cluster '"
+                                    + virtualCluster.namedTargetCluster() + "'"))
+                    .toTargetCluster();
         }
-        throw new IllegalConfigurationException(
-                "Virtual cluster '" + virtualCluster.name() + "' has no resolvable target cluster");
+        if (virtualCluster.router() != null) {
+            return resolveRouterPrimaryTargetCluster(virtualCluster);
+        }
+        return null;
     }
 
-    private TargetCluster resolveNamedTargetCluster(String clusterName, String virtualClusterName) {
-        return Optional.ofNullable(clusterDefinitions).orElse(List.of()).stream()
-                .filter(cd -> cd.name().equals(clusterName))
+    @Nullable
+    private TargetCluster resolveRouterPrimaryTargetCluster(VirtualCluster virtualCluster) {
+        if (routerDefinitions == null) {
+            return null;
+        }
+        return routerDefinitions.stream()
+                .filter(rd -> rd.name().equals(virtualCluster.router()))
                 .findFirst()
-                .orElseThrow(() -> new IllegalConfigurationException(
-                        "Virtual cluster '" + virtualClusterName + "' references unknown target cluster '" + clusterName + "'"))
-                .toTargetCluster();
+                .flatMap(rd -> rd.routes().stream()
+                        .filter(route -> route.cluster() != null)
+                        .findFirst()
+                        .map(route -> resolveNamedTargetCluster(route.cluster())))
+                .orElse(null);
+    }
+
+    @Nullable
+    private TargetCluster resolveNamedTargetCluster(String name) {
+        return Optional.ofNullable(clusterDefinitions).orElse(List.of()).stream()
+                .filter(tc -> tc.name().equals(name))
+                .findFirst()
+                .map(ClusterDefinition::toTargetCluster)
+                .orElse(null);
+    }
+
+    @Nullable
+    private Map<String, RouteDescriptor> resolveRouteDescriptors(
+                                                                 VirtualCluster virtualCluster,
+                                                                 Map<String, NamedFilterDefinition> filterDefinitionsByName) {
+        if (virtualCluster.router() == null || routerDefinitions == null) {
+            return null;
+        }
+        RouterDefinition rd = routerDefinitions.stream()
+                .filter(r -> r.name().equals(virtualCluster.router()))
+                .findFirst()
+                .orElse(null);
+        if (rd == null) {
+            return null;
+        }
+        return rd.routes().stream()
+                .collect(Collectors.toMap(
+                        RouteDefinition::name,
+                        route -> {
+                            TargetCluster tc = route.cluster() != null
+                                    ? resolveNamedTargetCluster(route.cluster())
+                                    : null;
+                            List<NamedFilterDefinition> routeFilters = route.filters() != null
+                                    ? resolveFilterNames(filterDefinitionsByName, route.filters())
+                                    : List.of();
+                            return new RouteDescriptor(route.name(), route.id(), tc, route.router(), routeFilters);
+                        }));
     }
 
     private static void addGateways(List<VirtualClusterGateway> gateways, VirtualClusterModel virtualClusterModel) {
@@ -313,13 +371,14 @@ public record Configuration(
     }
 
     public List<VirtualClusterModel> virtualClusterModel(PluginFactoryRegistry pfr) {
-        rejectUnsupportedRoutingConfig();
         var filterDefinitionsByName = buildFilterDefinitionsByName();
 
         return virtualClusters.stream()
                 .map(virtualCluster -> {
-                    List<NamedFilterDefinition> filterDefinitions = namedFilterDefinitionsForCluster(filterDefinitionsByName, virtualCluster);
-                    return toVirtualClusterModel(virtualCluster, filterDefinitions, pfr);
+                    List<NamedFilterDefinition> filterDefinitions = namedFilterDefinitionsForCluster(
+                            filterDefinitionsByName, virtualCluster);
+                    return toVirtualClusterModel(virtualCluster, filterDefinitions,
+                            filterDefinitionsByName, pfr);
                 })
                 .toList();
     }
@@ -334,7 +393,6 @@ public record Configuration(
      * @throws IllegalArgumentException if no virtual cluster with that name exists in this configuration
      */
     public VirtualClusterModel virtualClusterModel(PluginFactoryRegistry pfr, String clusterName) {
-        rejectUnsupportedRoutingConfig();
         var filterDefinitionsByName = buildFilterDefinitionsByName();
 
         return virtualClusters.stream()
@@ -342,23 +400,9 @@ public record Configuration(
                 .findFirst()
                 .map(virtualCluster -> {
                     List<NamedFilterDefinition> filterDefinitions = namedFilterDefinitionsForCluster(filterDefinitionsByName, virtualCluster);
-                    return toVirtualClusterModel(virtualCluster, filterDefinitions, pfr);
+                    return toVirtualClusterModel(virtualCluster, filterDefinitions, filterDefinitionsByName, pfr);
                 })
                 .orElseThrow(() -> new IllegalArgumentException("No virtual cluster named '" + clusterName + "' in this configuration"));
-    }
-
-    private void rejectUnsupportedRoutingConfig() {
-        if (routerDefinitions != null && !routerDefinitions.isEmpty()) {
-            throw new IllegalConfigurationException(
-                    "Routing is not yet supported in this version. Remove 'routerDefinitions' from configuration.");
-        }
-        for (var vc : virtualClusters) {
-            if (vc.router() != null) {
-                throw new IllegalConfigurationException(
-                        "Routing is not yet supported in this version. Virtual cluster '"
-                                + vc.name() + "' uses a router target, which is not yet implemented.");
-            }
-        }
     }
 
     private Map<String, NamedFilterDefinition> buildFilterDefinitionsByName() {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
@@ -55,10 +55,6 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
                             + " (case insensitive)");
         }
         validateTargetExclusivity(name, targetCluster, target);
-        if (target != null && target.router() != null) {
-            throw new IllegalConfigurationException(
-                    "illegal target.router for virtual cluster '" + name + "'. Only target.cluster is supported currently, please change to this.");
-        }
         if (gateways == null || gateways.isEmpty()) {
             throw new IllegalConfigurationException("no gateways configured for virtual cluster '" + name + "'");
         }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -435,10 +435,7 @@ public class ClientConnectionStateMachine {
      */
     void onResponseFromServer(ServerConnectionStateMachine scsm,
                               Object msg) {
-        if (routingResponseCallback != null) {
-            routingResponseCallback.onResponse(msg);
-        }
-        else {
+        if (routingResponseCallback == null || !routingResponseCallback.onResponse(msg)) {
             Objects.requireNonNull(frontendHandler).forwardToClient(msg);
         }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -7,6 +7,8 @@
 package io.kroxylicious.proxy.internal;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -146,6 +148,12 @@ public class ClientConnectionStateMachine {
 
     private final ActivationToken clientToProxyConnectionToken;
 
+    // Server-side metrics (passed to SCSM at construction)
+    private final Counter proxyToServerConnectionCounter;
+    private final Counter proxyToServerErrorCounter;
+    private final Timer serverToProxyBackpressureMeter;
+    private final ActivationToken proxyToServerConnectionToken;
+
     @VisibleForTesting
     @Nullable
     Timer.Sample clientToProxyBackpressureTimer;
@@ -180,12 +188,12 @@ public class ClientConnectionStateMachine {
     private @Nullable KafkaProxyFrontendHandler frontendHandler = null;
 
     /**
-     * The server connection state machine. Non-null once the first client request triggers
-     * backend connection setup (transition to {@link Forwarding}).
+     * Server connection state machines, keyed by remote address. Populated when the first client
+     * request triggers backend connection setup (transition to {@link Forwarding}). Currently
+     * contains at most one entry; routing will add more.
      */
     @VisibleForTesting
-    @Nullable
-    private ServerConnectionStateMachine serverConnectionStateMachine;
+    final Map<HostPort, ServerConnectionStateMachine> serverConnections = new HashMap<>();
 
     @Nullable
     private String clientSoftwareName;
@@ -223,8 +231,12 @@ public class ClientConnectionStateMachine {
         clientToProxyDisconnectsDrainCompletedCounter = Metrics.clientToProxyDisconnectsCounter(clusterName, nodeId, DisconnectCause.DRAIN_COMPLETED.label()).withTags();
         clientToProxyDisconnectsDrainTimeoutCounter = Metrics.clientToProxyDisconnectsCounter(clusterName, nodeId, DisconnectCause.DRAIN_TIMEOUT.label()).withTags();
         clientToProxyErrorCounter = Metrics.clientToProxyErrorCounter(clusterName, nodeId).withTags();
+        proxyToServerConnectionCounter = Metrics.proxyToServerConnectionCounter(clusterName, nodeId).withTags();
+        proxyToServerErrorCounter = Metrics.proxyToServerErrorCounter(clusterName, nodeId).withTags();
+        serverToProxyBackpressureMeter = Metrics.serverToProxyBackpressureTimer(clusterName, nodeId).withTags();
         clientToProxyBackPressureMeter = Metrics.clientToProxyBackpressureTimer(clusterName, nodeId).withTags();
         clientToProxyConnectionToken = Metrics.clientToProxyConnectionToken(node);
+        proxyToServerConnectionToken = Metrics.proxyToServerConnectionToken(node);
     }
 
     ClientConnectionState state() {
@@ -238,7 +250,7 @@ public class ClientConnectionStateMachine {
     @VisibleForTesting
     void forceState(ClientConnectionState state,
                     KafkaProxyFrontendHandler frontendHandler,
-                    @Nullable ServerConnectionStateMachine serverConnectionStateMachine,
+                    Map<HostPort, ServerConnectionStateMachine> serverConnections,
                     KafkaSession kafkaSession,
                     boolean transportSubjectReady) {
         LOGGER.atInfo()
@@ -246,12 +258,13 @@ public class ClientConnectionStateMachine {
                 .addKeyValue("virtualCluster", clusterName())
                 .addKeyValue("state", state)
                 .addKeyValue("frontendHandler", frontendHandler)
-                .addKeyValue("serverConnectionStateMachine", serverConnectionStateMachine)
+                .addKeyValue("serverConnections", serverConnections)
                 .log("Forcing state");
         this.state = state;
         this.kafkaSession = kafkaSession;
         this.frontendHandler = frontendHandler;
-        this.serverConnectionStateMachine = serverConnectionStateMachine;
+        this.serverConnections.clear();
+        this.serverConnections.putAll(serverConnections);
         this.transportSubjectReady = transportSubjectReady;
     }
 
@@ -261,7 +274,7 @@ public class ClientConnectionStateMachine {
                 "state=" + state +
                 ", clientReadsBlocked=" + clientReadsBlocked +
                 ", frontendHandler=" + frontendHandler +
-                ", serverConnectionStateMachine=" + serverConnectionStateMachine +
+                ", serverConnections=" + serverConnections +
                 '}';
     }
 
@@ -309,8 +322,8 @@ public class ClientConnectionStateMachine {
      * Notify the state machine when the client applies back pressure.
      */
     public void onClientUnwritable() {
-        if (serverConnectionStateMachine != null) {
-            serverConnectionStateMachine.applyBackpressure();
+        for (ServerConnectionStateMachine scsm : serverConnections.values()) {
+            scsm.applyBackpressure();
         }
     }
 
@@ -318,15 +331,15 @@ public class ClientConnectionStateMachine {
      * Notify the state machine when the client stops applying back pressure
      */
     public void onClientWritable() {
-        if (serverConnectionStateMachine != null) {
-            serverConnectionStateMachine.relieveBackpressure();
+        for (ServerConnectionStateMachine scsm : serverConnections.values()) {
+            scsm.relieveBackpressure();
         }
     }
 
     /**
      * Notify the state machine when the server applies back pressure
      */
-    public void onServerUnwritable() {
+    void onServerUnwritable(ServerConnectionStateMachine scsm) {
         if (!clientReadsBlocked) {
             clientReadsBlocked = true;
             clientToProxyBackpressureTimer = Timer.start();
@@ -337,7 +350,7 @@ public class ClientConnectionStateMachine {
     /**
      * Notify the state machine when the server stops applying back pressure
      */
-    public void onServerWritable() {
+    void onServerWritable(ServerConnectionStateMachine scsm) {
         if (clientReadsBlocked) {
             clientReadsBlocked = false;
             if (clientToProxyBackpressureTimer != null) {
@@ -374,7 +387,7 @@ public class ClientConnectionStateMachine {
     /**
      * Callback from {@link ServerConnectionStateMachine} when the upstream connection is ready for RPC calls.
      */
-    void onServerConnectionActive() {
+    void onServerConnectionActive(ServerConnectionStateMachine scsm) {
         if (state() instanceof Forwarding) {
             kafkaSession.transitionTo(KafkaSessionState.NOT_AUTHENTICATED);
         }
@@ -407,7 +420,8 @@ public class ClientConnectionStateMachine {
      * upstream node and should be passed to the downstream client.
      * @param msg the object received from the upstream
      */
-    void onResponseFromServer(Object msg) {
+    void onResponseFromServer(ServerConnectionStateMachine scsm,
+                              Object msg) {
         Objects.requireNonNull(frontendHandler).forwardToClient(msg);
 
         clientMessagesInFlightCount = Math.max(0, clientMessagesInFlightCount - 1);
@@ -433,7 +447,7 @@ public class ClientConnectionStateMachine {
     /**
      * Callback from {@link ServerConnectionStateMachine} when reading the upstream batch is complete.
      */
-    void onServerReadComplete() {
+    void onServerReadComplete(ServerConnectionStateMachine scsm) {
         Objects.requireNonNull(frontendHandler).flushToClient();
     }
 
@@ -451,7 +465,7 @@ public class ClientConnectionStateMachine {
      */
     void onClientFilterChainComplete(Object msg) {
         if (state() instanceof Forwarding || state() instanceof ClientConnectionState.Draining) {
-            Objects.requireNonNull(serverConnectionStateMachine).sendRequest(msg);
+            serverConnections.values().iterator().next().sendRequest(msg);
         }
         else {
             illegalState("Unexpected message received: " + (msg == null ? "null" : "message class=" + msg.getClass()));
@@ -503,7 +517,8 @@ public class ClientConnectionStateMachine {
      * Callback from {@link ServerConnectionStateMachine} when the upstream connection has been disconnected.
      * @param disconnectCause the cause of the disconnection
      */
-    void onServerConnectionClosed(DisconnectCause disconnectCause) {
+    void onServerConnectionClosed(ServerConnectionStateMachine scsm,
+                                  DisconnectCause disconnectCause) {
         toClosed(null, disconnectCause);
     }
 
@@ -611,7 +626,7 @@ public class ClientConnectionStateMachine {
                 .addKeyValue("virtualCluster", clusterName())
                 .addKeyValue("clientMessagesInFlightCount", clientMessagesInFlightCount)
                 .addKeyValue("serverMessagesInFlightCount",
-                        serverConnectionStateMachine != null ? serverConnectionStateMachine.serverMessagesInFlightCount : 0)
+                        serverConnections.values().stream().mapToInt(s -> s.serverMessagesInFlightCount).sum())
                 .log("Connection draining started — autoRead disabled, waiting for in-flight responses");
 
         if (clientMessagesInFlightCount <= 0) {
@@ -661,7 +676,8 @@ public class ClientConnectionStateMachine {
      * un-recoverable has happened on the upstream side.
      * @param cause the exception that triggered the issue
      */
-    void onServerConnectionException(@Nullable Throwable cause) {
+    void onServerConnectionException(ServerConnectionStateMachine scsm,
+                                     @Nullable Throwable cause) {
         toClosed(cause);
     }
 
@@ -785,9 +801,11 @@ public class ClientConnectionStateMachine {
     private void toForwarding(Forwarding forwarding,
                               HostPort remote) {
         setState(forwarding);
-        serverConnectionStateMachine = createServerConnection(remote);
+        proxyToServerConnectionCounter.increment();
+        var scsm = createServerConnection(remote);
+        serverConnections.put(remote, scsm);
         var frontend = Objects.requireNonNull(frontendHandler);
-        serverConnectionStateMachine.connect(Objects.requireNonNull(frontend.clientChannel()));
+        scsm.connect(Objects.requireNonNull(frontend.clientChannel()));
         log(Level.DEBUG)
                 .addKeyValue("remote", remote)
                 .addKeyValue("clientAddress", () -> HostPort.asString(frontend.remoteHost(), frontend.remotePort()))
@@ -800,11 +818,15 @@ public class ClientConnectionStateMachine {
                                             ClientConnectionStateMachine ccsm,
                                             VirtualClusterModel virtualCluster,
                                             String clusterName,
-                                            @Nullable Integer nodeId);
+                                            @Nullable Integer nodeId,
+                                            Counter proxyToServerErrorCounter,
+                                            Timer serverToProxyBackpressureMeter,
+                                            ActivationToken proxyToServerConnectionToken);
     }
 
     ServerConnectionStateMachine createServerConnection(HostPort remote) {
-        return serverConnectionFactory.create(remote, this, virtualCluster(), clusterName(), nodeId());
+        return serverConnectionFactory.create(remote, this, virtualCluster(), clusterName(), nodeId(),
+                proxyToServerErrorCounter, serverToProxyBackpressureMeter, proxyToServerConnectionToken);
     }
 
     /**
@@ -870,10 +892,11 @@ public class ClientConnectionStateMachine {
         incrementAppropriateDisconnectsMetric(disconnectCause);
 
         kafkaSession.transitionTo(KafkaSessionState.TERMINATING);
-        // Close the server connection
-        if (serverConnectionStateMachine != null) {
-            serverConnectionStateMachine.close();
+        // Close all server connections
+        for (ServerConnectionStateMachine scsm : serverConnections.values()) {
+            scsm.close();
         }
+        serverConnections.clear();
 
         // Close the client connection
         if (frontendHandler != null) { // Can be null if the error happens before clientActive (unlikely but possible)
@@ -892,7 +915,7 @@ public class ClientConnectionStateMachine {
                     .addKeyValue("errorCodeEx", errorCodeEx == null ? null : errorCodeEx.getClass().getSimpleName() + ": " + errorCodeEx.getMessage())
                     .addKeyValue("clientMessagesInFlightCount", clientMessagesInFlightCount)
                     .addKeyValue("serverMessagesInFlightCount",
-                            serverConnectionStateMachine != null ? serverConnectionStateMachine.serverMessagesInFlightCount : 0)
+                            serverConnections.values().stream().mapToInt(s -> s.serverMessagesInFlightCount).sum())
                     .log("Drain interrupted by connection close — signalling drain policy from toClosed path");
             pendingDrainCallback.run();
         }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -43,6 +43,7 @@ import io.kroxylicious.proxy.internal.ClientConnectionState.Forwarding;
 import io.kroxylicious.proxy.internal.codec.FrameOversizedException;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
+import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
 import io.kroxylicious.proxy.internal.routing.RoutingResponseCallback;
 import io.kroxylicious.proxy.internal.util.ActivationToken;
 import io.kroxylicious.proxy.internal.util.Metrics;
@@ -107,7 +108,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  *     Thus, when the proxy is notified that a peer is applying back pressure it results in action on the channel with the opposite peer.
  * </p>
  */
-@SuppressWarnings("java:S1133")
+@SuppressWarnings({ "java:S1133", "java:S1172" }) // S1172: scsm params on ServerConnectionStateMachine callbacks identify the caller for multi-backend routing
 public class ClientConnectionStateMachine {
     private static final Logger LOGGER = getLogger(ClientConnectionStateMachine.class);
 
@@ -207,6 +208,9 @@ public class ClientConnectionStateMachine {
     @Nullable
     private RoutingResponseCallback routingResponseCallback;
 
+    @Nullable
+    private Map<String, HostPort> routeTargets;
+
     public ClientConnectionStateMachine(EndpointBinding endpointBinding,
                                         TransportSubjectBuilder transportSubjectBuilder,
                                         KafkaSession kafkaSession) {
@@ -257,6 +261,16 @@ public class ClientConnectionStateMachine {
                     Map<HostPort, ServerConnectionStateMachine> serverConnections,
                     KafkaSession kafkaSession,
                     boolean transportSubjectReady) {
+        forceState(state, frontendHandler, serverConnections, kafkaSession, transportSubjectReady, null);
+    }
+
+    @VisibleForTesting
+    void forceState(ClientConnectionState state,
+                    KafkaProxyFrontendHandler frontendHandler,
+                    Map<HostPort, ServerConnectionStateMachine> serverConnections,
+                    KafkaSession kafkaSession,
+                    boolean transportSubjectReady,
+                    @Nullable Map<String, HostPort> routeTargets) {
         LOGGER.atInfo()
                 .addKeyValue("sessionId", kafkaSession.sessionId())
                 .addKeyValue("virtualCluster", clusterName())
@@ -270,6 +284,7 @@ public class ClientConnectionStateMachine {
         this.serverConnections.clear();
         this.serverConnections.putAll(serverConnections);
         this.transportSubjectReady = transportSubjectReady;
+        this.routeTargets = routeTargets;
     }
 
     @Override
@@ -641,7 +656,7 @@ public class ClientConnectionStateMachine {
                 .addKeyValue("virtualCluster", clusterName())
                 .addKeyValue("clientMessagesInFlightCount", clientMessagesInFlightCount)
                 .addKeyValue("serverMessagesInFlightCount",
-                        serverConnections.values().stream().mapToInt(s -> s.serverMessagesInFlightCount).sum())
+                        serverConnections.values().stream().mapToInt(ServerConnectionStateMachine::serverMessagesInFlightCount).sum())
                 .log("Connection draining started — autoRead disabled, waiting for in-flight responses");
 
         if (clientMessagesInFlightCount <= 0) {
@@ -839,6 +854,53 @@ public class ClientConnectionStateMachine {
                                             ActivationToken proxyToServerConnectionToken);
     }
 
+    @SuppressWarnings("java:S5738")
+    private void toForwardingWithRoutes(Forwarding forwarding) {
+        setState(forwarding);
+        Map<String, RouteDescriptor> descriptors = virtualCluster().routeDescriptors();
+        routeTargets = new HashMap<>();
+        var frontend = Objects.requireNonNull(frontendHandler);
+        Channel clientChannel = Objects.requireNonNull(frontend.clientChannel());
+        for (var entry : descriptors.entrySet()) {
+            RouteDescriptor rd = entry.getValue();
+            if (rd.targetsCluster()) {
+                HostPort target = rd.targetCluster().bootstrapServer();
+                routeTargets.put(entry.getKey(), target);
+                serverConnections.computeIfAbsent(target, t -> {
+                    proxyToServerConnectionCounter.increment();
+                    var newScsm = createServerConnection(t);
+                    newScsm.connect(clientChannel);
+                    return newScsm;
+                });
+            }
+        }
+        log(Level.DEBUG)
+                .addKeyValue("routeCount", routeTargets.size())
+                .addKeyValue("backendCount", serverConnections.size())
+                .log("Upstream connections initiated for routing VC");
+    }
+
+    /**
+     * Forward a message to the backend connection for the named route.
+     * Used by {@link io.kroxylicious.proxy.internal.routing.RouterDispatchHandler}
+     * for both static and dynamic routing paths.
+     */
+    public void forwardToRoute(String routeName, Object msg) {
+        if (state() instanceof Forwarding || state() instanceof ClientConnectionState.Draining) {
+            HostPort target = routeTargets.get(routeName);
+            if (target == null) {
+                illegalState("Unknown route: " + routeName);
+                return;
+            }
+            ServerConnectionStateMachine scsm = serverConnections.get(target);
+            scsm.sendRequest(msg);
+        }
+        else {
+            illegalState("forwardToRoute in unexpected state");
+        }
+    }
+
+    @VisibleForTesting
     ServerConnectionStateMachine createServerConnection(HostPort remote) {
         return serverConnectionFactory.create(remote, this, virtualCluster(), clusterName(), nodeId(),
                 proxyToServerErrorCounter, serverToProxyBackpressureMeter, proxyToServerConnectionToken);
@@ -872,8 +934,13 @@ public class ClientConnectionStateMachine {
             this.clientSoftwareVersion = apiVersionsFrame.body().clientSoftwareVersion();
         }
         if (msg instanceof RequestFrame) {
-            var target = Objects.requireNonNull(endpointBinding.upstreamTarget());
-            toForwarding(forwardingFactory.get(), target);
+            if (virtualCluster().usesRouter()) {
+                toForwardingWithRoutes(forwardingFactory.get());
+            }
+            else {
+                var target = Objects.requireNonNull(endpointBinding.upstreamTarget());
+                toForwarding(forwardingFactory.get(), target);
+            }
             tryUnblockClient();
             return true;
         }
@@ -930,7 +997,7 @@ public class ClientConnectionStateMachine {
                     .addKeyValue("errorCodeEx", errorCodeEx == null ? null : errorCodeEx.getClass().getSimpleName() + ": " + errorCodeEx.getMessage())
                     .addKeyValue("clientMessagesInFlightCount", clientMessagesInFlightCount)
                     .addKeyValue("serverMessagesInFlightCount",
-                            serverConnections.values().stream().mapToInt(s -> s.serverMessagesInFlightCount).sum())
+                            serverConnections.values().stream().mapToInt(ServerConnectionStateMachine::serverMessagesInFlightCount).sum())
                     .log("Drain interrupted by connection close — signalling drain policy from toClosed path");
             pendingDrainCallback.run();
         }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -43,6 +43,7 @@ import io.kroxylicious.proxy.internal.ClientConnectionState.Forwarding;
 import io.kroxylicious.proxy.internal.codec.FrameOversizedException;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
+import io.kroxylicious.proxy.internal.routing.RoutingResponseCallback;
 import io.kroxylicious.proxy.internal.util.ActivationToken;
 import io.kroxylicious.proxy.internal.util.Metrics;
 import io.kroxylicious.proxy.internal.util.StableKroxyliciousLinkGenerator;
@@ -203,6 +204,9 @@ public class ClientConnectionStateMachine {
     /** Tracks requests received from the client whose response hasn't been forwarded back yet (client↔proxy). */
     private int clientMessagesInFlightCount;
 
+    @Nullable
+    private RoutingResponseCallback routingResponseCallback;
+
     public ClientConnectionStateMachine(EndpointBinding endpointBinding,
                                         TransportSubjectBuilder transportSubjectBuilder,
                                         KafkaSession kafkaSession) {
@@ -318,6 +322,15 @@ public class ClientConnectionStateMachine {
         return clientSoftwareVersion;
     }
 
+    void setRoutingResponseCallback(@Nullable RoutingResponseCallback callback) {
+        this.routingResponseCallback = callback;
+    }
+
+    @Nullable
+    public Channel clientChannel() {
+        return frontendHandler != null ? frontendHandler.clientChannel() : null;
+    }
+
     /**
      * Notify the state machine when the client applies back pressure.
      */
@@ -422,7 +435,12 @@ public class ClientConnectionStateMachine {
      */
     void onResponseFromServer(ServerConnectionStateMachine scsm,
                               Object msg) {
-        Objects.requireNonNull(frontendHandler).forwardToClient(msg);
+        if (routingResponseCallback != null) {
+            routingResponseCallback.onResponse(msg);
+        }
+        else {
+            Objects.requireNonNull(frontendHandler).forwardToClient(msg);
+        }
 
         clientMessagesInFlightCount = Math.max(0, clientMessagesInFlightCount - 1);
 
@@ -463,7 +481,7 @@ public class ClientConnectionStateMachine {
      *
      * @param msg the RPC received from the upstream
      */
-    void onClientFilterChainComplete(Object msg) {
+    public void onClientFilterChainComplete(Object msg) {
         if (state() instanceof Forwarding || state() instanceof ClientConnectionState.Draining) {
             serverConnections.values().iterator().next().sendRequest(msg);
         }
@@ -787,7 +805,7 @@ public class ClientConnectionStateMachine {
         tryUnblockClient();
     }
 
-    Subject authenticatedSubject() {
+    public Subject authenticatedSubject() {
         return Objects.requireNonNull(clientSubjectManager).authenticatedSubject();
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/DelegatingDecodePredicate.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/DelegatingDecodePredicate.java
@@ -5,6 +5,8 @@
  */
 package io.kroxylicious.proxy.internal;
 
+import java.util.Set;
+
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +40,7 @@ class DelegatingDecodePredicate implements DecodePredicate {
     private static final Logger LOGGER = LoggerFactory.getLogger(DelegatingDecodePredicate.class);
 
     private @Nullable DecodePredicate delegate = null;
+    private @Nullable Set<ApiKeys> routerRequiresDecoding = null;
 
     DelegatingDecodePredicate() {
     }
@@ -49,20 +52,26 @@ class DelegatingDecodePredicate implements DecodePredicate {
         this.delegate = delegate;
     }
 
+    /**
+     * Sets the API keys for which the router requires decoded frames.
+     * These are the dynamically-routed keys that need {@code onClientRequest}.
+     */
+    void setRouterDecodingRequirements(@Nullable Set<ApiKeys> dynamicallyRoutedKeys) {
+        this.routerRequiresDecoding = dynamicallyRoutedKeys;
+    }
+
     @Override
     public boolean shouldDecodeRequest(ApiKeys apiKey, short apiVersion) {
         if (apiKey == ApiKeys.API_VERSIONS) {
-            // TODO For now let's assume we need to always decode this, since the NetHandler
-            // currently does this. At some point we'll need a way to figure out the mutual intersection
-            // of api versions over all backend clusters plus the proxy itself.
             return true;
         }
         if (delegate == null) {
-            // on the first request, before the delegate is set decode everything in case a filter wants
-            // to intercept it
             return true;
         }
-        return delegate.shouldDecodeRequest(apiKey, apiVersion);
+        if (delegate.shouldDecodeRequest(apiKey, apiVersion)) {
+            return true;
+        }
+        return routerRequiresDecoding != null && routerRequiresDecoding.contains(apiKey);
     }
 
     @Override
@@ -72,8 +81,9 @@ class DelegatingDecodePredicate implements DecodePredicate {
 
     @Override
     public String toString() {
-        return "SaslDecodePredicate(" +
-                ", delegate=" + delegate +
+        return "DelegatingDecodePredicate(" +
+                "delegate=" + delegate +
+                ", routerRequiresDecoding=" + routerRequiresDecoding +
                 ')';
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -8,6 +8,7 @@ package io.kroxylicious.proxy.internal;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -27,6 +28,7 @@ import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.concurrent.Future;
 
 import io.kroxylicious.proxy.authentication.TransportSubjectBuilder;
+import io.kroxylicious.proxy.bootstrap.RouterChainFactory;
 import io.kroxylicious.proxy.config.NettySettings;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.config.ProxyProtocolMode;
@@ -38,8 +40,11 @@ import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointBindingResolver;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
+import io.kroxylicious.proxy.internal.routing.RouterDispatchHandler;
 import io.kroxylicious.proxy.internal.util.Metrics;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
+import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.router.RouterFactoryContext;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.CheckReturnValue;
@@ -59,6 +64,8 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
     private final EndpointBindingResolver bindingResolver;
     private final EndpointReconciler endpointReconciler;
     private final PluginFactoryRegistry pfr;
+    @Nullable
+    private final RouterChainFactory routerChainFactory;
     private final ApiVersionsServiceImpl apiVersionsService;
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private final Optional<NettySettings> proxyNettySettings;
@@ -67,8 +74,9 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
     private final Long unauthenticatedIdleMillis;
     private final VirtualClusterRegistry virtualClusterRegistry;
 
-    @SuppressWarnings({ "OptionalUsedAsFieldOrParameterType", "java:S107" })
-    public KafkaProxyInitializer(PluginFactoryRegistry pfr,
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public KafkaProxyInitializer(@Nullable RouterChainFactory routerChainFactory,
+                                 PluginFactoryRegistry pfr,
                                  boolean tls,
                                  EndpointBindingResolver bindingResolver,
                                  EndpointReconciler endpointReconciler,
@@ -81,6 +89,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
         this.proxyProtocolMode = proxyProtocolMode;
         this.tls = tls;
         this.bindingResolver = bindingResolver;
+        this.routerChainFactory = routerChainFactory;
         this.apiVersionsService = apiVersionsService;
         this.proxyNettySettings = proxyNettySettings;
         this.clientToProxyErrorCounter = Metrics.clientToProxyErrorCounter("", null).withTags();
@@ -250,14 +259,49 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
                 proxyNettySettings);
 
         pipeline.addLast("frontendHandler", frontendHandler);
-        // Filter Handlers will be installed at this point in the pipeline by KafkaProxyFrontendHandler when the client channel fires channelActive()
-        pipeline.addLast("filterChainCompletionHandler", new FilterChainCompletionHandler(clientConnectionStateMachine));
+        if (virtualCluster.usesRouter() && routerChainFactory != null) {
+            var routerFactoryContext = createRouterFactoryContext(virtualCluster.getClusterName(), virtualCluster.routerName());
+            Router router = routerChainFactory.createRouter(virtualCluster.routerName(), routerFactoryContext);
+            var routeDescriptors = virtualCluster.routeDescriptors();
+            var dispatchHandler = new RouterDispatchHandler(router, routeDescriptors, clientConnectionStateMachine);
+            clientConnectionStateMachine.setRoutingResponseCallback(dispatchHandler);
+            pipeline.addLast("routerDispatchHandler", dispatchHandler);
+        }
+        else {
+            pipeline.addLast("filterChainCompletionHandler",
+                    new FilterChainCompletionHandler(clientConnectionStateMachine));
+        }
         addLoggingErrorHandler(pipeline);
 
         LOGGER.atDebug()
                 .addKeyValue("channelId", ch::toString)
                 .addKeyValue("pipeline", pipeline)
                 .log("Initial pipeline");
+    }
+
+    private RouterFactoryContext createRouterFactoryContext(String virtualClusterName, String routerName) {
+        return new RouterFactoryContext() {
+            @Override
+            public String virtualClusterName() {
+                return virtualClusterName;
+            }
+
+            @Override
+            public String routerName() {
+                return routerName;
+            }
+
+            @Override
+            public <P> P pluginInstance(Class<P> pluginClass,
+                                        String implementationName) {
+                return pfr.pluginFactory(pluginClass).pluginInstance(implementationName);
+            }
+
+            @Override
+            public <P> Set<String> pluginImplementationNames(Class<P> pluginClass) {
+                return pfr.pluginFactory(pluginClass).registeredInstanceNames();
+            }
+        };
     }
 
     private KafkaMessageListener buildMetricsMessageListenerForDecode(EndpointBinding binding, VirtualClusterModel virtualCluster) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -6,11 +6,14 @@
 package io.kroxylicious.proxy.internal;
 
 import java.time.Duration;
+import java.util.EnumSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,7 +77,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
     private final Long unauthenticatedIdleMillis;
     private final VirtualClusterRegistry virtualClusterRegistry;
 
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    @SuppressWarnings({ "OptionalUsedAsFieldOrParameterType", "java:S107" })
     public KafkaProxyInitializer(@Nullable RouterChainFactory routerChainFactory,
                                  PluginFactoryRegistry pfr,
                                  boolean tls,
@@ -263,7 +266,16 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
             var routerFactoryContext = createRouterFactoryContext(virtualCluster.getClusterName(), virtualCluster.routerName());
             Router router = routerChainFactory.createRouter(virtualCluster.routerName(), routerFactoryContext);
             var routeDescriptors = virtualCluster.routeDescriptors();
-            var dispatchHandler = new RouterDispatchHandler(router, routeDescriptors, clientConnectionStateMachine);
+            Map<ApiKeys, String> staticRoutes = router.staticRoutes();
+            if (!staticRoutes.isEmpty()) {
+                Set<ApiKeys> dynamicallyRoutedKeys = EnumSet.allOf(ApiKeys.class);
+                dynamicallyRoutedKeys.removeAll(staticRoutes.keySet());
+                dp.setRouterDecodingRequirements(dynamicallyRoutedKeys);
+            }
+            else {
+                dp.setRouterDecodingRequirements(EnumSet.allOf(ApiKeys.class));
+            }
+            var dispatchHandler = new RouterDispatchHandler(staticRoutes, clientConnectionStateMachine);
             clientConnectionStateMachine.setRoutingResponseCallback(dispatchHandler);
             pipeline.addLast("routerDispatchHandler", dispatchHandler);
         }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachine.java
@@ -41,7 +41,6 @@ import io.kroxylicious.proxy.internal.tls.ServerTlsCredentialSupplierContextImpl
 import io.kroxylicious.proxy.internal.tls.TlsCredentialsImpl;
 import io.kroxylicious.proxy.internal.util.ActivationToken;
 import io.kroxylicious.proxy.internal.util.Metrics;
-import io.kroxylicious.proxy.internal.util.VirtualClusterNode;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
@@ -62,8 +61,8 @@ import static org.slf4j.LoggerFactory.getLogger;
  *
  * <pre>
  *     Connecting ──→ Active ────────────→ Closed
- *         │             │            │
- *         └─────────────┴────────────┴──→ Closed (on error)
+ *         │             │
+ *         └─────────────┴──→ Closed (on error)
  * </pre>
  */
 class ServerConnectionStateMachine {
@@ -79,18 +78,19 @@ class ServerConnectionStateMachine {
     @Nullable
     private final Integer nodeId;
 
+    @VisibleForTesting
     int serverMessagesInFlightCount;
 
-    private boolean serverReadsBlocked;
-
-    @Nullable
     @VisibleForTesting
+    boolean serverReadsBlocked;
+
+    @VisibleForTesting
+    @Nullable
     Timer.Sample serverBackpressureTimer;
 
     @Nullable
     private List<Object> pendingRequests;
 
-    private final Counter proxyToServerConnectionCounter;
     private final Counter proxyToServerErrorCounter;
     private final Timer serverToProxyBackpressureMeter;
     private final ActivationToken proxyToServerConnectionToken;
@@ -100,19 +100,19 @@ class ServerConnectionStateMachine {
                                  ClientConnectionStateMachine ccsm,
                                  VirtualClusterModel virtualCluster,
                                  String clusterName,
-                                 @Nullable Integer nodeId) {
+                                 @Nullable Integer nodeId,
+                                 Counter proxyToServerErrorCounter,
+                                 Timer serverToProxyBackpressureMeter,
+                                 ActivationToken proxyToServerConnectionToken) {
         this.state = new ServerConnectionState.Connecting(remote);
         this.virtualCluster = Objects.requireNonNull(virtualCluster);
         this.clusterName = Objects.requireNonNull(clusterName);
         this.nodeId = nodeId;
         this.ccsm = Objects.requireNonNull(ccsm);
         this.backendHandler = new KafkaProxyBackendHandler(this);
-
-        var node = new VirtualClusterNode(clusterName, nodeId);
-        this.proxyToServerConnectionCounter = Metrics.proxyToServerConnectionCounter(clusterName, nodeId).withTags();
-        this.proxyToServerErrorCounter = Metrics.proxyToServerErrorCounter(clusterName, nodeId).withTags();
-        this.serverToProxyBackpressureMeter = Metrics.serverToProxyBackpressureTimer(clusterName, nodeId).withTags();
-        this.proxyToServerConnectionToken = Metrics.proxyToServerConnectionToken(node);
+        this.proxyToServerErrorCounter = proxyToServerErrorCounter;
+        this.serverToProxyBackpressureMeter = serverToProxyBackpressureMeter;
+        this.proxyToServerConnectionToken = proxyToServerConnectionToken;
     }
 
     ServerConnectionState state() {
@@ -138,7 +138,6 @@ class ServerConnectionStateMachine {
             ccsm.illegalState("connect() called while not in Connecting state");
             return;
         }
-        proxyToServerConnectionCounter.increment();
         HostPort remote = connecting.remote();
         final Bootstrap bootstrap = configureBootstrap(backendHandler, inboundChannel);
 
@@ -346,7 +345,7 @@ class ServerConnectionStateMachine {
             setState(connecting.toActive());
             proxyToServerConnectionToken.acquire();
             flushPendingRequests();
-            ccsm.onServerConnectionActive();
+            ccsm.onServerConnectionActive(this);
         }
         else {
             ccsm.illegalState("Server became active while not in the connecting state");
@@ -356,7 +355,7 @@ class ServerConnectionStateMachine {
     void onServerInactive() {
         if (!(state instanceof ServerConnectionState.Closed)) {
             toClosed();
-            ccsm.onServerConnectionClosed(ClientConnectionStateMachine.DisconnectCause.SERVER_CLOSED);
+            ccsm.onServerConnectionClosed(this, ClientConnectionStateMachine.DisconnectCause.SERVER_CLOSED);
         }
     }
 
@@ -371,25 +370,25 @@ class ServerConnectionStateMachine {
                             : "exception from server channel, increase log level to DEBUG for stacktrace");
             proxyToServerErrorCounter.increment();
             toClosed();
-            ccsm.onServerConnectionException(cause);
+            ccsm.onServerConnectionException(this, cause);
         }
     }
 
     void onMessageFromServer(Object msg) {
         serverMessagesInFlightCount = Math.max(0, serverMessagesInFlightCount - 1);
-        ccsm.onResponseFromServer(msg);
+        ccsm.onResponseFromServer(this, msg);
     }
 
     void serverReadComplete() {
-        ccsm.onServerReadComplete();
+        ccsm.onServerReadComplete(this);
     }
 
     void onServerUnwritable() {
-        ccsm.onServerUnwritable();
+        ccsm.onServerUnwritable(this);
     }
 
     void onServerWritable() {
-        ccsm.onServerWritable();
+        ccsm.onServerWritable(this);
     }
 
     void sendRequest(Object msg) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachine.java
@@ -81,6 +81,10 @@ class ServerConnectionStateMachine {
     @VisibleForTesting
     int serverMessagesInFlightCount;
 
+    int serverMessagesInFlightCount() {
+        return serverMessagesInFlightCount;
+    }
+
     @VisibleForTesting
     boolean serverReadsBlocked;
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/ResponseImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/ResponseImpl.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+import java.util.Objects;
+
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import io.kroxylicious.proxy.router.Response;
+
+/**
+ * Immutable implementation of {@link Response}.
+ */
+record ResponseImpl(ResponseHeaderData header,
+                    ApiMessage body)
+        implements Response {
+
+    ResponseImpl {
+        Objects.requireNonNull(header);
+        Objects.requireNonNull(body);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouteDescriptor.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouteDescriptor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+import java.util.List;
+import java.util.Objects;
+
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
+import io.kroxylicious.proxy.config.TargetCluster;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Runtime representation of a resolved route within a router.
+ *
+ * @param name the route name
+ * @param id numeric identifier used in the virtual node ID mapping formula
+ * @param targetCluster the target cluster for this route, or null if targeting a nested router
+ * @param routerName the name of a nested router to forward to, or null if targeting a cluster
+ * @param filters per-route filter definitions (may be empty)
+ */
+public record RouteDescriptor(
+                              String name,
+                              int id,
+                              @Nullable TargetCluster targetCluster,
+                              @Nullable String routerName,
+                              List<NamedFilterDefinition> filters) {
+
+    public RouteDescriptor {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(filters);
+        if ((targetCluster == null) == (routerName == null)) {
+            throw new IllegalArgumentException(
+                    "Route '" + name + "' must specify exactly one of targetCluster or routerName");
+        }
+    }
+
+    /**
+     * Returns true if this route targets a Kafka cluster.
+     */
+    public boolean targetsCluster() {
+        return targetCluster != null;
+    }
+
+    /**
+     * Returns true if this route targets a nested router.
+     */
+    public boolean targetsRouter() {
+        return routerName != null;
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.AttributeKey;
+
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.internal.ClientConnectionStateMachine;
+import io.kroxylicious.proxy.router.Response;
+import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.router.RouterContext;
+import io.kroxylicious.proxy.router.RouterResult;
+
+/**
+ * Sits at the end of the VC-level filter chain (replacing
+ * {@link io.kroxylicious.proxy.internal.FilterChainCompletionHandler}) when a
+ * virtual cluster uses a router. Unwraps incoming
+ * {@link DecodedRequestFrame}s and invokes {@link Router#onRequest(short, ApiKeys, RequestHeaderData, ApiMessage, RouterContext)}.
+ */
+public class RouterDispatchHandler extends ChannelInboundHandlerAdapter implements RoutingResponseCallback {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RouterDispatchHandler.class);
+    private static final AttributeKey<Map<Integer, CompletableFuture<Response>>> PENDING_RESPONSES = AttributeKey.valueOf(RouterDispatchHandler.class,
+            "pendingResponses");
+
+    private final Router router;
+    private final Map<String, RouteDescriptor> routes;
+    private final ClientConnectionStateMachine ccsm;
+
+    public RouterDispatchHandler(Router router,
+                                 Map<String, RouteDescriptor> routes,
+                                 ClientConnectionStateMachine ccsm) {
+        this.router = router;
+        this.routes = routes;
+        this.ccsm = ccsm;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        if (!(msg instanceof DecodedRequestFrame<?> frame)) {
+            LOGGER.atWarn()
+                    .addKeyValue("sessionId", ccsm.sessionId())
+                    .addKeyValue("messageClass", msg.getClass().getName())
+                    .log("RouterDispatchHandler received non-DecodedRequestFrame");
+            ccsm.onClientFilterChainComplete(msg);
+            return;
+        }
+
+        ApiKeys apiKey = frame.apiKey();
+        short apiVersion = frame.apiVersion();
+        int correlationId = frame.correlationId();
+
+        var routingContext = new RoutingContextImpl(
+                correlationId,
+                apiVersion,
+                ctx.channel(),
+                ccsm.sessionId(),
+                ccsm.authenticatedSubject(),
+                routes,
+                forwarded -> ccsm.onClientFilterChainComplete(forwarded));
+
+        router.onRequest(
+                apiVersion,
+                apiKey,
+                frame.header(),
+                frame.body(),
+                routingContext).whenComplete((result, error) -> {
+                    if (error != null) {
+                        LOGGER.atError()
+                                .addKeyValue("sessionId", ccsm.sessionId())
+                                .addKeyValue("apiKey", apiKey)
+                                .setCause(error)
+                                .log("Router returned failed future");
+                        ctx.channel().close();
+                        return;
+                    }
+                    if (result instanceof RouterResult.Completed completed) {
+                        var response = completed.response();
+                        var responseFrame = new DecodedResponseFrame<>(
+                                apiVersion,
+                                correlationId,
+                                response.header(),
+                                response.body());
+                        ctx.channel().write(responseFrame);
+                        ctx.channel().flush();
+                    }
+                    else if (result instanceof RouterResult.Disconnect) {
+                        ctx.channel().close();
+                    }
+                });
+    }
+
+    @Override
+    public void onResponse(Object msg) {
+        if (msg instanceof DecodedResponseFrame<?> frame) {
+            int correlationId = frame.correlationId();
+            Map<Integer, CompletableFuture<Response>> pending = getPendingResponses(ccsm.clientChannel());
+            CompletableFuture<Response> future = pending.remove(correlationId);
+            if (future != null) {
+                Response response = new ResponseImpl(
+                        (ResponseHeaderData) frame.header(),
+                        frame.body());
+                future.complete(response);
+            }
+            else {
+                LOGGER.atWarn()
+                        .addKeyValue("sessionId", ccsm.sessionId())
+                        .addKeyValue("correlationId", correlationId)
+                        .log("Received response with no pending future");
+            }
+        }
+    }
+
+    static void registerPendingResponse(Channel channel,
+                                        int correlationId,
+                                        CompletableFuture<Response> future) {
+        getPendingResponses(channel).put(correlationId, future);
+    }
+
+    private static Map<Integer, CompletableFuture<Response>> getPendingResponses(Channel channel) {
+        var attr = channel.attr(PENDING_RESPONSES);
+        Map<Integer, CompletableFuture<Response>> map = attr.get();
+        if (map == null) {
+            map = new ConcurrentHashMap<>();
+            attr.set(map);
+        }
+        return map;
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -9,10 +9,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.kafka.common.message.RequestHeaderData;
-import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ApiMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,17 +20,16 @@ import io.netty.util.AttributeKey;
 
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.frame.RequestFrame;
 import io.kroxylicious.proxy.internal.ClientConnectionStateMachine;
 import io.kroxylicious.proxy.router.Response;
-import io.kroxylicious.proxy.router.Router;
-import io.kroxylicious.proxy.router.RouterContext;
-import io.kroxylicious.proxy.router.RouterResult;
 
 /**
  * Sits at the end of the VC-level filter chain (replacing
  * {@link io.kroxylicious.proxy.internal.FilterChainCompletionHandler}) when a
- * virtual cluster uses a router. Unwraps incoming
- * {@link DecodedRequestFrame}s and invokes {@link Router#onRequest(short, ApiKeys, RequestHeaderData, ApiMessage, RouterContext)}.
+ * virtual cluster uses a router. Forwards statically-routed requests
+ * directly to the {@link ClientConnectionStateMachine}; rejects any
+ * request whose API key is not covered by the static routes.
  */
 public class RouterDispatchHandler extends ChannelInboundHandlerAdapter implements RoutingResponseCallback {
 
@@ -41,92 +37,58 @@ public class RouterDispatchHandler extends ChannelInboundHandlerAdapter implemen
     private static final AttributeKey<Map<Integer, CompletableFuture<Response>>> PENDING_RESPONSES = AttributeKey.valueOf(RouterDispatchHandler.class,
             "pendingResponses");
 
-    private final Router router;
-    private final Map<String, RouteDescriptor> routes;
+    private final Map<ApiKeys, String> staticRoutes;
     private final ClientConnectionStateMachine ccsm;
 
-    public RouterDispatchHandler(Router router,
-                                 Map<String, RouteDescriptor> routes,
+    public RouterDispatchHandler(Map<ApiKeys, String> staticRoutes,
                                  ClientConnectionStateMachine ccsm) {
-        this.router = router;
-        this.routes = routes;
+        this.staticRoutes = staticRoutes;
         this.ccsm = ccsm;
     }
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
-        if (!(msg instanceof DecodedRequestFrame<?> frame)) {
+        if (msg instanceof RequestFrame frame) {
+            ApiKeys apiKey = ApiKeys.forId(frame.apiKeyId());
+            String staticRoute = staticRoutes.get(apiKey);
+            if (staticRoute != null) {
+                ccsm.onClientFilterChainComplete(msg);
+                return;
+            }
+            if (msg instanceof DecodedRequestFrame<?> decoded) {
+                dispatchDynamically(decoded);
+                return;
+            }
             LOGGER.atWarn()
                     .addKeyValue("sessionId", ccsm.sessionId())
-                    .addKeyValue("messageClass", msg.getClass().getName())
-                    .log("RouterDispatchHandler received non-DecodedRequestFrame");
+                    .addKeyValue("apiKey", apiKey)
+                    .log("Dynamically-routed API key arrived as opaque frame, forwarding to CCSM");
             ccsm.onClientFilterChainComplete(msg);
             return;
         }
+        ccsm.onClientFilterChainComplete(msg);
+    }
 
-        ApiKeys apiKey = frame.apiKey();
-        short apiVersion = frame.apiVersion();
-        int correlationId = frame.correlationId();
-
-        var routingContext = new RoutingContextImpl(
-                correlationId,
-                apiVersion,
-                ctx.channel(),
-                ccsm.sessionId(),
-                ccsm.authenticatedSubject(),
-                routes,
-                forwarded -> ccsm.onClientFilterChainComplete(forwarded));
-
-        router.onRequest(
-                apiVersion,
-                apiKey,
-                frame.header(),
-                frame.body(),
-                routingContext).whenComplete((result, error) -> {
-                    if (error != null) {
-                        LOGGER.atError()
-                                .addKeyValue("sessionId", ccsm.sessionId())
-                                .addKeyValue("apiKey", apiKey)
-                                .setCause(error)
-                                .log("Router returned failed future");
-                        ctx.channel().close();
-                        return;
-                    }
-                    if (result instanceof RouterResult.Completed completed) {
-                        var response = completed.response();
-                        var responseFrame = new DecodedResponseFrame<>(
-                                apiVersion,
-                                correlationId,
-                                response.header(),
-                                response.body());
-                        ctx.channel().write(responseFrame);
-                        ctx.channel().flush();
-                    }
-                    else if (result instanceof RouterResult.Disconnect) {
-                        ctx.channel().close();
-                    }
-                });
+    private void dispatchDynamically(DecodedRequestFrame<?> frame) {
+        throw new IllegalStateException(
+                "Dynamic routing is not supported. API key " + frame.apiKey() + " is not covered by staticRoutes().");
     }
 
     @Override
-    public void onResponse(Object msg) {
+    public boolean onResponse(Object msg) {
         if (msg instanceof DecodedResponseFrame<?> frame) {
             int correlationId = frame.correlationId();
             Map<Integer, CompletableFuture<Response>> pending = getPendingResponses(ccsm.clientChannel());
             CompletableFuture<Response> future = pending.remove(correlationId);
             if (future != null) {
                 Response response = new ResponseImpl(
-                        (ResponseHeaderData) frame.header(),
+                        frame.header(),
                         frame.body());
                 future.complete(response);
-            }
-            else {
-                LOGGER.atWarn()
-                        .addKeyValue("sessionId", ccsm.sessionId())
-                        .addKeyValue("correlationId", correlationId)
-                        .log("Received response with no pending future");
+                return true;
             }
         }
+        return false;
     }
 
     static void registerPendingResponse(Channel channel,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -52,7 +52,7 @@ public class RouterDispatchHandler extends ChannelInboundHandlerAdapter implemen
             ApiKeys apiKey = ApiKeys.forId(frame.apiKeyId());
             String staticRoute = staticRoutes.get(apiKey);
             if (staticRoute != null) {
-                ccsm.onClientFilterChainComplete(msg);
+                ccsm.forwardToRoute(staticRoute, msg);
                 return;
             }
             if (msg instanceof DecodedRequestFrame<?> decoded) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingContextImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingContextImpl.java
@@ -41,7 +41,7 @@ class RoutingContextImpl implements RouterContext {
      */
     @FunctionalInterface
     interface RequestForwarder {
-        void forward(Object msg);
+        void forward(String routeName, Object msg);
     }
 
     RoutingContextImpl(int clientCorrelationId,
@@ -96,7 +96,7 @@ class RoutingContextImpl implements RouterContext {
         CompletableFuture<Response> future = new CompletableFuture<>();
         RouterDispatchHandler.registerPendingResponse(clientChannel, clientCorrelationId, future);
 
-        requestForwarder.forward(frame);
+        requestForwarder.forward(route, frame);
         return future;
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingContextImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingContextImpl.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import io.netty.channel.Channel;
+
+import io.kroxylicious.proxy.authentication.Subject;
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.router.Response;
+import io.kroxylicious.proxy.router.RouterContext;
+
+/**
+ * Per-request implementation of {@link RouterContext}. Created by
+ * {@link RouterDispatchHandler} for each incoming client request.
+ */
+class RoutingContextImpl implements RouterContext {
+
+    private final int clientCorrelationId;
+    private final short apiVersion;
+    private final Channel clientChannel;
+    private final String sessionId;
+    private final Subject subject;
+    private final Map<String, RouteDescriptor> routes;
+    private final RequestForwarder requestForwarder;
+
+    /**
+     * Callback interface for forwarding requests to the backend. The
+     * {@link RouterDispatchHandler} provides an implementation that
+     * delegates to the {@link io.kroxylicious.proxy.internal.ClientConnectionStateMachine}.
+     */
+    @FunctionalInterface
+    interface RequestForwarder {
+        void forward(Object msg);
+    }
+
+    RoutingContextImpl(int clientCorrelationId,
+                       short apiVersion,
+                       Channel clientChannel,
+                       String sessionId,
+                       Subject subject,
+                       Map<String, RouteDescriptor> routes,
+                       RequestForwarder requestForwarder) {
+        this.clientCorrelationId = clientCorrelationId;
+        this.apiVersion = apiVersion;
+        this.clientChannel = Objects.requireNonNull(clientChannel);
+        this.sessionId = Objects.requireNonNull(sessionId);
+        this.subject = Objects.requireNonNull(subject);
+        this.routes = Objects.requireNonNull(routes);
+        this.requestForwarder = Objects.requireNonNull(requestForwarder);
+    }
+
+    @Override
+    public int bootstrapNodeId(String route) {
+        RouteDescriptor rd = routes.get(route);
+        if (rd == null) {
+            throw new IllegalArgumentException("Unknown route: " + route);
+        }
+        return 0;
+    }
+
+    @Override
+    public CompletionStage<Response> sendRequestToNode(
+                                                       String route,
+                                                       int virtualNodeId,
+                                                       RequestHeaderData header,
+                                                       ApiMessage request) {
+        RouteDescriptor rd = routes.get(route);
+        if (rd == null) {
+            return CompletableFuture.failedFuture(
+                    new IllegalArgumentException("Unknown route: " + route));
+        }
+        if (!rd.targetsCluster()) {
+            return CompletableFuture.failedFuture(
+                    new UnsupportedOperationException(
+                            "Routing to nested routers is not yet supported (route: " + route + ")"));
+        }
+
+        var frame = new DecodedRequestFrame<>(
+                apiVersion,
+                clientCorrelationId,
+                true,
+                header,
+                request);
+
+        CompletableFuture<Response> future = new CompletableFuture<>();
+        RouterDispatchHandler.registerPendingResponse(clientChannel, clientCorrelationId, future);
+
+        requestForwarder.forward(frame);
+        return future;
+    }
+
+    @Override
+    public String sessionId() {
+        return sessionId;
+    }
+
+    @Override
+    public Subject authenticatedSubject() {
+        return subject;
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingResponseCallback.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingResponseCallback.java
@@ -10,5 +10,12 @@ package io.kroxylicious.proxy.internal.routing;
  */
 @FunctionalInterface
 public interface RoutingResponseCallback {
-    void onResponse(Object msg);
+    /**
+     * Handle a response from a backend server.
+     *
+     * @param msg the response message
+     * @return {@code true} if this callback handled the response (dynamically routed),
+     *         {@code false} if the caller should forward it to the client via the normal path
+     */
+    boolean onResponse(Object msg);
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingResponseCallback.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingResponseCallback.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+/**
+ * Callback for receiving responses from backend servers when routing is active.
+ */
+@FunctionalInterface
+public interface RoutingResponseCallback {
+    void onResponse(Object msg);
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -47,6 +47,7 @@ import io.kroxylicious.proxy.config.tls.TrustOptions;
 import io.kroxylicious.proxy.config.tls.TrustProvider;
 import io.kroxylicious.proxy.internal.filter.impl.TopicNameCacheFilter;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
+import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
 import io.kroxylicious.proxy.internal.subject.DefaultTransportSubjectBuilderService;
 import io.kroxylicious.proxy.internal.tls.NettyKeyProvider;
 import io.kroxylicious.proxy.internal.tls.NettyTrustProvider;
@@ -87,7 +88,7 @@ public class VirtualClusterModel implements AutoCloseable {
 
     private final String clusterName;
 
-    private final TargetCluster targetCluster;
+    private final @Nullable TargetCluster targetCluster;
 
     private final boolean logNetwork;
 
@@ -106,6 +107,8 @@ public class VirtualClusterModel implements AutoCloseable {
     private TopicNameCacheFilter topicNameCacheFilter = null;
 
     private final TlsCredentialSupplierManager tlsCredentialSupplierManager;
+    private final @Nullable String routerName;
+    private final @Nullable Map<String, RouteDescriptor> routeDescriptors;
 
     /**
      * The filter chain factory for <em>this</em> virtual cluster. Owned by the VCM — its
@@ -120,7 +123,8 @@ public class VirtualClusterModel implements AutoCloseable {
                                boolean logNetwork,
                                boolean logFrames,
                                List<NamedFilterDefinition> filters) {
-        this(clusterName, targetCluster, logNetwork, logFrames, filters, new CacheConfiguration(null, null, null), null, Duration.ofSeconds(10), null);
+        this(clusterName, targetCluster, logNetwork, logFrames, filters,
+                new CacheConfiguration(null, null, null), null, Duration.ofSeconds(10), null, null, null);
     }
 
     public VirtualClusterModel(String clusterName,
@@ -131,11 +135,12 @@ public class VirtualClusterModel implements AutoCloseable {
                                CacheConfiguration topicNameCacheConfig,
                                @Nullable TransportSubjectBuilderConfig transportSubjectBuilderConfig,
                                Duration drainTimeout) {
-        this(clusterName, targetCluster, logNetwork, logFrames, filters, topicNameCacheConfig, transportSubjectBuilderConfig, drainTimeout, null);
+        this(clusterName, targetCluster, logNetwork, logFrames, filters, topicNameCacheConfig,
+                transportSubjectBuilderConfig, drainTimeout, null, null, null);
     }
 
     public VirtualClusterModel(String clusterName,
-                               TargetCluster targetCluster,
+                               @Nullable TargetCluster targetCluster,
                                boolean logNetwork,
                                boolean logFrames,
                                List<NamedFilterDefinition> filters,
@@ -143,16 +148,34 @@ public class VirtualClusterModel implements AutoCloseable {
                                @Nullable TransportSubjectBuilderConfig transportSubjectBuilderConfig,
                                Duration drainTimeout,
                                @Nullable PluginFactoryRegistry pluginFactoryRegistry) {
+        this(clusterName, targetCluster, logNetwork, logFrames, filters, topicNameCacheConfig,
+                transportSubjectBuilderConfig, drainTimeout, pluginFactoryRegistry, null, null);
+    }
+
+    @SuppressWarnings("java:S107")
+    public VirtualClusterModel(String clusterName,
+                               @Nullable TargetCluster targetCluster,
+                               boolean logNetwork,
+                               boolean logFrames,
+                               List<NamedFilterDefinition> filters,
+                               CacheConfiguration topicNameCacheConfig,
+                               @Nullable TransportSubjectBuilderConfig transportSubjectBuilderConfig,
+                               Duration drainTimeout,
+                               @Nullable PluginFactoryRegistry pluginFactoryRegistry,
+                               @Nullable String routerName,
+                               @Nullable Map<String, RouteDescriptor> routeDescriptors) {
         this.clusterName = Objects.requireNonNull(clusterName);
-        this.targetCluster = Objects.requireNonNull(targetCluster);
+        this.targetCluster = targetCluster;
         this.logNetwork = logNetwork;
         this.logFrames = logFrames;
         this.filters = filters;
         this.topicNameCacheConfig = topicNameCacheConfig;
         this.transportSubjectBuilderConfig = transportSubjectBuilderConfig;
         this.drainTimeout = Objects.requireNonNull(drainTimeout);
+        this.routerName = routerName;
+        this.routeDescriptors = routeDescriptors;
 
-        if (pluginFactoryRegistry != null) {
+        if (pluginFactoryRegistry != null && targetCluster != null) {
             TlsCredentialSupplierConfig definition = targetCluster.tls()
                     .flatMap(tls -> Optional.ofNullable(tls.credentialSupplier()))
                     .orElse(null);
@@ -186,10 +209,24 @@ public class VirtualClusterModel implements AutoCloseable {
         return drainTimeout;
     }
 
-    public void logVirtualClusterSummary() {
-        var upstreamHostPort = targetCluster.bootstrapServersList();
-        var upstreamTlsSummary = generateTlsSummary(targetCluster.tls());
+    @Nullable
+    public String routerName() {
+        return routerName;
+    }
 
+    public boolean usesRouter() {
+        return routerName != null;
+    }
+
+    /**
+     * @return the route descriptors for the router, or {@code null} if this VC does not use a router
+     */
+    @Nullable
+    public Map<String, RouteDescriptor> routeDescriptors() {
+        return routeDescriptors;
+    }
+
+    public void logVirtualClusterSummary() {
         LOGGER.atInfo()
                 .addKeyValue("virtualCluster", clusterName)
                 .log("Gateway summary");
@@ -198,11 +235,17 @@ public class VirtualClusterModel implements AutoCloseable {
             var downstreamBootstrap = gateway.getClusterBootstrapAddress();
             var downstreamTlsSummary = generateTlsSummary(gateway.getTls());
 
-            LOGGER.atInfo()
+            var logBuilder = LOGGER.atInfo()
                     .addKeyValue("gateway", name)
-                    .addKeyValue("downstream", downstreamBootstrap + downstreamTlsSummary)
-                    .addKeyValue("upstream", upstreamHostPort + upstreamTlsSummary)
-                    .log("Gateway configuration");
+                    .addKeyValue("downstream", downstreamBootstrap + downstreamTlsSummary);
+            if (targetCluster != null) {
+                logBuilder = logBuilder.addKeyValue("upstream",
+                        targetCluster.bootstrapServersList() + generateTlsSummary(targetCluster.tls()));
+            }
+            else {
+                logBuilder = logBuilder.addKeyValue("upstream", "(via router)");
+            }
+            logBuilder.log("Gateway configuration");
         });
     }
 
@@ -231,7 +274,10 @@ public class VirtualClusterModel implements AutoCloseable {
         gateways.put(name, new VirtualClusterGatewayModel(this, nodeIdentificationStrategy, tls, name));
     }
 
-    public TargetCluster targetCluster() {
+    /**
+     * @return the target cluster, or {@code null} if this VC uses a router
+     */
+    public @Nullable TargetCluster targetCluster() {
         return targetCluster;
     }
 
@@ -328,6 +374,9 @@ public class VirtualClusterModel implements AutoCloseable {
     }
 
     private Optional<SslContext> buildUpstreamSslContext() {
+        if (targetCluster == null) {
+            return Optional.empty();
+        }
         return targetCluster.tls().map(targetClusterTls -> {
             try {
                 var sslContextBuilder = Optional.ofNullable(targetClusterTls.key()).map(NettyKeyProvider::new).map(NettyKeyProvider::forClient)

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/RouterChainFactoryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/RouterChainFactoryTest.java
@@ -1,0 +1,378 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.bootstrap;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.PluginFactory;
+import io.kroxylicious.proxy.config.PluginFactoryRegistry;
+import io.kroxylicious.proxy.config.RouteDefinition;
+import io.kroxylicious.proxy.config.RouteTarget;
+import io.kroxylicious.proxy.config.RouterDefinition;
+import io.kroxylicious.proxy.plugin.PluginConfigurationException;
+import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.router.RouterContext;
+import io.kroxylicious.proxy.router.RouterFactory;
+import io.kroxylicious.proxy.router.RouterFactoryContext;
+import io.kroxylicious.proxy.router.RouterResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RouterChainFactoryTest {
+
+    private static final List<RouteDefinition> DUMMY_ROUTES = List.of(
+            new RouteDefinition("route1", 0, null, new RouteTarget("someCluster", null)));
+
+    @Test
+    void shouldHandleNullDefinitions() {
+        try (var factory = new RouterChainFactory(testPfr(), null)) {
+            var ctx = testContext();
+            assertThatThrownBy(() -> factory.createRouter("nonexistent", ctx))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void shouldHandleEmptyDefinitions() {
+        try (var factory = new RouterChainFactory(testPfr(), List.of())) {
+            var ctx = testContext();
+            assertThatThrownBy(() -> factory.createRouter("nonexistent", ctx))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void shouldCreateRouterInstance() {
+        var rd = new RouterDefinition("myRouter", TestRouterFactory.class.getName(),
+                null, DUMMY_ROUTES);
+        try (var factory = new RouterChainFactory(testPfr(), List.of(rd))) {
+            Router router = factory.createRouter("myRouter", testContext());
+            assertThat(router).isNotNull();
+        }
+    }
+
+    @Test
+    void shouldThrowForUnknownRouterName() {
+        var rd = new RouterDefinition("myRouter", TestRouterFactory.class.getName(),
+                null, DUMMY_ROUTES);
+        try (var factory = new RouterChainFactory(testPfr(), List.of(rd))) {
+            var ctx = testContext();
+            assertThatThrownBy(() -> factory.createRouter("unknown", ctx))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("unknown");
+        }
+    }
+
+    @Test
+    void shouldInitializeFactoryOnConstruction() {
+        var initCount = new AtomicInteger(0);
+        var pfr = testPfrWith(new TestRouterFactory() {
+            @Override
+            public Object initialize(RouterFactoryContext context, Object config) {
+                initCount.incrementAndGet();
+                return super.initialize(context, config);
+            }
+        });
+        var rd = new RouterDefinition("r1", TestRouterFactory.class.getName(), null, DUMMY_ROUTES);
+        try (var factory = new RouterChainFactory(pfr, List.of(rd))) {
+            assertThat(initCount.get()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void shouldCloseFactoriesInReverseOrder() {
+        var closeOrder = new java.util.ArrayList<String>();
+        var pfr = testPfrWithMultiple(
+                new TestRouterFactory() {
+                    @Override
+                    public void close(Object initializationData) {
+                        closeOrder.add("first");
+                    }
+                },
+                new TestRouterFactory() {
+                    @Override
+                    public void close(Object initializationData) {
+                        closeOrder.add("second");
+                    }
+                });
+        var rd1 = new RouterDefinition("r1", "factory-0", null, DUMMY_ROUTES);
+        var rd2 = new RouterDefinition("r2", "factory-1", null, DUMMY_ROUTES);
+        var factory = new RouterChainFactory(pfr, List.of(rd1, rd2));
+        factory.close();
+
+        assertThat(closeOrder).containsExactly("second", "first");
+    }
+
+    @Test
+    void shouldThrowAfterClose() {
+        var rd = new RouterDefinition("r1", TestRouterFactory.class.getName(), null, DUMMY_ROUTES);
+        var factory = new RouterChainFactory(testPfr(), List.of(rd));
+        factory.close();
+
+        var ctx = testContext();
+        assertThatThrownBy(() -> factory.createRouter("r1", ctx))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldRejectMismatchedConfigType() {
+        var pfr = testPfrWithConfigType(String.class);
+        var rd = new RouterDefinition("r1", TestRouterFactory.class.getName(),
+                Integer.valueOf(42), DUMMY_ROUTES);
+
+        var defs = List.of(rd);
+        assertThatThrownBy(() -> new RouterChainFactory(pfr, defs))
+                .isInstanceOf(PluginConfigurationException.class)
+                .hasMessageContaining("config of type");
+    }
+
+    @Test
+    void shouldCloseAlreadyInitializedOnFailure() {
+        var closed = new AtomicBoolean(false);
+        var factories = new TestRouterFactory[]{
+                new TestRouterFactory() {
+                    @Override
+                    public void close(Object initializationData) {
+                        closed.set(true);
+                    }
+                },
+                new TestRouterFactory() {
+                    @Override
+                    public Object initialize(RouterFactoryContext context, Object config) {
+                        throw new RuntimeException("init boom");
+                    }
+                }
+        };
+        var pfr = testPfrWithMultiple(factories);
+        var rd1 = new RouterDefinition("r1", "factory-0", null, DUMMY_ROUTES);
+        var rd2 = new RouterDefinition("r2", "factory-1", null, DUMMY_ROUTES);
+
+        var defs = List.of(rd1, rd2);
+        assertThatThrownBy(() -> new RouterChainFactory(pfr, defs))
+                .isInstanceOf(PluginConfigurationException.class);
+        assertThat(closed.get()).isTrue();
+    }
+
+    @Test
+    void shouldSurfaceExceptionFromCloseAndStillCloseOthers() {
+        // Given
+        var secondClosed = new AtomicBoolean(false);
+        var pfr = testPfrWithMultiple(
+                new TestRouterFactory() {
+                    @Override
+                    public void close(Object initializationData) {
+                        secondClosed.set(true);
+                    }
+                },
+                new TestRouterFactory() {
+                    @Override
+                    public void close(Object initializationData) {
+                        throw new RuntimeException("close boom");
+                    }
+                });
+        var rd1 = new RouterDefinition("r1", "factory-0", null, DUMMY_ROUTES);
+        var rd2 = new RouterDefinition("r2", "factory-1", null, DUMMY_ROUTES);
+        var factory = new RouterChainFactory(pfr, List.of(rd1, rd2));
+
+        // When / Then
+        assertThatThrownBy(factory::close)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("close boom");
+        assertThat(secondClosed.get()).isTrue();
+    }
+
+    @Test
+    void shouldSuppressSecondCloseException() {
+        // Given
+        var pfr = testPfrWithMultiple(
+                new TestRouterFactory() {
+                    @Override
+                    public void close(Object initializationData) {
+                        throw new RuntimeException("first close boom");
+                    }
+                },
+                new TestRouterFactory() {
+                    @Override
+                    public void close(Object initializationData) {
+                        throw new RuntimeException("second close boom");
+                    }
+                });
+        var rd1 = new RouterDefinition("r1", "factory-0", null, DUMMY_ROUTES);
+        var rd2 = new RouterDefinition("r2", "factory-1", null, DUMMY_ROUTES);
+        var factory = new RouterChainFactory(pfr, List.of(rd1, rd2));
+
+        // When / Then
+        assertThatThrownBy(factory::close)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("second close boom")
+                .satisfies(e -> assertThat(e.getSuppressed()).hasSize(1)
+                        .singleElement().satisfies(s -> assertThat(s).hasMessage("first close boom")));
+    }
+
+    // -- test helpers --
+
+    static class TestRouterFactory implements RouterFactory<Object, Object> {
+
+        private static final Map<ApiKeys, String> ALL_STATIC = Arrays.stream(ApiKeys.values())
+                .collect(Collectors.toUnmodifiableMap(k -> k, k -> "default"));
+
+        @Override
+        public Object initialize(RouterFactoryContext context, Object config) {
+            return new Object();
+        }
+
+        @Override
+        public Router createRouter(RouterFactoryContext context, Object initializationData) {
+            return new Router() {
+                @Override
+                public CompletionStage<RouterResult> onRequest(short apiVersion, ApiKeys apiKey,
+                                                               RequestHeaderData header, ApiMessage request,
+                                                               RouterContext routerContext) {
+                    throw new IllegalStateException("Dynamic routing is not supported");
+                }
+
+                @Override
+                public Map<ApiKeys, String> staticRoutes() {
+                    return ALL_STATIC;
+                }
+            };
+        }
+
+        @SuppressWarnings("java:S1186") // intentional no-op for test factory
+        @Override
+        public void close(Object initializationData) {
+        }
+    }
+
+    private static PluginFactoryRegistry testPfr() {
+        return testPfrWith(new TestRouterFactory());
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static PluginFactoryRegistry testPfrWith(TestRouterFactory factoryInstance) {
+        return new PluginFactoryRegistry() {
+            @Override
+            public <P> PluginFactory<P> pluginFactory(Class<P> pluginClass) {
+                return (PluginFactory<P>) new PluginFactory<RouterFactory>() {
+                    @Override
+                    public RouterFactory pluginInstance(String instanceName) {
+                        return factoryInstance;
+                    }
+
+                    @Override
+                    public Class<?> configType(String instanceName) {
+                        return Object.class;
+                    }
+
+                    @Override
+                    public Set<String> registeredInstanceNames() {
+                        return Set.of(instanceName(factoryInstance));
+                    }
+
+                    private String instanceName(TestRouterFactory f) {
+                        return f.getClass().getName();
+                    }
+                };
+            }
+        };
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static PluginFactoryRegistry testPfrWithMultiple(TestRouterFactory... factories) {
+        return new PluginFactoryRegistry() {
+            @Override
+            public <P> PluginFactory<P> pluginFactory(Class<P> pluginClass) {
+                return (PluginFactory<P>) new PluginFactory<RouterFactory>() {
+                    @Override
+                    public RouterFactory pluginInstance(String instanceName) {
+                        if (instanceName.startsWith("factory-")) {
+                            int idx = Integer.parseInt(instanceName.substring("factory-".length()));
+                            return factories[idx];
+                        }
+                        for (var f : factories) {
+                            if (instanceName.equals(f.getClass().getName())) {
+                                return f;
+                            }
+                        }
+                        throw new RuntimeException("Unknown factory: " + instanceName);
+                    }
+
+                    @Override
+                    public Class<?> configType(String instanceName) {
+                        return Object.class;
+                    }
+
+                    @Override
+                    public Set<String> registeredInstanceNames() {
+                        return Set.of();
+                    }
+                };
+            }
+        };
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static PluginFactoryRegistry testPfrWithConfigType(Class<?> expectedConfigType) {
+        return new PluginFactoryRegistry() {
+            @Override
+            public <P> PluginFactory<P> pluginFactory(Class<P> pluginClass) {
+                return (PluginFactory<P>) new PluginFactory<RouterFactory>() {
+                    @Override
+                    public RouterFactory pluginInstance(String instanceName) {
+                        return new TestRouterFactory();
+                    }
+
+                    @Override
+                    public Class<?> configType(String instanceName) {
+                        return expectedConfigType;
+                    }
+
+                    @Override
+                    public Set<String> registeredInstanceNames() {
+                        return Set.of();
+                    }
+                };
+            }
+        };
+    }
+
+    private static RouterFactoryContext testContext() {
+        return new RouterFactoryContext() {
+            @Override
+            public String virtualClusterName() {
+                return "test-cluster";
+            }
+
+            @Override
+            public String routerName() {
+                return "test-router";
+            }
+
+            @Override
+            public <P> P pluginInstance(Class<P> pluginClass, String implementationName) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <P> Set<String> pluginImplementationNames(Class<P> pluginClass) {
+                return Set.of();
+            }
+        };
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
@@ -11,6 +11,9 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
+import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -92,28 +95,118 @@ class ConfigurationValidationTest {
     }
 
     @Test
-    void shouldRejectRouterTarget() {
+    void virtualClusterWithRouterTarget() {
         RouteTarget routerTarget = new RouteTarget(null, "nonexistent");
         List<VirtualClusterGateway> gateways = List.of(simpleGateway("gw"));
-        assertThatThrownBy(() -> new VirtualCluster("demo", null,
+        VirtualCluster demo = new VirtualCluster("demo", null,
                 routerTarget,
-                gateways, false, false, null, null, null, null))
-                .isInstanceOf(IllegalConfigurationException.class)
-                .hasMessageContaining("illegal target.router for virtual cluster 'demo'.");
+                gateways, false, false, null, null, null, null);
+        assertThat(demo.target()).isEqualTo(routerTarget);
     }
 
     @Test
-    void virtualClusterModelRejectsRouterDefinitions() {
+    void virtualClusterModelWithRouterDefinitions() {
         var cluster = new ClusterDefinition("c1", "broker:9092", null);
         var route = new RouteDefinition("r", 0, null, new RouteTarget("c1", null));
         var router = new RouterDefinition("myrouter", "Type", null, List.of(route));
-
+        VirtualCluster virtualCluster = new VirtualCluster("demo", null,
+                new RouteTarget(null, "myrouter"),
+                List.of(simpleGateway("gateway")), false, false, null, null, null, null);
         var config = new Configuration(null, List.of(cluster), null, null, List.of(router),
-                List.of(SIMPLE_VC), null, false, Optional.empty(), null, null);
+                List.of(virtualCluster), null, false, Optional.empty(), null, null);
+        List<VirtualClusterModel> virtualClusterModels = config.virtualClusterModel(null);
+        assertThat(virtualClusterModels).hasSize(1).singleElement().satisfies(vm -> {
+            assertThat(vm.usesRouter()).isTrue();
+            assertThat(vm.routerName()).isEqualTo("myrouter");
+        });
+    }
 
-        assertThatThrownBy(() -> config.virtualClusterModel(null))
-                .isInstanceOf(IllegalConfigurationException.class)
-                .hasMessageContaining("Routing is not yet supported");
+    @Test
+    void routerResolvesRouteDescriptors() {
+        var cluster = new ClusterDefinition("c1", "broker:9092", null);
+        var route = new RouteDefinition("route1", 0, null, new RouteTarget("c1", null));
+        var router = new RouterDefinition("myrouter", "Type", null, List.of(route));
+        var vc = new VirtualCluster("demo", null,
+                new RouteTarget(null, "myrouter"),
+                List.of(simpleGateway("gw")), false, false, null, null, null, null);
+        var config = new Configuration(null, List.of(cluster), null, null, List.of(router),
+                List.of(vc), null, false, Optional.empty(), null, null);
+
+        var model = config.virtualClusterModel(null).get(0);
+
+        assertThat(model.routeDescriptors()).containsKey("route1");
+        RouteDescriptor rd = model.routeDescriptors().get("route1");
+        assertThat(rd.name()).isEqualTo("route1");
+        assertThat(rd.id()).isZero();
+        assertThat(rd.targetsCluster()).isTrue();
+        assertThat(rd.targetCluster()).isNotNull();
+    }
+
+    @Test
+    void routerResolvesPrimaryTargetClusterFromFirstRoute() {
+        var c1 = new ClusterDefinition("c1", "broker1:9092", null);
+        var c2 = new ClusterDefinition("c2", "broker2:9092", null);
+        var route1 = new RouteDefinition("r1", 0, null, new RouteTarget("c1", null));
+        var route2 = new RouteDefinition("r2", 1, null, new RouteTarget("c2", null));
+        var router = new RouterDefinition("myrouter", "Type", null, List.of(route1, route2));
+        var vc = new VirtualCluster("demo", null,
+                new RouteTarget(null, "myrouter"),
+                List.of(simpleGateway("gw")), false, false, null, null, null, null);
+        var config = new Configuration(null, List.of(c1, c2), null, null, List.of(router),
+                List.of(vc), null, false, Optional.empty(), null, null);
+
+        var model = config.virtualClusterModel(null).get(0);
+
+        assertThat(model.targetCluster()).isNotNull();
+        assertThat(model.targetCluster().bootstrapServersList()).containsExactly(
+                new io.kroxylicious.proxy.service.HostPort("broker1", 9092));
+    }
+
+    @Test
+    void routerResolvesMultipleRoutes() {
+        var c1 = new ClusterDefinition("c1", "broker1:9092", null);
+        var c2 = new ClusterDefinition("c2", "broker2:9092", null);
+        var route1 = new RouteDefinition("r1", 0, null, new RouteTarget("c1", null));
+        var route2 = new RouteDefinition("r2", 1, null, new RouteTarget("c2", null));
+        var router = new RouterDefinition("myrouter", "Type", null, List.of(route1, route2));
+        var vc = new VirtualCluster("demo", null,
+                new RouteTarget(null, "myrouter"),
+                List.of(simpleGateway("gw")), false, false, null, null, null, null);
+        var config = new Configuration(null, List.of(c1, c2), null, null, List.of(router),
+                List.of(vc), null, false, Optional.empty(), null, null);
+
+        var model = config.virtualClusterModel(null).get(0);
+
+        assertThat(model.routeDescriptors()).hasSize(2).containsKeys("r1", "r2");
+    }
+
+    @Test
+    void routerResolvesPerRouteFilters() {
+        var cluster = new ClusterDefinition("c1", "broker:9092", null);
+        var filterDefs = List.of(new NamedFilterDefinition("f1", "Type1", null));
+        var route = new RouteDefinition("r1", 0, List.of("f1"), new RouteTarget("c1", null));
+        var router = new RouterDefinition("myrouter", "Type", null, List.of(route));
+        var vc = new VirtualCluster("demo", null,
+                new RouteTarget(null, "myrouter"),
+                List.of(simpleGateway("gw")), false, false, null, null, null, null);
+        var config = new Configuration(null, List.of(cluster), filterDefs, null, List.of(router),
+                List.of(vc), null, false, Optional.empty(), null, null);
+
+        var model = config.virtualClusterModel(null).get(0);
+
+        RouteDescriptor rd = model.routeDescriptors().get("r1");
+        assertThat(rd.filters()).hasSize(1);
+        assertThat(rd.filters().get(0).name()).isEqualTo("f1");
+    }
+
+    @Test
+    void virtualClusterWithoutRouterHasNullRouteDescriptors() {
+        var config = config(List.of(SIMPLE_VC));
+
+        var model = config.virtualClusterModel(null).get(0);
+
+        assertThat(model.usesRouter()).isFalse();
+        assertThat(model.routeDescriptors()).isNull();
     }
 
     @Test
@@ -165,6 +258,33 @@ class ConfigurationValidationTest {
     }
 
     @Test
+    void virtualClusterModelByNameWithRouter() {
+        var cluster = new ClusterDefinition("c1", "broker:9092", null);
+        var route = new RouteDefinition("r1", 0, null, new RouteTarget("c1", null));
+        var router = new RouterDefinition("myrouter", "Type", null, List.of(route));
+        var vc = new VirtualCluster("demo", null,
+                new RouteTarget(null, "myrouter"),
+                List.of(simpleGateway("gw")), false, false, null, null, null, null);
+        var config = new Configuration(null, List.of(cluster), null, null, List.of(router),
+                List.of(vc), null, false, Optional.empty(), null, null);
+
+        var model = config.virtualClusterModel(null, "demo");
+
+        assertThat(model.usesRouter()).isTrue();
+        assertThat(model.routerName()).isEqualTo("myrouter");
+        assertThat(model.routeDescriptors()).containsKey("r1");
+    }
+
+    @Test
+    void virtualClusterModelByNameThrowsForUnknown() {
+        var config = config(List.of(SIMPLE_VC));
+
+        assertThatThrownBy(() -> config.virtualClusterModel(null, "nonexistent"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("nonexistent");
+    }
+
+    @Test
     void shouldRejectNoVirtualClusters() {
         assertThatThrownBy(() -> new Configuration(null, null, null, null, null, List.of(), null, false, Optional.empty(), null, null))
                 .isInstanceOf(IllegalConfigurationException.class)
@@ -188,5 +308,93 @@ class ConfigurationValidationTest {
         assertThatThrownBy(() -> config(List.of(vc1, vc2)))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("duplicated");
+    }
+
+    @Test
+    void shouldRejectUnknownRouterReference() {
+        var vc = new VirtualCluster("demo", null,
+                new RouteTarget(null, "nonexistent-router"),
+                List.of(simpleGateway("gw")), false, false, null, null, null, null);
+
+        assertThatThrownBy(() -> new Configuration(null, null, null, null, null,
+                List.of(vc), null, false, Optional.empty(), null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("unknown router")
+                .hasMessageContaining("nonexistent-router");
+    }
+
+    @Test
+    void shouldAcceptKnownRouterReference() {
+        var cluster = new ClusterDefinition("c1", "broker:9092", null);
+        var route = new RouteDefinition("r1", 0, null, new RouteTarget("c1", null));
+        var router = new RouterDefinition("myrouter", "Type", null, List.of(route));
+        var vc = new VirtualCluster("demo", null,
+                new RouteTarget(null, "myrouter"),
+                List.of(simpleGateway("gw")), false, false, null, null, null, null);
+
+        assertThatCode(() -> new Configuration(null, List.of(cluster), null, null, List.of(router),
+                List.of(vc), null, false, Optional.empty(), null, null))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void routerRouteTargetingNestedRouterHasNullTargetCluster() {
+        var cluster = new ClusterDefinition("c1", "broker:9092", null);
+        var innerRoute = new RouteDefinition("inner-r", 0, null, new RouteTarget("c1", null));
+        var innerRouter = new RouterDefinition("inner", "Type", null, List.of(innerRoute));
+        var outerRoute = new RouteDefinition("outer-r", 0, null, new RouteTarget(null, "inner"));
+        var outerRouter = new RouterDefinition("outer", "Type", null, List.of(outerRoute));
+        var vc = new VirtualCluster("demo", null,
+                new RouteTarget(null, "outer"),
+                List.of(simpleGateway("gw")), false, false, null, null, null, null);
+        var config = new Configuration(null, List.of(cluster), null, null, List.of(outerRouter, innerRouter),
+                List.of(vc), null, false, Optional.empty(), null, null);
+
+        var model = config.virtualClusterModel(null).get(0);
+
+        RouteDescriptor rd = model.routeDescriptors().get("outer-r");
+        assertThat(rd.targetsCluster()).isFalse();
+        assertThat(rd.targetCluster()).isNull();
+        assertThat(rd.routerName()).isEqualTo("inner");
+    }
+
+    @Test
+    void routerPrimaryTargetClusterResolvedFromFirstClusterRoute() {
+        var c1 = new ClusterDefinition("c1", "broker1:9092", null);
+        var c2 = new ClusterDefinition("c2", "broker2:9092", null);
+        var innerRoute = new RouteDefinition("ir", 0, null, new RouteTarget("c2", null));
+        var innerRouter = new RouterDefinition("inner", "Type", null, List.of(innerRoute));
+        var routeToRouter = new RouteDefinition("r1", 0, null, new RouteTarget(null, "inner"));
+        var routeToCluster = new RouteDefinition("r2", 1, null, new RouteTarget("c1", null));
+        var router = new RouterDefinition("myrouter", "Type", null, List.of(routeToRouter, routeToCluster));
+        var vc = new VirtualCluster("demo", null,
+                new RouteTarget(null, "myrouter"),
+                List.of(simpleGateway("gw")), false, false, null, null, null, null);
+
+        var config = new Configuration(null, List.of(c1, c2), null, null, List.of(router, innerRouter),
+                List.of(vc), null, false, Optional.empty(), null, null);
+        var model = config.virtualClusterModel(null).get(0);
+
+        assertThat(model.targetCluster()).isNotNull();
+        assertThat(model.targetCluster().bootstrapServersList()).containsExactly(
+                new io.kroxylicious.proxy.service.HostPort("broker1", 9092));
+    }
+
+    @Test
+    void routerWithOnlyNestedRouterRoutesResolvesNullPrimaryTarget() {
+        var cluster = new ClusterDefinition("c1", "broker:9092", null);
+        var innerRoute = new RouteDefinition("inner-r", 0, null, new RouteTarget("c1", null));
+        var innerRouter = new RouterDefinition("inner", "Type", null, List.of(innerRoute));
+        var outerRoute = new RouteDefinition("outer-r", 0, null, new RouteTarget(null, "inner"));
+        var outerRouter = new RouterDefinition("outer", "Type", null, List.of(outerRoute));
+        var vc = new VirtualCluster("demo", null,
+                new RouteTarget(null, "outer"),
+                List.of(simpleGateway("gw")), false, false, null, null, null, null);
+
+        var config = new Configuration(null, List.of(cluster), null, null, List.of(outerRouter, innerRouter),
+                List.of(vc), null, false, Optional.empty(), null, null);
+        var model = config.virtualClusterModel(null).get(0);
+
+        assertThat(model.targetCluster()).isNull();
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
@@ -109,7 +109,8 @@ class ClientConnectionStateMachineEndToEndTest {
         var kafkaSession = new KafkaSession(KafkaSessionState.ESTABLISHING);
         // Override createServerConnection to substitute EmbeddedChannels for real TCP connections
         return new ClientConnectionStateMachine(binding, new DefaultSubjectBuilder(List.of()), kafkaSession,
-                (remote, ccsm, vc, cn, ni) -> new ServerConnectionStateMachine(remote, ccsm, vc, cn, ni) {
+                (remote, ccsm, vc, cn, ni, errorCounter, backpressureMeter, connectionToken) -> new ServerConnectionStateMachine(remote, ccsm, vc, cn, ni, errorCounter,
+                        backpressureMeter, connectionToken) {
                     @Override
                     Bootstrap configureBootstrap(
                                                  KafkaProxyBackendHandler capturedBackendHandler,
@@ -224,7 +225,7 @@ class ClientConnectionStateMachineEndToEndTest {
             clientConnectionStateMachine.forceState(
                     new ClientConnectionState.HaProxy(),
                     handler,
-                    null,
+                    java.util.Map.of(),
                     TEST_SESSION, false);
         }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
@@ -917,6 +917,87 @@ class ClientConnectionStateMachineTest {
     }
 
     @Test
+    void forwardToRouteShouldDispatchToCorrectScsm() {
+        // Given
+        var scsm1 = mock(ServerConnectionStateMachine.class);
+        var scsm2 = mock(ServerConnectionStateMachine.class);
+        var addr1 = new HostPort("host1", 9092);
+        var addr2 = new HostPort("host2", 9092);
+        var forwarding = new ClientConnectionState.Forwarding();
+        clientConnectionStateMachine.forceState(
+                forwarding,
+                frontendHandler,
+                Map.of(addr1, scsm1, addr2, scsm2),
+                TEST_KAFKA_SESSION,
+                true,
+                Map.of("route-a", addr1, "route-b", addr2));
+        Object msg = new Object();
+
+        // When
+        clientConnectionStateMachine.forwardToRoute("route-b", msg);
+
+        // Then
+        verify(scsm2).sendRequest(msg);
+        verifyNoInteractions(scsm1);
+    }
+
+    @Test
+    void forwardToRouteShouldShareScsmForRoutesWithSameTarget() {
+        // Given
+        var scsm = mock(ServerConnectionStateMachine.class);
+        var addr = new HostPort("host1", 9092);
+        var forwarding = new ClientConnectionState.Forwarding();
+        clientConnectionStateMachine.forceState(
+                forwarding,
+                frontendHandler,
+                Map.of(addr, scsm),
+                TEST_KAFKA_SESSION,
+                true,
+                Map.of("route-a", addr, "route-b", addr));
+        Object msg1 = new Object();
+        Object msg2 = new Object();
+
+        // When
+        clientConnectionStateMachine.forwardToRoute("route-a", msg1);
+        clientConnectionStateMachine.forwardToRoute("route-b", msg2);
+
+        // Then
+        verify(scsm).sendRequest(msg1);
+        verify(scsm).sendRequest(msg2);
+    }
+
+    @Test
+    void forwardToRouteWithUnknownRouteShouldTransitionToClosed() {
+        // Given
+        var forwarding = new ClientConnectionState.Forwarding();
+        clientConnectionStateMachine.forceState(
+                forwarding,
+                frontendHandler,
+                Map.of(BROKER_ADDRESS, serverConnectionStateMachine),
+                TEST_KAFKA_SESSION,
+                true,
+                Map.of("known-route", BROKER_ADDRESS));
+
+        // When
+        clientConnectionStateMachine.forwardToRoute("unknown-route", new Object());
+
+        // Then
+        assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Closed.class);
+    }
+
+    @Test
+    void forwardToRouteNotInForwardingShouldTransitionToClosed() {
+        // Given
+        stateMachineInClientActive();
+
+        // When
+        clientConnectionStateMachine.forwardToRoute("any-route", new Object());
+
+        // Then
+        assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Closed.class);
+    }
+
+    @Test
     void shouldFlushToClientWhenServerReadCompletes() {
         // Given
         stateMachineInForwarding();
@@ -926,6 +1007,95 @@ class ClientConnectionStateMachineTest {
 
         // Then
         verify(frontendHandler).flushToClient();
+    }
+
+    @Test
+    void onResponseFromServerShouldNotForwardToClientWhenRoutingCallbackHandles() {
+        // Given
+        stateMachineInForwarding();
+        clientConnectionStateMachine.setRoutingResponseCallback(msg -> true);
+        var msg = metadataResponse();
+
+        // When
+        clientConnectionStateMachine.onResponseFromServer(serverConnectionStateMachine, msg);
+
+        // Then
+        verify(frontendHandler, never()).forwardToClient(any());
+    }
+
+    @Test
+    void onResponseFromServerShouldForwardToClientWhenRoutingCallbackDeclines() {
+        // Given
+        stateMachineInForwarding();
+        clientConnectionStateMachine.setRoutingResponseCallback(msg -> false);
+        var msg = metadataResponse();
+
+        // When
+        clientConnectionStateMachine.onResponseFromServer(serverConnectionStateMachine, msg);
+
+        // Then
+        verify(frontendHandler).forwardToClient(msg);
+    }
+
+    @Test
+    void clientChannelShouldReturnNullBeforeClientActive() {
+        // When / Then
+        assertThat(clientConnectionStateMachine.clientChannel()).isNull();
+    }
+
+    @Test
+    void clientChannelShouldReturnChannelAfterClientActive() {
+        // Given
+        var channel = mock(Channel.class);
+        when(frontendHandler.clientChannel()).thenReturn(channel);
+        stateMachineInForwarding();
+
+        // When / Then
+        assertThat(clientConnectionStateMachine.clientChannel()).isSameAs(channel);
+    }
+
+    @Test
+    void onClientUnwritableShouldApplyBackpressureToAllServerConnections() {
+        // Given
+        var scsm1 = mock(ServerConnectionStateMachine.class);
+        var scsm2 = mock(ServerConnectionStateMachine.class);
+        var addr1 = new HostPort("host1", 9092);
+        var addr2 = new HostPort("host2", 9092);
+        clientConnectionStateMachine.forceState(
+                new ClientConnectionState.Forwarding(),
+                frontendHandler,
+                Map.of(addr1, scsm1, addr2, scsm2),
+                TEST_KAFKA_SESSION,
+                true);
+
+        // When
+        clientConnectionStateMachine.onClientUnwritable();
+
+        // Then
+        verify(scsm1).applyBackpressure();
+        verify(scsm2).applyBackpressure();
+    }
+
+    @Test
+    void onClientWritableShouldRelieveBackpressureOnAllServerConnections() {
+        // Given
+        var scsm1 = mock(ServerConnectionStateMachine.class);
+        var scsm2 = mock(ServerConnectionStateMachine.class);
+        var addr1 = new HostPort("host1", 9092);
+        var addr2 = new HostPort("host2", 9092);
+        clientConnectionStateMachine.forceState(
+                new ClientConnectionState.Forwarding(),
+                frontendHandler,
+                Map.of(addr1, scsm1, addr2, scsm2),
+                TEST_KAFKA_SESSION,
+                true);
+
+        // When
+        clientConnectionStateMachine.onClientWritable();
+
+        // Then
+        verify(scsm1).relieveBackpressure();
+        verify(scsm2).relieveBackpressure();
     }
 
     private int getVirtualNodeClientToProxyActiveConnections() {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
@@ -8,6 +8,7 @@ package io.kroxylicious.proxy.internal;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -116,7 +117,7 @@ class ClientConnectionStateMachineTest {
         when(endpointGateway.virtualCluster()).thenReturn(VIRTUAL_CLUSTER_MODEL);
         clientConnectionStateMachine = new ClientConnectionStateMachine(endpointBinding, new DefaultSubjectBuilder(List.of()),
                 new KafkaSession(KafkaSessionState.ESTABLISHING),
-                (remote, ccsm, vc, cn, ni) -> serverConnectionStateMachine);
+                (remote, ccsm, vc, cn, ni, errorCounter, backpressureMeter, connectionToken) -> serverConnectionStateMachine);
         when(frontendHandler.channelId()).thenReturn(DefaultChannelId.newInstance());
         when(frontendHandler.remoteHost()).thenReturn("testhost.example.com");
         when(frontendHandler.remotePort()).thenReturn(9476);
@@ -172,10 +173,27 @@ class ClientConnectionStateMachineTest {
         givenState.run();
 
         // When
-        clientConnectionStateMachine.onServerConnectionException(failure);
+        clientConnectionStateMachine.onServerConnectionException(serverConnectionStateMachine, failure);
 
         // Then — server error counting is now the SCSM's concern; CCSM just transitions to Closed
         assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Closed.class);
+    }
+
+    @Test
+    void shouldCountProxyToServerConnections() {
+        // Given
+        stateMachineInClientActive();
+        when(endpointBinding.upstreamTarget()).thenReturn(BROKER_ADDRESS);
+
+        // When — first client request triggers SCSM creation which increments the counter
+        clientConnectionStateMachine.onClientRequest(metadataRequest());
+
+        // Then
+        assertThat(Metrics.globalRegistry.get("kroxylicious_proxy_to_server_connections").counter())
+                .isNotNull()
+                .satisfies(counter -> assertThat(counter.getId()).isNotNull())
+                .satisfies(counter -> assertThat(counter.count())
+                        .isCloseTo(1.0, CLOSE_ENOUGH));
     }
 
     @Test
@@ -184,7 +202,7 @@ class ClientConnectionStateMachineTest {
         stateMachineInForwardingAwaitingTransportSubject();
 
         // When
-        clientConnectionStateMachine.onServerConnectionException(failure);
+        clientConnectionStateMachine.onServerConnectionException(serverConnectionStateMachine, failure);
 
         // Then — server error counting is now the SCSM's concern; CCSM just transitions to Closed
         assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Closed.class);
@@ -194,10 +212,10 @@ class ClientConnectionStateMachineTest {
     void shouldBlockClientReads() {
         // Given
         stateMachineInClientActive();
-        clientConnectionStateMachine.onServerUnwritable();
+        clientConnectionStateMachine.onServerUnwritable(serverConnectionStateMachine);
 
         // When
-        clientConnectionStateMachine.onServerUnwritable();
+        clientConnectionStateMachine.onServerUnwritable(serverConnectionStateMachine);
 
         // Then
         verify(frontendHandler, times(1)).applyBackpressure();
@@ -208,10 +226,10 @@ class ClientConnectionStateMachineTest {
         // Given
         stateMachineInClientActive();
         clientConnectionStateMachine.clientReadsBlocked = true;
-        clientConnectionStateMachine.onServerWritable();
+        clientConnectionStateMachine.onServerWritable(serverConnectionStateMachine);
 
         // When
-        clientConnectionStateMachine.onServerWritable();
+        clientConnectionStateMachine.onServerWritable(serverConnectionStateMachine);
 
         // Then
         verify(frontendHandler, times(1)).relieveBackpressure();
@@ -275,7 +293,7 @@ class ClientConnectionStateMachineTest {
         RuntimeException cause = new RuntimeException("Oops!");
 
         // When
-        clientConnectionStateMachine.onServerConnectionException(cause);
+        clientConnectionStateMachine.onServerConnectionException(serverConnectionStateMachine, cause);
 
         // Then
         assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Closed.class);
@@ -409,12 +427,12 @@ class ClientConnectionStateMachineTest {
         clientConnectionStateMachine.forceState(
                 new ClientConnectionState.Forwarding(),
                 frontendHandler,
-                serverConnectionStateMachine,
+                Map.of(BROKER_ADDRESS, serverConnectionStateMachine),
                 TEST_KAFKA_SESSION,
                 false);
 
         // When
-        clientConnectionStateMachine.onServerConnectionActive();
+        clientConnectionStateMachine.onServerConnectionActive(serverConnectionStateMachine);
 
         // Then — backend activation no longer participates in unblocking
         assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Forwarding.class);
@@ -441,7 +459,7 @@ class ClientConnectionStateMachineTest {
         stateMachineInClientActive();
 
         // When
-        clientConnectionStateMachine.onServerConnectionActive();
+        clientConnectionStateMachine.onServerConnectionActive(serverConnectionStateMachine);
 
         // Then
         assertThat(clientConnectionStateMachine.state())
@@ -473,7 +491,7 @@ class ClientConnectionStateMachineTest {
         var msg = metadataResponse();
 
         // When
-        clientConnectionStateMachine.onResponseFromServer(msg);
+        clientConnectionStateMachine.onResponseFromServer(serverConnectionStateMachine, msg);
 
         // Then
         assertThat(clientConnectionStateMachine.state()).isSameAs(forwarding);
@@ -490,7 +508,7 @@ class ClientConnectionStateMachineTest {
         doNothing().when(serverConnectionStateMachine).close();
 
         // When
-        clientConnectionStateMachine.onServerConnectionClosed(ClientConnectionStateMachine.DisconnectCause.SERVER_CLOSED);
+        clientConnectionStateMachine.onServerConnectionClosed(serverConnectionStateMachine, ClientConnectionStateMachine.DisconnectCause.SERVER_CLOSED);
 
         // Then
         assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Closed.class);
@@ -535,7 +553,7 @@ class ClientConnectionStateMachineTest {
         stateMachineInClosed();
 
         // When
-        clientConnectionStateMachine.onServerConnectionClosed(ClientConnectionStateMachine.DisconnectCause.SERVER_CLOSED);
+        clientConnectionStateMachine.onServerConnectionClosed(serverConnectionStateMachine, ClientConnectionStateMachine.DisconnectCause.SERVER_CLOSED);
 
         // Then
         verifyNoInteractions(frontendHandler, serverConnectionStateMachine);
@@ -549,7 +567,7 @@ class ClientConnectionStateMachineTest {
         doNothing().when(serverConnectionStateMachine).close();
 
         // When
-        clientConnectionStateMachine.onServerConnectionException(illegalStateException);
+        clientConnectionStateMachine.onServerConnectionException(serverConnectionStateMachine, illegalStateException);
 
         // Then
         assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Closed.class);
@@ -613,7 +631,7 @@ class ClientConnectionStateMachineTest {
         givenState.run();
 
         // When
-        clientConnectionStateMachine.onServerUnwritable();
+        clientConnectionStateMachine.onServerUnwritable(serverConnectionStateMachine);
 
         // Then
         assertThat(clientConnectionStateMachine.clientToProxyBackpressureTimer)
@@ -625,10 +643,10 @@ class ClientConnectionStateMachineTest {
     void shouldStopClientTimerWhenServerIsWritable(Runnable givenState) {
         // Given
         givenState.run();
-        clientConnectionStateMachine.onServerUnwritable();
+        clientConnectionStateMachine.onServerUnwritable(serverConnectionStateMachine);
 
         // When
-        clientConnectionStateMachine.onServerWritable();
+        clientConnectionStateMachine.onServerWritable(serverConnectionStateMachine);
 
         // Then
         assertThat(Metrics.globalRegistry.get("kroxylicious_client_to_proxy_reads_paused").timer())
@@ -691,7 +709,7 @@ class ClientConnectionStateMachineTest {
         clientConnectionStateMachine.forceState(
                 new ClientConnectionState.ClientActive(),
                 frontendHandler,
-                null,
+                Map.of(),
                 TEST_KAFKA_SESSION,
                 true);
     }
@@ -700,7 +718,7 @@ class ClientConnectionStateMachineTest {
         clientConnectionStateMachine.forceState(
                 new ClientConnectionState.HaProxy(),
                 frontendHandler,
-                null,
+                Map.of(),
                 TEST_KAFKA_SESSION,
                 true);
     }
@@ -710,7 +728,7 @@ class ClientConnectionStateMachineTest {
         clientConnectionStateMachine.forceState(
                 forwarding,
                 frontendHandler,
-                serverConnectionStateMachine,
+                Map.of(BROKER_ADDRESS, serverConnectionStateMachine),
                 TEST_KAFKA_SESSION,
                 true);
         return forwarding;
@@ -720,7 +738,7 @@ class ClientConnectionStateMachineTest {
         clientConnectionStateMachine.forceState(
                 new ClientConnectionState.Forwarding(),
                 frontendHandler,
-                serverConnectionStateMachine,
+                Map.of(BROKER_ADDRESS, serverConnectionStateMachine),
                 TEST_KAFKA_SESSION,
                 false);
     }
@@ -729,7 +747,7 @@ class ClientConnectionStateMachineTest {
         clientConnectionStateMachine.forceState(
                 new ClientConnectionState.Closed(),
                 frontendHandler,
-                serverConnectionStateMachine,
+                Map.of(BROKER_ADDRESS, serverConnectionStateMachine),
                 TEST_KAFKA_SESSION,
                 true);
     }
@@ -781,7 +799,7 @@ class ClientConnectionStateMachineTest {
         stateMachineInForwardingAwaitingTransportSubject();
 
         // When
-        clientConnectionStateMachine.onServerConnectionActive();
+        clientConnectionStateMachine.onServerConnectionActive(serverConnectionStateMachine);
 
         // Then — state is still Forwarding (latch decremented but not zero)
         assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Forwarding.class);
@@ -792,7 +810,7 @@ class ClientConnectionStateMachineTest {
         // Given - establish both client and server connections
         clientConnectionStateMachine.onClientActive(frontendHandler);
         stateMachineInForwardingAwaitingTransportSubject();
-        clientConnectionStateMachine.onServerConnectionActive();
+        clientConnectionStateMachine.onServerConnectionActive(serverConnectionStateMachine);
 
         int initialClientCount = getVirtualNodeClientToProxyActiveConnections();
 
@@ -810,12 +828,12 @@ class ClientConnectionStateMachineTest {
         // Given - establish both client and server connections
         clientConnectionStateMachine.onClientActive(frontendHandler);
         stateMachineInForwardingAwaitingTransportSubject();
-        clientConnectionStateMachine.onServerConnectionActive();
+        clientConnectionStateMachine.onServerConnectionActive(serverConnectionStateMachine);
 
         int initialClientCount = getVirtualNodeClientToProxyActiveConnections();
 
         // When
-        clientConnectionStateMachine.onServerConnectionClosed(ClientConnectionStateMachine.DisconnectCause.SERVER_CLOSED);
+        clientConnectionStateMachine.onServerConnectionClosed(serverConnectionStateMachine, ClientConnectionStateMachine.DisconnectCause.SERVER_CLOSED);
 
         // Then — server connection metric is now the SCSM's concern
         assertThat(getVirtualNodeClientToProxyActiveConnections())
@@ -841,12 +859,12 @@ class ClientConnectionStateMachineTest {
         // Given - establish both client and server connections
         clientConnectionStateMachine.onClientActive(frontendHandler);
         stateMachineInForwardingAwaitingTransportSubject();
-        clientConnectionStateMachine.onServerConnectionActive();
+        clientConnectionStateMachine.onServerConnectionActive(serverConnectionStateMachine);
 
         int initialClientCount = getVirtualNodeClientToProxyActiveConnections();
 
         // When
-        clientConnectionStateMachine.onServerConnectionException(new RuntimeException("test exception"));
+        clientConnectionStateMachine.onServerConnectionException(serverConnectionStateMachine, new RuntimeException("test exception"));
 
         // Then — server connection metric is now the SCSM's concern
         assertThat(getVirtualNodeClientToProxyActiveConnections())
@@ -904,7 +922,7 @@ class ClientConnectionStateMachineTest {
         stateMachineInForwarding();
 
         // When
-        clientConnectionStateMachine.onServerReadComplete();
+        clientConnectionStateMachine.onServerReadComplete(serverConnectionStateMachine);
 
         // Then
         verify(frontendHandler).flushToClient();
@@ -981,7 +999,7 @@ class ClientConnectionStateMachineTest {
             stateMachineInForwarding();
 
             // When
-            clientConnectionStateMachine.onServerConnectionClosed(ClientConnectionStateMachine.DisconnectCause.SERVER_CLOSED);
+            clientConnectionStateMachine.onServerConnectionClosed(serverConnectionStateMachine, ClientConnectionStateMachine.DisconnectCause.SERVER_CLOSED);
 
             // Then
             assertThat(Metrics.globalRegistry.find("kroxylicious_client_to_proxy_disconnects")
@@ -1115,7 +1133,7 @@ class ClientConnectionStateMachineTest {
         @Test
         void drainWhenStateIsNotForwardingStillCompletesFuture() {
             // Given — CCSM stuck in HaProxy state (not Forwarding)
-            clientConnectionStateMachine.forceState(new ClientConnectionState.HaProxy(), frontendHandler, null, TEST_KAFKA_SESSION, true);
+            clientConnectionStateMachine.forceState(new ClientConnectionState.HaProxy(), frontendHandler, Map.of(), TEST_KAFKA_SESSION, true);
 
             // When
             CompletableFuture<Void> closedFuture = clientConnectionStateMachine.drain(DRAIN_TIMEOUT);
@@ -1139,7 +1157,7 @@ class ClientConnectionStateMachineTest {
             assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Draining.class);
 
             // When — server delivers a response, decrementing client-in-flight to 0
-            clientConnectionStateMachine.onResponseFromServer(new Object());
+            clientConnectionStateMachine.onResponseFromServer(serverConnectionStateMachine, new Object());
 
             // Then — drain policy fired, state advanced to Closed (via onDrainCompleted → toClosed)
             assertThat(closedFuture).isCompleted();
@@ -1157,7 +1175,7 @@ class ClientConnectionStateMachineTest {
             assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Draining.class);
 
             // When — server delivers ONE response (client-in-flight goes 2 → 1, still > 0)
-            clientConnectionStateMachine.onResponseFromServer(new Object());
+            clientConnectionStateMachine.onResponseFromServer(serverConnectionStateMachine, new Object());
 
             // Then — still draining, future not yet completed (the "still waiting" branch ran)
             assertThat(closedFuture).isNotCompleted();
@@ -1185,7 +1203,7 @@ class ClientConnectionStateMachineTest {
             assertThat(closedFuture).isNotCompleted();
 
             // Now deliver the response for the original in-flight; counter goes 1 → 0 → policy fires
-            clientConnectionStateMachine.onResponseFromServer(new Object());
+            clientConnectionStateMachine.onResponseFromServer(serverConnectionStateMachine, new Object());
             assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Closed.class);
             assertThat(closedFuture).isCompleted();
         }
@@ -1263,7 +1281,7 @@ class ClientConnectionStateMachineTest {
             ArgumentCaptor<Runnable> timerCaptor = ArgumentCaptor.forClass(Runnable.class);
             CompletableFuture<Void> closedFuture = clientConnectionStateMachine.drain(DRAIN_TIMEOUT);
             verify(eventLoop).schedule(timerCaptor.capture(), anyLong(), any(TimeUnit.class));
-            clientConnectionStateMachine.onResponseFromServer(new Object());
+            clientConnectionStateMachine.onResponseFromServer(serverConnectionStateMachine, new Object());
             assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Closed.class);
             assertThat(closedFuture).isCompleted();
             double drainCompletedBefore = Metrics.globalRegistry.get("kroxylicious_client_to_proxy_disconnects")
@@ -1305,7 +1323,7 @@ class ClientConnectionStateMachineTest {
             assertThat(secondFuture).isNotCompleted();
 
             // When — the in-flight response arrives, completing the drain naturally
-            clientConnectionStateMachine.onResponseFromServer(new Object());
+            clientConnectionStateMachine.onResponseFromServer(serverConnectionStateMachine, new Object());
 
             // Then — the second future completes along with the connection closing
             assertThat(secondFuture).isCompleted();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/DelegatingDecodePredicateTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/DelegatingDecodePredicateTest.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy.internal;
 
+import java.util.Set;
+
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -109,6 +111,30 @@ class DelegatingDecodePredicateTest {
 
     private void assertPredicateDoesNotTargetRequestKey(ApiKeys key) {
         assertFalse(predicate.shouldDecodeRequest(key, key.latestVersion()), "predicate unexpectedly targeted key " + key);
+    }
+
+    @Test
+    void testRouterRequiresDecodingForcesDecodeForDynamicKeys() {
+        givenPredicate();
+        givenDelegateTargetsNothing();
+        predicate.setRouterDecodingRequirements(Set.of(ApiKeys.FETCH));
+        assertPredicateTargetsRequestKey(ApiKeys.FETCH);
+    }
+
+    @Test
+    void testRouterRequiresDecodingDoesNotForceDecodeForStaticKeys() {
+        givenPredicate();
+        givenDelegateTargetsNothing();
+        predicate.setRouterDecodingRequirements(Set.of(ApiKeys.FETCH));
+        assertPredicateDoesNotTargetRequestKey(ApiKeys.PRODUCE);
+    }
+
+    @Test
+    void testEmptyRouterRequirementsDoesNotForceDecoding() {
+        givenPredicate();
+        givenDelegateTargetsNothing();
+        predicate.setRouterDecodingRequirements(Set.of());
+        assertPredicateDoesNotTargetRequestKey(ApiKeys.FETCH);
     }
 
     private void assertPredicateTargetsResponseKey(ApiKeys key) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -100,10 +100,11 @@ public abstract class FilterHarness {
         var kafkaSession = new KafkaSession(KafkaSessionState.ESTABLISHING);
         clientConnectionStateMachine = new ClientConnectionStateMachine(endpointBinding, new DefaultSubjectBuilder(List.of()), kafkaSession);
         var forwarding = new ClientConnectionState.Forwarding();
+        var mockScsm = mock(ServerConnectionStateMachine.class);
         clientConnectionStateMachine.forceState(
                 forwarding,
                 mock(KafkaProxyFrontendHandler.class),
-                mock(ServerConnectionStateMachine.class),
+                java.util.Map.of(new io.kroxylicious.proxy.service.HostPort("broker", 9092), mockScsm),
                 kafkaSession,
                 true);
         var filterHandlers = Arrays.stream(filters)

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -83,7 +83,8 @@ class KafkaProxyFrontendHandlerTest {
     ClientConnectionStateMachine clientConnectionStateMachine(EndpointBinding endpointBinding) {
         var kafkaSession = new KafkaSession(KafkaSessionState.ESTABLISHING);
         return new ClientConnectionStateMachine(Objects.requireNonNull(endpointBinding), new DefaultSubjectBuilder(List.of()), kafkaSession,
-                (remote, ccsm, vc, cn, ni) -> new ServerConnectionStateMachine(remote, ccsm, vc, cn, ni) {
+                (remote, ccsm, vc, cn, ni, errorCounter, backpressureMeter, connectionToken) -> new ServerConnectionStateMachine(remote, ccsm, vc, cn, ni, errorCounter,
+                        backpressureMeter, connectionToken) {
                     @Override
                     Bootstrap configureBootstrap(
                                                  KafkaProxyBackendHandler capturedBackendHandler,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -419,7 +419,8 @@ class KafkaProxyInitializerTest {
                                                               ProxyProtocolMode proxyProtocolMode,
                                                               EndpointBindingResolver bindingResolver,
                                                               VirtualClusterRegistry vcc) {
-        return new KafkaProxyInitializer(pfr,
+        return new KafkaProxyInitializer(null,
+                pfr,
                 tls,
                 bindingResolver,
                 (virtualCluster, upstreamNodes) -> null,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachineTest.java
@@ -3,7 +3,6 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-
 package io.kroxylicious.proxy.internal;
 
 import java.lang.reflect.Method;
@@ -11,19 +10,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import org.assertj.core.data.Offset;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -33,14 +24,13 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoop;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.ssl.SslContext;
 
 import io.kroxylicious.proxy.internal.codec.KafkaRequestEncoder;
 import io.kroxylicious.proxy.internal.codec.KafkaResponseDecoder;
 import io.kroxylicious.proxy.internal.tls.ServerTlsCredentialSupplierContextImpl;
 import io.kroxylicious.proxy.internal.tls.TestCertificateUtil;
 import io.kroxylicious.proxy.internal.tls.TlsCredentialsImpl;
-import io.kroxylicious.proxy.internal.util.VirtualClusterNode;
+import io.kroxylicious.proxy.internal.util.ActivationToken;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.tls.ServerTlsCredentialSupplier;
@@ -49,87 +39,72 @@ import io.kroxylicious.proxy.tls.TlsCredentials;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
+/**
+ * Unit tests for {@link ServerConnectionStateMachine}.
+ */
 class ServerConnectionStateMachineTest {
 
-    private static final HostPort BROKER_ADDRESS = new HostPort("broker.example.com", 9092);
+    private static final HostPort REMOTE = new HostPort("broker", 9092);
     private static final String CLUSTER_NAME = "test-cluster";
-    private static final VirtualClusterNode VIRTUAL_CLUSTER_NODE = new VirtualClusterNode(CLUSTER_NAME, null);
-    private static final Offset<Double> CLOSE_ENOUGH = Offset.offset(0.00005);
 
-    @Mock
-    private ClientConnectionStateMachine ccsm;
-
-    @Mock
-    private VirtualClusterModel virtualCluster;
-
-    private ServerConnectionStateMachine serverStateMachine;
-    private SimpleMeterRegistry meterRegistry;
-
-    @BeforeEach
-    void setUp() {
-        meterRegistry = new SimpleMeterRegistry();
-        Metrics.globalRegistry.add(meterRegistry);
-
-        lenient().when(ccsm.sessionId()).thenReturn("test-session-123");
-        lenient().when(ccsm.clusterName()).thenReturn(CLUSTER_NAME);
-        lenient().when(virtualCluster.getUpstreamSslContext()).thenReturn(Optional.empty());
-
-        serverStateMachine = new ServerConnectionStateMachine(
-                BROKER_ADDRESS,
+    private ServerConnectionStateMachine createScsm() {
+        var ccsm = mock(ClientConnectionStateMachine.class);
+        when(ccsm.sessionId()).thenReturn("test-session");
+        when(ccsm.clusterName()).thenReturn(CLUSTER_NAME);
+        var virtualCluster = mock(VirtualClusterModel.class);
+        when(virtualCluster.getUpstreamSslContext()).thenReturn(Optional.empty());
+        return new ServerConnectionStateMachine(
+                REMOTE,
                 ccsm,
                 virtualCluster,
                 CLUSTER_NAME,
-                null);
-    }
-
-    @AfterEach
-    void tearDown() {
-        if (meterRegistry != null) {
-            meterRegistry.getMeters().forEach(Metrics.globalRegistry::remove);
-            Metrics.globalRegistry.remove(meterRegistry);
-        }
+                null,
+                mock(Counter.class),
+                mock(Timer.class),
+                mock(ActivationToken.class));
     }
 
     @Test
     void sendRequestWhileConnectingShouldBuffer() {
-        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Connecting.class);
+        var scsm = createScsm();
+        assertThat(scsm.state()).isInstanceOf(ServerConnectionState.Connecting.class);
 
         Object msg = new Object();
-        serverStateMachine.sendRequest(msg);
+        scsm.sendRequest(msg);
 
-        assertThat(serverStateMachine.serverMessagesInFlightCount).isZero();
+        assertThat(scsm.serverMessagesInFlightCount).isZero();
     }
 
     @Test
     void sendRequestWhileActiveShouldForwardImmediately() {
-        var channel = new EmbeddedChannel(serverStateMachine.backendHandler());
-        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Active.class);
+        var scsm = createScsm();
+        var channel = new EmbeddedChannel(scsm.backendHandler());
+        assertThat(scsm.state()).isInstanceOf(ServerConnectionState.Active.class);
 
         Object msg = "test-request";
-        serverStateMachine.sendRequest(msg);
+        scsm.sendRequest(msg);
 
-        assertThat(serverStateMachine.serverMessagesInFlightCount).isEqualTo(1);
+        assertThat(scsm.serverMessagesInFlightCount).isEqualTo(1);
         assertThat(channel.<Object> readOutbound()).isEqualTo(msg);
     }
 
     @Test
     void onServerActiveShouldFlushPendingRequests() {
-        serverStateMachine.sendRequest("req-1");
-        serverStateMachine.sendRequest("req-2");
-        assertThat(serverStateMachine.serverMessagesInFlightCount).isZero();
+        var scsm = createScsm();
+
+        scsm.sendRequest("req-1");
+        scsm.sendRequest("req-2");
+        assertThat(scsm.serverMessagesInFlightCount).isZero();
 
         // Registering the handler triggers channelActive → onServerActive → flush
-        var channel = new EmbeddedChannel(serverStateMachine.backendHandler());
-        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Active.class);
-        assertThat(serverStateMachine.serverMessagesInFlightCount).isEqualTo(2);
+        var channel = new EmbeddedChannel(scsm.backendHandler());
+        assertThat(scsm.state()).isInstanceOf(ServerConnectionState.Active.class);
+        assertThat(scsm.serverMessagesInFlightCount).isEqualTo(2);
 
         assertThat(channel.<Object> readOutbound()).isEqualTo("req-1");
         assertThat(channel.<Object> readOutbound()).isEqualTo("req-2");
@@ -138,376 +113,103 @@ class ServerConnectionStateMachineTest {
 
     @Test
     void onServerActiveShouldFlushBeforePcsmCallback() {
-        serverStateMachine.sendRequest("req-1");
-        verifyNoInteractions(ccsm);
+        var ccsm = mock(ClientConnectionStateMachine.class);
+        when(ccsm.sessionId()).thenReturn("test-session");
+        when(ccsm.clusterName()).thenReturn(CLUSTER_NAME);
+        var virtualCluster = mock(VirtualClusterModel.class);
+        when(virtualCluster.getUpstreamSslContext()).thenReturn(Optional.empty());
+        var scsm = new ServerConnectionStateMachine(
+                REMOTE, ccsm, virtualCluster, CLUSTER_NAME, null,
+                mock(Counter.class),
+                mock(Timer.class), mock(ActivationToken.class));
 
-        // channelActive → onServerActive → flush pending → pcsm callback
-        new EmbeddedChannel(serverStateMachine.backendHandler());
+        scsm.sendRequest("req-1");
 
-        // At the point pcsm.onServerConnectionActive() was called,
-        // the pending requests had already been flushed
-        assertThat(serverStateMachine.serverMessagesInFlightCount).isEqualTo(1);
-        verify(ccsm).onServerConnectionActive();
+        // channelActive → onServerActive → flush pending → ccsm callback
+        new EmbeddedChannel(scsm.backendHandler());
+
+        assertThat(scsm.serverMessagesInFlightCount).isEqualTo(1);
+        verify(ccsm).onServerConnectionActive(scsm);
     }
 
     @Test
     void closedShouldReleasePendingRequests() {
+        var scsm = createScsm();
+
         ByteBuf buf = Unpooled.buffer(4).writeInt(42);
         assertThat(buf.refCnt()).isEqualTo(1);
-        serverStateMachine.sendRequest(buf);
+        scsm.sendRequest(buf);
 
-        serverStateMachine.close();
+        scsm.close();
 
         assertThat(buf.refCnt()).isZero();
     }
 
     @Test
     void closedWithNoPendingRequestsShouldNotFail() {
-        serverStateMachine.close();
+        var scsm = createScsm();
 
-        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Closed.class);
+        scsm.close();
+
+        assertThat(scsm.state()).isInstanceOf(ServerConnectionState.Closed.class);
     }
 
     @Test
     void exceptionWhileConnectingShouldReleasePendingRequests() {
+        var scsm = createScsm();
+
         ByteBuf buf = Unpooled.buffer(4).writeInt(99);
-        serverStateMachine.sendRequest(buf);
+        scsm.sendRequest(buf);
         assertThat(buf.refCnt()).isEqualTo(1);
 
-        serverStateMachine.onServerException(new RuntimeException("connection failed"));
+        scsm.onServerException(new RuntimeException("connection failed"));
 
         assertThat(buf.refCnt()).isZero();
-        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Closed.class);
+        assertThat(scsm.state()).isInstanceOf(ServerConnectionState.Closed.class);
     }
 
     @Test
     void onServerActiveWithNoPendingRequestsShouldNotFail() {
-        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Connecting.class);
+        var scsm = createScsm();
+        assertThat(scsm.state()).isInstanceOf(ServerConnectionState.Connecting.class);
 
-        // channelActive triggers onServerActive — no pending requests to flush
-        new EmbeddedChannel(serverStateMachine.backendHandler());
+        new EmbeddedChannel(scsm.backendHandler());
 
-        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Active.class);
-        assertThat(serverStateMachine.serverMessagesInFlightCount).isZero();
+        assertThat(scsm.state()).isInstanceOf(ServerConnectionState.Active.class);
+        assertThat(scsm.serverMessagesInFlightCount).isZero();
     }
 
     @Test
     void pendingRequestsPreserveOrder() {
+        var scsm = createScsm();
+
         for (int i = 0; i < 5; i++) {
-            serverStateMachine.sendRequest("req-" + i);
+            scsm.sendRequest("req-" + i);
         }
 
-        var channel = new EmbeddedChannel(serverStateMachine.backendHandler());
+        var channel = new EmbeddedChannel(scsm.backendHandler());
 
         for (int i = 0; i < 5; i++) {
             assertThat(channel.<Object> readOutbound()).isEqualTo("req-" + i);
         }
         assertThat(channel.<Object> readOutbound()).isNull();
-        assertThat(serverStateMachine.serverMessagesInFlightCount).isEqualTo(5);
+        assertThat(scsm.serverMessagesInFlightCount).isEqualTo(5);
     }
 
-    @Test
-    void shouldStartInConnectingState() {
-        assertThat(serverStateMachine.state())
-                .isInstanceOf(ServerConnectionState.Connecting.class)
-                .extracting(state -> ((ServerConnectionState.Connecting) state).remote())
-                .isEqualTo(BROKER_ADDRESS);
-    }
+    // === connect() tests ===
 
-    @ParameterizedTest
-    @ValueSource(booleans = { true, false })
-    void shouldTrackTlsRequirement(boolean requiresTls) {
-        var vc = mock(VirtualClusterModel.class);
-        when(vc.getUpstreamSslContext()).thenReturn(requiresTls ? Optional.of(mock(SslContext.class)) : Optional.empty());
-
-        ServerConnectionStateMachine sm = new ServerConnectionStateMachine(
-                BROKER_ADDRESS,
-                ccsm,
-                vc,
-                CLUSTER_NAME,
-                null);
-
-        assertThat(sm.isUpstreamTls()).isEqualTo(requiresTls);
-    }
-
-    @Test
-    void shouldReturnBackendHandler() {
-        assertThat(serverStateMachine.backendHandler()).isNotNull();
-    }
-
-    @Test
-    void onServerActiveShouldTransitionToActiveAndNotifyClientStateMachine() {
-        int initialActiveCount = getActiveServerConnections();
-
-        serverStateMachine.onServerActive();
-
-        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Active.class);
-        assertThat(getActiveServerConnections()).isEqualTo(initialActiveCount + 1);
-        verify(ccsm).onServerConnectionActive();
-    }
-
-    @Test
-    void onServerActiveWhenNotInConnectingStateShouldReportIllegalState() {
-        serverStateMachine.onServerActive();
-        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Active.class);
-
-        serverStateMachine.onServerActive();
-
-        verify(ccsm).illegalState("Server became active while not in the connecting state");
-    }
-
-    @Test
-    void onServerInactiveShouldTransitionToClosedAndNotifyClientStateMachine() {
-        serverStateMachine.onServerActive();
-        int countAfterActive = getActiveServerConnections();
-
-        serverStateMachine.onServerInactive();
-
-        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Closed.class);
-        verify(ccsm).onServerConnectionClosed(ClientConnectionStateMachine.DisconnectCause.SERVER_CLOSED);
-        assertThat(getActiveServerConnections()).isEqualTo(countAfterActive - 1);
-    }
-
-    @Test
-    void onServerInactiveWhileConnectingShouldTransitionToClosedAndNotifyCcsm() {
-        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Connecting.class);
-
-        serverStateMachine.onServerInactive();
-
-        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Closed.class);
-        verify(ccsm).onServerConnectionClosed(ClientConnectionStateMachine.DisconnectCause.SERVER_CLOSED);
-    }
-
-    @Test
-    void onServerInactiveWhenAlreadyClosedShouldNotNotifyAgain() {
-        serverStateMachine.close();
-
-        serverStateMachine.onServerInactive();
-
-        verify(ccsm, never()).onServerConnectionClosed(ClientConnectionStateMachine.DisconnectCause.SERVER_CLOSED);
-    }
-
-    @Test
-    void onServerExceptionShouldIncrementErrorCounterAndTransitionToClosed() {
-        serverStateMachine.onServerActive();
-        int countAfterActive = getActiveServerConnections();
-        RuntimeException cause = new RuntimeException("Connection failed");
-
-        serverStateMachine.onServerException(cause);
-
-        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Closed.class);
-        assertThat(getProxyToServerErrorCount()).isCloseTo(1.0, CLOSE_ENOUGH);
-        verify(ccsm).onServerConnectionException(cause);
-        assertThat(getActiveServerConnections()).isEqualTo(countAfterActive - 1);
-    }
-
-    @Test
-    void onServerExceptionWithNullCauseShouldStillTransitionToClosed() {
-        serverStateMachine.onServerActive();
-
-        serverStateMachine.onServerException(null);
-
-        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Closed.class);
-        assertThat(getProxyToServerErrorCount()).isCloseTo(1.0, CLOSE_ENOUGH);
-        verify(ccsm).onServerConnectionException(null);
-    }
-
-    @Test
-    void onServerExceptionWhenAlreadyClosedShouldNotIncrementErrorCounter() {
-        serverStateMachine.close();
-        double errorCountBefore = getProxyToServerErrorCount();
-
-        serverStateMachine.onServerException(new RuntimeException("test"));
-
-        assertThat(getProxyToServerErrorCount()).isEqualTo(errorCountBefore);
-        verify(ccsm, never()).onServerConnectionException(null);
-    }
-
-    @Test
-    void onMessageFromServerShouldDecrementInFlightCountAndDelegateToCcsm() {
-        serverStateMachine.serverMessagesInFlightCount = 2;
-        Object message = new Object();
-
-        serverStateMachine.onMessageFromServer(message);
-
-        assertThat(serverStateMachine.serverMessagesInFlightCount).isEqualTo(1);
-        verify(ccsm).onResponseFromServer(message);
-    }
-
-    @Test
-    void onMessageFromServerShouldNotDecrementBelowZero() {
-        serverStateMachine.serverMessagesInFlightCount = 0;
-        Object message = new Object();
-
-        serverStateMachine.onMessageFromServer(message);
-
-        assertThat(serverStateMachine.serverMessagesInFlightCount).isZero();
-        verify(ccsm).onResponseFromServer(message);
-    }
-
-    @Test
-    void serverReadCompleteShouldDelegateToCcsm() {
-        serverStateMachine.serverReadComplete();
-
-        verify(ccsm).onServerReadComplete();
-    }
-
-    @Test
-    void onServerUnwritableShouldDelegateToCcsm() {
-        serverStateMachine.onServerUnwritable();
-
-        verify(ccsm).onServerUnwritable();
-    }
-
-    @Test
-    void onServerWritableShouldDelegateToCcsm() {
-        serverStateMachine.onServerWritable();
-
-        verify(ccsm).onServerWritable();
-    }
-
-    @Test
-    void sendRequestShouldIncrementInFlightCount() {
-        serverStateMachine.onServerActive();
-        Object message = new Object();
-
-        serverStateMachine.sendRequest(message);
-
-        assertThat(serverStateMachine.serverMessagesInFlightCount).isEqualTo(1);
-    }
-
-    @Test
-    void sendRequestShouldIncrementInFlightCountMultipleTimes() {
-        serverStateMachine.onServerActive();
-
-        serverStateMachine.sendRequest(new Object());
-        serverStateMachine.sendRequest(new Object());
-        serverStateMachine.sendRequest(new Object());
-
-        assertThat(serverStateMachine.serverMessagesInFlightCount).isEqualTo(3);
-    }
-
-    @Test
-    void applyBackpressureShouldStartTimer() {
-        serverStateMachine.onServerActive();
-
-        serverStateMachine.applyBackpressure();
-
-        assertThat(serverStateMachine).extracting("serverBackpressureTimer").isNotNull();
-    }
-
-    @Test
-    void applyBackpressureShouldBeIdempotent() {
-        serverStateMachine.onServerActive();
-
-        serverStateMachine.applyBackpressure();
-        Object firstTimer = serverStateMachine.serverBackpressureTimer;
-        serverStateMachine.applyBackpressure();
-        Object secondTimer = serverStateMachine.serverBackpressureTimer;
-
-        assertThat(firstTimer).isSameAs(secondTimer);
-    }
-
-    @Test
-    void relieveBackpressureShouldStopTimerAndRecordMetric() {
-        serverStateMachine.onServerActive();
-
-        serverStateMachine.applyBackpressure();
-        serverStateMachine.relieveBackpressure();
-
-        assertThat(serverStateMachine).extracting("serverBackpressureTimer").isNull();
-        assertThat(getBackpressureTimerCount()).isGreaterThanOrEqualTo(1);
-    }
-
-    @Test
-    void relieveBackpressureShouldBeIdempotent() {
-        serverStateMachine.onServerActive();
-
-        serverStateMachine.applyBackpressure();
-        serverStateMachine.relieveBackpressure();
-        long countAfterFirst = getBackpressureTimerCount();
-        serverStateMachine.relieveBackpressure();
-        long countAfterSecond = getBackpressureTimerCount();
-
-        assertThat(countAfterSecond).isEqualTo(countAfterFirst);
-    }
-
-    @Test
-    void relieveBackpressureWhenNotAppliedShouldBeNoOp() {
-        serverStateMachine.relieveBackpressure();
-
-        assertThat(serverStateMachine).extracting("serverBackpressureTimer").isNull();
-        assertThat(getBackpressureTimerCount()).isZero();
-    }
-
-    @Test
-    void closeShouldTransitionToClosedAndReleaseActivationToken() {
-        serverStateMachine.onServerActive();
-        int countAfterActive = getActiveServerConnections();
-
-        serverStateMachine.close();
-
-        assertThat(serverStateMachine.state()).isInstanceOf(ServerConnectionState.Closed.class);
-        assertThat(getActiveServerConnections()).isEqualTo(countAfterActive - 1);
-    }
-
-    @Test
-    void closeShouldBeIdempotent() {
-        serverStateMachine.onServerActive();
-        int countAfterActive = getActiveServerConnections();
-
-        serverStateMachine.close();
-        serverStateMachine.close();
-
-        assertThat(getActiveServerConnections()).isEqualTo(countAfterActive - 1);
-    }
-
-    @Test
-    void toStringShouldIncludeStateAndCounters() {
-        serverStateMachine.serverMessagesInFlightCount = 3;
-
-        String result = serverStateMachine.toString();
-
-        assertThat(result)
-                .contains("ServerConnectionStateMachine")
-                .contains("state=")
-                .contains("serverReadsBlocked=")
-                .contains("serverMessagesInFlightCount=3");
-    }
-
-    @Test
-    void shouldReleaseActivationTokenOnlyOnceWhenTransitioningToClosed() {
-        serverStateMachine.onServerActive();
-        int countAfterActive = getActiveServerConnections();
-
-        serverStateMachine.close();
-        serverStateMachine.onServerInactive();
-        serverStateMachine.onServerException(new RuntimeException("test"));
-
-        assertThat(getActiveServerConnections()).isEqualTo(countAfterActive - 1);
-    }
-
-    @Test
-    void shouldNotifyClientStateMachineOnEachEventBeforeClosing() {
-        serverStateMachine.onServerActive();
-        RuntimeException exception = new RuntimeException("test exception");
-
-        serverStateMachine.onServerException(exception);
-
-        verify(ccsm).onServerConnectionException(exception);
-    }
-
-    private ServerConnectionStateMachine createConnectableScsm(ClientConnectionStateMachine mockCcsm,
-                                                               VirtualClusterModel mockVirtualCluster,
+    private ServerConnectionStateMachine createConnectableScsm(ClientConnectionStateMachine ccsm,
+                                                               VirtualClusterModel virtualCluster,
                                                                EmbeddedChannel[] outboundHolder) {
-        lenient().when(mockCcsm.sessionId()).thenReturn("test-session");
-        lenient().when(mockCcsm.clusterName()).thenReturn(CLUSTER_NAME);
-        lenient().when(mockVirtualCluster.getUpstreamSslContext()).thenReturn(Optional.empty());
-        when(mockVirtualCluster.usesDynamicTlsCredentials()).thenReturn(false);
-        when(mockVirtualCluster.socketFrameMaxSizeBytes()).thenReturn(
-                VirtualClusterModel.DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES);
+        when(ccsm.sessionId()).thenReturn("test-session");
+        when(ccsm.clusterName()).thenReturn(CLUSTER_NAME);
+        when(virtualCluster.getUpstreamSslContext()).thenReturn(Optional.empty());
+        when(virtualCluster.usesDynamicTlsCredentials()).thenReturn(false);
+        when(virtualCluster.socketFrameMaxSizeBytes()).thenReturn(
+                io.kroxylicious.proxy.model.VirtualClusterModel.DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES);
         return new ServerConnectionStateMachine(
-                BROKER_ADDRESS, mockCcsm, mockVirtualCluster, CLUSTER_NAME, null) {
+                REMOTE, ccsm, virtualCluster, CLUSTER_NAME, null,
+                mock(Counter.class), mock(Timer.class), mock(ActivationToken.class)) {
             @Override
             Bootstrap configureBootstrap(KafkaProxyBackendHandler backendHandler,
                                          Channel inboundChannel) {
@@ -531,9 +233,9 @@ class ServerConnectionStateMachineTest {
 
     @Test
     void connectInWrongStateShouldCallIllegalState() {
-        var mockCcsm = mock(ClientConnectionStateMachine.class);
-        var mockVirtualCluster = mock(VirtualClusterModel.class);
-        var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
+        var ccsm = mock(ClientConnectionStateMachine.class);
+        var virtualCluster = mock(VirtualClusterModel.class);
+        var scsm = createScsmWithMocks(ccsm, virtualCluster);
 
         // Force to Active state
         new EmbeddedChannel(scsm.backendHandler());
@@ -542,15 +244,15 @@ class ServerConnectionStateMachineTest {
         // Calling connect() in Active state should trigger illegalState
         scsm.connect(mock(Channel.class));
 
-        verify(mockCcsm).illegalState("connect() called while not in Connecting state");
+        verify(ccsm).illegalState("connect() called while not in Connecting state");
     }
 
     @Test
     void connectShouldAssemblePipelineInCorrectOrder() {
-        var mockCcsm = mock(ClientConnectionStateMachine.class);
-        var mockVirtualCluster = mock(VirtualClusterModel.class);
+        var ccsm = mock(ClientConnectionStateMachine.class);
+        var virtualCluster = mock(VirtualClusterModel.class);
         var outboundHolder = new EmbeddedChannel[1];
-        var scsm = createConnectableScsm(mockCcsm, mockVirtualCluster, outboundHolder);
+        var scsm = createConnectableScsm(ccsm, virtualCluster, outboundHolder);
 
         scsm.connect(new EmbeddedChannel());
 
@@ -570,55 +272,19 @@ class ServerConnectionStateMachineTest {
     }
 
     @Test
-    void connecthouldIncrementConnectionCounter() {
-        double initialCount = getProxyToServerConnectionCount();
-        var mockCcsm = mock(ClientConnectionStateMachine.class);
-        var mockVirtualCluster = mock(VirtualClusterModel.class);
-        var outboundHolder = new EmbeddedChannel[1];
-        var scsm = createConnectableScsm(mockCcsm, mockVirtualCluster, outboundHolder);
-        scsm.connect(new EmbeddedChannel());
-        assertThat(getProxyToServerConnectionCount()).isCloseTo(initialCount + 1.0, CLOSE_ENOUGH);
-    }
-
-    @Test
-    void connectShouldAddFrameLoggerWhenLogFramesEnabled() {
-        var mockCcsm = mock(ClientConnectionStateMachine.class);
-        var mockVirtualCluster = mock(VirtualClusterModel.class);
-        when(mockVirtualCluster.isLogFrames()).thenReturn(true);
-        var outboundHolder = new EmbeddedChannel[1];
-        var scsm = createConnectableScsm(mockCcsm, mockVirtualCluster, outboundHolder);
-
-        scsm.connect(new EmbeddedChannel());
-
-        assertThat(outboundHolder[0].pipeline().get("frameLogger")).isNotNull();
-    }
-
-    @Test
-    void connectShouldAddNetworkLoggerWhenLogNetworkEnabled() {
-        var mockCcsm = mock(ClientConnectionStateMachine.class);
-        var mockVirtualCluster = mock(VirtualClusterModel.class);
-        when(mockVirtualCluster.isLogNetwork()).thenReturn(true);
-        var outboundHolder = new EmbeddedChannel[1];
-        var scsm = createConnectableScsm(mockCcsm, mockVirtualCluster, outboundHolder);
-
-        scsm.connect(new EmbeddedChannel());
-
-        assertThat(outboundHolder[0].pipeline().get("networkLogger")).isNotNull();
-    }
-
-    @Test
     void connectTcpFailureShouldCallOnServerException() {
-        var mockCcsm = mock(ClientConnectionStateMachine.class);
-        var mockVirtualCluster = mock(VirtualClusterModel.class);
-        lenient().when(mockCcsm.sessionId()).thenReturn("test-session");
-        lenient().when(mockCcsm.clusterName()).thenReturn(CLUSTER_NAME);
-        when(mockVirtualCluster.getUpstreamSslContext()).thenReturn(Optional.empty());
-        when(mockVirtualCluster.usesDynamicTlsCredentials()).thenReturn(false);
-        when(mockVirtualCluster.socketFrameMaxSizeBytes()).thenReturn(
-                VirtualClusterModel.DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES);
+        var ccsm = mock(ClientConnectionStateMachine.class);
+        var virtualCluster = mock(VirtualClusterModel.class);
+        when(ccsm.sessionId()).thenReturn("test-session");
+        when(ccsm.clusterName()).thenReturn(CLUSTER_NAME);
+        when(virtualCluster.getUpstreamSslContext()).thenReturn(Optional.empty());
+        when(virtualCluster.usesDynamicTlsCredentials()).thenReturn(false);
+        when(virtualCluster.socketFrameMaxSizeBytes()).thenReturn(
+                io.kroxylicious.proxy.model.VirtualClusterModel.DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES);
         var tcpFailure = new RuntimeException("Connection refused");
         var scsm = new ServerConnectionStateMachine(
-                BROKER_ADDRESS, mockCcsm, mockVirtualCluster, CLUSTER_NAME, null) {
+                REMOTE, ccsm, virtualCluster, CLUSTER_NAME, null,
+                mock(Counter.class), mock(Timer.class), mock(ActivationToken.class)) {
             @Override
             Bootstrap configureBootstrap(KafkaProxyBackendHandler backendHandler,
                                          Channel inboundChannel) {
@@ -640,30 +306,35 @@ class ServerConnectionStateMachineTest {
 
         scsm.connect(new EmbeddedChannel());
 
-        verify(mockCcsm).onServerConnectionException(tcpFailure);
+        verify(ccsm).onServerConnectionException(scsm, tcpFailure);
         assertThat(scsm.state()).isInstanceOf(ServerConnectionState.Closed.class);
     }
 
-    private ServerConnectionStateMachine createScsmWithMocks(ClientConnectionStateMachine mockCcsm,
-                                                             VirtualClusterModel mockVirtualCluster) {
-        lenient().when(mockCcsm.sessionId()).thenReturn("test-session");
-        lenient().when(mockCcsm.clusterName()).thenReturn(CLUSTER_NAME);
-        lenient().when(mockVirtualCluster.getUpstreamSslContext()).thenReturn(Optional.empty());
+    // === TLS credential tests ===
+
+    private ServerConnectionStateMachine createScsmWithMocks(ClientConnectionStateMachine ccsm,
+                                                             VirtualClusterModel virtualCluster) {
+        when(ccsm.sessionId()).thenReturn("test-session");
+        when(ccsm.clusterName()).thenReturn(CLUSTER_NAME);
+        when(virtualCluster.getUpstreamSslContext()).thenReturn(Optional.empty());
         return new ServerConnectionStateMachine(
-                BROKER_ADDRESS,
-                mockCcsm,
-                mockVirtualCluster,
+                REMOTE,
+                ccsm,
+                virtualCluster,
                 CLUSTER_NAME,
-                null);
+                null,
+                mock(Counter.class),
+                mock(Timer.class),
+                mock(ActivationToken.class));
     }
 
     @Test
     void invokeTlsCredentialSupplierReportsSynchronousFailure() throws Exception {
-        var mockCcsm = mock(ClientConnectionStateMachine.class);
-        var mockVirtualCluster = mock(VirtualClusterModel.class);
+        var ccsm = mock(ClientConnectionStateMachine.class);
+        var virtualCluster = mock(VirtualClusterModel.class);
         RuntimeException failure = new RuntimeException("manager failed");
-        when(mockVirtualCluster.getTlsCredentialSupplierManager()).thenThrow(failure);
-        var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
+        when(virtualCluster.getTlsCredentialSupplierManager()).thenThrow(failure);
+        var scsm = createScsmWithMocks(ccsm, virtualCluster);
 
         Channel channel = mock(Channel.class);
         ChannelPipeline pipeline = mock(ChannelPipeline.class);
@@ -671,16 +342,16 @@ class ServerConnectionStateMachineTest {
                 "invokeTlsCredentialSupplier", HostPort.class, Channel.class, ChannelPipeline.class);
         method.setAccessible(true);
 
-        method.invoke(scsm, BROKER_ADDRESS, channel, pipeline);
+        method.invoke(scsm, REMOTE, channel, pipeline);
 
-        verify(mockCcsm).onServerConnectionException(failure);
+        verify(ccsm).onServerConnectionException(scsm, failure);
     }
 
     @Test
     void requestTlsCredentialsAppliesCredentialsOnEventLoop() {
-        var mockCcsm = mock(ClientConnectionStateMachine.class);
-        var mockVirtualCluster = mock(VirtualClusterModel.class);
-        var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
+        var ccsm = mock(ClientConnectionStateMachine.class);
+        var virtualCluster = mock(VirtualClusterModel.class);
+        var scsm = createScsmWithMocks(ccsm, virtualCluster);
 
         TlsCredentials badCreds = mock(TlsCredentials.class);
         ServerTlsCredentialSupplier supplier = context -> CompletableFuture.completedFuture(badCreds);
@@ -693,10 +364,10 @@ class ServerConnectionStateMachineTest {
             return null;
         }).when(eventLoop).execute(any(Runnable.class));
 
-        scsm.requestTlsCredentials(supplier, supplierContext, BROKER_ADDRESS, channel, mock(ChannelPipeline.class));
+        scsm.requestTlsCredentials(supplier, supplierContext, REMOTE, channel, mock(ChannelPipeline.class));
 
         ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
-        verify(mockCcsm).onServerConnectionException(captor.capture());
+        verify(ccsm).onServerConnectionException(any(ServerConnectionStateMachine.class), captor.capture());
         assertThat(captor.getValue())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Unexpected TlsCredentials implementation");
@@ -704,9 +375,9 @@ class ServerConnectionStateMachineTest {
 
     @Test
     void requestTlsCredentialsReportsSupplierFailureOnEventLoop() {
-        var mockCcsm = mock(ClientConnectionStateMachine.class);
-        var mockVirtualCluster = mock(VirtualClusterModel.class);
-        var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
+        var ccsm = mock(ClientConnectionStateMachine.class);
+        var virtualCluster = mock(VirtualClusterModel.class);
+        var scsm = createScsmWithMocks(ccsm, virtualCluster);
 
         RuntimeException failure = new RuntimeException("boom");
         ServerTlsCredentialSupplier supplier = context -> CompletableFuture.failedFuture(failure);
@@ -719,10 +390,10 @@ class ServerConnectionStateMachineTest {
             return null;
         }).when(eventLoop).execute(any(Runnable.class));
 
-        scsm.requestTlsCredentials(supplier, supplierContext, BROKER_ADDRESS, channel, mock(ChannelPipeline.class));
+        scsm.requestTlsCredentials(supplier, supplierContext, REMOTE, channel, mock(ChannelPipeline.class));
 
         ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
-        verify(mockCcsm).onServerConnectionException(captor.capture());
+        verify(ccsm).onServerConnectionException(any(ServerConnectionStateMachine.class), captor.capture());
         assertThat(captor.getValue())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Failed to obtain TLS credentials")
@@ -731,17 +402,17 @@ class ServerConnectionStateMachineTest {
 
     @Test
     void handleTlsCredentialSupplierResultReportsNullCredentials() {
-        var mockCcsm = mock(ClientConnectionStateMachine.class);
-        var mockVirtualCluster = mock(VirtualClusterModel.class);
-        var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
+        var ccsm = mock(ClientConnectionStateMachine.class);
+        var virtualCluster = mock(VirtualClusterModel.class);
+        var scsm = createScsmWithMocks(ccsm, virtualCluster);
 
         Channel channel = mock(Channel.class);
         ChannelPipeline pipeline = mock(ChannelPipeline.class);
 
-        scsm.handleTlsCredentialSupplierResult(null, null, BROKER_ADDRESS, channel, pipeline);
+        scsm.handleTlsCredentialSupplierResult(null, null, REMOTE, channel, pipeline);
 
         ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
-        verify(mockCcsm).onServerConnectionException(captor.capture());
+        verify(ccsm).onServerConnectionException(any(ServerConnectionStateMachine.class), captor.capture());
         assertThat(captor.getValue())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("TLS credential supplier returned null");
@@ -749,18 +420,18 @@ class ServerConnectionStateMachineTest {
 
     @Test
     void handleTlsCredentialSupplierResultAppliesCredentials() {
-        var mockCcsm = mock(ClientConnectionStateMachine.class);
-        var mockVirtualCluster = mock(VirtualClusterModel.class);
-        var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
+        var ccsm = mock(ClientConnectionStateMachine.class);
+        var virtualCluster = mock(VirtualClusterModel.class);
+        var scsm = createScsmWithMocks(ccsm, virtualCluster);
 
         TlsCredentials badCreds = mock(TlsCredentials.class);
         Channel channel = mock(Channel.class);
         ChannelPipeline pipeline = mock(ChannelPipeline.class);
 
-        scsm.handleTlsCredentialSupplierResult(badCreds, null, BROKER_ADDRESS, channel, pipeline);
+        scsm.handleTlsCredentialSupplierResult(badCreds, null, REMOTE, channel, pipeline);
 
         ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
-        verify(mockCcsm).onServerConnectionException(captor.capture());
+        verify(ccsm).onServerConnectionException(any(ServerConnectionStateMachine.class), captor.capture());
         assertThat(captor.getValue())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Unexpected TlsCredentials implementation");
@@ -768,18 +439,18 @@ class ServerConnectionStateMachineTest {
 
     @Test
     void applyTlsContextToChannelRejectsNonTlsCredentialsImpl() {
-        var mockCcsm = mock(ClientConnectionStateMachine.class);
-        var mockVirtualCluster = mock(VirtualClusterModel.class);
-        var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
+        var ccsm = mock(ClientConnectionStateMachine.class);
+        var virtualCluster = mock(VirtualClusterModel.class);
+        var scsm = createScsmWithMocks(ccsm, virtualCluster);
 
         TlsCredentials badCreds = mock(TlsCredentials.class);
         Channel channel = mock(Channel.class);
         ChannelPipeline pipeline = mock(ChannelPipeline.class);
 
-        scsm.applyTlsContextToChannel(badCreds, BROKER_ADDRESS, channel, pipeline);
+        scsm.applyTlsContextToChannel(badCreds, REMOTE, channel, pipeline);
 
         ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
-        verify(mockCcsm).onServerConnectionException(captor.capture());
+        verify(ccsm).onServerConnectionException(any(ServerConnectionStateMachine.class), captor.capture());
         assertThat(captor.getValue())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Unexpected TlsCredentials implementation");
@@ -787,9 +458,9 @@ class ServerConnectionStateMachineTest {
 
     @Test
     void applyTlsContextToChannelAddsSslHandlerWithValidCredentials() throws Exception {
-        var mockCcsm = mock(ClientConnectionStateMachine.class);
-        var mockVirtualCluster = mock(VirtualClusterModel.class);
-        var scsm = createScsmWithMocks(mockCcsm, mockVirtualCluster);
+        var ccsm = mock(ClientConnectionStateMachine.class);
+        var virtualCluster = mock(VirtualClusterModel.class);
+        var scsm = createScsmWithMocks(ccsm, virtualCluster);
 
         var keyAndCert = TestCertificateUtil.generateKeyStoreAndCert();
         var creds = new TlsCredentialsImpl(
@@ -797,37 +468,14 @@ class ServerConnectionStateMachineTest {
 
         EmbeddedChannel channel = new EmbeddedChannel();
 
-        when(mockVirtualCluster.targetCluster()).thenReturn(mock(io.kroxylicious.proxy.config.TargetCluster.class));
-        when(mockVirtualCluster.targetCluster().tls()).thenReturn(Optional.empty());
+        when(virtualCluster.targetCluster()).thenReturn(mock(io.kroxylicious.proxy.config.TargetCluster.class));
+        when(virtualCluster.targetCluster().tls()).thenReturn(Optional.empty());
 
-        scsm.applyTlsContextToChannel(creds, BROKER_ADDRESS, channel, channel.pipeline());
+        scsm.applyTlsContextToChannel(creds, REMOTE, channel, channel.pipeline());
 
         assertThat(channel.pipeline().get("ssl")).isNotNull();
-        verify(mockCcsm, never()).onServerConnectionException(any());
+        verify(ccsm, never()).onServerConnectionException(any(), any());
 
         channel.close();
-    }
-
-    private int getActiveServerConnections() {
-        return io.kroxylicious.proxy.internal.util.Metrics
-                .proxyToServerConnectionCounter(VIRTUAL_CLUSTER_NODE).get();
-    }
-
-    private double getProxyToServerConnectionCount() {
-        return Metrics.globalRegistry
-                .get("kroxylicious_proxy_to_server_connections")
-                .counter().count();
-    }
-
-    private double getProxyToServerErrorCount() {
-        return Metrics.globalRegistry
-                .get("kroxylicious_proxy_to_server_errors")
-                .counter().count();
-    }
-
-    private long getBackpressureTimerCount() {
-        return Metrics.globalRegistry
-                .get("kroxylicious_server_to_proxy_reads_paused")
-                .timer().count();
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterLifecycleTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterLifecycleTest.java
@@ -40,12 +40,10 @@ class VirtualClusterLifecycleTest {
     private static final String CLUSTER_NAME = "test-cluster";
     private static final Duration DRAIN_TIMEOUT = Duration.ofSeconds(5);
     private VirtualClusterLifecycle manager;
-    private ClientConnectionStateMachine ccsm;
 
     @BeforeEach
     void setUp() {
         manager = new VirtualClusterLifecycle(CLUSTER_NAME, DRAIN_TIMEOUT);
-        ccsm = mock(ClientConnectionStateMachine.class);
     }
 
     @Test
@@ -211,6 +209,7 @@ class VirtualClusterLifecycleTest {
     @Test
     void shouldRejectConnectionRegistrationWhenInitializing() {
         // given - lifecycle starts in Initializing
+        var ccsm = mock(ClientConnectionStateMachine.class);
 
         // when
         var registered = manager.registerConnection(ccsm);
@@ -224,6 +223,7 @@ class VirtualClusterLifecycleTest {
     void shouldAcceptConnectionRegistrationWhenServing() {
         // given
         manager.initializationSucceeded();
+        var ccsm = mock(ClientConnectionStateMachine.class);
 
         // when
         var registered = manager.registerConnection(ccsm);
@@ -238,6 +238,7 @@ class VirtualClusterLifecycleTest {
         // given
         manager.initializationSucceeded();
         manager.startDraining();
+        var ccsm = mock(ClientConnectionStateMachine.class);
 
         // when
         var registered = manager.registerConnection(ccsm);
@@ -250,6 +251,7 @@ class VirtualClusterLifecycleTest {
     void shouldRejectConnectionRegistrationWhenFailed() {
         // given
         manager.initializationFailed(new RuntimeException("oops"));
+        var ccsm = mock(ClientConnectionStateMachine.class);
 
         // when
         var registered = manager.registerConnection(ccsm);
@@ -264,6 +266,7 @@ class VirtualClusterLifecycleTest {
         // given
         manager.initializationFailed(new RuntimeException("oops"));
         manager.stop();
+        var ccsm = mock(ClientConnectionStateMachine.class);
 
         // when
         var registered = manager.registerConnection(ccsm);
@@ -271,6 +274,8 @@ class VirtualClusterLifecycleTest {
         // then
         assertThat(registered).isFalse();
     }
+
+    // --- Concurrency ---
 
     @Test
     void concurrentRegisterAndDeregisterDoesNotLoseConnection() throws Exception {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
@@ -734,29 +734,27 @@ class VirtualClusterRegistryTest {
         // when
         vcc.removeVirtualCluster(CLUSTER_A).join();
 
-        // then — callback invoked with (clusterName, Optional.empty()) per the no-failure case
+        // then
         verify(noOpCallback).accept(CLUSTER_A, Optional.empty());
     }
 
     @Test
     void removeVirtualClusterIsNoOpWhenAlreadyStopped() {
-        // given — drive the cluster to Stopped via the normal remove path
+        // given
         vcc.initializationSucceeded(CLUSTER_A);
         vcc.removeVirtualCluster(CLUSTER_A).join();
         assertThat(requireLifecycle(CLUSTER_A).state()).isInstanceOf(VirtualClusterLifecycleState.Stopped.class);
 
-        // when — call remove again on an already-Stopped cluster
+        // when
         var future = vcc.removeVirtualCluster(CLUSTER_A);
 
-        // then — completes immediately, no exception
+        // then
         assertThat(future).succeedsWithin(1, TimeUnit.SECONDS);
         assertThat(requireLifecycle(CLUSTER_A).state()).isInstanceOf(VirtualClusterLifecycleState.Stopped.class);
     }
 
     @Test
     void removeVirtualClusterThrowsForUnknownClusterName() {
-        // The real removeVirtualCluster validates via requireKnownCluster, unlike the previous
-        // stub which silently accepted unknown names.
         assertThatThrownBy(() -> vcc.removeVirtualCluster("never-existed"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Unknown cluster");
@@ -771,8 +769,7 @@ class VirtualClusterRegistryTest {
         // when
         var future = vcc.addVirtualCluster(newModel);
 
-        // then — future already completed; lifecycle exists in INITIALIZING (orchestrator will
-        // call initializationSucceeded once gateways are bound).
+        // then
         assertThat(future).isCompleted();
         assertThat(vcc.lifecycleFor(CLUSTER_B)).isNotNull()
                 .extracting(VirtualClusterLifecycle::state)

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ChangeDetectorPipelineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ChangeDetectorPipelineTest.java
@@ -51,8 +51,10 @@ class ChangeDetectorPipelineTest {
                 new TargetCluster("kafka:9092", Optional.empty()),
                 List.of(gateway("default", 9999)), // port changed
                 false, false, List.of("filter-a"));
-        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null, List.of(oldVc), null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, null, List.of(newFilter), null, null, List.of(newVc), null, false, Optional.empty(), null, null);
+        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null,
+                List.of(oldVc), null, false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, null, List.of(newFilter), null, null,
+                List.of(newVc), null, false, Optional.empty(), null, null);
         var context = new ConfigurationChangeContext(oldConfig, newConfig);
 
         // Both detectors independently flag the cluster
@@ -80,8 +82,10 @@ class ChangeDetectorPipelineTest {
         var newFilter = new NamedFilterDefinition("filter-a", "io.kroxylicious.test.FakeFilter", "v2");
         var existing = vc("existing", List.of("filter-a"));
         var newlyAdded = vc("newly-added", List.of("filter-a"));
-        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null, List.of(existing), null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, null, List.of(newFilter), null, null, List.of(existing, newlyAdded), null, false, Optional.empty(), null, null);
+        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null,
+                List.of(existing), null, false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, null, List.of(newFilter), null, null,
+                List.of(existing, newlyAdded), null, false, Optional.empty(), null, null);
         var context = new ConfigurationChangeContext(oldConfig, newConfig);
 
         var vccResult = vccDetector.detect(context);
@@ -108,8 +112,10 @@ class ChangeDetectorPipelineTest {
         var oldFilter = new NamedFilterDefinition("filter-a", "io.kroxylicious.test.FakeFilter", "v1");
         var goingAway = vc("going-away", List.of("filter-a"));
         var staying = vcWithoutFilters("staying");
-        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null, List.of(goingAway, staying), null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, null, null, null, null, List.of(staying), null, false, Optional.empty(), null, null);
+        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null,
+                List.of(goingAway, staying), null, false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, null, null, null, null,
+                List.of(staying), null, false, Optional.empty(), null, null);
         var context = new ConfigurationChangeContext(oldConfig, newConfig);
 
         var vccResult = vccDetector.detect(context);
@@ -146,10 +152,12 @@ class ChangeDetectorPipelineTest {
         var filterChangedCluster = vc("filter-changed", List.of("filter-x"));
         var addedCluster = vcWithoutFilters("added");
 
-        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null, List.of(keepUnchanged, removedCluster, oldGatewayChanged, filterChangedCluster),
+        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null,
+                List.of(keepUnchanged, removedCluster, oldGatewayChanged, filterChangedCluster),
                 null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, null, List.of(newFilter), null, null, List.of(keepUnchanged, newGatewayChanged, filterChangedCluster, addedCluster), null,
-                false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, null, List.of(newFilter), null, null,
+                List.of(keepUnchanged, newGatewayChanged, filterChangedCluster, addedCluster),
+                null, false, Optional.empty(), null, null);
         var context = new ConfigurationChangeContext(oldConfig, newConfig);
 
         var merged = vccDetector.detect(context).merge(filterDetector.detect(context));
@@ -166,7 +174,8 @@ class ChangeDetectorPipelineTest {
         // accidentally introduce non-empty defaults in a detector's output.
         var filter = new NamedFilterDefinition("filter-a", "io.kroxylicious.test.FakeFilter", "v1");
         var cluster = vc("cluster", List.of("filter-a"));
-        var config = new Configuration(null, null, List.of(filter), null, null, List.of(cluster), null, false, Optional.empty(), null, null);
+        var config = new Configuration(null, null, List.of(filter), null, null,
+                List.of(cluster), null, false, Optional.empty(), null, null);
         var context = new ConfigurationChangeContext(config, config);
 
         var vccResult = vccDetector.detect(context);
@@ -194,10 +203,10 @@ class ChangeDetectorPipelineTest {
                 false, false, List.of());
         var filterChangedCluster = vc("filter-changed", List.of("filter-x"));
 
-        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null, List.of(oldGatewayChanged, filterChangedCluster), null, false, Optional.empty(),
-                null, null);
-        var newConfig = new Configuration(null, null, List.of(newFilter), null, null, List.of(newGatewayChanged, filterChangedCluster), null, false, Optional.empty(),
-                null, null);
+        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null,
+                List.of(oldGatewayChanged, filterChangedCluster), null, false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, null, List.of(newFilter), null, null,
+                List.of(newGatewayChanged, filterChangedCluster), null, false, Optional.empty(), null, null);
         var context = new ConfigurationChangeContext(oldConfig, newConfig);
 
         var vccResult = vccDetector.detect(context);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/FilterChangeDetectorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/FilterChangeDetectorTest.java
@@ -173,7 +173,8 @@ class FilterChangeDetectorTest {
     private static Configuration configWith(@Nullable List<NamedFilterDefinition> filterDefs,
                                             @Nullable List<String> defaultFilters,
                                             VirtualCluster... clusters) {
-        return new Configuration(null, null, filterDefs, defaultFilters, null, List.of(clusters), null, false, Optional.empty(), null, null);
+        return new Configuration(null, null, filterDefs, defaultFilters, null, List.of(clusters), null, false,
+                Optional.empty(), null, null);
     }
 
     private static NamedFilterDefinition filterDef(String name, String opaqueConfig) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/OperationsPlannerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/OperationsPlannerTest.java
@@ -236,7 +236,8 @@ class OperationsPlannerTest {
 
     private static Configuration configWith(String... clusterNames) {
         var clusters = Arrays.stream(clusterNames).map(OperationsPlannerTest::vc).toList();
-        return new Configuration(null, null, null, null, null, clusters, null, false, Optional.empty(), null, null);
+        return new Configuration(null, null, null, null, null, clusters, null, false,
+                Optional.empty(), null, null);
     }
 
     private static VirtualCluster vc(String name) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/router/TestRouterFactory.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/router/TestRouterFactory.java
@@ -6,8 +6,10 @@
 
 package io.kroxylicious.proxy.internal.router;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.Arrays;
+import java.util.Map;
 import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -23,6 +25,8 @@ import io.kroxylicious.proxy.router.RouterResult;
 @Plugin(configType = Void.class)
 public class TestRouterFactory implements RouterFactory<Void, Void> {
 
+    public static final String DEFAULT_ROUTE = "default";
+
     @Override
     public Void initialize(RouterFactoryContext context, Void config) {
         return null;
@@ -30,12 +34,19 @@ public class TestRouterFactory implements RouterFactory<Void, Void> {
 
     @Override
     public Router createRouter(RouterFactoryContext context, Void initializationData) {
+        Map<ApiKeys, String> allStatic = Arrays.stream(ApiKeys.values())
+                .collect(Collectors.toUnmodifiableMap(k -> k, k -> DEFAULT_ROUTE));
         return new Router() {
             @Override
             public CompletionStage<RouterResult> onRequest(short apiVersion, ApiKeys apiKey,
                                                            RequestHeaderData header, ApiMessage request,
                                                            RouterContext routerContext) {
-                return CompletableFuture.completedFuture(new RouterResult.Disconnect());
+                throw new IllegalStateException("Dynamic routing is not supported");
+            }
+
+            @Override
+            public Map<ApiKeys, String> staticRoutes() {
+                return allStatic;
             }
         };
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/ResponseImplTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/ResponseImplTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ResponseImplTest {
+
+    @Test
+    void shouldStoreHeaderAndBody() {
+        var header = new ResponseHeaderData();
+        var body = new FetchResponseData();
+
+        var response = new ResponseImpl(header, body);
+
+        assertThat(response.header()).isSameAs(header);
+        assertThat(response.body()).isSameAs(body);
+    }
+
+    @Test
+    void shouldRejectNullHeader() {
+        FetchResponseData body = new FetchResponseData();
+        assertThatThrownBy(() -> new ResponseImpl(null, body)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldRejectNullBody() {
+        ResponseHeaderData header = new ResponseHeaderData();
+        assertThatThrownBy(() -> new ResponseImpl(header, null)).isInstanceOf(NullPointerException.class);
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouteDescriptorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouteDescriptorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
+import io.kroxylicious.proxy.config.TargetCluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RouteDescriptorTest {
+
+    private static final TargetCluster TARGET = new TargetCluster("localhost:9092", Optional.empty());
+
+    @Test
+    void shouldCreateClusterRoute() {
+        var rd = new RouteDescriptor("route-a", 0, TARGET, null, List.of());
+        assertThat(rd.targetsCluster()).isTrue();
+        assertThat(rd.targetsRouter()).isFalse();
+        assertThat(rd.targetCluster()).isSameAs(TARGET);
+        assertThat(rd.routerName()).isNull();
+        assertThat(rd.name()).isEqualTo("route-a");
+        assertThat(rd.filters()).isEmpty();
+    }
+
+    @Test
+    void shouldCreateRouterRoute() {
+        var rd = new RouteDescriptor("route-b", 0, null, "nested-router", List.of());
+        assertThat(rd.targetsCluster()).isFalse();
+        assertThat(rd.targetsRouter()).isTrue();
+        assertThat(rd.routerName()).isEqualTo("nested-router");
+        assertThat(rd.targetCluster()).isNull();
+    }
+
+    @Test
+    void shouldPreserveFilters() {
+        var filter = new NamedFilterDefinition("f1", "com.example.MyFilter", null);
+        var rd = new RouteDescriptor("route-c", 0, TARGET, null, List.of(filter));
+        assertThat(rd.filters()).containsExactly(filter);
+    }
+
+    @Test
+    void shouldRejectBothTargetClusterAndRouter() {
+        assertThatThrownBy(() -> new RouteDescriptor("bad", 0, TARGET, "router", List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exactly one");
+    }
+
+    @Test
+    void shouldRejectNeitherTargetClusterNorRouter() {
+        assertThatThrownBy(() -> new RouteDescriptor("bad", 0, null, null, List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exactly one");
+    }
+
+    @Test
+    void shouldRejectNullName() {
+        assertThatThrownBy(() -> new RouteDescriptor(null, 0, TARGET, null, List.of()))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldRejectNullFilters() {
+        assertThatThrownBy(() -> new RouteDescriptor("route", 0, TARGET, null, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
@@ -105,7 +105,7 @@ class RouterDispatchHandlerTest {
     }
 
     @Test
-    void shouldForwardStaticallyRoutedDecodedFrameDirectlyToCcsm() {
+    void shouldForwardStaticallyRoutedDecodedFrameViaForwardToRoute() {
         var staticRoutes = Map.of(ApiKeys.FETCH, "default");
         var handler = new RouterDispatchHandler(staticRoutes, ccsm);
         channel = new EmbeddedChannel(handler);
@@ -116,11 +116,11 @@ class RouterDispatchHandlerTest {
 
         channel.writeInbound(frame);
 
-        verify(ccsm).onClientFilterChainComplete(frame);
+        verify(ccsm).forwardToRoute("default", frame);
     }
 
     @Test
-    void shouldForwardStaticallyRoutedOpaqueFrameDirectlyToCcsm() {
+    void shouldForwardStaticallyRoutedOpaqueFrameViaForwardToRoute() {
         var staticRoutes = Map.of(ApiKeys.FETCH, "default");
         var handler = new RouterDispatchHandler(staticRoutes, ccsm);
         channel = new EmbeddedChannel(handler);
@@ -131,7 +131,7 @@ class RouterDispatchHandlerTest {
 
         channel.writeInbound(opaqueFrame);
 
-        verify(ccsm).onClientFilterChainComplete(opaqueFrame);
+        verify(ccsm).forwardToRoute("default", opaqueFrame);
         buf.release();
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
@@ -6,92 +6,44 @@
 package io.kroxylicious.proxy.internal.routing;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.common.message.FetchRequestData;
 import org.apache.kafka.common.message.FetchResponseData;
-import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 
-import io.kroxylicious.proxy.authentication.Subject;
-import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.frame.OpaqueRequestFrame;
 import io.kroxylicious.proxy.internal.ClientConnectionStateMachine;
 import io.kroxylicious.proxy.router.Response;
-import io.kroxylicious.proxy.router.Router;
-import io.kroxylicious.proxy.router.RouterContext;
-import io.kroxylicious.proxy.router.RouterResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyShort;
-import static org.mockito.Mockito.doAnswer;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class RouterDispatchHandlerTest {
 
-    private static final TargetCluster TARGET = new TargetCluster("localhost:9092", Optional.empty());
     private static final int CORRELATION_ID = 42;
 
     @Mock
     private ClientConnectionStateMachine ccsm;
 
-    @Mock
-    private Router router;
-
     private EmbeddedChannel channel;
-    private Map<String, RouteDescriptor> routes;
-
-    @BeforeEach
-    void setUp() {
-        routes = Map.of("default", new RouteDescriptor("default", 0, TARGET, null, java.util.List.of()));
-    }
-
-    private void stubCcsmForRouting() {
-        when(ccsm.sessionId()).thenReturn("test-session");
-        when(ccsm.authenticatedSubject()).thenReturn(Subject.anonymous());
-    }
-
-    @Test
-    void shouldInvokeRouterOnDecodedRequestFrame() {
-        stubCcsmForRouting();
-        when(router.onRequest(anyShort(), any(ApiKeys.class), any(), any(), any(RouterContext.class)))
-                .thenReturn(CompletableFuture.completedFuture(new RouterResult.CompletedNoResponse()));
-
-        var handler = new RouterDispatchHandler(router, routes, ccsm);
-        channel = new EmbeddedChannel(handler);
-
-        var header = new RequestHeaderData();
-        var body = new FetchRequestData();
-        var frame = new DecodedRequestFrame<>((short) 12, CORRELATION_ID, true, header, body);
-
-        channel.writeInbound(frame);
-
-        verify(router).onRequest(
-                anyShort(),
-                any(ApiKeys.class),
-                any(),
-                any(),
-                any(RouterContext.class));
-    }
 
     @Test
     void shouldDelegateNonFrameMessagesToCcsm() {
-        when(ccsm.sessionId()).thenReturn("test-session");
-        var handler = new RouterDispatchHandler(router, routes, ccsm);
+        var handler = new RouterDispatchHandler(Map.of(), ccsm);
         channel = new EmbeddedChannel(handler);
 
         var nonFrame = "not-a-frame";
@@ -101,28 +53,24 @@ class RouterDispatchHandlerTest {
     }
 
     @Test
-    void shouldCloseChannelWhenRouterReturnsFailed() {
-        stubCcsmForRouting();
-        when(router.onRequest(anyShort(), any(ApiKeys.class), any(), any(), any(RouterContext.class)))
-                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("router error")));
-
-        var handler = new RouterDispatchHandler(router, routes, ccsm);
+    void shouldThrowForDynamicallyRoutedDecodedFrame() {
+        var handler = new RouterDispatchHandler(Map.of(), ccsm);
         channel = new EmbeddedChannel(handler);
 
-        var header = new RequestHeaderData();
+        var header = new org.apache.kafka.common.message.RequestHeaderData();
         var body = new FetchRequestData();
         var frame = new DecodedRequestFrame<>((short) 12, CORRELATION_ID, true, header, body);
 
-        channel.writeInbound(frame);
-
-        assertThat(channel.isOpen()).isFalse();
+        assertThatThrownBy(() -> channel.writeInbound(frame))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Dynamic routing is not supported");
     }
 
     @Test
     void shouldCompletePendingFutureOnResponse() {
         when(ccsm.clientChannel()).thenReturn(null);
 
-        var handler = new RouterDispatchHandler(router, routes, ccsm);
+        var handler = new RouterDispatchHandler(Map.of(), ccsm);
         channel = new EmbeddedChannel(handler);
         when(ccsm.clientChannel()).thenReturn(channel);
 
@@ -143,7 +91,7 @@ class RouterDispatchHandlerTest {
 
     @Test
     void shouldNotFailWhenResponseHasNoPendingFuture() {
-        var handler = new RouterDispatchHandler(router, routes, ccsm);
+        var handler = new RouterDispatchHandler(Map.of(), ccsm);
         channel = new EmbeddedChannel(handler);
         when(ccsm.clientChannel()).thenReturn(channel);
 
@@ -151,43 +99,78 @@ class RouterDispatchHandlerTest {
         var responseBody = new FetchResponseData();
         var responseFrame = new DecodedResponseFrame<>((short) 12, 999, responseHeader, responseBody);
 
-        handler.onResponse(responseFrame);
-        // should not throw — just logs a warning
+        boolean handled = handler.onResponse(responseFrame);
+
+        assertThat(handled).isFalse();
     }
 
     @Test
-    void shouldForwardRequestViaCcsmWhenRouterSendsRequest() {
-        stubCcsmForRouting();
-        AtomicReference<Object> forwarded = new AtomicReference<>();
-
-        doAnswer(invocation -> {
-            RouterContext ctx = invocation.getArgument(4);
-            var reqHeader = new RequestHeaderData();
-            var reqBody = new FetchRequestData();
-            ctx.sendRequestToNode("default", 0, reqHeader, reqBody);
-            return CompletableFuture.completedFuture(new RouterResult.CompletedNoResponse());
-        }).when(router).onRequest(anyShort(), any(ApiKeys.class), any(), any(), any(RouterContext.class));
-
-        doAnswer(invocation -> {
-            forwarded.set(invocation.getArgument(0));
-            return null;
-        }).when(ccsm).onClientFilterChainComplete(any());
-
-        var handler = new RouterDispatchHandler(router, routes, ccsm);
+    void shouldForwardStaticallyRoutedDecodedFrameDirectlyToCcsm() {
+        var staticRoutes = Map.of(ApiKeys.FETCH, "default");
+        var handler = new RouterDispatchHandler(staticRoutes, ccsm);
         channel = new EmbeddedChannel(handler);
 
-        var header = new RequestHeaderData();
+        var header = new org.apache.kafka.common.message.RequestHeaderData();
         var body = new FetchRequestData();
         var frame = new DecodedRequestFrame<>((short) 12, CORRELATION_ID, true, header, body);
 
         channel.writeInbound(frame);
 
-        assertThat(forwarded.get()).isInstanceOf(DecodedRequestFrame.class);
+        verify(ccsm).onClientFilterChainComplete(frame);
+    }
+
+    @Test
+    void shouldForwardStaticallyRoutedOpaqueFrameDirectlyToCcsm() {
+        var staticRoutes = Map.of(ApiKeys.FETCH, "default");
+        var handler = new RouterDispatchHandler(staticRoutes, ccsm);
+        channel = new EmbeddedChannel(handler);
+
+        var buf = Unpooled.buffer();
+        var opaqueFrame = new OpaqueRequestFrame(
+                buf, (short) ApiKeys.FETCH.id, (short) 12, CORRELATION_ID, false, 0, true);
+
+        channel.writeInbound(opaqueFrame);
+
+        verify(ccsm).onClientFilterChainComplete(opaqueFrame);
+        buf.release();
+    }
+
+    @Test
+    void shouldReturnTrueFromOnResponseWhenPendingFutureExists() {
+        when(ccsm.clientChannel()).thenReturn(null);
+        var handler = new RouterDispatchHandler(Map.of(), ccsm);
+        channel = new EmbeddedChannel(handler);
+        when(ccsm.clientChannel()).thenReturn(channel);
+
+        CompletableFuture<Response> future = new CompletableFuture<>();
+        RouterDispatchHandler.registerPendingResponse(channel, CORRELATION_ID, future);
+
+        var responseHeader = new ResponseHeaderData().setCorrelationId(CORRELATION_ID);
+        var responseFrame = new DecodedResponseFrame<>((short) 12, CORRELATION_ID, responseHeader, new FetchResponseData());
+
+        boolean handled = handler.onResponse(responseFrame);
+
+        assertThat(handled).isTrue();
+        assertThat(future).isCompleted();
+    }
+
+    @Test
+    void shouldReturnFalseFromOnResponseWhenNoPendingFuture() {
+        var handler = new RouterDispatchHandler(Map.of(), ccsm);
+        channel = new EmbeddedChannel(handler);
+        when(ccsm.clientChannel()).thenReturn(channel);
+
+        var responseHeader = new ResponseHeaderData().setCorrelationId(999);
+        var responseFrame = new DecodedResponseFrame<>((short) 12, 999, responseHeader, new FetchResponseData());
+
+        boolean handled = handler.onResponse(responseFrame);
+
+        assertThat(handled).isFalse();
     }
 
     @Test
     void shouldRegisterAndRetrievePendingResponses() {
-        var handler = new RouterDispatchHandler(router, routes, ccsm);
+        var handler = new RouterDispatchHandler(Map.of(), ccsm);
         channel = new EmbeddedChannel(handler);
 
         CompletableFuture<Response> future1 = new CompletableFuture<>();
@@ -205,4 +188,30 @@ class RouterDispatchHandlerTest {
         assertThat(future2).isNotCompleted();
     }
 
+    @Test
+    void shouldFallThroughToCcsmForOpaqueFrameNotInStaticRoutes() {
+        var staticRoutes = Map.of(ApiKeys.PRODUCE, "default");
+        var handler = new RouterDispatchHandler(staticRoutes, ccsm);
+        channel = new EmbeddedChannel(handler);
+        when(ccsm.sessionId()).thenReturn("test-session");
+
+        var buf = Unpooled.buffer();
+        var opaqueFrame = new OpaqueRequestFrame(
+                buf, (short) ApiKeys.FETCH.id, (short) 12, CORRELATION_ID, false, 0, true);
+
+        channel.writeInbound(opaqueFrame);
+
+        verify(ccsm).onClientFilterChainComplete(opaqueFrame);
+        buf.release();
+    }
+
+    @Test
+    void shouldReturnFalseFromOnResponseForNonDecodedFrame() {
+        var handler = new RouterDispatchHandler(Map.of(), ccsm);
+        channel = new EmbeddedChannel(handler);
+
+        boolean handled = handler.onResponse("not-a-decoded-response-frame");
+
+        assertThat(handled).isFalse();
+    }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.common.message.FetchRequestData;
+import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+import io.kroxylicious.proxy.authentication.Subject;
+import io.kroxylicious.proxy.config.TargetCluster;
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.internal.ClientConnectionStateMachine;
+import io.kroxylicious.proxy.router.Response;
+import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.router.RouterContext;
+import io.kroxylicious.proxy.router.RouterResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RouterDispatchHandlerTest {
+
+    private static final TargetCluster TARGET = new TargetCluster("localhost:9092", Optional.empty());
+    private static final int CORRELATION_ID = 42;
+
+    @Mock
+    private ClientConnectionStateMachine ccsm;
+
+    @Mock
+    private Router router;
+
+    private EmbeddedChannel channel;
+    private Map<String, RouteDescriptor> routes;
+
+    @BeforeEach
+    void setUp() {
+        routes = Map.of("default", new RouteDescriptor("default", 0, TARGET, null, java.util.List.of()));
+    }
+
+    private void stubCcsmForRouting() {
+        when(ccsm.sessionId()).thenReturn("test-session");
+        when(ccsm.authenticatedSubject()).thenReturn(Subject.anonymous());
+    }
+
+    @Test
+    void shouldInvokeRouterOnDecodedRequestFrame() {
+        stubCcsmForRouting();
+        when(router.onRequest(anyShort(), any(ApiKeys.class), any(), any(), any(RouterContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(new RouterResult.CompletedNoResponse()));
+
+        var handler = new RouterDispatchHandler(router, routes, ccsm);
+        channel = new EmbeddedChannel(handler);
+
+        var header = new RequestHeaderData();
+        var body = new FetchRequestData();
+        var frame = new DecodedRequestFrame<>((short) 12, CORRELATION_ID, true, header, body);
+
+        channel.writeInbound(frame);
+
+        verify(router).onRequest(
+                anyShort(),
+                any(ApiKeys.class),
+                any(),
+                any(),
+                any(RouterContext.class));
+    }
+
+    @Test
+    void shouldDelegateNonFrameMessagesToCcsm() {
+        when(ccsm.sessionId()).thenReturn("test-session");
+        var handler = new RouterDispatchHandler(router, routes, ccsm);
+        channel = new EmbeddedChannel(handler);
+
+        var nonFrame = "not-a-frame";
+        channel.writeInbound(nonFrame);
+
+        verify(ccsm).onClientFilterChainComplete(nonFrame);
+    }
+
+    @Test
+    void shouldCloseChannelWhenRouterReturnsFailed() {
+        stubCcsmForRouting();
+        when(router.onRequest(anyShort(), any(ApiKeys.class), any(), any(), any(RouterContext.class)))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("router error")));
+
+        var handler = new RouterDispatchHandler(router, routes, ccsm);
+        channel = new EmbeddedChannel(handler);
+
+        var header = new RequestHeaderData();
+        var body = new FetchRequestData();
+        var frame = new DecodedRequestFrame<>((short) 12, CORRELATION_ID, true, header, body);
+
+        channel.writeInbound(frame);
+
+        assertThat(channel.isOpen()).isFalse();
+    }
+
+    @Test
+    void shouldCompletePendingFutureOnResponse() {
+        when(ccsm.clientChannel()).thenReturn(null);
+
+        var handler = new RouterDispatchHandler(router, routes, ccsm);
+        channel = new EmbeddedChannel(handler);
+        when(ccsm.clientChannel()).thenReturn(channel);
+
+        CompletableFuture<Response> future = new CompletableFuture<>();
+        RouterDispatchHandler.registerPendingResponse(channel, CORRELATION_ID, future);
+
+        var responseHeader = new ResponseHeaderData().setCorrelationId(CORRELATION_ID);
+        var responseBody = new FetchResponseData();
+        var responseFrame = new DecodedResponseFrame<>((short) 12, CORRELATION_ID, responseHeader, responseBody);
+
+        handler.onResponse(responseFrame);
+
+        assertThat(future).isCompleted();
+        Response response = future.join();
+        assertThat(response.header()).isEqualTo(responseHeader);
+        assertThat(response.body()).isEqualTo(responseBody);
+    }
+
+    @Test
+    void shouldNotFailWhenResponseHasNoPendingFuture() {
+        var handler = new RouterDispatchHandler(router, routes, ccsm);
+        channel = new EmbeddedChannel(handler);
+        when(ccsm.clientChannel()).thenReturn(channel);
+
+        var responseHeader = new ResponseHeaderData().setCorrelationId(999);
+        var responseBody = new FetchResponseData();
+        var responseFrame = new DecodedResponseFrame<>((short) 12, 999, responseHeader, responseBody);
+
+        handler.onResponse(responseFrame);
+        // should not throw — just logs a warning
+    }
+
+    @Test
+    void shouldForwardRequestViaCcsmWhenRouterSendsRequest() {
+        stubCcsmForRouting();
+        AtomicReference<Object> forwarded = new AtomicReference<>();
+
+        doAnswer(invocation -> {
+            RouterContext ctx = invocation.getArgument(4);
+            var reqHeader = new RequestHeaderData();
+            var reqBody = new FetchRequestData();
+            ctx.sendRequestToNode("default", 0, reqHeader, reqBody);
+            return CompletableFuture.completedFuture(new RouterResult.CompletedNoResponse());
+        }).when(router).onRequest(anyShort(), any(ApiKeys.class), any(), any(), any(RouterContext.class));
+
+        doAnswer(invocation -> {
+            forwarded.set(invocation.getArgument(0));
+            return null;
+        }).when(ccsm).onClientFilterChainComplete(any());
+
+        var handler = new RouterDispatchHandler(router, routes, ccsm);
+        channel = new EmbeddedChannel(handler);
+
+        var header = new RequestHeaderData();
+        var body = new FetchRequestData();
+        var frame = new DecodedRequestFrame<>((short) 12, CORRELATION_ID, true, header, body);
+
+        channel.writeInbound(frame);
+
+        assertThat(forwarded.get()).isInstanceOf(DecodedRequestFrame.class);
+    }
+
+    @Test
+    void shouldRegisterAndRetrievePendingResponses() {
+        var handler = new RouterDispatchHandler(router, routes, ccsm);
+        channel = new EmbeddedChannel(handler);
+
+        CompletableFuture<Response> future1 = new CompletableFuture<>();
+        CompletableFuture<Response> future2 = new CompletableFuture<>();
+
+        RouterDispatchHandler.registerPendingResponse(channel, 1, future1);
+        RouterDispatchHandler.registerPendingResponse(channel, 2, future2);
+
+        when(ccsm.clientChannel()).thenReturn(channel);
+
+        var header1 = new ResponseHeaderData().setCorrelationId(1);
+        handler.onResponse(new DecodedResponseFrame<>((short) 12, 1, header1, new FetchResponseData()));
+
+        assertThat(future1).isCompleted();
+        assertThat(future2).isNotCompleted();
+    }
+
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RoutingContextImplTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RoutingContextImplTest.java
@@ -35,7 +35,8 @@ class RoutingContextImplTest {
 
     private EmbeddedChannel channel;
     private Map<String, RouteDescriptor> routes;
-    private AtomicReference<Object> forwarded;
+    private AtomicReference<String> forwardedRoute;
+    private AtomicReference<Object> forwardedMsg;
 
     @BeforeEach
     void setUp() {
@@ -43,7 +44,8 @@ class RoutingContextImplTest {
         routes = Map.of(
                 "cluster-route", new RouteDescriptor("cluster-route", 0, TARGET, null, List.of()),
                 "router-route", new RouteDescriptor("router-route", 1, null, "nested", List.of()));
-        forwarded = new AtomicReference<>();
+        forwardedRoute = new AtomicReference<>();
+        forwardedMsg = new AtomicReference<>();
     }
 
     private RoutingContextImpl createContext() {
@@ -54,7 +56,10 @@ class RoutingContextImplTest {
                 SESSION_ID,
                 Subject.anonymous(),
                 routes,
-                forwarded::set);
+                (routeName, msg) -> {
+                    forwardedRoute.set(routeName);
+                    forwardedMsg.set(msg);
+                });
     }
 
     @Test
@@ -77,7 +82,8 @@ class RoutingContextImplTest {
 
         CompletableFuture<Response> future = (CompletableFuture<Response>) ctx.sendRequestToNode("cluster-route", 0, header, body);
 
-        assertThat(forwarded.get())
+        assertThat(forwardedRoute.get()).isEqualTo("cluster-route");
+        assertThat(forwardedMsg.get())
                 .isInstanceOfSatisfying(DecodedRequestFrame.class, frame -> {
                     assertThat(frame.correlationId()).isEqualTo(CORRELATION_ID);
                     assertThat(frame.apiVersion()).isEqualTo(API_VERSION);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RoutingContextImplTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RoutingContextImplTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.common.message.FetchRequestData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+import io.kroxylicious.proxy.authentication.Subject;
+import io.kroxylicious.proxy.config.TargetCluster;
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.router.Response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RoutingContextImplTest {
+
+    private static final TargetCluster TARGET = new TargetCluster("localhost:9092", Optional.empty());
+    private static final int CORRELATION_ID = 7;
+    private static final short API_VERSION = 12;
+    private static final String SESSION_ID = "sess-1";
+
+    private EmbeddedChannel channel;
+    private Map<String, RouteDescriptor> routes;
+    private AtomicReference<Object> forwarded;
+
+    @BeforeEach
+    void setUp() {
+        channel = new EmbeddedChannel();
+        routes = Map.of(
+                "cluster-route", new RouteDescriptor("cluster-route", 0, TARGET, null, List.of()),
+                "router-route", new RouteDescriptor("router-route", 1, null, "nested", List.of()));
+        forwarded = new AtomicReference<>();
+    }
+
+    private RoutingContextImpl createContext() {
+        return new RoutingContextImpl(
+                CORRELATION_ID,
+                API_VERSION,
+                channel,
+                SESSION_ID,
+                Subject.anonymous(),
+                routes,
+                forwarded::set);
+    }
+
+    @Test
+    void shouldReturnSessionId() {
+        var ctx = createContext();
+        assertThat(ctx.sessionId()).isEqualTo(SESSION_ID);
+    }
+
+    @Test
+    void shouldReturnAnonymousSubject() {
+        var ctx = createContext();
+        assertThat(ctx.authenticatedSubject()).isEqualTo(Subject.anonymous());
+    }
+
+    @Test
+    void shouldForwardRequestToClusterRoute() {
+        var ctx = createContext();
+        var header = new RequestHeaderData();
+        var body = new FetchRequestData();
+
+        CompletableFuture<Response> future = (CompletableFuture<Response>) ctx.sendRequestToNode("cluster-route", 0, header, body);
+
+        assertThat(forwarded.get())
+                .isInstanceOfSatisfying(DecodedRequestFrame.class, frame -> {
+                    assertThat(frame.correlationId()).isEqualTo(CORRELATION_ID);
+                    assertThat(frame.apiVersion()).isEqualTo(API_VERSION);
+                    assertThat(frame.header()).isSameAs(header);
+                    assertThat(frame.body()).isSameAs(body);
+                });
+        assertThat(future).isNotCompleted();
+    }
+
+    @Test
+    void shouldFailForUnknownRoute() {
+        var ctx = createContext();
+        var future = ctx.sendRequestToNode("nonexistent", 0, new RequestHeaderData(), new FetchRequestData());
+
+        assertThat(future.toCompletableFuture()).isCompletedExceptionally();
+        assertThatThrownBy(() -> future.toCompletableFuture().join())
+                .hasCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown route: nonexistent");
+    }
+
+    @Test
+    void shouldFailForNestedRouterRoute() {
+        var ctx = createContext();
+        var future = ctx.sendRequestToNode("router-route", 0, new RequestHeaderData(), new FetchRequestData());
+
+        assertThat(future.toCompletableFuture()).isCompletedExceptionally();
+        assertThatThrownBy(() -> future.toCompletableFuture().join())
+                .hasCauseInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("nested routers");
+    }
+
+    @Test
+    void shouldReturnBootstrapNodeIdForKnownRoute() {
+        var ctx = createContext();
+        assertThat(ctx.bootstrapNodeId("cluster-route")).isZero();
+    }
+
+    @Test
+    void shouldThrowForBootstrapNodeIdWithUnknownRoute() {
+        var ctx = createContext();
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> ctx.bootstrapNodeId("nonexistent"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown route: nonexistent");
+    }
+
+    @Test
+    void shouldRegisterPendingResponseOnSend() {
+        var ctx = createContext();
+
+        ctx.sendRequestToNode("cluster-route", 0, new RequestHeaderData(), new FetchRequestData());
+
+        CompletableFuture<Response> pendingFuture = new CompletableFuture<>();
+        RouterDispatchHandler.registerPendingResponse(channel, 999, pendingFuture);
+        assertThat(pendingFuture).isNotCompleted();
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
@@ -9,6 +9,7 @@ package io.kroxylicious.proxy.model;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -34,6 +35,7 @@ import io.kroxylicious.proxy.config.tls.TrustStore;
 import io.kroxylicious.proxy.filter.FilterFactory;
 import io.kroxylicious.proxy.internal.filter.FlakyConfig;
 import io.kroxylicious.proxy.internal.filter.FlakyFactory;
+import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
 import io.kroxylicious.proxy.internal.tls.TlsTestConstants;
 import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
@@ -42,6 +44,7 @@ import io.kroxylicious.proxy.tls.ServerTlsCredentialSupplierFactory;
 import io.kroxylicious.proxy.tls.ServerTlsCredentialSupplierFactoryContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
@@ -194,6 +197,29 @@ class VirtualClusterModelTest {
                 .cause()
                 .isExactlyInstanceOf(RuntimeException.class)
                 .hasMessage("init kaboom");
+    }
+
+    @Test
+    void routerBasedVcmHasNullTargetClusterAndEmptyUpstreamSslContext() {
+        var routeDescriptors = Map.of("route1",
+                new RouteDescriptor("route1", 0, new TargetCluster("broker:9092", Optional.empty()), null, List.of()));
+
+        VirtualClusterModel model = new VirtualClusterModel("routed-vc", null, false, false, EMPTY_FILTERS,
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null, "myrouter", routeDescriptors);
+
+        assertThat(model.targetCluster()).isNull();
+        assertThat(model.usesRouter()).isTrue();
+        assertThat(model.routerName()).isEqualTo("myrouter");
+        assertThat(model.routeDescriptors()).containsKey("route1");
+        assertThat(model.getUpstreamSslContext()).isEmpty();
+    }
+
+    @Test
+    void logVirtualClusterSummaryHandlesNullTargetCluster() {
+        VirtualClusterModel model = new VirtualClusterModel("routed-vc", null, false, false, EMPTY_FILTERS,
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null, "myrouter", null);
+
+        assertThatCode(model::logVirtualClusterSummary).doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

**note: this is a PR into a feature branch, which we are using to collect refined router commits extracted from the much messier prototype branches**

1. resolves routing configuration into runtime model, checking router graph for cycles and making route infomation part of VirtualClusterModel
2. support multiple server connections per client, refactors the connection state machines
3. add routing engine and wire into proxy lifecycle
4. implement static routing and pass-through router with integration test

With this PR it becomes possible to make your virtual cluster target a Router, and implement a very simple Router that uses the staticRoutes functionality to route ALL Kafka RPCs to a given route. Dynamic routing using `onRequest` is not implemented, if we encounter an RPC that is not in the staticRoutes Map, then we explode with an exception.

Note that this implementation establishes multiple upstream connections up front during client connection establishment, later commits in the prototype branch make this a lazy process, only connecting when the Router decides to send a message to a particular upstream node. But the evolution that gets there is complex, so for now we go with eager upstream connections.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
