### PR TITLE
docs(operator): document operator testing philosophy and Given/When/Then convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Other modules, such as `kroxylicious-runtime`, are implementation. These can be 
 
 ### Philosophy
 
-Tests are documentation as much as they are verification. A test that passes tells you the system works; a test that fails tells you exactly what broke; and a test that is read tells the next developer what the system is supposed to do. All three matter.
+Tests are documentation as much as they are verification. A test that passes tells you the system works; a test that fails tells you exactly what broke; and a test that is read tells the next developer what the system is supposed to do. All three matter. We call this the **documentation-first** approach to testing.
 
 This is an aspirational standard — the existing codebase has a mix of styles — but it is the direction new tests should move in.
 
@@ -183,5 +183,5 @@ Every test should tell a coherent story on its own, without requiring the reader
 
 - **`kroxylicious-filter-test-support`**: Utilities for unit testing filters in isolation
 - **`kroxylicious-integration-test-support`**: Infrastructure for integration tests with real Kafka clusters
-- **`kroxylicious-operator-test-support`**: Three-actor model for operator integration tests — see [kroxylicious-kubernetes/kroxylicious-operator/README.md](kroxylicious-kubernetes/kroxylicious-operator/README.md)
+- **`kroxylicious-operator-test-support`**: Three-actor model for operator integration tests — see [kroxylicious-kubernetes/kroxylicious-operator-test-support/README.md](kroxylicious-kubernetes/kroxylicious-operator-test-support/README.md)
 - **Example patterns**: Study existing tests for patterns; the operator ITs are the clearest expression of the documentation-first approach

--- a/README.md
+++ b/README.md
@@ -167,6 +167,21 @@ Other modules, such as `kroxylicious-runtime`, are implementation. These can be 
 
 ## Testing
 
+### Philosophy
+
+Tests are documentation as much as they are verification. A test that passes tells you the system works; a test that fails tells you exactly what broke; and a test that is read tells the next developer what the system is supposed to do. All three matter.
+
+This is an aspirational standard — the existing codebase has a mix of styles — but it is the direction new tests should move in.
+
+Every test should tell a coherent story on its own, without requiring the reader to consult surrounding context or class Javadoc. The test name names the scenario; the test body narrates it using three labelled sections:
+
+- **Given** — minimum state required for the action to be meaningful. Establishes preconditions only; contains no assertions. If a precondition is worth asserting, it belongs in its own dedicated test.
+- **When** — the single action whose effects the test is observing. There is exactly one `When` per test. The code in this block should be self-evident through intention-revealing names; if you feel the urge to describe it in the comment, the code needs refactoring.
+- **Then** — assertions on the post-`When` state. A test has one reason to fail: the `When` did not produce the expected outcome.
+
+### Test support modules
+
 - **`kroxylicious-filter-test-support`**: Utilities for unit testing filters in isolation
 - **`kroxylicious-integration-test-support`**: Infrastructure for integration tests with real Kafka clusters
-- **Example patterns**: Study existing filter tests in `kroxylicious-filters` modules for patterns
+- **`kroxylicious-operator-test-support`**: Three-actor model for operator integration tests — see [kroxylicious-kubernetes/kroxylicious-operator/README.md](kroxylicious-kubernetes/kroxylicious-operator/README.md)
+- **Example patterns**: Study existing tests for patterns; the operator ITs are the clearest expression of the documentation-first approach

--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ Other modules, such as `kroxylicious-runtime`, are implementation. These can be 
 
 ### Philosophy
 
-Tests are documentation as much as they are verification. A test that passes tells you the system works; a test that fails tells you exactly what broke; and a test that is read tells the next developer what the system is supposed to do. All three matter. We call this the **documentation-first** approach to testing.
+We treat tests as executable specifications. Taking inspiration from the Behaviour Driven Development (BDD) community, we adopt a Given/When/Then structure to give tests a narrative flow when documenting what the system is supposed to do. A failing test should tell you what *value* is broken — not what technical thing failed.
+
+Tests are organised into layers, each documenting a wider scope of value. The technical characteristics of each layer — whether it uses mocks, a real cluster, or a full external system — are consequences of the scope of value being claimed, not defining properties of the layer. A unit test uses mocks because the value claim is about a component's logic in isolation; an integration test uses real infrastructure because the value claim extends across that boundary.
 
 This is an aspirational standard — the existing codebase has a mix of styles — but it is the direction new tests should move in.
 
@@ -184,4 +186,4 @@ Every test should tell a coherent story on its own, without requiring the reader
 - **`kroxylicious-filter-test-support`**: Utilities for unit testing filters in isolation
 - **`kroxylicious-integration-test-support`**: Infrastructure for integration tests with real Kafka clusters
 - **`kroxylicious-operator-test-support`**: Three-actor model for operator integration tests — see [kroxylicious-kubernetes/kroxylicious-operator-test-support/README.md](kroxylicious-kubernetes/kroxylicious-operator-test-support/README.md)
-- **Example patterns**: Study existing tests for patterns; the operator ITs are the clearest expression of the documentation-first approach
+- **Example patterns**: Study existing tests for patterns; the operator ITs are the clearest expression of the executable-specification approach described above

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/README.md
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/README.md
@@ -1,0 +1,108 @@
+# Kroxylicious Operator Test Support
+
+JUnit Jupiter extensions and utilities for writing integration tests against the Kroxylicious operator.
+
+## Testing philosophy
+
+Operator integration tests involve three distinct actors, each with a different role:
+
+| Actor | Class | Role |
+|-------|-------|------|
+| **Operator under test** | `LocalKroxyliciousOperatorExtension` | The system being tested. Manages the full reconciler lifecycle: RBAC, namespace, CRDs, operator start/stop, and between-test cleanup. |
+| **Cluster user** | `ClusterUser` | Represents an end user interacting with the cluster — creating, updating, and deleting Kroxylicious custom resources. Scoped to the RBAC of a regular user, not the operator itself. |
+| **External operator** | `ExternalOperator` | Drives status state that a reconciler external to the one under test would normally produce. "External" includes both truly external controllers (e.g. Strimzi setting status on a `Kafka` resource) and sibling Kroxylicious reconcilers whose output the reconciler-under-test depends on. |
+
+Keeping these actors separate makes the intent of each test action legible: code that goes through `ClusterUser` is a user action; code that goes through `ExternalOperator` is a precondition being established by another controller.
+
+## Setting up an IT
+
+### Single-reconciler tests
+
+Register only the reconciler under test. Use `ExternalOperator` to supply the status state that sibling reconcilers would normally produce.
+
+```java
+@EnabledIf(value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable",
+           disabledReason = "no viable kube client available")
+class KafkaProxyReconcilerIT {
+
+    @RegisterExtension
+    static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
+            .withReconciler(new KafkaProxyReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR))
+            .build();
+
+    private ClusterUser clusterUser;
+    private ExternalOperator externalOperator;
+
+    @BeforeEach
+    void setUp() {
+        clusterUser = operator.clusterUser();
+        externalOperator = operator.externalOperator();
+    }
+
+    @Test
+    void shouldSetReadyConditionOnValidProxy() {
+        // Given
+        KafkaProxy proxy = clusterUser.create(new KafkaProxyBuilder()
+                .withNewMetadata().withName("my-proxy").endMetadata()
+                .build());
+
+        // When / Then — reconciler sets the Ready condition
+        AWAIT.untilAsserted(() ->
+            assertThat(clusterUser.get(KafkaProxy.class, "my-proxy"))
+                .isNotNull()
+                .extracting(KafkaProxy::getStatus)
+                // ... assert conditions
+        );
+    }
+}
+```
+
+### Multi-reconciler tests
+
+To test reconcilers working together, register all of them. The `AllReconcilersIT` is the canonical example: it focuses on status conditions reported end-to-end, while the individual reconciler ITs test each reconciler's logic in depth.
+
+### Third-party CRDs (e.g. Strimzi)
+
+If the reconciler under test watches a third-party CRD, install it via `withSetupAction` / `withTeardownAction` and register the CR type for between-test cleanup with `withAdditionalCleanupTypes`:
+
+```java
+@RegisterExtension
+static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
+        .withReconciler(new KafkaServiceReconciler(Clock.systemUTC(), sharedInformerManager))
+        .withSetupAction(() -> {
+            try (KubernetesClient client = OperatorTestUtils.kubeClient()) {
+                client.apiextensions().v1().customResourceDefinitions()
+                      .resource(Crds.kafka()).createOr(Updatable::update);
+            }
+        })
+        .withTeardownAction(() -> {
+            try (KubernetesClient client = OperatorTestUtils.kubeClient()) {
+                client.apiextensions().v1().customResourceDefinitions()
+                      .resource(Crds.kafka()).delete();
+            }
+        })
+        .withAdditionalCleanupTypes(Kafka.class)
+        .build();
+```
+
+## Lifecycle
+
+`LocalKroxyliciousOperatorExtension` manages state at two granularities:
+
+- **Per test class** (`@BeforeAll` / `@AfterAll`): RBAC setup, namespace creation, CRD application, operator startup, and final cleanup. The namespace and CRDs are shared across all tests in the class to avoid the overhead of per-test CRD deletion and re-application.
+- **Per test** (`@AfterEach`): all Kroxylicious CRs, Secrets, and ConfigMaps in the namespace are deleted between tests. Additional resource types registered via `withAdditionalCleanupTypes` are also deleted.
+
+Obtain fresh `ClusterUser` and `ExternalOperator` instances in `@BeforeEach` — they are lightweight wrappers and safe to recreate each test.
+
+## Skipping when no cluster is available
+
+Guard every IT class with `@EnabledIf` so tests skip gracefully on machines without a running Kubernetes cluster:
+
+```java
+@EnabledIf(
+    value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable",
+    disabledReason = "no viable kube client available"
+)
+```
+
+`OperatorTestUtils.isKubeClientAvailable()` probes the cluster with a short timeout so it fails fast rather than hanging.

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/README.md
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/README.md
@@ -1,6 +1,8 @@
 # Kroxylicious Operator Test Support
 
-JUnit Jupiter extensions and utilities that implement the three-actor testing model for Kroxylicious operator integration tests. See the [operator README](../kroxylicious-operator/README.md) for the philosophy behind this model.
+JUnit Jupiter extensions and utilities for writing Kroxylicious operator integration tests. They implement a three-actor model in which the **operator under test** runs under `LocalKroxyliciousOperatorExtension`, a **cluster user** (`ClusterUser`) performs user-side CR interactions, and an **external operator** (`ExternalOperator`) drives status state that sibling or external controllers would normally produce. This separation makes each test readable as a self-contained story of who did what and what the operator produced in response.
+
+See the [operator README](../kroxylicious-operator/README.md) for the testing philosophy, including when to use each test layer and why the actor model exists.
 
 ## Setting up an IT
 
@@ -64,7 +66,7 @@ static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorEx
 
 Integration tests are documentation as much as they are verification. A test should tell its reader a coherent story: a user did X, an external system did Y, and the operator-under-test produced Z. The three-actor model exists to make that story legible — it is a convention for test *readers*, not a technical enforcement.
 
-The `operator` extension field has Kubernetes access internally (it needs it to manage the test lifecycle), but using it directly in test bodies breaks the story. A reader who sees `operator.someKubeCall()` cannot tell whether that represents a user action, an external controller, or internal test plumbing. Code that goes through `ClusterUser` is a user action; code that goes through `ExternalOperator` is an external controller; everything else disappears into the background.
+The `operator` extension field has Kubernetes access internally (it needs it to manage the test lifecycle), but using it directly in test bodies breaks the story. A reader who sees `operator.someKubeCall()` cannot tell whether that represents a user action, an external controller, or internal test plumbing. Code that goes through the cluster user (`ClusterUser`) is a user action; code that goes through the external operator (`ExternalOperator`) is an external controller; everything else disappears into the background.
 
 | What you're doing | Use |
 |---|---|

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/README.md
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/README.md
@@ -64,7 +64,7 @@ static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorEx
 
 ## What belongs in each actor
 
-Integration tests are documentation as much as they are verification. A test should tell its reader a coherent story: a user did X, an external system did Y, and the operator-under-test produced Z. The three-actor model exists to make that story legible — it is a convention for test *readers*, not a technical enforcement.
+We treat tests as executable specifications — each test tells a coherent story: a user did X, an external system did Y, and the operator-under-test produced Z. The three-actor model exists to make that story legible to test *readers*; it is a convention, not a technical enforcement.
 
 The `operator` extension field has Kubernetes access internally (it needs it to manage the test lifecycle), but using it directly in test bodies breaks the story. A reader who sees `operator.someKubeCall()` cannot tell whether that represents a user action, an external controller, or internal test plumbing. Code that goes through the cluster user (`ClusterUser`) is a user action; code that goes through the external operator (`ExternalOperator`) is an external controller; everything else disappears into the background.
 

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/README.md
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/README.md
@@ -62,10 +62,14 @@ static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorEx
 
 ## What belongs in each actor
 
+Integration tests are documentation as much as they are verification. A test should tell its reader a coherent story: a user did X, an external system did Y, and the operator-under-test produced Z. The three-actor model exists to make that story legible — it is a convention for test *readers*, not a technical enforcement.
+
+The `operator` extension field has Kubernetes access internally (it needs it to manage the test lifecycle), but using it directly in test bodies breaks the story. A reader who sees `operator.someKubeCall()` cannot tell whether that represents a user action, an external controller, or internal test plumbing. Code that goes through `ClusterUser` is a user action; code that goes through `ExternalOperator` is an external controller; everything else disappears into the background.
+
 | What you're doing | Use |
 |---|---|
 | Creating or modifying a custom resource | `ClusterUser` |
-| Reading a CR to assert on its status | `ClusterUser` |
+| Reading a CR to assert on its status conditions | `ClusterUser` |
+| Reading operator-managed resources (e.g. the proxy `ConfigMap` to verify virtual cluster config) | `ClusterUser` |
 | Simulating Strimzi or another external controller setting resource status | `ExternalOperator` |
 | Simulating a sibling Kroxylicious reconciler setting status on a resource the reconciler-under-test depends on | `ExternalOperator` |
-| Reading operator-managed resources (Deployments, ConfigMaps written by the reconciler) | `ClusterUser` |

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/README.md
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/README.md
@@ -1,24 +1,10 @@
 # Kroxylicious Operator Test Support
 
-JUnit Jupiter extensions and utilities for writing integration tests against the Kroxylicious operator.
-
-## Testing philosophy
-
-Operator integration tests involve three distinct actors, each with a different role:
-
-| Actor | Class | Role |
-|-------|-------|------|
-| **Operator under test** | `LocalKroxyliciousOperatorExtension` | The system being tested. Manages the full reconciler lifecycle: RBAC, namespace, CRDs, operator start/stop, and between-test cleanup. |
-| **Cluster user** | `ClusterUser` | Represents an end user interacting with the cluster — creating, updating, and deleting Kroxylicious custom resources. Scoped to the RBAC of a regular user, not the operator itself. |
-| **External operator** | `ExternalOperator` | Drives status state that a reconciler external to the one under test would normally produce. "External" includes both truly external controllers (e.g. Strimzi setting status on a `Kafka` resource) and sibling Kroxylicious reconcilers whose output the reconciler-under-test depends on. |
-
-Keeping these actors separate makes the intent of each test action legible: code that goes through `ClusterUser` is a user action; code that goes through `ExternalOperator` is a precondition being established by another controller.
+JUnit Jupiter extensions and utilities that implement the three-actor testing model for Kroxylicious operator integration tests. See the [operator README](../kroxylicious-operator/README.md) for the philosophy behind this model.
 
 ## Setting up an IT
 
-### Single-reconciler tests
-
-Register only the reconciler under test. Use `ExternalOperator` to supply the status state that sibling reconcilers would normally produce.
+Declare `LocalKroxyliciousOperatorExtension` as a static field and register the reconcilers under test. Obtain `ClusterUser` and `ExternalOperator` in `@BeforeEach`.
 
 ```java
 @EnabledIf(value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable",
@@ -38,32 +24,14 @@ class KafkaProxyReconcilerIT {
         clusterUser = operator.clusterUser();
         externalOperator = operator.externalOperator();
     }
-
-    @Test
-    void shouldSetReadyConditionOnValidProxy() {
-        // Given
-        KafkaProxy proxy = clusterUser.create(new KafkaProxyBuilder()
-                .withNewMetadata().withName("my-proxy").endMetadata()
-                .build());
-
-        // When / Then — reconciler sets the Ready condition
-        AWAIT.untilAsserted(() ->
-            assertThat(clusterUser.get(KafkaProxy.class, "my-proxy"))
-                .isNotNull()
-                .extracting(KafkaProxy::getStatus)
-                // ... assert conditions
-        );
-    }
 }
 ```
 
-### Multi-reconciler tests
+The `@EnabledIf` guard causes tests to skip gracefully when no cluster is reachable. `OperatorTestUtils.isKubeClientAvailable()` probes with a short timeout so it fails fast.
 
-To test reconcilers working together, register all of them. The `AllReconcilersIT` is the canonical example: it focuses on status conditions reported end-to-end, while the individual reconciler ITs test each reconciler's logic in depth.
+## Third-party CRDs
 
-### Third-party CRDs (e.g. Strimzi)
-
-If the reconciler under test watches a third-party CRD, install it via `withSetupAction` / `withTeardownAction` and register the CR type for between-test cleanup with `withAdditionalCleanupTypes`:
+If the reconciler under test watches a third-party CRD (e.g. Strimzi `Kafka`), install it via `withSetupAction` / `withTeardownAction` and register the CR type for between-test cleanup:
 
 ```java
 @RegisterExtension
@@ -89,20 +57,15 @@ static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorEx
 
 `LocalKroxyliciousOperatorExtension` manages state at two granularities:
 
-- **Per test class** (`@BeforeAll` / `@AfterAll`): RBAC setup, namespace creation, CRD application, operator startup, and final cleanup. The namespace and CRDs are shared across all tests in the class to avoid the overhead of per-test CRD deletion and re-application.
-- **Per test** (`@AfterEach`): all Kroxylicious CRs, Secrets, and ConfigMaps in the namespace are deleted between tests. Additional resource types registered via `withAdditionalCleanupTypes` are also deleted.
+- **Per test class** (`@BeforeAll` / `@AfterAll`): RBAC, namespace creation, CRD installation, operator startup, and final namespace teardown. The namespace and CRDs are shared across all tests in the class to avoid the cost of per-test CRD churn.
+- **Per test** (`@AfterEach`): all Kroxylicious CRs, Secrets, and ConfigMaps in the namespace are deleted. Additional types registered via `withAdditionalCleanupTypes` are also deleted.
 
-Obtain fresh `ClusterUser` and `ExternalOperator` instances in `@BeforeEach` — they are lightweight wrappers and safe to recreate each test.
+## What belongs in each actor
 
-## Skipping when no cluster is available
-
-Guard every IT class with `@EnabledIf` so tests skip gracefully on machines without a running Kubernetes cluster:
-
-```java
-@EnabledIf(
-    value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable",
-    disabledReason = "no viable kube client available"
-)
-```
-
-`OperatorTestUtils.isKubeClientAvailable()` probes the cluster with a short timeout so it fails fast rather than hanging.
+| What you're doing | Use |
+|---|---|
+| Creating or modifying a custom resource | `ClusterUser` |
+| Reading a CR to assert on its status | `ClusterUser` |
+| Simulating Strimzi or another external controller setting resource status | `ExternalOperator` |
+| Simulating a sibling Kroxylicious reconciler setting status on a resource the reconciler-under-test depends on | `ExternalOperator` |
+| Reading operator-managed resources (Deployments, ConfigMaps written by the reconciler) | `ClusterUser` |

--- a/kroxylicious-kubernetes/kroxylicious-operator/README.md
+++ b/kroxylicious-kubernetes/kroxylicious-operator/README.md
@@ -177,17 +177,19 @@ deployment.getMetadata().setOwnerReferences(List.of(
 
 ## Operator-Specific Testing
 
-**Unit tests** test reconciliation logic in isolation using Mockito or the fabric8 mock client, with no real Kubernetes cluster required.
+The operator has three layers of tests, each with a distinct scope.
 
-**Integration tests** run against a real cluster and are found in `src/test/java` classes ending in `IT`. They use the `kroxylicious-operator-test-support` module, which provides a three-actor model to keep test intent clear:
+**Unit tests** test one reconciler's logic in isolation — given this input resource, does the reconciler produce the right Kubernetes output? They run without a real cluster, using Mockito or the fabric8 mock client to stub API calls.
 
-- `LocalKroxyliciousOperatorExtension` — manages the operator lifecycle (RBAC, namespace, CRDs, start/stop, cleanup)
-- `ClusterUser` — performs user-side actions (creating and modifying CRs)
-- `ExternalOperator` — drives status state that a sibling or external reconciler would produce
+**Integration tests** (`*IT` classes) run against a real cluster and test that the reconciler interacts with Kubernetes correctly over time: does it set the right status conditions? does it react to resource changes? They use a three-actor model to keep test intent explicit:
 
-Single-reconciler ITs register only the reconciler under test and use `ExternalOperator` to supply any dependent state. `AllReconcilersIT` registers all reconcilers and focuses on end-to-end status conditions.
+- The **operator under test** is managed by `LocalKroxyliciousOperatorExtension`, which handles RBAC, namespace, CRD installation, and cleanup.
+- The **cluster user** (`ClusterUser`) represents an end user — it creates, modifies, and deletes custom resources. Code that goes through `ClusterUser` is a user action.
+- The **external operator** (`ExternalOperator`) drives status state that a reconciler outside the one under test would normally produce — either a sibling Kroxylicious reconciler or a truly external controller such as Strimzi. This ensures that dependent preconditions are exactly what the test needs without relying on other reconcilers to run.
 
-See [kroxylicious-operator-test-support/README.md](../kroxylicious-operator-test-support/README.md) for full documentation of the testing philosophy and setup patterns.
+Most ITs register only the single reconciler under test, using `ExternalOperator` to supply any dependent state produced by sibling reconcilers. `AllReconcilersIT` registers all reconcilers together and focuses on end-to-end status conditions — verifying that the reconcilers work correctly as a whole rather than testing each in depth.
+
+See [kroxylicious-operator-test-support/README.md](../kroxylicious-operator-test-support/README.md) for the module's API and setup patterns.
 
 **System tests** are end-to-end tests that run against a real Kafka cluster deployed via the operator. They live in a separate system-test module and verify full proxy behaviour — producing and consuming through a proxied cluster — rather than operator reconciliation logic in isolation.
 

--- a/kroxylicious-kubernetes/kroxylicious-operator/README.md
+++ b/kroxylicious-kubernetes/kroxylicious-operator/README.md
@@ -177,77 +177,17 @@ deployment.getMetadata().setOwnerReferences(List.of(
 
 ## Operator-Specific Testing
 
-**Unit tests:**
+**Unit tests** test reconciliation logic in isolation using Mockito or the fabric8 mock client, with no real Kubernetes cluster required.
 
-Test reconciliation logic in isolation:
+**Integration tests** run against a real cluster and are found in `src/test/java` classes ending in `IT`. They use the `kroxylicious-operator-test-support` module, which provides a three-actor model to keep test intent clear:
 
-```java
-@Test
-void testReconcileCreatesDeployment() {
-    var kafkaProxy = new KafkaProxyBuilder()
-            .withNewMetadata().withName("test").endMetadata()
-            .withNewSpec().withReplicas(2).endSpec()
-            .build();
+- `LocalKroxyliciousOperatorExtension` — manages the operator lifecycle (RBAC, namespace, CRDs, start/stop, cleanup)
+- `ClusterUser` — performs user-side actions (creating and modifying CRs)
+- `ExternalOperator` — drives status state that a sibling or external reconciler would produce
 
-    var controller = new KafkaProxyController(mockClient);
-    controller.reconcile(kafkaProxy, context);
+Single-reconciler ITs register only the reconciler under test and use `ExternalOperator` to supply any dependent state. `AllReconcilersIT` registers all reconcilers and focuses on end-to-end status conditions.
 
-    verify(mockClient.apps().deployments()).inNamespace(any())
-            .create(deploymentCaptor.capture());
-
-    var deployment = deploymentCaptor.getValue();
-    assertThat(deployment.getSpec().getReplicas()).isEqualTo(2);
-}
-```
-
-**Integration tests:**
-
-Use `kroxylicious-operator-test-support` for tests with real Kubernetes:
-
-```java
-@OperatorTest
-class KafkaProxyIT {
-    @RegisterExtension
-    static K3s k3s = new K3s();
-
-    @Test
-    void testProxyDeployment() {
-        var kafkaProxy = new KafkaProxyBuilder()
-                .withNewMetadata().withName("test").endMetadata()
-                .withNewSpec().withReplicas(1).endSpec()
-                .build();
-
-        client.resource(kafkaProxy).create();
-
-        // Wait for deployment to be ready
-        await().untilAsserted(() -> {
-            var deployment = client.apps().deployments()
-                    .inNamespace(namespace)
-                    .withName("test")
-                    .get();
-            assertThat(deployment).isNotNull();
-            assertThat(deployment.getStatus().getReadyReplicas()).isEqualTo(1);
-        });
-    }
-}
-```
-
-**System tests:**
-
-End-to-end tests with Kafka clusters:
-
-```java
-@SystemTest
-class ProxySystemTest {
-    @Test
-    void testProduceConsumeViaProxy() {
-        // Deploy Kafka cluster
-        // Deploy proxy via operator
-        // Produce/consume messages through proxy
-        // Verify filter behavior
-    }
-}
-```
+See [kroxylicious-operator-test-support/README.md](../kroxylicious-operator-test-support/README.md) for full documentation of the testing philosophy and setup patterns.
 
 ## Operator Lifecycle
 

--- a/kroxylicious-kubernetes/kroxylicious-operator/README.md
+++ b/kroxylicious-kubernetes/kroxylicious-operator/README.md
@@ -189,6 +189,8 @@ Single-reconciler ITs register only the reconciler under test and use `ExternalO
 
 See [kroxylicious-operator-test-support/README.md](../kroxylicious-operator-test-support/README.md) for full documentation of the testing philosophy and setup patterns.
 
+**System tests** are end-to-end tests that run against a real Kafka cluster deployed via the operator. They live in a separate system-test module and verify full proxy behaviour — producing and consuming through a proxied cluster — rather than operator reconciliation logic in isolation.
+
 ## Operator Lifecycle
 
 **Startup:**

--- a/kroxylicious-kubernetes/kroxylicious-operator/README.md
+++ b/kroxylicious-kubernetes/kroxylicious-operator/README.md
@@ -177,21 +177,21 @@ deployment.getMetadata().setOwnerReferences(List.of(
 
 ## Operator-Specific Testing
 
-The operator has three layers of tests, each with a distinct scope.
+The operator has three test layers, each documenting a wider scope of value. The technical characteristics of each layer follow from that scope — they are not the defining property.
 
-**Unit tests** test one reconciler's logic in isolation — given this input resource, does the reconciler produce the right Kubernetes output? They run without a real cluster, using Mockito or the fabric8 mock client to stub API calls.
+**Unit tests** document the value a single reconciler is responsible for: given these input resources, does it produce the correct Kubernetes output? The scope is one component's logic; the infrastructure around it is stubbed with Mockito or the fabric8 mock client because it is not part of the value claim.
 
-**Integration tests** (`*IT` classes) run against a real cluster and test that the reconciler interacts with Kubernetes correctly over time: does it set the right status conditions? does it react to resource changes? They use a three-actor model to keep test intent explicit:
+**Integration tests** (`*IT` classes) widen the scope to include the reconciler's interaction with a real Kubernetes cluster. The value claim now covers status propagation, resource watches, and eventual consistency — things that only manifest against a real API server. They use a three-actor model to keep test intent explicit:
 
 - The **operator under test** is managed by `LocalKroxyliciousOperatorExtension`, which handles RBAC, namespace, CRD installation, and cleanup.
 - The **cluster user** (`ClusterUser`) represents an end user — it creates, modifies, and deletes custom resources. Code that goes through `ClusterUser` is a user action.
 - The **external operator** (`ExternalOperator`) drives status state that a reconciler outside the one under test would normally produce — either a sibling Kroxylicious reconciler or a truly external controller such as Strimzi. This ensures that dependent preconditions are exactly what the test needs without relying on other reconcilers to run.
 
-Most ITs register only the single reconciler under test, using `ExternalOperator` to supply any dependent state produced by sibling reconcilers. `AllReconcilersIT` registers all reconcilers together and focuses on end-to-end status conditions — verifying that the reconcilers work correctly as a whole rather than testing each in depth.
+Most ITs register only the single reconciler under test, using `ExternalOperator` to supply any dependent state produced by sibling reconcilers. `AllReconcilersIT` registers all reconcilers together and widens the scope further — verifying that the reconcilers deliver their combined value correctly, rather than testing each in depth.
 
 See [kroxylicious-operator-test-support/README.md](../kroxylicious-operator-test-support/README.md) for the module's API and setup patterns.
 
-**System tests** are end-to-end tests that run against a real Kafka cluster deployed via the operator. They live in a separate system-test module and verify full proxy behaviour — producing and consuming through a proxied cluster — rather than operator reconciliation logic in isolation.
+**System tests** widen the scope to the full user-visible value: does the proxy, deployed by the operator, correctly proxy Kafka traffic end-to-end? They live in a separate system-test module and verify producing and consuming through a real proxied cluster.
 
 ## Operator Lifecycle
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Reframes our testing practices as being about executable specifications and providing narrative structure to tests for all readers.

Drawing on the BDD tradition (Given/When/Then, specification by example), the root README now establishes that tests document what the system is *supposed to do* — a failing test should reveal what value is broken, not what technical thing failed. Test layers are described as expanding scopes of value rather than by their technical characteristics.

The operator README replaces placeholder content with an accurate description of the three-layer approach and the three-actor model. The new `kroxylicious-operator-test-support` README explains the model for standalone readers and makes explicit that it is a convention for test *readers*, not a technical enforcement.

### Additional Context

Accompanies the operator test infrastructure refactor (#4085) which introduced `kroxylicious-operator-test-support` and the three-actor model. This documents the *why* so future contributors know what pattern to follow and why.

### Checklist

- [x] If making a user-facing change, documentation is provided — this PR *is* the documentation
- [x] Existing unit/integration/system tests passing
- [x] AI tools assisted — `Assisted-by:` trailers present in all commits