### PR TITLE
fix(build): skip archetype integration test when -DskipTests is set

### DIFF
--- a/kroxylicious-filter-archetype/pom.xml
+++ b/kroxylicious-filter-archetype/pom.xml
@@ -116,6 +116,13 @@
                     </delimiters>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-archetype-plugin</artifactId>
+                <configuration>
+                    <skip>${skipTests}</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -184,7 +191,6 @@
                         <artifactId>maven-archetype-plugin</artifactId>
                         <configuration>
                             <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
-                            <skip>${skipITs}</skip>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `build_artifacts` CI job runs `install` with `-DskipTests` and `!qa`. With
the `qa` profile deactivated, `maven-archetype-plugin` had no `<skip>`
configuration, so its nested Maven invocation ran `SampleFilterIT` regardless
of `-DskipTests` being set on the outer build.

Two changes:

1. Add `<skip>${skipTests}</skip>` in the base build configuration for
   `maven-archetype-plugin`, so the archetype integration test is skipped
   whenever `-DskipTests` is passed, regardless of active profiles.

2. Remove the now-redundant `<skip>${skipITs}</skip>` from the `qa` profile.
   It was using a different flag inconsistently and, when `qa` was active,
   would override the base config — meaning `-DskipTests` alone would not
   skip the archetype test.

### Additional Context

Identified from a failing `build_artifacts` job in the System Tests for
Pull-Requests workflow, where `SampleFilterIT` was being run inside the
archetype plugin's nested build despite `-DskipTests` being passed to the
outer Maven invocation.

### Checklist

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).