### PR TITLE
ci: publish SNAPSHOT artifacts on push to main and release branches

### DIFF
--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -1,0 +1,131 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+name: Publish SNAPSHOT
+
+# Publishes SNAPSHOT Maven artifacts to the Central Portal snapshot repository
+# on every push to main, so that external users can test pre-release changes
+# without building from source.
+#
+# The workflow is a no-op when the POM version does not end with -SNAPSHOT
+# (e.g. during the release process).
+#
+# Prerequisites:
+# - SNAPSHOT publishing must be enabled for the io.kroxylicious namespace on the
+#   Central Portal (https://central.sonatype.com/publishing/namespaces).
+#
+# It requires the following:
+# variables:
+# KROXYLICIOUS_SONATYPE_TOKEN_USERNAME        - Sonatype Access User Token Username
+# secrets:
+# KROXYLICIOUS_SONATYPE_TOKEN_PASSWORD        - Sonatype Access User Token Password
+#
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-snapshot:
+    runs-on: ubuntu-latest
+    if: github.repository == 'kroxylicious/kroxylicious'
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: 'Check out repository'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+
+      - name: 'Cache Maven packages'
+        uses: ./.github/actions/common/cache-maven-packages
+
+      - name: 'Set up Java'
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          java-version: 21
+          distribution: temurin
+          server-id: central
+          server-username: SONATYPE_TOKEN_USERNAME
+          server-password: SONATYPE_TOKEN_PASSWORD
+          overwrite-settings: true
+
+      - name: 'Determine project version'
+        id: version
+        run: |
+          PROJECT_VERSION=$(mvn --quiet help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "PROJECT_VERSION=${PROJECT_VERSION}" >> "$GITHUB_OUTPUT"
+          if [[ "${PROJECT_VERSION}" == *-SNAPSHOT ]]; then
+            echo "is_snapshot=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_snapshot=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 'Deploy snapshot'
+        if: steps.version.outputs.is_snapshot == 'true'
+        env:
+          SONATYPE_TOKEN_USERNAME: ${{ vars.KROXYLICIOUS_SONATYPE_TOKEN_USERNAME }}
+          SONATYPE_TOKEN_PASSWORD: ${{ secrets.KROXYLICIOUS_SONATYPE_TOKEN_PASSWORD }}
+        run: |
+          mvn --batch-mode \
+            -DskipTests \
+            -DskipDocs=true \
+            -Derrorprone.skip=true \
+            -P-qa \
+            -Pdist \
+            -DskipContainerImageBuild=true \
+            deploy
+
+      - name: 'Summary'
+        if: steps.version.outputs.is_snapshot == 'true'
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" << 'SUMMARY'
+          ## SNAPSHOT Published
+
+          **Version:** `${{ steps.version.outputs.PROJECT_VERSION }}`
+          **Commit:** `${{ github.sha }}`
+
+          ### Consumer configuration
+
+          Add the Central Portal snapshot repository to your `pom.xml` or `settings.xml`:
+
+          ```xml
+          <repositories>
+            <repository>
+              <id>central-snapshots</id>
+              <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+              <snapshots>
+                <enabled>true</enabled>
+              </snapshots>
+            </repository>
+          </repositories>
+          ```
+          SUMMARY
+
+      - name: 'Summary (skipped)'
+        if: steps.version.outputs.is_snapshot != 'true'
+        run: |
+          echo "## SNAPSHOT Publish Skipped" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Version \`${{ steps.version.outputs.PROJECT_VERSION }}\` does not end with \`-SNAPSHOT\`, nothing to publish." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Type of change

Enhancement / new feature

### Description

Adds a GitHub Actions workflow that automatically publishes SNAPSHOT Maven artifacts to the Central Portal snapshot repository on every push to main and `release/*` branches.

The workflow:
1. Reads the POM version
2. Skips the deploy if the version does not end with `-SNAPSHOT` (safe during the release process)
3. Deploys all Maven artifacts to the Central Portal snapshot repository
4. Writes a step summary with the published version and consumer configuration snippet

This is an alternative to #4107. Instead of a manually-triggered `workflow_dispatch` with date-stamped versions, this approach publishes the current POM SNAPSHOT version automatically on every push to main — zero effort, always up to date.

### Additional Context

An external user asked for a way to test changes from main without building from source or waiting for a scheduled release ([#4105](https://github.com/kroxylicious/kroxylicious/issues/4105)). This workflow provides continuous snapshot publishing so main is always available as a Maven dependency.

**Prerequisite:** A namespace admin must enable SNAPSHOT publishing for `io.kroxylicious` on the [Central Portal namespaces page](https://central.sonatype.com/publishing/namespaces) before first use.

### Checklist

- [x] New tests written (where applicable). _N/A — CI workflow only, no testable code._
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment). _N/A_
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too). _N/A — CI-only change._