### PR TITLE
fix(runtime): Convert micrometer definition configs to record to prevent StaticDiff error during HotReload

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/micrometer/CommonTagsHook.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/micrometer/CommonTagsHook.java
@@ -11,14 +11,10 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 
 import io.kroxylicious.proxy.plugin.Plugin;
-
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 @Plugin(configType = CommonTagsHook.CommonTagsHookConfig.class)
 public class CommonTagsHook implements MicrometerConfigurationHookService<CommonTagsHook.CommonTagsHookConfig> {
@@ -30,12 +26,9 @@ public class CommonTagsHook implements MicrometerConfigurationHookService<Common
         return new Hook(config);
     }
 
-    public static class CommonTagsHookConfig {
-        private final Map<String, String> commonTags;
-
-        @JsonCreator
-        public CommonTagsHookConfig(@Nullable Map<String, String> commonTags) {
-            this.commonTags = commonTags == null ? Map.of() : commonTags;
+    public record CommonTagsHookConfig(Map<String, String> commonTags) {
+        public CommonTagsHookConfig {
+            commonTags = commonTags == null ? Map.of() : commonTags;
         }
     }
 
@@ -51,7 +44,7 @@ public class CommonTagsHook implements MicrometerConfigurationHookService<Common
 
         @Override
         public void configure(MeterRegistry targetRegistry) {
-            List<Tag> tags = config.commonTags.entrySet().stream().map(entry -> Tag.of(entry.getKey(), entry.getValue())).toList();
+            List<Tag> tags = config.commonTags().entrySet().stream().map(entry -> Tag.of(entry.getKey(), entry.getValue())).toList();
             targetRegistry.config().commonTags(tags);
             log.atInfo()
                     .addKeyValue("tags", tags)

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/micrometer/CommonTagsHook.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/micrometer/CommonTagsHook.java
@@ -16,6 +16,8 @@ import io.micrometer.core.instrument.Tag;
 
 import io.kroxylicious.proxy.plugin.Plugin;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 @Plugin(configType = CommonTagsHook.CommonTagsHookConfig.class)
 public class CommonTagsHook implements MicrometerConfigurationHookService<CommonTagsHook.CommonTagsHookConfig> {
 
@@ -27,8 +29,8 @@ public class CommonTagsHook implements MicrometerConfigurationHookService<Common
     }
 
     public record CommonTagsHookConfig(Map<String, String> commonTags) {
-        public CommonTagsHookConfig {
-            commonTags = commonTags == null ? Map.of() : commonTags;
+        public CommonTagsHookConfig(@Nullable Map<String, String> commonTags) {
+            this.commonTags = commonTags == null ? Map.of() : commonTags;
         }
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/micrometer/PauseDetectorHook.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/micrometer/PauseDetectorHook.java
@@ -5,14 +5,11 @@
  */
 package io.kroxylicious.proxy.micrometer;
 
-import java.beans.ConstructorProperties;
 import java.time.Duration;
 import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.distribution.pause.ClockDriftPauseDetector;
@@ -32,7 +29,9 @@ public class PauseDetectorHook implements MicrometerConfigurationHookService<Pau
         return new Hook(config);
     }
 
-    public static class PauseDetectorHookConfig {
+    // The raw millisecond components are kept nullable so that "unset" is distinct from an explicit
+    // value for equality (used by reconfigure's static-section diff); the getters apply defaults.
+    public record PauseDetectorHookConfig(@Nullable Long sleepIntervalMs, @Nullable Long pauseThresholdMs) {
 
         // 100ms is the micrometer recommended default
         static final long DEFAULT_SLEEP_INTERVAL_MS = 100;
@@ -40,23 +39,12 @@ public class PauseDetectorHook implements MicrometerConfigurationHookService<Pau
         // 100ms is the micrometer recommended default
         static final long DEFAULT_PAUSE_THRESHOLD_MS = 100;
 
-        private final Duration sleepIntervalMs;
-
-        private final Duration pauseThresholdMs;
-
-        @JsonCreator
-        @ConstructorProperties({ "sleepIntervalMs", "pauseThresholdMs" })
-        public PauseDetectorHookConfig(final @Nullable Long sleepIntervalMs, final @Nullable Long pauseThresholdMs) {
-            this.sleepIntervalMs = Duration.ofMillis(sleepIntervalMs != null ? sleepIntervalMs : DEFAULT_SLEEP_INTERVAL_MS);
-            this.pauseThresholdMs = Duration.ofMillis(pauseThresholdMs != null ? pauseThresholdMs : DEFAULT_PAUSE_THRESHOLD_MS);
-        }
-
         public Duration getSleepInterval() {
-            return sleepIntervalMs;
+            return Duration.ofMillis(sleepIntervalMs != null ? sleepIntervalMs : DEFAULT_SLEEP_INTERVAL_MS);
         }
 
         public Duration getPauseThreshold() {
-            return pauseThresholdMs;
+            return Duration.ofMillis(pauseThresholdMs != null ? pauseThresholdMs : DEFAULT_PAUSE_THRESHOLD_MS);
         }
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/micrometer/StandardBindersHook.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/micrometer/StandardBindersHook.java
@@ -11,8 +11,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
@@ -29,8 +27,6 @@ import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
-
 @Plugin(configType = StandardBindersHook.StandardBindersHookConfig.class)
 public class StandardBindersHook implements MicrometerConfigurationHookService<StandardBindersHook.StandardBindersHookConfig> {
 
@@ -41,12 +37,9 @@ public class StandardBindersHook implements MicrometerConfigurationHookService<S
         return new Hook(config);
     }
 
-    public static class StandardBindersHookConfig {
-        private final List<String> binderNames;
-
-        @JsonCreator
-        public StandardBindersHookConfig(@Nullable List<String> binderNames) {
-            this.binderNames = binderNames == null ? List.of() : binderNames;
+    public record StandardBindersHookConfig(List<String> binderNames) {
+        public StandardBindersHookConfig {
+            binderNames = binderNames == null ? List.of() : binderNames;
         }
     }
 
@@ -64,7 +57,7 @@ public class StandardBindersHook implements MicrometerConfigurationHookService<S
 
         @Override
         public void configure(MeterRegistry targetRegistry) {
-            for (String binderName : this.config.binderNames) {
+            for (String binderName : this.config.binderNames()) {
                 MeterBinder binder = getBinder(binderName);
                 binder.bindTo(targetRegistry);
                 if (binder instanceof AutoCloseable closeable) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/micrometer/StandardBindersHook.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/micrometer/StandardBindersHook.java
@@ -27,6 +27,8 @@ import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 @Plugin(configType = StandardBindersHook.StandardBindersHookConfig.class)
 public class StandardBindersHook implements MicrometerConfigurationHookService<StandardBindersHook.StandardBindersHookConfig> {
 
@@ -38,8 +40,8 @@ public class StandardBindersHook implements MicrometerConfigurationHookService<S
     }
 
     public record StandardBindersHookConfig(List<String> binderNames) {
-        public StandardBindersHookConfig {
-            binderNames = binderNames == null ? List.of() : binderNames;
+        public StandardBindersHookConfig(@Nullable List<String> binderNames) {
+            this.binderNames = binderNames == null ? List.of() : binderNames;
         }
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/StaticSectionDifferTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/StaticSectionDifferTest.java
@@ -8,8 +8,13 @@ package io.kroxylicious.proxy.internal.reload;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.MicrometerDefinition;
@@ -24,10 +29,14 @@ import io.kroxylicious.proxy.config.VirtualClusterGateway;
 import io.kroxylicious.proxy.config.admin.EndpointsConfiguration;
 import io.kroxylicious.proxy.config.admin.ManagementConfiguration;
 import io.kroxylicious.proxy.config.admin.PrometheusMetricsConfig;
+import io.kroxylicious.proxy.micrometer.CommonTagsHook;
+import io.kroxylicious.proxy.micrometer.PauseDetectorHook;
+import io.kroxylicious.proxy.micrometer.StandardBindersHook;
 import io.kroxylicious.proxy.service.HostPort;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 class StaticSectionDifferTest {
 
@@ -56,6 +65,26 @@ class StaticSectionDifferTest {
                 new ManagementConfiguration(null, null, new EndpointsConfiguration(new PrometheusMetricsConfig())));
         var newConfig = withManagement(baseConfig(),
                 new ManagementConfiguration(null, null, new EndpointsConfiguration(new PrometheusMetricsConfig())));
+        assertThat(differ.diff(oldConfig, newConfig)).isEmpty();
+    }
+
+    static Stream<Arguments> equivalentHookConfigs() {
+        // Each supplier produces a fresh-but-equal plugin config instance, mimicking what re-parsing
+        // configuration yields. Covers every built-in micrometer hook config type.
+        return Stream.of(
+                argumentSet("CommonTagsHook", (Supplier<Object>) () -> new CommonTagsHook.CommonTagsHookConfig(Map.of("zone", "a"))),
+                argumentSet("StandardBindersHook", (Supplier<Object>) () -> new StandardBindersHook.StandardBindersHookConfig(List.of("UptimeMetrics"))),
+                argumentSet("PauseDetectorHook", (Supplier<Object>) () -> new PauseDetectorHook.PauseDetectorHookConfig(250L, 250L)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("equivalentHookConfigs")
+    void micrometerSectionsWithEquivalentHookConfigsDoNotDiff(Supplier<Object> configFactory) {
+        // Re-parsing configuration yields a fresh plugin config instance each time. Unless those
+        // plugin config types have value equality, the micrometer section would be flagged as a
+        // static change on every reconfigure of a proxy with micrometer hooks configured.
+        var oldConfig = withMicrometer(baseConfig(), List.of(new MicrometerDefinition("hook", configFactory.get())));
+        var newConfig = withMicrometer(baseConfig(), List.of(new MicrometerDefinition("hook", configFactory.get())));
         assertThat(differ.diff(oldConfig, newConfig)).isEmpty();
     }
 
@@ -175,6 +204,12 @@ class StaticSectionDifferTest {
     private static Configuration withManagement(Configuration base, ManagementConfiguration management) {
         return new Configuration(management, base.filterDefinitions(), base.defaultFilters(),
                 base.virtualClusters(), base.micrometer(),
+                base.useIoUring(), base.development(), base.network(), base.proxyProtocol());
+    }
+
+    private static Configuration withMicrometer(Configuration base, List<MicrometerDefinition> micrometer) {
+        return new Configuration(base.management(), base.filterDefinitions(), base.defaultFilters(),
+                base.virtualClusters(), micrometer,
                 base.useIoUring(), base.development(), base.network(), base.proxyProtocol());
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix


### Description

Static Diff is complaining about micrometer definition being changed during hot reload.
This is due to the fact that the micrometer.config is an Object without any equality checks, treating each new instance as unique.
This bug is similar to what we had in `PrometheusMetricsConfig`, which was fixed here https://github.com/kroxylicious/kroxylicious/pull/4125#discussion_r3420540481


### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
