### PR TITLE
Add Routing API and Configuration

### DIFF
--- a/kroxylicious-api/README.md
+++ b/kroxylicious-api/README.md
@@ -238,6 +238,43 @@ if (response == null) {
 return context.forwardResponse(response);
 ```
 
+## Router API
+
+### VirtualNode
+
+`VirtualNode` is an opaque reference type for node identity in the Router API. Routers obtain instances from `RouterContext` methods and pass them to `sendRequest()`. The type is intentionally opaque — routers must not inspect or construct instances directly.
+
+**Why opaque?** The integer-based port-per-broker networking model encodes route and target broker into a single int. An alternative networking model (where proxy instances act as brokers) needs richer routing information. `VirtualNode` hides this difference so routers work with either model unchanged.
+
+**Key methods on `RouterContext`:**
+- `virtualNode()` — the node the client connected to (empty for bootstrap)
+- `anyNode(route)` — an arbitrary node on a route (for discovery requests)
+- `nodeForId(int)` — converts a protocol integer (from METADATA, FIND_COORDINATOR responses) to a `VirtualNode`. This is the bridge between the Kafka wire protocol (integers) and the opaque API. Routers need this when interpreting node IDs in protocol response bodies — for example, when merging METADATA responses from multiple routes.
+- `sendRequest(node, header, request)` — sends to a specific node
+
+### TopologyService
+
+`TopologyService` is an opt-in topology cache for routers that need leader, coordinator, broker, or topic ID information. Routers obtain it from `RouterFactoryContext.topologyService()` during `RouterFactory.initialize()`. Routers that never call `topologyService()` pay no cost — no cache is created.
+
+**Cache population model:** The cache is populated as a **side effect** of METADATA responses flowing through the routing pipeline. When any request sent via `RouterContext.sendRequest()` produces a METADATA response, the runtime updates the topology cache before completing the router's `CompletionStage`. This means after a METADATA request's future completes, the cache is guaranteed to reflect that response.
+
+**Read-only queries (synchronous):**
+- `leaderOf(topicName, partitionIndex)` — cached partition leader
+- `coordinatorOf(route, keyType, key)` — cached coordinator
+- `partitionInfoFor(topicName, partitionIndex)` — leader + replicas + ISR (for follower-fetch)
+- `brokerInfo(node)` — host, port, rack (for AZ-aware routing)
+
+**Active methods (may send requests):**
+- `topicNames(Set<Uuid>)` — batched topic ID resolution
+- `ensureLeadersCached(Map<String, Set<String>>)` — batched leader cache warming
+- `discoverCoordinator(route, keyType, key)` — two-hop coordinator discovery (METADATA then FIND_COORDINATOR)
+
+**Invalidation:** `invalidateRoute(route)` performs coarse invalidation — clears all partition info, coordinators, and broker info for a route. Topic ID→name mappings are not cleared (they are stable within a cluster). The router calls this when it observes staleness indicators (e.g. `NOT_LEADER_OR_FOLLOWER`) in responses. No background refresh is fired — the client drives the refresh via its own METADATA request.
+
+**Why coarse invalidation?** A single `invalidateRoute()` replaces what would otherwise be `invalidateLeader()`, `invalidateCoordinator()`, `invalidateNode()`. Over-invalidation is acceptable because the cache is repopulated cheaply from the client's next METADATA request. This avoids an ever-growing set of invalidation methods as more cached entity types are added.
+
+**Why the router handles invalidation, not the runtime:** The runtime would need to deserialise an open-ended and growing set of response types to scan for error codes. Different error codes have different semantics. Routers that don't use the topology cache shouldn't pay the deserialisation cost.
+
 ## Cross-References
 
 - **Protocol contracts**: See [`../README.md#architecture`](../README.md#architecture)

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/Subject.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/Subject.java
@@ -30,14 +30,26 @@ public record Subject(Set<Principal> principals) {
 
     private static final Subject ANONYMOUS = new Subject(Set.of());
 
+    /**
+     * Returns the anonymous subject (no principals).
+     * @return the anonymous subject
+     */
     public static Subject anonymous() {
         return ANONYMOUS;
     }
 
+    /**
+     * Creates a subject from the given principals.
+     * @param principals the principals
+     */
     public Subject(Principal... principals) {
         this(Set.of(principals));
     }
 
+    /**
+     * Creates a subject from the given principal set. Validates that non-empty subjects have exactly one {@link User} principal.
+     * @param principals the principals
+     */
     public Subject(Set<Principal> principals) {
         principals.stream()
                 .collect(Collectors.groupingBy(Object::getClass))
@@ -55,10 +67,20 @@ public record Subject(Set<Principal> principals) {
         this.principals = Set.copyOf(principals);
     }
 
+    /**
+     * Returns the unique principal of the given type, if present.
+     * @param uniquePrincipalType the principal type, which must be annotated with {@link Unique}
+     * @param <P> the principal type
+     * @return the principal, or empty
+     */
     public <P extends Principal> Optional<P> uniquePrincipalOfType(Class<P> uniquePrincipalType) {
         return uniquePrincipalOfType(this.principals, uniquePrincipalType);
     }
 
+    /**
+     * Returns whether this is the anonymous subject.
+     * @return true if this subject has no principals
+     */
     public boolean isAnonymous() {
         return this.principals.isEmpty();
     }
@@ -75,6 +97,12 @@ public record Subject(Set<Principal> principals) {
         }
     }
 
+    /**
+     * Returns all principals of the given type.
+     * @param principalType the principal type
+     * @param <P> the principal type
+     * @return the matching principals
+     */
     public <P extends Principal> Set<P> allPrincipalsOfType(Class<P> principalType) {
         return this.principals.stream()
                 .filter(principalType::isInstance)

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/Tls.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/Tls.java
@@ -58,10 +58,19 @@ public record Tls(@Nullable KeyProvider key,
 
     public static final String PEM = "PEM";
 
+    /**
+     * Returns the store type, defaulting to the platform default if null.
+     * @param storeType the store type, or null for platform default
+     * @return the resolved store type in upper case
+     */
     public static String getStoreTypeOrPlatformDefault(@Nullable String storeType) {
         return storeType == null ? KeyStore.getDefaultType().toUpperCase(Locale.ROOT) : storeType.toUpperCase(Locale.ROOT);
     }
 
+    /**
+     * Returns whether a key provider is configured.
+     * @return true if a key provider is set
+     */
     public boolean definesKey() {
         return key != null;
     }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/TlsCredentialSupplierConfig.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/TlsCredentialSupplierConfig.java
@@ -32,6 +32,7 @@ public record TlsCredentialSupplierConfig(
                                           @PluginImplName(ServerTlsCredentialSupplierFactory.class) @JsonProperty(required = true) String type,
                                           @Nullable @PluginImplConfig(implNameProperty = "type") Object config) {
 
+    /** Validates that the type is non-null. */
     @JsonCreator
     public TlsCredentialSupplierConfig {
         Objects.requireNonNull(type, "TLS credential supplier type must not be null");

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/CloseOrTerminalStage.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/CloseOrTerminalStage.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.router;
+
+/**
+ * Combined stage of the {@link RouterContext} builder API that allows
+ * both closing the connection and building the result.
+ */
+public interface CloseOrTerminalStage extends TerminalStage, CloseStage {
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/CloseStage.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/CloseStage.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.router;
+
+/**
+ * Stage of the {@link RouterContext} builder API that allows
+ * requesting that the client connection be closed.
+ */
+public interface CloseStage {
+    /**
+     * Signals that the client connection should be closed after
+     * the result is delivered.
+     *
+     * @return the terminal stage
+     */
+    TerminalStage withCloseConnection();
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/Router.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/Router.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.router;
+
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+/**
+ * A router decides which route should handle a given incoming Kafka request.
+ *
+ * <p>Router implementations use the {@link RouterContext} to send requests
+ * down named routes and to deliver a response back to the client. A single
+ * incoming request may result in multiple outgoing requests to different
+ * routes (e.g. fan-out), with the router composing the final response.</p>
+ *
+ * <h2>Observability guidelines for router implementations</h2>
+ *
+ * <p>The runtime automatically logs and measures the following on behalf of
+ * all router implementations:</p>
+ * <ul>
+ *   <li>Which route each request was sent to (at TRACE level, with {@code route} key)</li>
+ *   <li>Request/response correlation</li>
+ *   <li>Per-route request counts, error counts, and latency (as Micrometer metrics)</li>
+ *   <li>Error conditions such as unknown routes and router failures</li>
+ * </ul>
+ *
+ * <p>Router implementations should <strong>not</strong> duplicate the above.
+ * Instead, implementations should log:</p>
+ * <ul>
+ *   <li><strong>Routing rationale at DEBUG:</strong> explain <em>why</em> a
+ *       particular route was chosen when the logic is non-trivial. Always
+ *       include {@link RouterContext#sessionId()} for correlation with
+ *       runtime logs.</li>
+ *   <li><strong>Configuration at INFO during initialisation:</strong> log once
+ *       from {@link RouterFactory#createRouter} to describe the router's
+ *       configuration.</li>
+ *   <li><strong>Response mutation at DEBUG:</strong> if the router modifies
+ *       responses (e.g. version capping in {@code API_VERSIONS}), log the
+ *       modification since it changes protocol behaviour visible to
+ *       clients.</li>
+ *   <li><strong>Recovered errors at WARN:</strong> if the router catches
+ *       exceptions internally and recovers, log them with conditional stack
+ *       traces (include the full stack trace only when DEBUG is enabled).</li>
+ * </ul>
+ *
+ * <p>Router implementations <strong>must not</strong>:</p>
+ * <ul>
+ *   <li>Log Kafka message content (may contain sensitive data).</li>
+ *   <li>Log at INFO or above on every request (reserve INFO+ for lifecycle
+ *       events; per-request logging at that level causes excessive volume
+ *       in production).</li>
+ * </ul>
+ */
+public interface Router {
+
+    /**
+     * Called for each incoming client request that is dynamically routed.
+     *
+     * <p>The implementation inspects the request, sends one or more requests
+     * via {@link RouterContext#sendRequest}, and returns a
+     * {@link RouterResponse} encoding the outcome. Use the builder methods on
+     * {@link RouterContext} to construct results:
+     * {@link RouterContext#respondWith(ApiMessage) respondWith} to deliver a
+     * response, {@link RouterContext#respondWithoutReply() respondWithoutReply}
+     * for acks=0 {@code Produce} requests, or
+     * {@link RouterContext#respondWithError respondWithError} to generate an
+     * error response.</p>
+     *
+     * <p><strong>Threading model</strong></p>
+     *
+     * <p>All invocations of this method, all calls to
+     * {@link RouterContext#sendRequest}, and all
+     * {@link CompletionStage} callbacks chained on the futures returned
+     * by {@code sendRequest}, execute on the same Netty event loop
+     * thread. Router implementations do not need to synchronise access
+     * to their own state.</p>
+     *
+     * @param apiKey the API key identifying the request type
+     * @param apiVersion the API version of the request
+     * @param header the request header
+     * @param request the request body
+     * @param context the router context for sending requests
+     * @return a stage that completes with the routing outcome
+     */
+    CompletionStage<RouterResponse> onRequest(ApiKeys apiKey,
+                                              short apiVersion,
+                                              RequestHeaderData header,
+                                              ApiMessage request,
+                                              RouterContext context);
+
+    /**
+     * Called by the runtime when the client connection is torn down.
+     *
+     * <p>Implementations should release any per-connection resources
+     * (e.g. reclaim cache slots).</p>
+     *
+     * <p>Guaranteed to be called on the same event loop thread as
+     * {@link #onRequest}. Called at most once per router instance.</p>
+     */
+    default void close() {
+    }
+
+    /**
+     * <p>Declares API keys that are always forwarded to a fixed named route
+     * without deserialisation. For these API keys the runtime forwards
+     * frames directly (opaque or decoded) without calling
+     * {@link #onRequest}. API keys absent from this map are
+     * considered dynamically routed and will be decoded so that
+     * {@code onRequest} can inspect them.</p>
+     *
+     * <p>This method may only be called once in the lifetime of a Router.
+     * The runtime is free to call it once and cache the result.</p>
+     *
+     * @return a map from API key to route name; empty means all API keys
+     *         are dynamically routed (the default)
+     */
+    default Map<ApiKeys, String> staticRoutes() {
+        return Map.of();
+    }
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterContext.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.router;
+
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.errors.ApiException;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import io.kroxylicious.proxy.authentication.Subject;
+import io.kroxylicious.proxy.topology.VirtualNode;
+
+/**
+ * Context passed to {@link Router#onRequest} for issuing requests
+ * to named routes and constructing the routing outcome.
+ *
+ * <p>A fresh instance is created for each {@link Router#onRequest}
+ * invocation. All methods on this interface, and all
+ * {@link java.util.concurrent.CompletionStage CompletionStage}
+ * callbacks chained on futures returned by {@link #sendRequest},
+ * execute on the same Netty event loop thread. Router implementations
+ * do not need to synchronise access to their own state.</p>
+ *
+ * <h2>Response delivery</h2>
+ *
+ * <p>The runtime automatically rewrites correlation IDs in responses
+ * to match the client's original request. Router implementations do
+ * not need to manage correlation IDs.</p>
+ *
+ * <h2>Error handling</h2>
+ *
+ * <p>If the {@code CompletionStage<RouterResponse>} returned by
+ * {@link Router#onRequest} completes exceptionally, or an unchecked
+ * exception escapes from {@code onRequest}, the runtime closes the
+ * client connection. For protocol-level errors (e.g. topic not found,
+ * authorization failure) routers should use
+ * {@link #respondWithError} rather than throwing.</p>
+ */
+public interface RouterContext {
+
+    /**
+     * Returns the virtual node of the broker that the client connected to.
+     *
+     * <p>When the client connected to a broker-specific endpoint (i.e. an
+     * address that corresponds to a particular broker in the cluster topology),
+     * this returns that broker's virtual node. The router can use this to
+     * send requests — such as {@code API_VERSIONS} — to the specific broker
+     * the client believes it is talking to, rather than an arbitrary broker.</p>
+     *
+     * <p>When the client connected to a bootstrap address, this returns empty,
+     * because the proxy does not know which broker the client intended.
+     * In that case the router should use {@link #anyNode(String)} to obtain
+     * a node for sending requests.</p>
+     *
+     * @return the virtual node if the client connected to a broker-specific
+     *         endpoint, or empty if the client connected to a bootstrap address
+     */
+    Optional<VirtualNode> virtualNode();
+
+    /**
+     * Returns a virtual node that, when passed to {@link #sendRequest},
+     * causes the runtime to send the request to an arbitrary broker on the
+     * named route's cluster.
+     *
+     * <p>This is used for initial discovery requests (e.g. {@code METADATA},
+     * {@code FIND_COORDINATOR}) before the router has learned the cluster
+     * topology, and for requests that are not broker-specific. The runtime
+     * selects which broker to use. Repeated calls with the same route
+     * may return different nodes.</p>
+     *
+     * @param route the name of the route
+     * @return a virtual node representing any broker on the route's cluster
+     * @throws IllegalArgumentException if the route name is not known
+     */
+    VirtualNode anyNode(String route);
+
+    /**
+     * Converts an integer node ID from a protocol response body into a
+     * {@link VirtualNode}.
+     *
+     * <p>This is the bridge between the Kafka wire protocol (which uses
+     * integer node IDs) and the {@code VirtualNode} API. Routers need this
+     * when interpreting node IDs in protocol messages — for example, broker
+     * node IDs in {@code METADATA} responses, coordinator node IDs in
+     * {@code FIND_COORDINATOR} responses, or leader IDs in partition
+     * metadata.</p>
+     *
+     * @param virtualNodeId the integer node ID from a protocol response
+     * @return the corresponding virtual node
+     */
+    VirtualNode nodeForId(int virtualNodeId);
+
+    /**
+     * Sends a request to a specific broker identified by virtual node.
+     *
+     * <p>The runtime derives the route from the virtual node and resolves
+     * it to a specific upstream broker address, opening a new connection if
+     * necessary. The returned stage completes when the broker produces a
+     * response.</p>
+     *
+     * <p>The {@code node} can be:</p>
+     * <ul>
+     *   <li>A value obtained from {@link #virtualNode()} — sends to the
+     *       broker the client connected to</li>
+     *   <li>A value obtained from {@link #anyNode(String)} — sends to an
+     *       arbitrary broker on a route</li>
+     *   <li>A value obtained from {@link #nodeForId(int)} — sends to a
+     *       broker whose ID was learned from a protocol response</li>
+     *   <li>A value obtained from
+     *       {@link io.kroxylicious.proxy.topology.TopologyService
+     *       TopologyService} discovery methods (e.g.
+     *       {@link io.kroxylicious.proxy.topology.PartitionLeaders#leaderOf
+     *       PartitionLeaders.leaderOf})</li>
+     * </ul>
+     *
+     * @param node the virtual node of the target broker
+     * @param header the request header
+     * @param request the request body
+     * @return a stage that completes with the response body from the broker
+     * @throws IllegalStateException if the upstream address for the node is
+     *         not yet known (metadata not yet reconciled)
+     */
+    CompletionStage<ApiMessage> sendRequest(
+                                            VirtualNode node,
+                                            RequestHeaderData header,
+                                            ApiMessage request);
+
+    /**
+     * Returns the unique identifier for the current proxy session.
+     *
+     * <p>The same session ID is observed for all routers (including
+     * nested routers) and filters that handle requests from a given
+     * client connection.</p>
+     *
+     * @return the unique identifier for the current proxy session
+     */
+    String sessionId();
+
+    /**
+     * <p>Returns the client subject.</p>
+     *
+     * <p>Depending on configuration, the subject can be based on network-level
+     * or Kafka protocol-level information (or both):</p>
+     * <ul>
+     *   <li>This will return an anonymous {@code Subject} (one with an empty
+     *   {@code principals} set) when no authentication is configured, or the
+     *   transport layer cannot provide authentication (e.g. TCP or non-mutual
+     *   TLS transports).</li>
+     *   <li>When client mutual TLS authentication is configured this will
+     *   initially return a non-anonymous {@code Subject} based on the TLS
+     *   certificate presented by the client.</li>
+     *   <li>Because of the possibility of <em>reauthentication</em> it is
+     *   also possible for the subject to change.</li>
+     * </ul>
+     *
+     * <p>Because the subject can change, callers are advised to avoid caching
+     * subjects, or decisions derived from them.</p>
+     *
+     * <p>Which principals are present in the returned subject, and what their
+     * {@code name}s look like, depends on the configuration of network and/or
+     * authentication filters. In general, routers should be configurable with
+     * respect to the principal type when interrogating the returned subject.</p>
+     *
+     * <p><strong>SASL filter placement:</strong>
+     * This value reflects authentication performed on the virtual cluster
+     * filter chain only. "SASL initiator" filters placed on per-route
+     * filter chains do <strong>not</strong> affect the subject returned here
+     * — those authenticate the proxy's outbound connection to the upstream
+     * cluster, not the client's identity.</p>
+     *
+     * @return the client subject
+     */
+    Subject authenticatedSubject();
+
+    /**
+     * Begins building a router response that delivers the given response
+     * body to the client. The runtime provides a response header.
+     *
+     * @param body the response body
+     * @return a stage that can optionally close the connection
+     */
+    CloseOrTerminalStage respondWith(ApiMessage body);
+
+    /**
+     * Begins building a router response that delivers a synthesised
+     * response to the client.
+     *
+     * @param header the response header
+     * @param body the response body
+     * @return a stage that can optionally close the connection
+     */
+    CloseOrTerminalStage respondWith(
+                                     ResponseHeaderData header,
+                                     ApiMessage body);
+
+    /**
+     * Begins building a router result that generates an error response
+     * for the client. The generated error response is API-specific.
+     *
+     * @param header the request header
+     * @param request the request body
+     * @param exception the exception that triggered the error
+     * @return a stage that can optionally close the connection
+     */
+    CloseOrTerminalStage respondWithError(
+                                          RequestHeaderData header,
+                                          ApiMessage request,
+                                          ApiException exception);
+
+    /**
+     * Begins building a router result for a fire-and-forget request
+     * where no response is delivered to the client (e.g. acks=0
+     * {@code PRODUCE}).
+     *
+     * @return a stage that can optionally close the connection
+     */
+    CloseOrTerminalStage respondWithoutReply();
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterFactory.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterFactory.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.router;
+
+import io.kroxylicious.proxy.plugin.PluginConfigurationException;
+
+import edu.umd.cs.findbugs.annotations.UnknownNullness;
+
+/**
+ * A pluggable source of {@link Router} instances.
+ *
+ * <p>RouterFactories are {@linkplain java.util.ServiceLoader service}
+ * implementations called by the proxy
+ * runtime to create router instances. Each {@code RouterFactory} instance
+ * is scoped to a single virtual cluster.</p>
+ *
+ * <p>The proxy runtime guarantees that:</p>
+ * <ol>
+ *   <li>instances will be {@linkplain #initialize initialized} before
+ *       any attempt to {@linkplain #createRouter create} router instances,</li>
+ *   <li>instances will eventually be {@linkplain #close closed} if and only
+ *       if they were successfully initialized,</li>
+ *   <li>no attempts to create router instances will be made once a
+ *       {@code RouterFactory} instance is closed,</li>
+ *   <li>instances will be initialized and closed on the same thread.</li>
+ * </ol>
+ *
+ * <p><strong>Per-connection router instances:</strong>
+ * {@link #createRouter} is called once per client connection, so each
+ * connection gets its own {@link Router} instance. Any state that must
+ * survive a client disconnect and reconnect (e.g. producer ID mappings)
+ * must be stored in the shared initialisation data {@code I}, not in
+ * the {@code Router} instance itself.</p>
+ *
+ * @param <C> the configuration type, deserialized from the router's
+ *           {@code config} property in the configuration file.
+ *           Use {@link Void} if not configurable.
+ * @param <I> the initialisation data type
+ */
+public interface RouterFactory<C, I> {
+
+    /**
+     * Initializes the factory with the given configuration.
+     *
+     * <p>Called once per virtual cluster. The returned initialisation data
+     * is shared across all {@link Router} instances created by
+     * {@link #createRouter} and <strong>must be thread-safe</strong>,
+     * since routers run on different Netty event loop threads.</p>
+     *
+     * @param context the factory context
+     * @param config the configuration
+     * @return initialisation data to be passed to {@link #createRouter}
+     * @throws PluginConfigurationException if the configuration is invalid
+     */
+    @UnknownNullness
+    I initialize(
+                 RouterFactoryContext context,
+                 @UnknownNullness C config)
+            throws PluginConfigurationException;
+
+    /**
+     * Creates a new router instance.
+     *
+     * <p>This may be called on a different thread from
+     * {@link #initialize} and {@link #close}.</p>
+     *
+     * @param context the factory context
+     * @param initializationData the data returned from {@link #initialize}
+     * @return a new router instance
+     */
+    Router createRouter(
+                        RouterFactoryContext context,
+                        @UnknownNullness I initializationData);
+
+    /**
+     * Releases resources associated with the given initialisation data.
+     *
+     * @param initializationData the data returned from {@link #initialize}
+     */
+    default void close(@UnknownNullness I initializationData) {
+    }
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterFactoryContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterFactoryContext.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.router;
+
+import java.util.Set;
+
+import io.kroxylicious.proxy.plugin.UnknownPluginInstanceException;
+import io.kroxylicious.proxy.topology.TopologyService;
+
+/**
+ * Context for {@link RouterFactory} initialisation and router creation,
+ * providing access to the plugin registry and router identity.
+ */
+public interface RouterFactoryContext {
+
+    /**
+     * Returns the name of the virtual cluster that owns this router.
+     *
+     * @return the virtual cluster name
+     */
+    String virtualClusterName();
+
+    /**
+     * Returns the name of this router, as declared in the router definition.
+     *
+     * @return the router name
+     */
+    String routerName();
+
+    /**
+     * Gets a plugin instance for the given plugin type and name.
+     *
+     * @param <P> the plugin type
+     * @param pluginClass the plugin class
+     * @param implementationName the plugin implementation name
+     * @return the plugin instance
+     * @throws UnknownPluginInstanceException if the named implementation is unknown
+     */
+    <P> P pluginInstance(Class<P> pluginClass, String implementationName);
+
+    /**
+     * Returns the names of the routes configured for this router.
+     *
+     * <p>These are the route names declared in the router definition,
+     * not route names that appear in the router's plugin configuration.
+     * Router implementations can use this during
+     * {@link RouterFactory#initialize} to validate that route names
+     * referenced in the plugin configuration actually exist.</p>
+     *
+     * @return an unmodifiable set of route names
+     */
+    Set<String> routeNames();
+
+    /**
+     * Returns the implementation names of the registered instances
+     * of the given plugin type.
+     *
+     * @param <P> the plugin type
+     * @param pluginClass the plugin class
+     * @return the set of known implementation names
+     */
+    <P> Set<String> pluginImplementationNames(Class<P> pluginClass);
+
+    /**
+     * Returns a {@link TopologyService} for this router level.
+     *
+     * <p>The runtime creates the underlying topology cache on first
+     * call and populates it from METADATA responses flowing through
+     * the routing pipeline. If no router at a level calls this method,
+     * no cache is created and no cost is incurred.</p>
+     *
+     * <p>When called during {@link RouterFactory#initialize}, this
+     * triggers cache creation as an opt-in side effect. The returned
+     * instance should <em>not</em> be stored in the factory's
+     * initialization data.</p>
+     *
+     * <p>When called during {@link RouterFactory#createRouter}, this
+     * returns a fresh per-connection instance backed by the shared
+     * cache. This is the instance the router should use for discovery
+     * methods ({@link TopologyService#leaders},
+     * {@link TopologyService#coordinators}, etc.).</p>
+     *
+     * @return the topology service for this router level
+     */
+    TopologyService topologyService();
+
+    /**
+     * Declares that this router supports routes targeting the same
+     * cluster.
+     *
+     * <p>By default, the runtime rejects configurations where two
+     * routes in the same router resolve to the same cluster (directly
+     * or transitively via nested routers), because most routers assume
+     * each route is a distinct destination and will produce incorrect
+     * results otherwise. Routers that handle this call this method
+     * during {@link RouterFactory#initialize} to suppress the
+     * check.</p>
+     */
+    void allowSharedClusterTargets();
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterResponse.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterResponse.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.router;
+
+import org.apache.kafka.common.protocol.ApiMessage;
+
+/**
+ * The outcome of {@link Router#onRequest} processing.
+ *
+ * <p>Instances are created via the builder methods on {@link RouterContext}:
+ * {@link RouterContext#respondWith(ApiMessage) respondWith},
+ * {@link RouterContext#respondWithError respondWithError}, and
+ * {@link RouterContext#respondWithoutReply() respondWithoutReply}.</p>
+ */
+public interface RouterResponse {
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/TerminalStage.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/TerminalStage.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.router;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Terminal stage of the {@link RouterContext} builder API.
+ */
+public interface TerminalStage {
+    /**
+     * Constructs the router result.
+     *
+     * @return router result
+     */
+    RouterResponse build();
+
+    /**
+     * Produces the router result contained within a completed {@link CompletionStage}.
+     *
+     * @return completion stage containing the router result
+     */
+    CompletionStage<RouterResponse> completed();
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/package-info.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * The router API.
+ *
+ * <p>A {@link io.kroxylicious.proxy.router.Router} is a plugin that decides which
+ * {@linkplain io.kroxylicious.proxy.router.RouterContext#sendRequest route}
+ * should handle a given incoming Kafka request. Routes lead to targets &mdash;
+ * either a backing Kafka cluster or another {@code Router}.
+ * The routers defined in a proxy configuration are validated at startup
+ * to ensure that all routes end in a defined target and to ensure the
+ * router graph is acyclic.</p>
+ *
+ * <p>Router implementations are discovered at runtime via
+ * {@link java.util.ServiceLoader} using
+ * {@link io.kroxylicious.proxy.router.RouterFactory} as the service type.</p>
+ */
+@ReturnValuesAreNonnullByDefault
+@DefaultAnnotationForParameters(NonNull.class)
+@DefaultAnnotation(NonNull.class)
+package io.kroxylicious.proxy.router;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotationForParameters;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/topology/BrokerInfo.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/topology/BrokerInfo.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.topology;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Broker metadata: host, port, and optional rack assignment.
+ *
+ * @param host the broker hostname
+ * @param port the broker port
+ * @param rack the rack assignment, or null if not configured
+ */
+public record BrokerInfo(String host, int port, @Nullable String rack) {}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/topology/Coordinators.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/topology/Coordinators.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.topology;
+
+import java.util.Optional;
+
+/**
+ * A snapshot of coordinator assignments, returned by
+ * {@link TopologyService#coordinators}.
+ *
+ * <p>This is a self-contained result — callers should use it
+ * directly rather than querying the topology cache separately.
+ * The key type is implicit (it was specified in the
+ * {@code coordinators()} call that produced this result).</p>
+ */
+public interface Coordinators {
+
+    /**
+     * Returns the coordinator for the given key, or empty if the
+     * coordinator was not discovered (e.g. the group or transaction
+     * does not exist, or the coordinator is unavailable).
+     *
+     * @param key the group or transaction ID
+     * @return the coordinator's virtual node, or empty
+     */
+    Optional<VirtualNode> coordinatorFor(String key);
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/topology/PartitionInfo.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/topology/PartitionInfo.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.topology;
+
+import java.util.List;
+
+/**
+ * Partition topology: leader, replicas, and in-sync replicas.
+ * All node references are virtual (already translated by the runtime).
+ *
+ * @param leader the partition leader
+ * @param replicas all replicas of this partition
+ * @param isr the in-sync replicas
+ */
+public record PartitionInfo(VirtualNode leader, List<VirtualNode> replicas, List<VirtualNode> isr) {
+    /** Defensive-copies the replica and ISR lists. */
+    public PartitionInfo {
+        replicas = List.copyOf(replicas);
+        isr = List.copyOf(isr);
+    }
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/topology/PartitionLeaders.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/topology/PartitionLeaders.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.topology;
+
+import java.util.Optional;
+
+/**
+ * A snapshot of partition leader assignments, returned by
+ * {@link TopologyService#leaders}.
+ *
+ * <p>This is a self-contained result — callers should use it
+ * directly rather than querying the topology cache separately.
+ * The snapshot is immutable and safe to use across async
+ * callback boundaries.</p>
+ */
+public interface PartitionLeaders {
+
+    /**
+     * Returns the leader for the given topic-partition, or empty
+     * if the leader was not discovered (e.g. the topic does not
+     * exist, or the partition has no leader).
+     *
+     * @param topicName the topic name
+     * @param partitionIndex the partition index
+     * @return the leader's virtual node, or empty
+     */
+    Optional<VirtualNode> leaderOf(String topicName, int partitionIndex);
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/topology/TopologyService.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/topology/TopologyService.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.topology;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.Uuid;
+
+/**
+ * Opt-in topology cache for routers that need leader, coordinator,
+ * broker, or topic ID information.
+ *
+ * <p>Routers that need topology information obtain a
+ * {@code TopologyService} from
+ * {@link io.kroxylicious.proxy.router.RouterFactoryContext#topologyService()} during
+ * {@link io.kroxylicious.proxy.router.RouterFactory#initialize}. The runtime creates the
+ * underlying cache on first request. Routers that never call
+ * {@code topologyService()} pay no cost.</p>
+ *
+ * <h2>Discovery methods</h2>
+ *
+ * <p>The three discovery methods — {@link #leaders}, {@link #coordinators},
+ * {@link #topicNames} — are async and return self-contained result
+ * objects. They may send requests internally to warm the cache
+ * (METADATA for leaders and topic names, FIND_COORDINATOR for
+ * coordinators). The results are valid immediately upon completion
+ * and do not require further cache queries.</p>
+ *
+ * <h2>Cache population</h2>
+ *
+ * <p>The cache is populated as a <b>side effect</b> of responses
+ * flowing through the routing pipeline:</p>
+ * <ul>
+ *   <li>METADATA responses populate partition leaders, replicas,
+ *       ISR, broker info, and topicId→name mappings.</li>
+ *   <li>FIND_COORDINATOR responses populate coordinator mappings,
+ *       using request-side context (keyType, key) carried by the
+ *       runtime's {@code PendingResponse}.</li>
+ * </ul>
+ * <p>By the time a discovery method's {@code CompletionStage}
+ * completes, the cache is guaranteed to reflect the response.</p>
+ *
+ * <h2>Cache scope</h2>
+ *
+ * <p>The cache is shared per router level (not per connection),
+ * so all connections through the same router level share the same
+ * topology view. The cache is thread-safe.</p>
+ *
+ * <h2>Authorization and cache scope</h2>
+ *
+ * <p>The topology cache is <b>not scoped by authenticated subject</b>.
+ * When Kafka brokers filter METADATA responses based on ACLs, different
+ * connections may receive different subsets of topics. Because the cache
+ * is shared, it converges toward the <b>union</b> of all connections'
+ * views: each METADATA response adds or updates entries for topics
+ * present in the response, but does not remove entries for topics
+ * absent from the response.</p>
+ *
+ * <p>This is safe because the cache is a <b>routing optimization</b>,
+ * not an access-control mechanism:</p>
+ * <ul>
+ *   <li>The cache stores <i>where</i> to send requests (partition
+ *       leaders, coordinator nodes, broker addresses), not <i>whether</i>
+ *       a client is authorized.</li>
+ *   <li>Backend brokers enforce ACLs on every request. A client that
+ *       resolves a leader from the cache but lacks permission to
+ *       produce or fetch will receive an authorization error from the
+ *       broker, exactly as it would without the proxy.</li>
+ *   <li>Cache misses trigger discovery requests on the current
+ *       connection's sender, which carries that connection's
+ *       authentication context. A low-privilege connection's filtered
+ *       METADATA response adds a subset of entries without corrupting
+ *       entries populated by other connections.</li>
+ * </ul>
+ *
+ * <p><b>Router authors must not use the topology cache for
+ * authorization decisions.</b> The cache may contain entries
+ * populated by connections with different privileges. Routers
+ * should use the cache only for routing (leader selection,
+ * coordinator discovery, broker address resolution) and rely on
+ * backend broker ACL enforcement for access control. If a router
+ * needs to make authorization decisions, it should use
+ * {@link io.kroxylicious.proxy.router.RouterContext#authenticatedSubject()}
+ * and consult an external authorization service.</p>
+ *
+ * <h2>Cache consistency and staleness</h2>
+ *
+ * <p>The cache uses <b>additive semantics</b>: responses add or
+ * update entries but never remove entries for topics absent from
+ * the response. The cache does not observe topic lifecycle events
+ * (deletion, recreation) independently — it only learns about
+ * cluster state from responses that flow through the proxy. Stale
+ * entries can therefore persist, for example partition leaders for a
+ * topic that has been deleted and recreated with different partition
+ * assignments.</p>
+ *
+ * <p>Staleness is safe because the cache is a <b>routing
+ * optimization</b>, not an authoritative source of cluster state.
+ * Stale routing decisions (including incorrect fan-out grouping)
+ * produce broker error codes ({@code NOT_LEADER_OR_FOLLOWER},
+ * {@code UNKNOWN_TOPIC_OR_PARTITION}), never silent misdirection
+ * or data corruption — the broker validates every request against
+ * its own authoritative state. Routers should treat these errors
+ * as staleness indicators and call {@link #invalidateRoute} to
+ * trigger cache repopulation from subsequent responses.</p>
+ */
+public interface TopologyService {
+
+    /**
+     * Discovers partition leaders for the given topics on the given
+     * routes, sending METADATA requests as needed. Uncached topics
+     * are batched into one METADATA request per route.
+     *
+     * <p>The returned {@link PartitionLeaders} is a self-contained
+     * snapshot — callers should use it directly rather than querying
+     * the cache separately.</p>
+     *
+     * @param topicsByRoute map from route name to set of topic names
+     * @return a stage that completes with the discovered leaders
+     */
+    CompletionStage<PartitionLeaders> leaders(Map<String, Set<String>> topicsByRoute);
+
+    /**
+     * Discovers coordinators for the given keys on the given route,
+     * sending METADATA (if needed) then FIND_COORDINATOR. Supports
+     * batched lookup matching the FIND_COORDINATOR v4+ protocol.
+     *
+     * <p>The returned {@link Coordinators} is a self-contained
+     * snapshot — callers should use it directly rather than querying
+     * the cache separately.</p>
+     *
+     * @param route the route name
+     * @param keyType 0 for group, 1 for transaction
+     * @param keys the group or transaction IDs to discover
+     * @return a stage that completes with the discovered coordinators
+     */
+    CompletionStage<Coordinators> coordinators(String route, byte keyType, Set<String> keys);
+
+    /**
+     * Resolves topic IDs to topic names for a given route, batching
+     * cache misses into a single METADATA request.
+     *
+     * <p>The route parameter is required because per-route filter
+     * chains can transform topic names differently — the same
+     * cluster-level topic ID can map to different router-visible
+     * names on different routes.</p>
+     *
+     * <p>Returns a map containing an entry for each topic ID that
+     * was successfully resolved. Topic IDs that could not be resolved
+     * (e.g. deleted topics) are absent from the returned map.</p>
+     *
+     * @param route the route to resolve names for
+     * @param topicIds the topic IDs to resolve
+     * @return a stage that completes with the resolved mappings
+     */
+    CompletionStage<Map<Uuid, String>> topicNames(String route, Set<Uuid> topicIds);
+
+    /**
+     * Returns full partition info (leader, replicas, ISR) for a
+     * topic-partition, or empty if not cached.
+     *
+     * <p>This is a supplementary lookup for use cases like
+     * follower-fetch / AZ-aware routing where the router needs
+     * replica and rack information beyond what {@link PartitionLeaders}
+     * provides. If this returns empty, the router can fall back to
+     * the leader from {@link PartitionLeaders}.</p>
+     *
+     * @param topicName the topic name
+     * @param partitionIndex the partition index
+     * @return the partition info, or empty if not cached
+     */
+    Optional<PartitionInfo> partitionInfo(String topicName, int partitionIndex);
+
+    /**
+     * Returns broker metadata (host, port, rack) for a virtual node,
+     * or empty if not cached.
+     *
+     * @param node the virtual node
+     * @return the broker info, or empty if not cached
+     */
+    Optional<BrokerInfo> brokerInfo(VirtualNode node);
+
+    /**
+     * Coarse invalidation: clears all partition info, coordinators,
+     * broker info, and topic ID to name mappings for a route.
+     *
+     * <p>Topic ID to name mappings for the route are also cleared,
+     * because per-route filter chains can present different names
+     * for the same underlying cluster topic.</p>
+     *
+     * <p>Called by the router when it observes staleness indicators
+     * (e.g. {@code NOT_LEADER_OR_FOLLOWER}, {@code NOT_COORDINATOR})
+     * in responses. No background refresh is fired — the client
+     * drives the refresh via its own METADATA request, which
+     * repopulates the cache as a side effect.</p>
+     *
+     * @param route the route to invalidate
+     */
+    void invalidateRoute(String route);
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/topology/VirtualNode.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/topology/VirtualNode.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.topology;
+
+/**
+ * Opaque reference to a node in the virtual cluster topology.
+ *
+ * <p>Routers obtain {@code VirtualNode} instances from
+ * {@link io.kroxylicious.proxy.router.RouterContext RouterContext} methods and pass them back to
+ * {@link io.kroxylicious.proxy.router.RouterContext#sendRequest RouterContext.sendRequest}. Implementations provide
+ * {@code equals}/{@code hashCode} so that {@code VirtualNode}
+ * instances can be used as map keys.</p>
+ *
+ * <p>This type is intentionally opaque — routers should not
+ * inspect or construct instances directly. The runtime provides
+ * the implementation.</p>
+ */
+public interface VirtualNode {
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/topology/package-info.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/topology/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * Topology types: cluster structure, node identity, and topology
+ * caching for routers (and potentially filters).
+ */
+@ReturnValuesAreNonnullByDefault
+@DefaultAnnotationForParameters(NonNull.class)
+@DefaultAnnotation(NonNull.class)
+package io.kroxylicious.proxy.topology;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotationForParameters;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/config/ConfigurationTest.java
@@ -590,15 +590,7 @@ class ConfigurationTest {
                 new NamedFilterDefinition("foo", "", ""));
         Optional<Map<String, Object>> development = Optional.empty();
         var virtualCluster = List.of(VIRTUAL_CLUSTER);
-        assertThatThrownBy(() -> new Configuration(null,
-                filterDefinitions,
-                null,
-                virtualCluster,
-                null,
-                false,
-                development,
-                null,
-                null))
+        assertThatThrownBy(() -> new Configuration(null, null, filterDefinitions, null, null, virtualCluster, null, false, development, null, null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("'filterDefinitions' contains multiple items with the same names: [foo]");
     }
@@ -609,14 +601,7 @@ class ConfigurationTest {
         List<NamedFilterDefinition> filterDefinitions = List.of();
         List<String> defaultFilters = List.of("missing");
         var virtualCluster = List.of(VIRTUAL_CLUSTER);
-        assertThatThrownBy(() -> new Configuration(null, filterDefinitions,
-                defaultFilters,
-                virtualCluster,
-                null,
-                false,
-                development,
-                null,
-                null))
+        assertThatThrownBy(() -> new Configuration(null, null, filterDefinitions, defaultFilters, null, virtualCluster, null, false, development, null, null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("'defaultFilters' references filters not defined in 'filterDefinitions': [missing]");
     }
@@ -629,15 +614,7 @@ class ConfigurationTest {
         TargetCluster targetCluster = new TargetCluster("unused:9082", Optional.empty());
         List<VirtualCluster> virtualClusters = List
                 .of(new VirtualCluster("vc1", targetCluster, defaultGateway, false, false, List.of("missing")));
-        assertThatThrownBy(() -> new Configuration(
-                null,
-                filterDefinitions,
-                null,
-                virtualClusters,
-                null, false,
-                development,
-                null,
-                null))
+        assertThatThrownBy(() -> new Configuration(null, null, filterDefinitions, null, null, virtualClusters, null, false, development, null, null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("'virtualClusters.vc1.filters' references filters not defined in 'filterDefinitions': [missing]");
     }
@@ -656,15 +633,7 @@ class ConfigurationTest {
         List<VirtualClusterGateway> defaultGateway = List.of(VIRTUAL_CLUSTER_GATEWAY);
         TargetCluster targetCluster = new TargetCluster("unused:9082", Optional.empty());
         List<VirtualCluster> virtualClusters = List.of(new VirtualCluster("vc1", targetCluster, defaultGateway, false, false, List.of("used2")));
-        assertThatThrownBy(() -> new Configuration(null,
-                filterDefinitions,
-                defaultFilters,
-                virtualClusters,
-                null,
-                false,
-                development,
-                null,
-                null))
+        assertThatThrownBy(() -> new Configuration(null, null, filterDefinitions, defaultFilters, null, virtualClusters, null, false, development, null, null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage(
                         "'filterDefinitions' defines filters which are not used in 'defaultFilters', in any virtual cluster's 'filters', or in any route's 'filters': [unused]");
@@ -680,16 +649,8 @@ class ConfigurationTest {
         VirtualCluster direct = buildVirtualCluster("direct", "y:9092", List.of("foo")); // filters defined on cluster
         VirtualCluster defaulted = buildVirtualCluster("defaulted", "x:9092", null); // filters not defined => should default to the top level
 
-        Configuration configuration = new Configuration(
-                null,
-                filterDefinitions,
-                List.of("bar"),
-                List.of(direct, defaulted),
-                null,
-                false,
-                Optional.empty(),
-                null,
-                null);
+        Configuration configuration = new Configuration(null, null, filterDefinitions, List.of("bar"), null, List.of(direct, defaulted), null, false, Optional.empty(),
+                null, null);
 
         // When
         var model = configuration.virtualClusterModel(null);
@@ -705,37 +666,29 @@ class ConfigurationTest {
 
     @Test
     void proxyProtocolModeShouldReturnRequiredWhenRequired() {
-        Configuration configuration = new Configuration(null, null, null,
-                List.of(buildVirtualCluster("vc", "x:9092", null)),
-                null, false, Optional.empty(), null,
-                new ProxyProtocolConfig(ProxyProtocolMode.REQUIRED));
+        Configuration configuration = new Configuration(null, null, null, null, null, List.of(buildVirtualCluster("vc", "x:9092", null)), null, false, Optional.empty(),
+                null, new ProxyProtocolConfig(ProxyProtocolMode.REQUIRED));
         assertThat(configuration.proxyProtocolMode()).isEqualTo(ProxyProtocolMode.REQUIRED);
     }
 
     @Test
     void proxyProtocolModeShouldReturnAllowedWhenAllowed() {
-        Configuration configuration = new Configuration(null, null, null,
-                List.of(buildVirtualCluster("vc", "x:9092", null)),
-                null, false, Optional.empty(), null,
-                new ProxyProtocolConfig(ProxyProtocolMode.ALLOWED));
+        Configuration configuration = new Configuration(null, null, null, null, null, List.of(buildVirtualCluster("vc", "x:9092", null)), null, false, Optional.empty(),
+                null, new ProxyProtocolConfig(ProxyProtocolMode.ALLOWED));
         assertThat(configuration.proxyProtocolMode()).isEqualTo(ProxyProtocolMode.ALLOWED);
     }
 
     @Test
     void proxyProtocolModeShouldReturnDisabledWhenDisabled() {
-        Configuration configuration = new Configuration(null, null, null,
-                List.of(buildVirtualCluster("vc", "x:9092", null)),
-                null, false, Optional.empty(), null,
-                new ProxyProtocolConfig(ProxyProtocolMode.DISABLED));
+        Configuration configuration = new Configuration(null, null, null, null, null, List.of(buildVirtualCluster("vc", "x:9092", null)), null, false, Optional.empty(),
+                null, new ProxyProtocolConfig(ProxyProtocolMode.DISABLED));
         assertThat(configuration.proxyProtocolMode()).isEqualTo(ProxyProtocolMode.DISABLED);
     }
 
     @Test
     void proxyProtocolDefaultsToDisabledWhenNull() {
-        Configuration configuration = new Configuration(null, null, null,
-                List.of(buildVirtualCluster("vc", "x:9092", null)),
-                null, false, Optional.empty(), null,
-                null);
+        Configuration configuration = new Configuration(null, null, null, null, null, List.of(buildVirtualCluster("vc", "x:9092", null)), null, false, Optional.empty(),
+                null, null);
         assertThat(configuration.proxyProtocolMode()).isEqualTo(ProxyProtocolMode.DISABLED);
     }
 

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/testing/integration/config/ConfigurationTest.java
@@ -666,7 +666,8 @@ class ConfigurationTest {
                 null,
                 null))
                 .isInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("'filterDefinitions' defines filters which are not used in 'defaultFilters' or in any virtual cluster's 'filters': [unused]");
+                .hasMessage(
+                        "'filterDefinitions' defines filters which are not used in 'defaultFilters', in any virtual cluster's 'filters', or in any route's 'filters': [unused]");
     }
 
     @Test

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGenerator.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGenerator.java
@@ -127,16 +127,7 @@ class ProxyConfigGenerator {
                 ? filterDefs.stream().map(NamedFilterDefinition::name).toList()
                 : null;
 
-        var configuration = new Configuration(
-                management,
-                filterDefs,
-                defaultFilters,
-                List.of(virtualCluster),
-                null,
-                false,
-                Optional.empty(),
-                null,
-                null);
+        var configuration = new Configuration(management, null, filterDefs, defaultFilters, null, List.of(virtualCluster), null, false, Optional.empty(), null, null);
 
         return toYaml(configuration);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/assertj/OperatorAssertionsTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/assertj/OperatorAssertionsTest.java
@@ -91,23 +91,15 @@ class OperatorAssertionsTest {
     @Test
     void shouldReturnConfigurationAssert() {
         // Given
-        var configurations = new Configuration(null,
-                List.of(),
-                List.of(),
-                List.of(new VirtualCluster("Bob",
-                        new TargetCluster("", Optional.empty()),
-                        List.of(new VirtualClusterGateway("gateway",
-                                new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9090), null, null, List.of()),
-                                null,
-                                Optional.empty())),
-                        false,
-                        false,
-                        List.of())),
-                List.of(),
+        var configurations = new Configuration(null, null, List.of(), List.of(), null, List.of(new VirtualCluster("Bob",
+                new TargetCluster("", Optional.empty()),
+                List.of(new VirtualClusterGateway("gateway",
+                        new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9090), null, null, List.of()),
+                        null,
+                        Optional.empty())),
                 false,
-                Optional.empty(),
-                null,
-                null);
+                false,
+                List.of())), List.of(), false, Optional.empty(), null, null);
 
         // When
         Assert<?, ?> actualAssertion = OperatorAssertions.assertThat(configurations);

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/assertj/ProxyConfigAssertTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/assertj/ProxyConfigAssertTest.java
@@ -29,7 +29,7 @@ class ProxyConfigAssertTest {
         VirtualCluster virtualCluster = new VirtualCluster("cluster", new TargetCluster("localhost:9092", Optional.empty()),
                 List.of(virtualClusterGateway), false,
                 false, List.of());
-        Configuration config = new Configuration(null, null, null, List.of(virtualCluster), List.of(), false, Optional.empty(), null, null);
+        Configuration config = new Configuration(null, null, null, null, null, List.of(virtualCluster), List.of(), false, Optional.empty(), null, null);
 
         Assertions.assertThatThrownBy(() -> {
             OperatorAssertions.assertThat(config).cluster("arbitrary");
@@ -44,7 +44,7 @@ class ProxyConfigAssertTest {
         VirtualCluster virtualCluster = new VirtualCluster(clusterName, new TargetCluster("localhost:9092", Optional.empty()),
                 List.of(virtualClusterGateway), false,
                 false, List.of());
-        Configuration config = new Configuration(null, null, null, List.of(virtualCluster), List.of(), false, Optional.empty(), null, null);
+        Configuration config = new Configuration(null, null, null, null, null, List.of(virtualCluster), List.of(), false, Optional.empty(), null, null);
 
         ProxyConfigAssert.ProxyConfigClusterAssert cluster = OperatorAssertions.assertThat(config).cluster(clusterName);
         Assertions.assertThat(cluster.actual()).isNotNull().isSameAs(virtualCluster);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconciler.java
@@ -215,16 +215,8 @@ public class KafkaProxyReconciler implements
                 .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(VolumeMount::getMountPath).reversed())));
 
         return new ConfigurationFragment<>(
-                new Configuration(
-                        new ManagementConfiguration(null, null, new EndpointsConfiguration(new PrometheusMetricsConfig())),
-                        referencedFilters,
-                        null, // no defaultFilters <= each of the virtualClusters specifies its own
-                        virtualClusters.stream().map(ConfigurationFragment::fragment).toList(),
-                        List.of(),
-                        false,
-                        // micrometer
-                        Optional.empty(),
-                        NetworkDefinitionBuilder.build(proxy),
+                new Configuration(new ManagementConfiguration(null, null, new EndpointsConfiguration(new PrometheusMetricsConfig())), null, referencedFilters, null, null,
+                        virtualClusters.stream().map(ConfigurationFragment::fragment).toList(), List.of(), false, Optional.empty(), NetworkDefinitionBuilder.build(proxy),
                         null),
                 allVolumes,
                 allMounts);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/NetworkDefinitionBuilderTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/NetworkDefinitionBuilderTest.java
@@ -13,7 +13,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
+import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.config.NettySettings;
 import io.kroxylicious.proxy.config.NetworkDefinition;
 
@@ -261,5 +264,15 @@ class NetworkDefinitionBuilderTest {
         assertThatThrownBy(() -> NetworkDefinitionBuilder.build(proxy))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("not-a-duration");
+    }
+
+    @Test
+    void serializesDeterministically() throws JsonProcessingException {
+        NettySettings management = new NettySettings(Optional.of(1), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        NettySettings proxy = new NettySettings(Optional.of(2), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        NetworkDefinition networkDefinition = new NetworkDefinition(management, proxy);
+        String a = ConfigParser.createBaseObjectMapper().writeValueAsString(networkDefinition);
+        String b = ConfigParser.createBaseObjectMapper().writeValueAsString(networkDefinition);
+        assertThat(b).isEqualTo(a);
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/ClusterDefinition.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/ClusterDefinition.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.kroxylicious.proxy.config.tls.Tls;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * A named cluster definition, referenced by routes and virtual clusters.
+ *
+ * @param name unique name for this cluster
+ * @param bootstrapServers comma-separated list of host:port pairs
+ * @param tls optional TLS configuration for the upstream connection
+ */
+public record ClusterDefinition(
+                                @JsonProperty(required = true) String name,
+                                @JsonProperty(required = true) String bootstrapServers,
+                                @Nullable Tls tls) {
+
+    @JsonCreator
+    public ClusterDefinition {
+        Objects.requireNonNull(name, "'name' is required in a cluster definition");
+        Objects.requireNonNull(bootstrapServers, "'bootstrapServers' is required in a cluster definition");
+        bootstrapServers = bootstrapServers.replaceAll("\\s", "");
+    }
+
+    /**
+     * Converts this definition to a {@link TargetCluster} for use in the runtime.
+     */
+    public TargetCluster toTargetCluster() {
+        return new TargetCluster(bootstrapServers, Optional.ofNullable(tls));
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -33,6 +33,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * <br>
  *
  * @param management management configuration
+ * @param clusterDefinitions Named target cluster definitions, referenced by virtual clusters via {@code target.cluster}.
  * @param filterDefinitions A list of named filter definitions (names must be unique)
  * @param defaultFilters The names of the {@link #filterDefinitions()} to be use when a {@link VirtualCluster} doesn't specify its own {@link VirtualCluster#filters()}.
  * @param virtualClusters The virtual clusters
@@ -42,9 +43,11 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * @param network Controls aspects of network configuration for the proxy.
  * @param proxyProtocol PROXY protocol configuration.
  */
-@JsonPropertyOrder({ "management", "filterDefinitions", "defaultFilters", "virtualClusters", "micrometer", "useIoUring", "development", "network", "proxyProtocol" })
+@JsonPropertyOrder({ "management", "clusterDefinitions", "filterDefinitions", "defaultFilters", "virtualClusters", "micrometer", "useIoUring", "development", "network",
+        "proxyProtocol" })
 public record Configuration(
                             @Nullable ManagementConfiguration management,
+                            @Nullable List<ClusterDefinition> clusterDefinitions,
                             @Nullable List<NamedFilterDefinition> filterDefinitions,
                             @Nullable List<String> defaultFilters,
                             @JsonProperty(required = true) List<VirtualCluster> virtualClusters,
@@ -57,6 +60,22 @@ public record Configuration(
     private static final Logger LOGGER = LoggerFactory.getLogger(Configuration.class);
 
     /**
+     * Convenience constructor matching main branch signature, setting {@code clusterDefinitions} to {@code null}.
+     */
+    public Configuration(
+                         @Nullable ManagementConfiguration management,
+                         @Nullable List<NamedFilterDefinition> filterDefinitions,
+                         @Nullable List<String> defaultFilters,
+                         List<VirtualCluster> virtualClusters,
+                         @Nullable List<MicrometerDefinition> micrometer,
+                         boolean useIoUring,
+                         Optional<Map<String, Object>> development,
+                         @Nullable NetworkDefinition network,
+                         @Nullable ProxyProtocolConfig proxyProtocol) {
+        this(management, null, filterDefinitions, defaultFilters, virtualClusters, micrometer, useIoUring, development, network, proxyProtocol);
+    }
+
+    /**
      * Creates an instance of configuration.
      *
      */
@@ -67,6 +86,8 @@ public record Configuration(
         }
 
         validateNoDuplicatedClusterNames(virtualClusters);
+        Set<String> targetClusterNames = validateClusterDefinitions(clusterDefinitions);
+        validateVirtualClusterNamedTargets(virtualClusters, targetClusterNames);
 
         // Enforce post condition: filterDefinitions have a unique name
         if (filterDefinitions != null) {
@@ -76,15 +97,38 @@ public record Configuration(
                 throw new IllegalConfigurationException("'filterDefinitions' contains multiple items with the same names: " + duplicatedNames);
             }
 
-            // Enforce post condition: Every filter referenced by a name is defined in the filterDefinitions
-            Set<String> filterDefsByName = Optional.ofNullable(filterDefinitions).orElse(List.of()).stream().map(NamedFilterDefinition::name).collect(
-                    Collectors.toSet());
+            Set<String> filterDefsByName = filterDefinitions.stream().map(NamedFilterDefinition::name).collect(Collectors.toSet());
             checkNamedFiltersAreDefined(filterDefsByName, defaultFilters, "defaultFilters");
             for (var virtualCluster : virtualClusters) {
                 checkNamedFiltersAreDefined(filterDefsByName, virtualCluster.filters(), "virtualClusters." + virtualCluster.name() + ".filters");
             }
 
             checkAllNamedFilterAreUsed(filterDefinitions, virtualClusters, defaultFilters);
+        }
+    }
+
+    private static Set<String> validateClusterDefinitions(@Nullable List<ClusterDefinition> clusterDefinitions) {
+        if (clusterDefinitions == null || clusterDefinitions.isEmpty()) {
+            return Set.of();
+        }
+        var names = clusterDefinitions.stream().map(ClusterDefinition::name).toList();
+        var duplicates = names.stream()
+                .filter(n -> Collections.frequency(names, n) > 1)
+                .collect(Collectors.toSet());
+        if (!duplicates.isEmpty()) {
+            throw new IllegalConfigurationException(
+                    "'clusterDefinitions' contains duplicate names: " + duplicates);
+        }
+        return new HashSet<>(names);
+    }
+
+    private static void validateVirtualClusterNamedTargets(List<VirtualCluster> virtualClusters,
+                                                           Set<String> targetClusterNames) {
+        for (var vc : virtualClusters) {
+            if (vc.namedTargetCluster() != null && !targetClusterNames.contains(vc.namedTargetCluster())) {
+                throw new IllegalConfigurationException(
+                        "Virtual cluster '" + vc.name() + "' references unknown target cluster '" + vc.namedTargetCluster() + "'");
+            }
         }
     }
 
@@ -132,12 +176,13 @@ public record Configuration(
         }
     }
 
-    private static VirtualClusterModel toVirtualClusterModel(VirtualCluster virtualCluster,
-                                                             List<NamedFilterDefinition> filterDefinitions,
-                                                             PluginFactoryRegistry pfr) {
+    private VirtualClusterModel toVirtualClusterModel(VirtualCluster virtualCluster,
+                                                      List<NamedFilterDefinition> filterDefinitions,
+                                                      PluginFactoryRegistry pfr) {
+        TargetCluster resolvedTargetCluster = resolveTargetCluster(virtualCluster);
 
         VirtualClusterModel virtualClusterModel = new VirtualClusterModel(virtualCluster.name(),
-                virtualCluster.targetCluster(),
+                resolvedTargetCluster,
                 virtualCluster.logNetwork(),
                 virtualCluster.logFrames(),
                 filterDefinitions,
@@ -150,6 +195,26 @@ public record Configuration(
         virtualClusterModel.logVirtualClusterSummary();
 
         return virtualClusterModel;
+    }
+
+    private TargetCluster resolveTargetCluster(VirtualCluster virtualCluster) {
+        if (virtualCluster.targetCluster() != null) {
+            return virtualCluster.targetCluster();
+        }
+        if (virtualCluster.namedTargetCluster() != null) {
+            return resolveNamedTargetCluster(virtualCluster.namedTargetCluster(), virtualCluster.name());
+        }
+        throw new IllegalConfigurationException(
+                "Virtual cluster '" + virtualCluster.name() + "' has no resolvable target cluster");
+    }
+
+    private TargetCluster resolveNamedTargetCluster(String clusterName, String virtualClusterName) {
+        return Optional.ofNullable(clusterDefinitions).orElse(List.of()).stream()
+                .filter(cd -> cd.name().equals(clusterName))
+                .findFirst()
+                .orElseThrow(() -> new IllegalConfigurationException(
+                        "Virtual cluster '" + virtualClusterName + "' references unknown target cluster '" + clusterName + "'"))
+                .toTargetCluster();
     }
 
     private static void addGateways(List<VirtualClusterGateway> gateways, VirtualClusterModel virtualClusterModel) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -62,22 +62,6 @@ public record Configuration(
     private static final Logger LOGGER = LoggerFactory.getLogger(Configuration.class);
 
     /**
-     * Convenience constructor matching main branch signature, setting {@code clusterDefinitions} and {@code routerDefinitions} to {@code null}.
-     */
-    public Configuration(
-                         @Nullable ManagementConfiguration management,
-                         @Nullable List<NamedFilterDefinition> filterDefinitions,
-                         @Nullable List<String> defaultFilters,
-                         List<VirtualCluster> virtualClusters,
-                         @Nullable List<MicrometerDefinition> micrometer,
-                         boolean useIoUring,
-                         Optional<Map<String, Object>> development,
-                         @Nullable NetworkDefinition network,
-                         @Nullable ProxyProtocolConfig proxyProtocol) {
-        this(management, null, filterDefinitions, defaultFilters, null, virtualClusters, micrometer, useIoUring, development, network, proxyProtocol);
-    }
-
-    /**
      * Creates an instance of configuration.
      *
      */

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -6,8 +6,8 @@
 package io.kroxylicious.proxy.config;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -33,9 +33,10 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * <br>
  *
  * @param management management configuration
- * @param clusterDefinitions Named target cluster definitions, referenced by virtual clusters via {@code target.cluster}.
+ * @param clusterDefinitions Named target cluster definitions, referenced by virtual clusters and routes.
  * @param filterDefinitions A list of named filter definitions (names must be unique)
  * @param defaultFilters The names of the {@link #filterDefinitions()} to be use when a {@link VirtualCluster} doesn't specify its own {@link VirtualCluster#filters()}.
+ * @param routerDefinitions Named router definitions.
  * @param virtualClusters The virtual clusters
  * @param micrometer The micrometer config
  * @param useIoUring true to use iouring
@@ -43,13 +44,14 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * @param network Controls aspects of network configuration for the proxy.
  * @param proxyProtocol PROXY protocol configuration.
  */
-@JsonPropertyOrder({ "management", "clusterDefinitions", "filterDefinitions", "defaultFilters", "virtualClusters", "micrometer", "useIoUring", "development", "network",
-        "proxyProtocol" })
+@JsonPropertyOrder({ "management", "clusterDefinitions", "filterDefinitions", "defaultFilters", "routerDefinitions", "virtualClusters", "micrometer", "useIoUring",
+        "development", "network", "proxyProtocol" })
 public record Configuration(
                             @Nullable ManagementConfiguration management,
                             @Nullable List<ClusterDefinition> clusterDefinitions,
                             @Nullable List<NamedFilterDefinition> filterDefinitions,
                             @Nullable List<String> defaultFilters,
+                            @Nullable List<RouterDefinition> routerDefinitions,
                             @JsonProperty(required = true) List<VirtualCluster> virtualClusters,
                             @Nullable List<MicrometerDefinition> micrometer,
                             boolean useIoUring,
@@ -60,7 +62,7 @@ public record Configuration(
     private static final Logger LOGGER = LoggerFactory.getLogger(Configuration.class);
 
     /**
-     * Convenience constructor matching main branch signature, setting {@code clusterDefinitions} to {@code null}.
+     * Convenience constructor matching main branch signature, setting {@code clusterDefinitions} and {@code routerDefinitions} to {@code null}.
      */
     public Configuration(
                          @Nullable ManagementConfiguration management,
@@ -72,7 +74,7 @@ public record Configuration(
                          Optional<Map<String, Object>> development,
                          @Nullable NetworkDefinition network,
                          @Nullable ProxyProtocolConfig proxyProtocol) {
-        this(management, null, filterDefinitions, defaultFilters, virtualClusters, micrometer, useIoUring, development, network, proxyProtocol);
+        this(management, null, filterDefinitions, defaultFilters, null, virtualClusters, micrometer, useIoUring, development, network, proxyProtocol);
     }
 
     /**
@@ -89,7 +91,7 @@ public record Configuration(
         Set<String> targetClusterNames = validateClusterDefinitions(clusterDefinitions);
         validateVirtualClusterNamedTargets(virtualClusters, targetClusterNames);
 
-        // Enforce post condition: filterDefinitions have a unique name
+        Set<String> filterDefsByName = Set.of();
         if (filterDefinitions != null) {
             Map<String, List<NamedFilterDefinition>> groupdByName = filterDefinitions.stream().collect(Collectors.groupingBy(NamedFilterDefinition::name));
             var duplicatedNames = groupdByName.entrySet().stream().filter(entry -> entry.getValue().size() > 1).map(Map.Entry::getKey).toList();
@@ -97,37 +99,87 @@ public record Configuration(
                 throw new IllegalConfigurationException("'filterDefinitions' contains multiple items with the same names: " + duplicatedNames);
             }
 
-            Set<String> filterDefsByName = filterDefinitions.stream().map(NamedFilterDefinition::name).collect(Collectors.toSet());
+            filterDefsByName = filterDefinitions.stream().map(NamedFilterDefinition::name).collect(Collectors.toSet());
             checkNamedFiltersAreDefined(filterDefsByName, defaultFilters, "defaultFilters");
             for (var virtualCluster : virtualClusters) {
                 checkNamedFiltersAreDefined(filterDefsByName, virtualCluster.filters(), "virtualClusters." + virtualCluster.name() + ".filters");
             }
+        }
 
-            checkAllNamedFilterAreUsed(filterDefinitions, virtualClusters, defaultFilters);
+        validateRouterDefinitions(routerDefinitions, targetClusterNames, filterDefsByName);
+        validateVirtualClusterReceivers(virtualClusters, targetClusterNames, routerDefinitions);
+
+        if (filterDefinitions != null) {
+            checkAllNamedFilterAreUsed(filterDefinitions, virtualClusters, defaultFilters, routerDefinitions);
         }
     }
 
+    /**
+     * Validates that cluster definition names are unique and returns the set of names.
+     */
     private static Set<String> validateClusterDefinitions(@Nullable List<ClusterDefinition> clusterDefinitions) {
         if (clusterDefinitions == null || clusterDefinitions.isEmpty()) {
             return Set.of();
         }
-        var names = clusterDefinitions.stream().map(ClusterDefinition::name).toList();
-        var duplicates = names.stream()
-                .filter(n -> Collections.frequency(names, n) > 1)
-                .collect(Collectors.toSet());
-        if (!duplicates.isEmpty()) {
-            throw new IllegalConfigurationException(
-                    "'clusterDefinitions' contains duplicate names: " + duplicates);
-        }
-        return new HashSet<>(names);
+        return validateUniqueNames(clusterDefinitions, ClusterDefinition::name, "clusterDefinitions");
     }
 
+    /**
+     * Validates that router definition names are unique, that all route filter references
+     * are defined, and that the router graph is a valid DAG.
+     */
+    private static void validateRouterDefinitions(@Nullable List<RouterDefinition> routerDefinitions,
+                                                  Set<String> targetClusterNames,
+                                                  Set<String> filterDefsByName) {
+        if (routerDefinitions == null || routerDefinitions.isEmpty()) {
+            return;
+        }
+        validateUniqueNames(routerDefinitions, RouterDefinition::name, "routerDefinitions");
+
+        for (var router : routerDefinitions) {
+            for (var route : router.routes()) {
+                if (route.filters() != null) {
+                    checkNamedFiltersAreDefined(filterDefsByName, route.filters(),
+                            "routerDefinitions." + router.name() + ".routes." + route.name() + ".filters");
+                }
+            }
+        }
+
+        RouterGraphValidator.validate(routerDefinitions, targetClusterNames);
+    }
+
+    /**
+     * Validates that named target cluster references in virtual clusters resolve to known cluster definitions.
+     */
     private static void validateVirtualClusterNamedTargets(List<VirtualCluster> virtualClusters,
                                                            Set<String> targetClusterNames) {
         for (var vc : virtualClusters) {
             if (vc.namedTargetCluster() != null && !targetClusterNames.contains(vc.namedTargetCluster())) {
                 throw new IllegalConfigurationException(
                         "Virtual cluster '" + vc.name() + "' references unknown target cluster '" + vc.namedTargetCluster() + "'");
+            }
+        }
+    }
+
+    /**
+     * Validates that virtual cluster target references (both cluster and router) resolve
+     * to known definitions.
+     */
+    private static void validateVirtualClusterReceivers(List<VirtualCluster> virtualClusters,
+                                                        Set<String> targetClusterNames,
+                                                        @Nullable List<RouterDefinition> routerDefinitions) {
+        Set<String> routerNames = Optional.ofNullable(routerDefinitions).orElse(List.of()).stream()
+                .map(RouterDefinition::name)
+                .collect(Collectors.toSet());
+
+        for (var vc : virtualClusters) {
+            if (vc.namedTargetCluster() != null && !targetClusterNames.contains(vc.namedTargetCluster())) {
+                throw new IllegalConfigurationException(
+                        "Virtual cluster '" + vc.name() + "' references unknown target cluster '" + vc.namedTargetCluster() + "'");
+            }
+            if (vc.router() != null && !routerNames.contains(vc.router())) {
+                throw new IllegalConfigurationException(
+                        "Virtual cluster '" + vc.name() + "' references unknown router '" + vc.router() + "'");
             }
         }
     }
@@ -145,14 +197,17 @@ public record Configuration(
         }
     }
 
+    /**
+     * Validates that virtual cluster names are unique (case-insensitive comparison).
+     */
     private void validateNoDuplicatedClusterNames(List<VirtualCluster> clusters) {
-        var names = clusters.stream()
-                .map(VirtualCluster::name)
-                .map(name -> name.toLowerCase(Locale.ROOT))
-                .toList();
-        var duplicates = names.stream()
-                .filter(i -> Collections.frequency(names, i) > 1)
-                .collect(Collectors.toSet());
+        Set<String> seen = new HashSet<>();
+        Set<String> duplicates = new LinkedHashSet<>();
+        for (var vc : clusters) {
+            if (!seen.add(vc.name().toLowerCase(Locale.ROOT))) {
+                duplicates.add(vc.name().toLowerCase(Locale.ROOT));
+            }
+        }
         if (!duplicates.isEmpty()) {
             throw new IllegalConfigurationException(
                     "Virtual cluster must be unique (case insensitive). The following virtual cluster names are duplicated: [%s]".formatted(
@@ -160,7 +215,27 @@ public record Configuration(
         }
     }
 
-    private void checkAllNamedFilterAreUsed(List<NamedFilterDefinition> filterDefinitions, List<VirtualCluster> clusters, List<String> defaultFilters) {
+    private static <T> Set<String> validateUniqueNames(List<T> items,
+                                                       Function<T, String> nameExtractor,
+                                                       String context) {
+        Set<String> seen = new HashSet<>();
+        Set<String> duplicates = new LinkedHashSet<>();
+        for (T item : items) {
+            if (!seen.add(nameExtractor.apply(item))) {
+                duplicates.add(nameExtractor.apply(item));
+            }
+        }
+        if (!duplicates.isEmpty()) {
+            throw new IllegalConfigurationException(
+                    "'" + context + "' contains duplicate names: " + duplicates);
+        }
+        return seen;
+    }
+
+    private static void checkAllNamedFilterAreUsed(List<NamedFilterDefinition> filterDefinitions,
+                                                   List<VirtualCluster> clusters,
+                                                   @Nullable List<String> defaultFilters,
+                                                   @Nullable List<RouterDefinition> routerDefinitions) {
         var defined = filterDefinitions.stream().map(NamedFilterDefinition::name).collect(Collectors.toCollection(HashSet::new));
         if (defaultFilters != null) {
             defaultFilters.forEach(defined::remove);
@@ -170,9 +245,18 @@ public record Configuration(
                 .filter(Objects::nonNull)
                 .flatMap(Collection::stream)
                 .forEach(defined::remove);
+        if (routerDefinitions != null) {
+            routerDefinitions.stream()
+                    .flatMap(r -> r.routes().stream())
+                    .map(RouteDefinition::filters)
+                    .filter(Objects::nonNull)
+                    .flatMap(Collection::stream)
+                    .forEach(defined::remove);
+        }
         if (!defined.isEmpty()) {
             throw new IllegalConfigurationException(
-                    "'filterDefinitions' defines filters which are not used in 'defaultFilters' or in any virtual cluster's 'filters': " + defined);
+                    "'filterDefinitions' defines filters which are not used in 'defaultFilters', "
+                            + "in any virtual cluster's 'filters', or in any route's 'filters': " + defined);
         }
     }
 
@@ -245,6 +329,7 @@ public record Configuration(
     }
 
     public List<VirtualClusterModel> virtualClusterModel(PluginFactoryRegistry pfr) {
+        rejectUnsupportedRoutingConfig();
         var filterDefinitionsByName = buildFilterDefinitionsByName();
 
         return virtualClusters.stream()
@@ -265,6 +350,7 @@ public record Configuration(
      * @throws IllegalArgumentException if no virtual cluster with that name exists in this configuration
      */
     public VirtualClusterModel virtualClusterModel(PluginFactoryRegistry pfr, String clusterName) {
+        rejectUnsupportedRoutingConfig();
         var filterDefinitionsByName = buildFilterDefinitionsByName();
 
         return virtualClusters.stream()
@@ -275,6 +361,20 @@ public record Configuration(
                     return toVirtualClusterModel(virtualCluster, filterDefinitions, pfr);
                 })
                 .orElseThrow(() -> new IllegalArgumentException("No virtual cluster named '" + clusterName + "' in this configuration"));
+    }
+
+    private void rejectUnsupportedRoutingConfig() {
+        if (routerDefinitions != null && !routerDefinitions.isEmpty()) {
+            throw new IllegalConfigurationException(
+                    "Routing is not yet supported in this version. Remove 'routerDefinitions' from configuration.");
+        }
+        for (var vc : virtualClusters) {
+            if (vc.router() != null) {
+                throw new IllegalConfigurationException(
+                        "Routing is not yet supported in this version. Virtual cluster '"
+                                + vc.name() + "' uses a router target, which is not yet implemented.");
+            }
+        }
     }
 
     private Map<String, NamedFilterDefinition> buildFilterDefinitionsByName() {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouteDefinition.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouteDefinition.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * A route within a router definition.
+ *
+ * @param name unique name within the enclosing router
+ * @param id numeric identifier for this route, used in the virtual node ID mapping formula
+ * @param filters optional list of filter names applied to requests on this route
+ * @param target the route's target (a cluster or another router)
+ */
+public record RouteDefinition(
+                              @JsonProperty(required = true) String name,
+                              @JsonInclude(JsonInclude.Include.ALWAYS) @JsonProperty(required = true) int id,
+                              @Nullable List<String> filters,
+                              @JsonProperty(required = true) RouteTarget target) {
+
+    @JsonCreator
+    public RouteDefinition {
+        Objects.requireNonNull(name, "'name' is required in a route definition");
+        Objects.requireNonNull(target, "'target' is required in route '" + name + "'");
+        if (id < 0) {
+            throw new IllegalConfigurationException(
+                    "Route '" + name + "' has invalid id " + id + ": must be >= 0");
+        }
+    }
+
+    @Nullable
+    public String cluster() {
+        return target.cluster();
+    }
+
+    @Nullable
+    public String router() {
+        return target.router();
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouteTarget.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouteTarget.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * A target for a route: exactly one of {@code cluster} or {@code router} must be specified.
+ *
+ * @param cluster name of a cluster defined in {@code clusterDefinitions}
+ * @param router name of a router defined in {@code routerDefinitions}
+ */
+public record RouteTarget(@Nullable String cluster,
+                          @Nullable String router) {
+
+    @JsonCreator
+    public RouteTarget {
+        if (cluster != null && router != null) {
+            throw new IllegalConfigurationException(
+                    "Route target must specify exactly one of 'cluster' or 'router', but both were provided");
+        }
+        if (cluster == null && router == null) {
+            throw new IllegalConfigurationException(
+                    "Route target must specify exactly one of 'cluster' or 'router', but neither was provided");
+        }
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouterDefinition.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouterDefinition.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.kroxylicious.proxy.plugin.PluginImplConfig;
+import io.kroxylicious.proxy.plugin.PluginImplName;
+import io.kroxylicious.proxy.router.RouterFactory;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * A named router definition referencing a {@link RouterFactory} plugin type.
+ *
+ * @param name unique name for this router
+ * @param type the {@link RouterFactory} plugin implementation name
+ * @param config optional plugin-specific configuration
+ * @param routes the routes available from this router
+ */
+public record RouterDefinition(
+                               @JsonProperty(required = true) String name,
+                               @PluginImplName(RouterFactory.class) @JsonProperty(required = true) String type,
+                               @Nullable @PluginImplConfig(implNameProperty = "type") Object config,
+                               @JsonProperty(required = true) List<RouteDefinition> routes) {
+
+    @JsonCreator
+    public RouterDefinition {
+        Objects.requireNonNull(name, "'name' is required in a router definition");
+        Objects.requireNonNull(type, "'type' is required in a router definition");
+        if (routes == null || routes.isEmpty()) {
+            throw new IllegalConfigurationException("Router '" + name + "' must have at least one route");
+        }
+        var routeNames = routes.stream()
+                .map(RouteDefinition::name)
+                .toList();
+        var nameDuplicates = routeNames.stream()
+                .filter(n -> Collections.frequency(routeNames, n) > 1)
+                .collect(Collectors.toSet());
+        if (!nameDuplicates.isEmpty()) {
+            throw new IllegalConfigurationException(
+                    "Router '" + name + "' has duplicate route names: " + nameDuplicates);
+        }
+        var routeIds = routes.stream()
+                .map(RouteDefinition::id)
+                .toList();
+        var idDuplicates = routeIds.stream()
+                .filter(id -> Collections.frequency(routeIds, id) > 1)
+                .collect(Collectors.toSet());
+        if (!idDuplicates.isEmpty()) {
+            throw new IllegalConfigurationException(
+                    "Router '" + name + "' has duplicate route ids: " + idDuplicates);
+        }
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouterGraphValidator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouterGraphValidator.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Validates that router definitions form a directed acyclic graph (DAG).
+ */
+class RouterGraphValidator {
+
+    static final int MAX_SAFE_TARGET_NODE_ID = 100_000;
+
+    private RouterGraphValidator() {
+    }
+
+    /**
+     * Validates that the given router definitions form a DAG, and that all
+     * target cluster and router references are resolvable.
+     *
+     * @param routerDefinitions the router definitions to validate
+     * @param targetClusterNames the set of known target cluster names
+     * @throws IllegalConfigurationException if the graph contains a cycle or a dangling reference
+     */
+    static void validate(List<RouterDefinition> routerDefinitions,
+                         Set<String> targetClusterNames) {
+        Map<String, RouterDefinition> routersByName = routerDefinitions.stream()
+                .collect(Collectors.toMap(RouterDefinition::name, r -> r));
+
+        validateReferences(routerDefinitions, routersByName, targetClusterNames);
+        validateRouteIds(routerDefinitions);
+        detectCycles(routerDefinitions, routersByName);
+    }
+
+    private static void validateReferences(List<RouterDefinition> routerDefinitions,
+                                           Map<String, RouterDefinition> routersByName,
+                                           Set<String> targetClusterNames) {
+        for (var router : routerDefinitions) {
+            for (var route : router.routes()) {
+                if (route.cluster() != null && !targetClusterNames.contains(route.cluster())) {
+                    throw new IllegalConfigurationException(
+                            "Route '" + route.name() + "' in router '" + router.name()
+                                    + "' references unknown cluster '" + route.cluster() + "'");
+                }
+                if (route.router() != null && !routersByName.containsKey(route.router())) {
+                    throw new IllegalConfigurationException(
+                            "Route '" + route.name() + "' in router '" + router.name()
+                                    + "' references unknown router '" + route.router() + "'");
+                }
+            }
+        }
+    }
+
+    private static void validateRouteIds(List<RouterDefinition> routerDefinitions) {
+        for (var router : routerDefinitions) {
+            int routeCount = router.routes().size();
+            for (var route : router.routes()) {
+                if (route.id() >= routeCount) {
+                    throw new IllegalConfigurationException(
+                            "Route '" + route.name() + "' in router '" + router.name()
+                                    + "' has id " + route.id()
+                                    + " which is outside the valid range [0, " + routeCount + ")");
+                }
+            }
+            if (routeCount >= 2) {
+                long maxVirtual = (long) routeCount * MAX_SAFE_TARGET_NODE_ID;
+                if (maxVirtual > Integer.MAX_VALUE) {
+                    throw new IllegalConfigurationException(
+                            "Router '" + router.name() + "' has " + routeCount
+                                    + " routes which risks integer overflow in virtual node ID mapping"
+                                    + " for target node IDs up to " + MAX_SAFE_TARGET_NODE_ID);
+                }
+            }
+        }
+    }
+
+    private static void detectCycles(List<RouterDefinition> routerDefinitions,
+                                     Map<String, RouterDefinition> routersByName) {
+        Set<String> visited = new HashSet<>();
+        Set<String> inStack = new HashSet<>();
+
+        for (var router : routerDefinitions) {
+            if (!visited.contains(router.name())) {
+                List<String> path = new ArrayList<>();
+                // When hasCycle returns true, path ends with the repeated node that closes
+                // the cycle (e.g. [A, B, C, A]). formatCycle uses this to extract and
+                // format just the cycle portion.
+                if (hasCycle(router.name(), routersByName, visited, inStack, path)) {
+                    throw new IllegalConfigurationException(
+                            "Router definitions contain a cycle: " + formatCycle(path));
+                }
+            }
+        }
+    }
+
+    private static boolean hasCycle(String routerName,
+                                    Map<String, RouterDefinition> routersByName,
+                                    Set<String> visited,
+                                    Set<String> inStack,
+                                    List<String> path) {
+        visited.add(routerName);
+        inStack.add(routerName);
+        path.add(routerName);
+
+        RouterDefinition router = routersByName.get(routerName);
+        if (router != null) {
+            for (var route : router.routes()) {
+                String target = route.router();
+                if (target != null) {
+                    if (inStack.contains(target)) {
+                        path.add(target);
+                        return true;
+                    }
+                    if (!visited.contains(target) && hasCycle(target, routersByName, visited, inStack, path)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        inStack.remove(routerName);
+        path.remove(path.size() - 1);
+        return false;
+    }
+
+    private static String formatCycle(List<String> path) {
+        int cycleStart = path.indexOf(path.get(path.size() - 1));
+        return String.join(" -> ", path.subList(cycleStart, path.size()));
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
@@ -31,7 +31,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * @param drainTimeout maximum time to wait for in-flight requests to complete during
  *                     graceful connection draining for this cluster
  */
-@SuppressWarnings("java:S1123")
+@SuppressWarnings("java:S1123") // suppressing the spurious warning about missing @deprecated in javadoc. It is the field that is deprecated, not the class.
 public record VirtualCluster(@JsonProperty(required = true) String name,
                              @Deprecated @Nullable TargetCluster targetCluster,
                              @Nullable RouteTarget target,
@@ -46,7 +46,7 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
     private static final Pattern DNS_LABEL_PATTERN = Pattern.compile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", Pattern.CASE_INSENSITIVE);
     private static final Duration DEFAULT_DRAIN_TIMEOUT = Duration.ofSeconds(10);
 
-    @SuppressWarnings("java:S2789")
+    @SuppressWarnings("java:S2789") // S2789 - checking for null tls is the intent
     public VirtualCluster {
         Objects.requireNonNull(name);
         if (!isDnsLabel(name)) {
@@ -66,6 +66,10 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
             throw new IllegalConfigurationException("one or more gateways were null for virtual cluster '" + name + "'");
         }
         validateNoDuplicatedGatewayNames(gateways);
+        // Validate explicitly-supplied drainTimeout. A null drainTimeout is allowed and
+        // means "use the proxy's default"; the resolved value is supplied by
+        // effectiveDrainTimeout() at the use site so that round-trip serialization
+        // preserves null and the operator-generated configs don't bake in today's default.
         if (drainTimeout != null && (drainTimeout.isZero() || drainTimeout.isNegative())) {
             throw new IllegalConfigurationException(
                     "drainTimeout for virtual cluster '" + name + "' must be positive, got: " + drainTimeout);
@@ -131,10 +135,29 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
         return topicNameCache == null ? CacheConfiguration.DEFAULT : topicNameCache;
     }
 
+    /**
+     * Resolves the {@code drainTimeout} for this virtual cluster, applying the proxy's
+     * default when the field is {@code null}. Used at the construction site of
+     * {@link io.kroxylicious.proxy.model.VirtualClusterModel} so that the raw record
+     * component remains nullable (preserving Jackson round-trip fidelity), while the
+     * runtime always sees a resolved {@link java.time.Duration}.
+     */
     Duration effectiveDrainTimeout() {
         return drainTimeout == null ? DEFAULT_DRAIN_TIMEOUT : drainTimeout;
     }
 
+    /**
+     * Returns {@code true} if this cluster's deployment-time configuration is semantically
+     * identical to {@code other}'s. Used by the configuration change-detection pipeline
+     * (see {@code VirtualClusterChangeDetector}) to decide whether a virtual cluster needs
+     * to be restarted across a {@code reconfigure()}.
+     *
+     * <p>Implementation uses the record's auto-generated {@link #equals(Object)} after
+     * canonicalising gateway order &mdash; {@code gateways} is a name-keyed semantic set,
+     * so reordering YAML entries is a no-op and must not produce a false positive. All
+     * other components (including any added in the future) are compared by the record's
+     * auto-equals, so this method extends automatically.
+     */
     public boolean sameAs(@Nullable VirtualCluster other) {
         if (this == other) {
             return true;
@@ -145,6 +168,11 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
         return this.canonical().equals(other.canonical());
     }
 
+    /**
+     * Returns an equivalent {@link VirtualCluster} with gateways sorted by name. Used only
+     * as an internal helper of {@link #sameAs(VirtualCluster)} to normalise the one
+     * order-insensitive component before the record's auto-equals does the rest.
+     */
     private VirtualCluster canonical() {
         List<VirtualClusterGateway> sortedGateways = gateways.stream()
                 .sorted(java.util.Comparator.comparing(VirtualClusterGateway::name))

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
@@ -20,26 +20,21 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * A virtual cluster.
  *
  * @param name virtual cluster name
- * @param targetCluster the cluster being proxied
+ * @param targetCluster inline target cluster definition (mutually exclusive with {@code target})
+ * @param target reference to a named cluster or router (mutually exclusive with {@code targetCluster})
  * @param gateways virtual cluster gateways
  * @param logNetwork if true, network will be logged
  * @param logFrames if true, kafka rpcs will be logged
- * @param filters filers.
+ * @param filters filters applied to requests
  * @param subjectBuilder subject builder configuration (optional)
  * @param topicNameCache topic-name cache configuration (optional)
  * @param drainTimeout maximum time to wait for in-flight requests to complete during
- *                     graceful connection draining for this cluster. Must be strictly
- *                     less than the Netty shutdown timeout (configured via
- *                     {@code network.proxy.shutdownTimeout}, default 15 s) — otherwise
- *                     Netty's force-close runs first and the per-connection drain timer
- *                     never fires. {@code null} means "use the proxy's default" — the
- *                     resolved value is supplied at the use site by
- *                     {@link #effectiveDrainTimeout()}. The default is currently 10 s
- *                     and may evolve in future proxy versions.
+ *                     graceful connection draining for this cluster
  */
-@SuppressWarnings("java:S1123") // suppressing the spurious warning about missing @deprecated in javadoc. It is the field that is deprecated, not the class.
+@SuppressWarnings("java:S1123")
 public record VirtualCluster(@JsonProperty(required = true) String name,
-                             @JsonProperty(required = true) TargetCluster targetCluster,
+                             @Deprecated @Nullable TargetCluster targetCluster,
+                             @Nullable RouteTarget target,
                              @JsonProperty(required = true) List<VirtualClusterGateway> gateways,
                              boolean logNetwork,
                              boolean logFrames,
@@ -51,14 +46,18 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
     private static final Pattern DNS_LABEL_PATTERN = Pattern.compile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", Pattern.CASE_INSENSITIVE);
     private static final Duration DEFAULT_DRAIN_TIMEOUT = Duration.ofSeconds(10);
 
-    @SuppressWarnings("java:S2789") // S2789 - checking for null tls is the intent
+    @SuppressWarnings("java:S2789")
     public VirtualCluster {
         Objects.requireNonNull(name);
-        Objects.requireNonNull(targetCluster);
         if (!isDnsLabel(name)) {
             throw new IllegalConfigurationException(
                     "Virtual cluster name '" + name + "' is invalid. It must be less than 64 characters long and match pattern " + DNS_LABEL_PATTERN.pattern()
                             + " (case insensitive)");
+        }
+        validateTargetExclusivity(name, targetCluster, target);
+        if (target != null && target.router() != null) {
+            throw new IllegalConfigurationException(
+                    "illegal target.router for virtual cluster '" + name + "'. Only target.cluster is supported currently, please change to this.");
         }
         if (gateways == null || gateways.isEmpty()) {
             throw new IllegalConfigurationException("no gateways configured for virtual cluster '" + name + "'");
@@ -67,23 +66,42 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
             throw new IllegalConfigurationException("one or more gateways were null for virtual cluster '" + name + "'");
         }
         validateNoDuplicatedGatewayNames(gateways);
-        // Validate explicitly-supplied drainTimeout. A null drainTimeout is allowed and
-        // means "use the proxy's default"; the resolved value is supplied by
-        // effectiveDrainTimeout() at the use site so that round-trip serialization
-        // preserves null and the operator-generated configs don't bake in today's default.
         if (drainTimeout != null && (drainTimeout.isZero() || drainTimeout.isNegative())) {
             throw new IllegalConfigurationException(
                     "drainTimeout for virtual cluster '" + name + "' must be positive, got: " + drainTimeout);
         }
     }
 
-    public VirtualCluster(@JsonProperty(required = true) String name,
-                          @JsonProperty(required = true) TargetCluster targetCluster,
-                          @JsonProperty(required = true) List<VirtualClusterGateway> gateways,
+    public VirtualCluster(String name,
+                          TargetCluster targetCluster,
+                          List<VirtualClusterGateway> gateways,
                           boolean logNetwork,
                           boolean logFrames,
                           @Nullable List<String> filters) {
-        this(name, targetCluster, gateways, logNetwork, logFrames, filters, null, null, null);
+        this(name, targetCluster, null, gateways, logNetwork, logFrames, filters, null, null, null);
+    }
+
+    @Nullable
+    public String router() {
+        return target != null ? target.router() : null;
+    }
+
+    @Nullable
+    public String namedTargetCluster() {
+        return target != null ? target.cluster() : null;
+    }
+
+    private static void validateTargetExclusivity(String name,
+                                                  @Nullable TargetCluster targetCluster,
+                                                  @Nullable RouteTarget target) {
+        if (targetCluster != null && target != null) {
+            throw new IllegalConfigurationException(
+                    "Virtual cluster '" + name + "' must specify exactly one of 'targetCluster' or 'target'");
+        }
+        if (targetCluster == null && target == null) {
+            throw new IllegalConfigurationException(
+                    "Virtual cluster '" + name + "' must specify exactly one of 'targetCluster' or 'target'");
+        }
     }
 
     boolean isDnsLabel(String name) {
@@ -113,29 +131,10 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
         return topicNameCache == null ? CacheConfiguration.DEFAULT : topicNameCache;
     }
 
-    /**
-     * Resolves the {@code drainTimeout} for this virtual cluster, applying the proxy's
-     * default when the field is {@code null}. Used at the construction site of
-     * {@link io.kroxylicious.proxy.model.VirtualClusterModel} so that the raw record
-     * component remains nullable (preserving Jackson round-trip fidelity), while the
-     * runtime always sees a resolved {@link Duration}.
-     */
     Duration effectiveDrainTimeout() {
         return drainTimeout == null ? DEFAULT_DRAIN_TIMEOUT : drainTimeout;
     }
 
-    /**
-     * Returns {@code true} if this cluster's deployment-time configuration is semantically
-     * identical to {@code other}'s. Used by the configuration change-detection pipeline
-     * (see {@code VirtualClusterChangeDetector}) to decide whether a virtual cluster needs
-     * to be restarted across a {@code reconfigure()}.
-     *
-     * <p>Implementation uses the record's auto-generated {@link #equals(Object)} after
-     * canonicalising gateway order &mdash; {@code gateways} is a name-keyed semantic set,
-     * so reordering YAML entries is a no-op and must not produce a false positive. All
-     * other components (including any added in the future) are compared by the record's
-     * auto-equals, so this method extends automatically.
-     */
     public boolean sameAs(@Nullable VirtualCluster other) {
         if (this == other) {
             return true;
@@ -146,11 +145,6 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
         return this.canonical().equals(other.canonical());
     }
 
-    /**
-     * Returns an equivalent {@link VirtualCluster} with gateways sorted by name. Used only
-     * as an internal helper of {@link #sameAs(VirtualCluster)} to normalise the one
-     * order-insensitive component before the record's auto-equals does the rest.
-     */
     private VirtualCluster canonical() {
         List<VirtualClusterGateway> sortedGateways = gateways.stream()
                 .sorted(java.util.Comparator.comparing(VirtualClusterGateway::name))
@@ -158,6 +152,7 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
         return new VirtualCluster(
                 name,
                 targetCluster,
+                target,
                 sortedGateways,
                 logNetwork,
                 logFrames,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ClusterDefinitionTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ClusterDefinitionTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.kroxylicious.proxy.config.tls.Tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterDefinitionTest {
+
+    @Mock
+    Tls tls;
+
+    @Test
+    void shouldCreateValidDefinition() {
+        var def = new ClusterDefinition("my-cluster", "broker1:9092,broker2:9092", null);
+
+        assertThat(def.name()).isEqualTo("my-cluster");
+        assertThat(def.bootstrapServers()).isEqualTo("broker1:9092,broker2:9092");
+        assertThat(def.tls()).isNull();
+    }
+
+    @Test
+    void shouldStripWhitespaceFromBootstrapServers() {
+        var def = new ClusterDefinition("c1", "broker1:9092 , broker2:9092", null);
+
+        assertThat(def.bootstrapServers()).isEqualTo("broker1:9092,broker2:9092");
+    }
+
+    @Test
+    void shouldRejectNullName() {
+        assertThatThrownBy(() -> new ClusterDefinition(null, "broker:9092", null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("name");
+    }
+
+    @Test
+    void shouldRejectNullBootstrapServers() {
+        assertThatThrownBy(() -> new ClusterDefinition("c1", null, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("bootstrapServers");
+    }
+
+    @Test
+    void toTargetClusterWithoutTls() {
+        var def = new ClusterDefinition("c1", "broker:9092", null);
+
+        var target = def.toTargetCluster();
+
+        assertThat(target.bootstrapServers()).isEqualTo("broker:9092");
+        assertThat(target.tls()).isEmpty();
+    }
+
+    @Test
+    void toTargetClusterWithTls() {
+        var def = new ClusterDefinition("c1", "broker:9092", tls);
+
+        var target = def.toTargetCluster();
+
+        assertThat(target.bootstrapServers()).isEqualTo("broker:9092");
+        assertThat(target.tls()).contains(tls);
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -963,15 +963,8 @@ class ConfigParserTest {
         var targetCluster = new TargetCluster("mycluster:9082", Optional.empty());
         var gateway = new VirtualClusterGateway("gw", new PortIdentifiesNodeIdentificationStrategy(HostPort.parse("localhost:9082"), null, null, null), null,
                 Optional.empty());
-        var config = new Configuration(null,
-                List.of(new NamedFilterDefinition("foo", "", new NonSerializableConfig(""))),
-                List.of("foo"),
-                List.of(new VirtualCluster("demo", targetCluster, List.of(gateway), false, false, List.of())),
-                null,
-                false,
-                Optional.empty(),
-                null,
-                null);
+        var config = new Configuration(null, null, List.of(new NamedFilterDefinition("foo", "", new NonSerializableConfig(""))), List.of("foo"), null,
+                List.of(new VirtualCluster("demo", targetCluster, List.of(gateway), false, false, List.of())), null, false, Optional.empty(), null, null);
 
         ConfigParser cp = new ConfigParser();
         assertThatThrownBy(() -> {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -317,6 +317,51 @@ class ConfigParserTest {
                           - name: mygateway
                             portIdentifiesNode:
                               bootstrapAddress: "localhost:9082"
+                        """),
+                argumentSet("Cluster definitions", """
+                        clusterDefinitions:
+                        - name: my-cluster
+                          bootstrapServers: broker1:9092,broker2:9092
+                        virtualClusters:
+                        - name: demo1
+                          target:
+                            cluster: my-cluster
+                          gateways:
+                          - name: mygateway
+                            portIdentifiesNode:
+                              bootstrapAddress: "localhost:9082"
+                        """),
+                argumentSet("Cluster definitions with TLS", """
+                        clusterDefinitions:
+                        - name: my-cluster
+                          bootstrapServers: broker1:9092
+                          tls:
+                            trust:
+                              storeFile: /tmp/trust.jks
+                              storePassword:
+                                password: changeit
+                              storeType: JKS
+                        virtualClusters:
+                        - name: demo1
+                          target:
+                            cluster: my-cluster
+                          gateways:
+                          - name: mygateway
+                            portIdentifiesNode:
+                              bootstrapAddress: "localhost:9082"
+                        """),
+                argumentSet("Virtual cluster with target cluster reference", """
+                        clusterDefinitions:
+                        - name: my-cluster
+                          bootstrapServers: broker:9092
+                        virtualClusters:
+                        - name: demo1
+                          target:
+                            cluster: my-cluster
+                          gateways:
+                          - name: mygateway
+                            portIdentifiesNode:
+                              bootstrapAddress: "localhost:9082"
                         """));
     }
 
@@ -695,7 +740,7 @@ class ConfigParserTest {
                 // Then
                 .isInstanceOf(IllegalArgumentException.class)
                 .cause()
-                .hasMessageContaining("Missing required creator property 'targetCluster'");
+                .hasMessageContaining("must specify exactly one of 'targetCluster' or 'target'");
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
@@ -30,7 +30,7 @@ class ConfigurationValidationTest {
     }
 
     private static Configuration config(List<VirtualCluster> vcs) {
-        return new Configuration(null, null, null, vcs, null, false, Optional.empty(), null, null);
+        return new Configuration(null, null, null, null, null, vcs, null, false, Optional.empty(), null, null);
     }
 
     @Test
@@ -126,16 +126,14 @@ class ConfigurationValidationTest {
     @Test
     void getMicrometerReturnsConfiguredValue() {
         var micrometer = List.of(new MicrometerDefinition("JmxMeterRegistry", null));
-        var config = new Configuration(null, null, null,
-                List.of(SIMPLE_VC), micrometer, false, Optional.empty(), null, null);
+        var config = new Configuration(null, null, null, null, null, List.of(SIMPLE_VC), micrometer, false, Optional.empty(), null, null);
 
         assertThat(config.getMicrometer()).isEqualTo(micrometer);
     }
 
     @Test
     void isUseIoUringReturnsConfiguredValue() {
-        var config = new Configuration(null, null, null,
-                List.of(SIMPLE_VC), null, true, Optional.empty(), null, null);
+        var config = new Configuration(null, null, null, null, null, List.of(SIMPLE_VC), null, true, Optional.empty(), null, null);
 
         assertThat(config.isUseIoUring()).isTrue();
     }
@@ -168,16 +166,14 @@ class ConfigurationValidationTest {
 
     @Test
     void shouldRejectNoVirtualClusters() {
-        assertThatThrownBy(() -> new Configuration(null, null, null,
-                List.of(), null, false, Optional.empty(), null, null))
+        assertThatThrownBy(() -> new Configuration(null, null, null, null, null, List.of(), null, false, Optional.empty(), null, null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("At least one virtual cluster");
     }
 
     @Test
     void shouldRejectNullVirtualClusters() {
-        assertThatThrownBy(() -> new Configuration(null, null, null,
-                null, null, false, Optional.empty(), null, null))
+        assertThatThrownBy(() -> new Configuration(null, null, null, null, null, null, null, false, Optional.empty(), null, null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("At least one virtual cluster");
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
@@ -33,15 +33,13 @@ class ConfigurationValidationTest {
         return new Configuration(null, null, null, vcs, null, false, Optional.empty(), null, null);
     }
 
-    // Cluster definition validation
-
     @Test
     void shouldRejectDuplicateClusterDefinitionNames() {
         var clusters = List.of(
                 new ClusterDefinition("dup", "broker1:9092", null),
                 new ClusterDefinition("dup", "broker2:9092", null));
 
-        assertThatThrownBy(() -> new Configuration(null, clusters, null, null,
+        assertThatThrownBy(() -> new Configuration(null, clusters, null, null, null,
                 List.of(SIMPLE_VC), null, false, Optional.empty(), null, null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("duplicate names")
@@ -54,7 +52,20 @@ class ConfigurationValidationTest {
                 .doesNotThrowAnyException();
     }
 
-    // Virtual cluster target validation
+    @Test
+    void shouldRejectDuplicateRouterDefinitionNames() {
+        var cluster = new ClusterDefinition("c1", "broker:9092", null);
+        var route = new RouteDefinition("route1", 0, null, new RouteTarget("c1", null));
+        var routers = List.of(
+                new RouterDefinition("dup", "Type", null, List.of(route)),
+                new RouterDefinition("dup", "Type", null, List.of(route)));
+
+        assertThatThrownBy(() -> new Configuration(null, List.of(cluster), null, null, routers,
+                List.of(SIMPLE_VC), null, false, Optional.empty(), null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("duplicate names")
+                .hasMessageContaining("dup");
+    }
 
     @Test
     void shouldRejectUnknownNamedTargetCluster() {
@@ -75,26 +86,35 @@ class ConfigurationValidationTest {
                 new RouteTarget("known", null),
                 List.of(simpleGateway("gw")), false, false, null, null, null, null);
 
-        assertThatCode(() -> new Configuration(null, List.of(cluster), null, null,
+        assertThatCode(() -> new Configuration(null, List.of(cluster), null, null, null,
                 List.of(vcWithNamedTarget), null, false, Optional.empty(), null, null))
                 .doesNotThrowAnyException();
     }
 
-    // TODO in future VCs will be allowed to target a router
     @Test
     void shouldRejectRouterTarget() {
         RouteTarget routerTarget = new RouteTarget(null, "nonexistent");
         List<VirtualClusterGateway> gateways = List.of(simpleGateway("gw"));
-        assertThatThrownBy(() -> {
-            new VirtualCluster("demo", null,
-                    routerTarget,
-                    gateways, false, false, null, null, null, null);
-        })
+        assertThatThrownBy(() -> new VirtualCluster("demo", null,
+                routerTarget,
+                gateways, false, false, null, null, null, null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("illegal target.router for virtual cluster 'demo'.");
     }
 
-    // Convenience methods
+    @Test
+    void virtualClusterModelRejectsRouterDefinitions() {
+        var cluster = new ClusterDefinition("c1", "broker:9092", null);
+        var route = new RouteDefinition("r", 0, null, new RouteTarget("c1", null));
+        var router = new RouterDefinition("myrouter", "Type", null, List.of(route));
+
+        var config = new Configuration(null, List.of(cluster), null, null, List.of(router),
+                List.of(SIMPLE_VC), null, false, Optional.empty(), null, null);
+
+        assertThatThrownBy(() -> config.virtualClusterModel(null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("Routing is not yet supported");
+    }
 
     @Test
     void getMicrometerReturnsEmptyListWhenNull() {
@@ -118,6 +138,32 @@ class ConfigurationValidationTest {
                 List.of(SIMPLE_VC), null, true, Optional.empty(), null, null);
 
         assertThat(config.isUseIoUring()).isTrue();
+    }
+
+    @Test
+    void shouldRejectFilterInRouteNotDefinedInFilterDefinitions() {
+        var cluster = new ClusterDefinition("c1", "broker:9092", null);
+        var filterDefs = List.of(new NamedFilterDefinition("f1", "Type1", null));
+        var route = new RouteDefinition("r", 0, List.of("undefined-filter"), new RouteTarget("c1", null));
+        var router = new RouterDefinition("myrouter", "Type", null, List.of(route));
+
+        assertThatThrownBy(() -> new Configuration(null, List.of(cluster), filterDefs, null, List.of(router),
+                List.of(SIMPLE_VC), null, false, Optional.empty(), null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("references filters not defined")
+                .hasMessageContaining("undefined-filter");
+    }
+
+    @Test
+    void shouldAcceptFilterUsedInRouteAsUsed() {
+        var cluster = new ClusterDefinition("c1", "broker:9092", null);
+        var filterDefs = List.of(new NamedFilterDefinition("f1", "Type1", null));
+        var route = new RouteDefinition("r", 0, List.of("f1"), new RouteTarget("c1", null));
+        var router = new RouterDefinition("myrouter", "Type", null, List.of(route));
+
+        assertThatCode(() -> new Configuration(null, List.of(cluster), filterDefs, null, List.of(router),
+                List.of(SIMPLE_VC), null, false, Optional.empty(), null, null))
+                .doesNotThrowAnyException();
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ConfigurationValidationTest {
+
+    private static final VirtualCluster SIMPLE_VC = new VirtualCluster("demo",
+            new TargetCluster("broker:9092", Optional.empty()),
+            List.of(simpleGateway("gw")),
+            false, false, null);
+
+    private static VirtualClusterGateway simpleGateway(String name) {
+        return new VirtualClusterGateway(name,
+                new PortIdentifiesNodeIdentificationStrategy(
+                        new io.kroxylicious.proxy.service.HostPort("localhost", 9192), null, null, null),
+                null, Optional.empty());
+    }
+
+    private static Configuration config(List<VirtualCluster> vcs) {
+        return new Configuration(null, null, null, vcs, null, false, Optional.empty(), null, null);
+    }
+
+    // Cluster definition validation
+
+    @Test
+    void shouldRejectDuplicateClusterDefinitionNames() {
+        var clusters = List.of(
+                new ClusterDefinition("dup", "broker1:9092", null),
+                new ClusterDefinition("dup", "broker2:9092", null));
+
+        assertThatThrownBy(() -> new Configuration(null, clusters, null, null,
+                List.of(SIMPLE_VC), null, false, Optional.empty(), null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("duplicate names")
+                .hasMessageContaining("dup");
+    }
+
+    @Test
+    void shouldAcceptNullClusterDefinitions() {
+        assertThatCode(() -> config(List.of(SIMPLE_VC)))
+                .doesNotThrowAnyException();
+    }
+
+    // Virtual cluster target validation
+
+    @Test
+    void shouldRejectUnknownNamedTargetCluster() {
+        var vcWithNamedTarget = new VirtualCluster("demo", null,
+                new RouteTarget("nonexistent", null),
+                List.of(simpleGateway("gw")), false, false, null, null, null, null);
+
+        assertThatThrownBy(() -> config(List.of(vcWithNamedTarget)))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("unknown target cluster")
+                .hasMessageContaining("nonexistent");
+    }
+
+    @Test
+    void shouldAcceptKnownNamedTargetCluster() {
+        var cluster = new ClusterDefinition("known", "broker:9092", null);
+        var vcWithNamedTarget = new VirtualCluster("demo", null,
+                new RouteTarget("known", null),
+                List.of(simpleGateway("gw")), false, false, null, null, null, null);
+
+        assertThatCode(() -> new Configuration(null, List.of(cluster), null, null,
+                List.of(vcWithNamedTarget), null, false, Optional.empty(), null, null))
+                .doesNotThrowAnyException();
+    }
+
+    // TODO in future VCs will be allowed to target a router
+    @Test
+    void shouldRejectRouterTarget() {
+        RouteTarget routerTarget = new RouteTarget(null, "nonexistent");
+        List<VirtualClusterGateway> gateways = List.of(simpleGateway("gw"));
+        assertThatThrownBy(() -> {
+            new VirtualCluster("demo", null,
+                    routerTarget,
+                    gateways, false, false, null, null, null, null);
+        })
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("illegal target.router for virtual cluster 'demo'.");
+    }
+
+    // Convenience methods
+
+    @Test
+    void getMicrometerReturnsEmptyListWhenNull() {
+        var config = config(List.of(SIMPLE_VC));
+
+        assertThat(config.getMicrometer()).isEmpty();
+    }
+
+    @Test
+    void getMicrometerReturnsConfiguredValue() {
+        var micrometer = List.of(new MicrometerDefinition("JmxMeterRegistry", null));
+        var config = new Configuration(null, null, null,
+                List.of(SIMPLE_VC), micrometer, false, Optional.empty(), null, null);
+
+        assertThat(config.getMicrometer()).isEqualTo(micrometer);
+    }
+
+    @Test
+    void isUseIoUringReturnsConfiguredValue() {
+        var config = new Configuration(null, null, null,
+                List.of(SIMPLE_VC), null, true, Optional.empty(), null, null);
+
+        assertThat(config.isUseIoUring()).isTrue();
+    }
+
+    @Test
+    void shouldRejectNoVirtualClusters() {
+        assertThatThrownBy(() -> new Configuration(null, null, null,
+                List.of(), null, false, Optional.empty(), null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("At least one virtual cluster");
+    }
+
+    @Test
+    void shouldRejectNullVirtualClusters() {
+        assertThatThrownBy(() -> new Configuration(null, null, null,
+                null, null, false, Optional.empty(), null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("At least one virtual cluster");
+    }
+
+    @Test
+    void shouldRejectDuplicateVirtualClusterNamesCaseInsensitive() {
+        var vc1 = new VirtualCluster("demo", new TargetCluster("b1:9092", Optional.empty()),
+                List.of(simpleGateway("gw1")), false, false, null);
+        var vc2 = new VirtualCluster("DEMO", new TargetCluster("b2:9092", Optional.empty()),
+                List.of(simpleGateway("gw2")), false, false, null);
+
+        assertThatThrownBy(() -> config(List.of(vc1, vc2)))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("duplicated");
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/RouteDefinitionTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/RouteDefinitionTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RouteDefinitionTest {
+
+    private static final RouteTarget CLUSTER_TARGET = new RouteTarget("c1", null);
+
+    @Test
+    void shouldCreateValidRoute() {
+        var route = new RouteDefinition("route1", 0, null, CLUSTER_TARGET);
+
+        assertThat(route.name()).isEqualTo("route1");
+        assertThat(route.id()).isZero();
+        assertThat(route.filters()).isNull();
+        assertThat(route.target()).isSameAs(CLUSTER_TARGET);
+    }
+
+    @Test
+    void shouldAcceptFilters() {
+        var route = new RouteDefinition("route1", 0, List.of("filter1", "filter2"), CLUSTER_TARGET);
+
+        assertThat(route.filters()).containsExactly("filter1", "filter2");
+    }
+
+    @Test
+    void clusterAccessorDelegatesToTarget() {
+        var route = new RouteDefinition("route1", 0, null, new RouteTarget("my-cluster", null));
+
+        assertThat(route.cluster()).isEqualTo("my-cluster");
+        assertThat(route.router()).isNull();
+    }
+
+    @Test
+    void routerAccessorDelegatesToTarget() {
+        var route = new RouteDefinition("route1", 0, null, new RouteTarget(null, "my-router"));
+
+        assertThat(route.cluster()).isNull();
+        assertThat(route.router()).isEqualTo("my-router");
+    }
+
+    @Test
+    void shouldRejectNullName() {
+        assertThatThrownBy(() -> new RouteDefinition(null, 0, null, CLUSTER_TARGET))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("name");
+    }
+
+    @Test
+    void shouldRejectNullTarget() {
+        assertThatThrownBy(() -> new RouteDefinition("route1", 0, null, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("target");
+    }
+
+    @Test
+    void shouldRejectNegativeId() {
+        assertThatThrownBy(() -> new RouteDefinition("route1", -1, null, CLUSTER_TARGET))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("invalid id -1")
+                .hasMessageContaining("must be >= 0");
+    }
+
+    @Test
+    void shouldAcceptZeroId() {
+        assertThatCode(() -> new RouteDefinition("route1", 0, null, CLUSTER_TARGET))
+                .doesNotThrowAnyException();
+    }
+
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/RouteTargetTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/RouteTargetTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RouteTargetTest {
+
+    @Test
+    void shouldAcceptClusterOnly() {
+        var target = new RouteTarget("my-cluster", null);
+
+        assertThat(target.cluster()).isEqualTo("my-cluster");
+        assertThat(target.router()).isNull();
+    }
+
+    @Test
+    void shouldAcceptRouterOnly() {
+        var target = new RouteTarget(null, "my-router");
+
+        assertThat(target.cluster()).isNull();
+        assertThat(target.router()).isEqualTo("my-router");
+    }
+
+    @Test
+    void shouldRejectBothProvided() {
+        assertThatThrownBy(() -> new RouteTarget("cluster", "router"))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("both were provided");
+    }
+
+    @Test
+    void shouldRejectNeitherProvided() {
+        assertThatThrownBy(() -> new RouteTarget(null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("neither was provided");
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/RouterDefinitionTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/RouterDefinitionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RouterDefinitionTest {
+
+    private static RouteDefinition route(String name, int id) {
+        return new RouteDefinition(name, id, null, new RouteTarget("c1", null));
+    }
+
+    @Test
+    void shouldCreateValidDefinition() {
+        var def = new RouterDefinition("r1", "MyRouterFactory", null, List.of(route("route1", 0)));
+
+        assertThat(def.name()).isEqualTo("r1");
+        assertThat(def.type()).isEqualTo("MyRouterFactory");
+        assertThat(def.config()).isNull();
+        assertThat(def.routes()).hasSize(1);
+    }
+
+    @Test
+    void shouldRejectNullName() {
+        assertThatThrownBy(() -> new RouterDefinition(null, "type", null, List.of(route("r", 0))))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("name");
+    }
+
+    @Test
+    void shouldRejectNullType() {
+        assertThatThrownBy(() -> new RouterDefinition("r1", null, null, List.of(route("r", 0))))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("type");
+    }
+
+    @Test
+    void shouldRejectNullRoutes() {
+        assertThatThrownBy(() -> new RouterDefinition("r1", "type", null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("must have at least one route");
+    }
+
+    @Test
+    void shouldRejectEmptyRoutes() {
+        assertThatThrownBy(() -> new RouterDefinition("r1", "type", null, List.of()))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("must have at least one route");
+    }
+
+    @Test
+    void shouldRejectDuplicateRouteNames() {
+        var routes = List.of(route("dup", 0), route("dup", 1));
+
+        assertThatThrownBy(() -> new RouterDefinition("r1", "type", null, routes))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("duplicate route names")
+                .hasMessageContaining("dup");
+    }
+
+    @Test
+    void shouldRejectDuplicateRouteIds() {
+        var routes = List.of(route("a", 0), route("b", 0));
+
+        assertThatThrownBy(() -> new RouterDefinition("r1", "type", null, routes))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("duplicate route ids")
+                .hasMessageContaining("0");
+    }
+
+    @Test
+    void shouldAcceptMultipleUniqueRoutes() {
+        var routes = List.of(route("a", 0), route("b", 1));
+
+        assertThatCode(() -> new RouterDefinition("r1", "type", null, routes))
+                .doesNotThrowAnyException();
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/RouterGraphValidatorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/RouterGraphValidatorTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RouterGraphValidatorTest {
+
+    private static RouteDefinition clusterRoute(String name, int id, String cluster) {
+        return new RouteDefinition(name, id, null, new RouteTarget(cluster, null));
+    }
+
+    private static RouteDefinition routerRoute(String name, int id, String router) {
+        return new RouteDefinition(name, id, null, new RouteTarget(null, router));
+    }
+
+    private static RouterDefinition router(String name, RouteDefinition... routes) {
+        return new RouterDefinition(name, "SomeType", null, List.of(routes));
+    }
+
+    @Test
+    void shouldAcceptSingleRouterWithClusterRoute() {
+        var routers = List.of(router("r1", clusterRoute("foo", 0, "c1")));
+        assertThatCode(() -> RouterGraphValidator.validate(routers, Set.of("c1")))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldAcceptLinearChain() {
+        var routers = List.of(
+                router("r1", routerRoute("next", 0, "r2")),
+                router("r2", clusterRoute("foo", 0, "c1")));
+        assertThatCode(() -> RouterGraphValidator.validate(routers, Set.of("c1")))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldAcceptDiamondDag() {
+        var routers = List.of(
+                router("r1", routerRoute("left", 0, "r2"), routerRoute("right", 1, "r3")),
+                router("r2", clusterRoute("foo", 0, "c1")),
+                router("r3", clusterRoute("bar", 0, "c1")));
+        assertThatCode(() -> RouterGraphValidator.validate(routers, Set.of("c1")))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldRejectSelfCycle() {
+        var routers = List.of(router("r1", routerRoute("loop", 0, "r1")));
+        assertThatThrownBy(() -> RouterGraphValidator.validate(routers, Set.of()))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("cycle")
+                .hasMessageContaining("r1");
+    }
+
+    @Test
+    void shouldRejectSimpleCycle() {
+        var routers = List.of(
+                router("r1", routerRoute("next", 0, "r2")),
+                router("r2", routerRoute("back", 0, "r1")));
+        assertThatThrownBy(() -> RouterGraphValidator.validate(routers, Set.of()))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("cycle")
+                .hasMessageContaining("r1")
+                .hasMessageContaining("r2");
+    }
+
+    @Test
+    void shouldRejectThreeNodeCycle() {
+        var routers = List.of(
+                router("r1", routerRoute("next", 0, "r2")),
+                router("r2", routerRoute("next", 0, "r3")),
+                router("r3", routerRoute("back", 0, "r1")));
+        assertThatThrownBy(() -> RouterGraphValidator.validate(routers, Set.of()))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("cycle");
+    }
+
+    @Test
+    void shouldRejectDanglingClusterReference() {
+        var routers = List.of(router("r1", clusterRoute("foo", 0, "nonexistent")));
+        assertThatThrownBy(() -> RouterGraphValidator.validate(routers, Set.of("c1")))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("unknown cluster")
+                .hasMessageContaining("nonexistent");
+    }
+
+    @Test
+    void shouldRejectDanglingRouterReference() {
+        var routers = List.of(router("r1", routerRoute("next", 0, "nonexistent")));
+        assertThatThrownBy(() -> RouterGraphValidator.validate(routers, Set.of()))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("unknown router")
+                .hasMessageContaining("nonexistent");
+    }
+
+    @Test
+    void shouldRejectRouteIdOutOfRange() {
+        var routers = List.of(router("r1",
+                clusterRoute("foo", 0, "c1"),
+                clusterRoute("bar", 5, "c1")));
+        assertThatThrownBy(() -> RouterGraphValidator.validate(routers, Set.of("c1")))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("outside the valid range")
+                .hasMessageContaining("[0, 2)");
+    }
+
+    @Test
+    void shouldRejectOverflowProneRouteCount() {
+        int routeCount = RouterGraphValidator.MAX_SAFE_TARGET_NODE_ID + 1;
+        RouteDefinition[] routes = new RouteDefinition[routeCount];
+        for (int i = 0; i < routeCount; i++) {
+            routes[i] = clusterRoute("r" + i, i, "c1");
+        }
+        var routers = List.of(router("r1", routes));
+        assertThatThrownBy(() -> RouterGraphValidator.validate(routers, Set.of("c1")))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("overflow");
+    }
+
+    @Test
+    void shouldAcceptValidRouteIds() {
+        var routers = List.of(router("r1",
+                clusterRoute("foo", 0, "c1"),
+                clusterRoute("bar", 1, "c1")));
+        assertThatCode(() -> RouterGraphValidator.validate(routers, Set.of("c1")))
+                .doesNotThrowAnyException();
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/VirtualClusterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/VirtualClusterTest.java
@@ -145,7 +145,7 @@ class VirtualClusterTest {
         // Given — VirtualCluster constructed with an explicit drainTimeout
         var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
         var explicitTimeout = Duration.ofSeconds(45);
-        var vc = new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS, null, null, explicitTimeout);
+        var vc = new VirtualCluster("mycluster", targetCluster, null, gateways, false, false, NO_FILTERS, null, null, explicitTimeout);
 
         // When
         var resolved = vc.effectiveDrainTimeout();
@@ -161,7 +161,7 @@ class VirtualClusterTest {
         var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
 
         // When/Then
-        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS, null, null, Duration.ZERO))
+        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, null, gateways, false, false, NO_FILTERS, null, null, Duration.ZERO))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("drainTimeout for virtual cluster 'mycluster' must be positive");
     }
@@ -172,7 +172,7 @@ class VirtualClusterTest {
         var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
 
         // When/Then
-        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS, null, null, Duration.ofSeconds(-5)))
+        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, null, gateways, false, false, NO_FILTERS, null, null, Duration.ofSeconds(-5)))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("drainTimeout for virtual cluster 'mycluster' must be positive");
     }
@@ -183,7 +183,103 @@ class VirtualClusterTest {
         var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
 
         // When/Then — happy path: a positive explicit drainTimeout passes validation
-        assertThatCode(() -> new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS, null, null, Duration.ofMillis(1)))
+        assertThatCode(() -> new VirtualCluster("mycluster", targetCluster, null, gateways, false, false, NO_FILTERS, null, null, Duration.ofMillis(1)))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    void routerReturnsNullWhenTargetIsNull() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var vc = new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS);
+
+        assertThat(vc.router()).isNull();
+    }
+
+    @Test
+    void namedTargetClusterReturnsNullWhenTargetIsNull() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var vc = new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS);
+
+        assertThat(vc.namedTargetCluster()).isNull();
+    }
+
+    @Test
+    void namedTargetClusterReturnsValueFromTarget() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var target = new RouteTarget("my-cluster", null);
+        var vc = new VirtualCluster("mycluster", null, target, gateways, false, false, NO_FILTERS, null, null, null);
+
+        assertThat(vc.namedTargetCluster()).isEqualTo("my-cluster");
+    }
+
+    @Test
+    void topicNameCacheConfigReturnsDefaultWhenNull() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var vc = new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS);
+
+        assertThat(vc.topicNameCacheConfig()).isEqualTo(CacheConfiguration.DEFAULT);
+    }
+
+    @Test
+    void topicNameCacheConfigReturnsExplicitValue() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var cacheConfig = new CacheConfiguration(1000, null, null);
+        var vc = new VirtualCluster("mycluster", targetCluster, null, gateways, false, false, NO_FILTERS, null, cacheConfig, null);
+
+        assertThat(vc.topicNameCacheConfig()).isSameAs(cacheConfig);
+    }
+
+    @Test
+    void sameAsSameInstanceReturnsTrue() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var vc = new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS);
+
+        assertThat(vc.sameAs(vc)).isTrue();
+    }
+
+    @Test
+    void sameAsNullReturnsFalse() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var vc = new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS);
+
+        assertThat(vc.sameAs(null)).isFalse();
+    }
+
+    @Test
+    void sameAsEqualClusterReturnsTrue() {
+        var gw1 = new VirtualClusterGateway("b", portIdentifiesNode1, null, Optional.empty());
+        var gw2 = new VirtualClusterGateway("a", portIdentifiesNode2, null, Optional.empty());
+        var vc1 = new VirtualCluster("mycluster", targetCluster, null, List.of(gw1, gw2), false, false, NO_FILTERS, null, null, null);
+        var vc2 = new VirtualCluster("mycluster", targetCluster, null, List.of(gw2, gw1), false, false, NO_FILTERS, null, null, null);
+
+        assertThat(vc1.sameAs(vc2)).isTrue();
+    }
+
+    @Test
+    void sameAsDifferentClusterReturnsFalse() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var vc1 = new VirtualCluster("cluster1", targetCluster, gateways, false, false, NO_FILTERS);
+        var vc2 = new VirtualCluster("cluster2", targetCluster, gateways, false, false, NO_FILTERS);
+
+        assertThat(vc1.sameAs(vc2)).isFalse();
+    }
+
+    @Test
+    void rejectsBothTargetClusterAndTarget() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+        var target = new RouteTarget("named-cluster", null);
+
+        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, target, gateways, false, false, NO_FILTERS, null, null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("must specify exactly one of 'targetCluster' or 'target'");
+    }
+
+    @Test
+    void rejectsNeitherTargetClusterNorTarget() {
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+
+        assertThatThrownBy(() -> new VirtualCluster("mycluster", null, null, gateways, false, false, NO_FILTERS, null, null, null))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("must specify exactly one of 'targetCluster' or 'target'");
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/config/FeaturesTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/config/FeaturesTest.java
@@ -68,7 +68,7 @@ class FeaturesTest {
     void supportsValidTestConfiguration(Features features, Map<String, Object> developmentConfig) {
         VirtualCluster mockCluster = mock(VirtualCluster.class);
         when(mockCluster.name()).thenReturn("test");
-        Configuration configuration = new Configuration(null, List.of(), List.of(), List.of(mockCluster), null, false, Optional.ofNullable(developmentConfig),
+        Configuration configuration = new Configuration(null, null, List.of(), List.of(), null, List.of(mockCluster), null, false, Optional.ofNullable(developmentConfig),
                 null, null);
         List<String> errorMessages = features.supports(configuration);
         assertThat(errorMessages).isEmpty();
@@ -80,7 +80,7 @@ class FeaturesTest {
         Optional<Map<String, Object>> a = Optional.of(Map.of("a", "b"));
         VirtualCluster mockCluster = mock(VirtualCluster.class);
         when(mockCluster.name()).thenReturn("test");
-        Configuration configuration = new Configuration(null, List.of(), List.of(), List.of(mockCluster), null, false, a, null, null);
+        Configuration configuration = new Configuration(null, null, List.of(), List.of(), null, List.of(mockCluster), null, false, a, null, null);
         List<String> errors = Features.defaultFeatures().supports(configuration);
         assertThat(errors).containsExactly("test-only configuration for proxy present, but loading test-only configuration not enabled");
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ChangeDetectorPipelineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ChangeDetectorPipelineTest.java
@@ -51,10 +51,8 @@ class ChangeDetectorPipelineTest {
                 new TargetCluster("kafka:9092", Optional.empty()),
                 List.of(gateway("default", 9999)), // port changed
                 false, false, List.of("filter-a"));
-        var oldConfig = new Configuration(null, List.of(oldFilter), null,
-                List.of(oldVc), null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, List.of(newFilter), null,
-                List.of(newVc), null, false, Optional.empty(), null, null);
+        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null, List.of(oldVc), null, false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, null, List.of(newFilter), null, null, List.of(newVc), null, false, Optional.empty(), null, null);
         var context = new ConfigurationChangeContext(oldConfig, newConfig);
 
         // Both detectors independently flag the cluster
@@ -82,10 +80,8 @@ class ChangeDetectorPipelineTest {
         var newFilter = new NamedFilterDefinition("filter-a", "io.kroxylicious.test.FakeFilter", "v2");
         var existing = vc("existing", List.of("filter-a"));
         var newlyAdded = vc("newly-added", List.of("filter-a"));
-        var oldConfig = new Configuration(null, List.of(oldFilter), null,
-                List.of(existing), null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, List.of(newFilter), null,
-                List.of(existing, newlyAdded), null, false, Optional.empty(), null, null);
+        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null, List.of(existing), null, false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, null, List.of(newFilter), null, null, List.of(existing, newlyAdded), null, false, Optional.empty(), null, null);
         var context = new ConfigurationChangeContext(oldConfig, newConfig);
 
         var vccResult = vccDetector.detect(context);
@@ -112,10 +108,8 @@ class ChangeDetectorPipelineTest {
         var oldFilter = new NamedFilterDefinition("filter-a", "io.kroxylicious.test.FakeFilter", "v1");
         var goingAway = vc("going-away", List.of("filter-a"));
         var staying = vcWithoutFilters("staying");
-        var oldConfig = new Configuration(null, List.of(oldFilter), null,
-                List.of(goingAway, staying), null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, null, null,
-                List.of(staying), null, false, Optional.empty(), null, null);
+        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null, List.of(goingAway, staying), null, false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, null, null, null, null, List.of(staying), null, false, Optional.empty(), null, null);
         var context = new ConfigurationChangeContext(oldConfig, newConfig);
 
         var vccResult = vccDetector.detect(context);
@@ -152,12 +146,10 @@ class ChangeDetectorPipelineTest {
         var filterChangedCluster = vc("filter-changed", List.of("filter-x"));
         var addedCluster = vcWithoutFilters("added");
 
-        var oldConfig = new Configuration(null, List.of(oldFilter), null,
-                List.of(keepUnchanged, removedCluster, oldGatewayChanged, filterChangedCluster),
+        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null, List.of(keepUnchanged, removedCluster, oldGatewayChanged, filterChangedCluster),
                 null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, List.of(newFilter), null,
-                List.of(keepUnchanged, newGatewayChanged, filterChangedCluster, addedCluster),
-                null, false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, null, List.of(newFilter), null, null, List.of(keepUnchanged, newGatewayChanged, filterChangedCluster, addedCluster), null,
+                false, Optional.empty(), null, null);
         var context = new ConfigurationChangeContext(oldConfig, newConfig);
 
         var merged = vccDetector.detect(context).merge(filterDetector.detect(context));
@@ -174,8 +166,7 @@ class ChangeDetectorPipelineTest {
         // accidentally introduce non-empty defaults in a detector's output.
         var filter = new NamedFilterDefinition("filter-a", "io.kroxylicious.test.FakeFilter", "v1");
         var cluster = vc("cluster", List.of("filter-a"));
-        var config = new Configuration(null, List.of(filter), null,
-                List.of(cluster), null, false, Optional.empty(), null, null);
+        var config = new Configuration(null, null, List.of(filter), null, null, List.of(cluster), null, false, Optional.empty(), null, null);
         var context = new ConfigurationChangeContext(config, config);
 
         var vccResult = vccDetector.detect(context);
@@ -203,10 +194,10 @@ class ChangeDetectorPipelineTest {
                 false, false, List.of());
         var filterChangedCluster = vc("filter-changed", List.of("filter-x"));
 
-        var oldConfig = new Configuration(null, List.of(oldFilter), null,
-                List.of(oldGatewayChanged, filterChangedCluster), null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, List.of(newFilter), null,
-                List.of(newGatewayChanged, filterChangedCluster), null, false, Optional.empty(), null, null);
+        var oldConfig = new Configuration(null, null, List.of(oldFilter), null, null, List.of(oldGatewayChanged, filterChangedCluster), null, false, Optional.empty(),
+                null, null);
+        var newConfig = new Configuration(null, null, List.of(newFilter), null, null, List.of(newGatewayChanged, filterChangedCluster), null, false, Optional.empty(),
+                null, null);
         var context = new ConfigurationChangeContext(oldConfig, newConfig);
 
         var vccResult = vccDetector.detect(context);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
@@ -795,7 +795,7 @@ class ConfigurationReloadOrchestratorTest {
 
     private static Configuration withDifferentUseIoUring(Configuration base) {
         return new Configuration(base.management(), base.clusterDefinitions(), base.filterDefinitions(), base.defaultFilters(),
-                base.virtualClusters(), base.micrometer(),
+                base.routerDefinitions(), base.virtualClusters(), base.micrometer(),
                 !base.useIoUring(),
                 base.development(), base.network(),
                 // also vary proxyProtocol just to make the diff non-empty even if useIoUring matches

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
@@ -794,7 +794,7 @@ class ConfigurationReloadOrchestratorTest {
     }
 
     private static Configuration withDifferentUseIoUring(Configuration base) {
-        return new Configuration(base.management(), base.filterDefinitions(), base.defaultFilters(),
+        return new Configuration(base.management(), base.clusterDefinitions(), base.filterDefinitions(), base.defaultFilters(),
                 base.virtualClusters(), base.micrometer(),
                 !base.useIoUring(),
                 base.development(), base.network(),

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestratorTest.java
@@ -789,8 +789,7 @@ class ConfigurationReloadOrchestratorTest {
     }
 
     private static Configuration configWith(VirtualCluster... clusters) {
-        return new Configuration(null, null, null, List.of(clusters), null, false,
-                Optional.empty(), null, null);
+        return new Configuration(null, null, null, null, null, List.of(clusters), null, false, Optional.empty(), null, null);
     }
 
     private static Configuration withDifferentUseIoUring(Configuration base) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/FilterChangeDetectorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/FilterChangeDetectorTest.java
@@ -173,8 +173,7 @@ class FilterChangeDetectorTest {
     private static Configuration configWith(@Nullable List<NamedFilterDefinition> filterDefs,
                                             @Nullable List<String> defaultFilters,
                                             VirtualCluster... clusters) {
-        return new Configuration(null, filterDefs, defaultFilters, List.of(clusters), null, false,
-                Optional.empty(), null, null);
+        return new Configuration(null, null, filterDefs, defaultFilters, null, List.of(clusters), null, false, Optional.empty(), null, null);
     }
 
     private static NamedFilterDefinition filterDef(String name, String opaqueConfig) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/OperationsPlannerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/OperationsPlannerTest.java
@@ -236,8 +236,7 @@ class OperationsPlannerTest {
 
     private static Configuration configWith(String... clusterNames) {
         var clusters = Arrays.stream(clusterNames).map(OperationsPlannerTest::vc).toList();
-        return new Configuration(null, null, null, clusters, null, false,
-                Optional.empty(), null, null);
+        return new Configuration(null, null, null, null, null, clusters, null, false, Optional.empty(), null, null);
     }
 
     private static VirtualCluster vc(String name) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/StaticSectionDifferTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/StaticSectionDifferTest.java
@@ -200,9 +200,7 @@ class StaticSectionDifferTest {
     // -------- fixture helpers --------
 
     private static Configuration baseConfig() {
-        return new Configuration(null, null, null,
-                List.of(vc("base-cluster")), null,
-                false, Optional.empty(), null, null);
+        return new Configuration(null, null, null, null, null, List.of(vc("base-cluster")), null, false, Optional.empty(), null, null);
     }
 
     private static Configuration withManagement(Configuration base, ManagementConfiguration management) {
@@ -212,8 +210,8 @@ class StaticSectionDifferTest {
     }
 
     private static Configuration withMicrometer(Configuration base, List<MicrometerDefinition> micrometer) {
-        return new Configuration(base.management(), base.filterDefinitions(), base.defaultFilters(),
-                base.virtualClusters(), micrometer,
+        return new Configuration(base.management(), base.clusterDefinitions(), base.filterDefinitions(), base.defaultFilters(),
+                base.routerDefinitions(), base.virtualClusters(), micrometer,
                 base.useIoUring(), base.development(), base.network(), base.proxyProtocol());
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/StaticSectionDifferTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/StaticSectionDifferTest.java
@@ -92,7 +92,7 @@ class StaticSectionDifferTest {
     void differingUseIoUringIsDetected() {
         var oldConfig = baseConfig();
         var newConfig = new Configuration(oldConfig.management(), oldConfig.clusterDefinitions(), oldConfig.filterDefinitions(),
-                oldConfig.defaultFilters(), oldConfig.virtualClusters(), oldConfig.micrometer(),
+                oldConfig.defaultFilters(), oldConfig.routerDefinitions(), oldConfig.virtualClusters(), oldConfig.micrometer(),
                 !oldConfig.useIoUring(), // toggled
                 oldConfig.development(), oldConfig.network(), oldConfig.proxyProtocol());
         assertThat(differ.diff(oldConfig, newConfig)).containsExactly("useIoUring");
@@ -109,7 +109,7 @@ class StaticSectionDifferTest {
     void differingMicrometerIsDetected() {
         var oldConfig = baseConfig();
         var newConfig = new Configuration(oldConfig.management(), oldConfig.clusterDefinitions(), oldConfig.filterDefinitions(),
-                oldConfig.defaultFilters(), oldConfig.virtualClusters(),
+                oldConfig.defaultFilters(), oldConfig.routerDefinitions(), oldConfig.virtualClusters(),
                 List.of(new MicrometerDefinition("SomeMicrometerType", null)), // different from base's null
                 oldConfig.useIoUring(), oldConfig.development(), oldConfig.network(), oldConfig.proxyProtocol());
         assertThat(differ.diff(oldConfig, newConfig)).containsExactly("micrometer");
@@ -126,7 +126,7 @@ class StaticSectionDifferTest {
     void differingDevelopmentIsDetected() {
         var oldConfig = baseConfig();
         var newConfig = new Configuration(oldConfig.management(), oldConfig.clusterDefinitions(), oldConfig.filterDefinitions(),
-                oldConfig.defaultFilters(), oldConfig.virtualClusters(), oldConfig.micrometer(),
+                oldConfig.defaultFilters(), oldConfig.routerDefinitions(), oldConfig.virtualClusters(), oldConfig.micrometer(),
                 oldConfig.useIoUring(),
                 Optional.of(Map.of("debug", "true")), // different from base's Optional.empty()
                 oldConfig.network(), oldConfig.proxyProtocol());
@@ -141,6 +141,7 @@ class StaticSectionDifferTest {
                 oldConfig.clusterDefinitions(),
                 oldConfig.filterDefinitions(),
                 oldConfig.defaultFilters(),
+                oldConfig.routerDefinitions(),
                 oldConfig.virtualClusters(),
                 oldConfig.micrometer(),
                 !oldConfig.useIoUring(), // changed: useIoUring
@@ -161,6 +162,7 @@ class StaticSectionDifferTest {
                 oldConfig.clusterDefinitions(),
                 List.of(new NamedFilterDefinition("filter-a", "SomeFilterType", null)), // changed: filterDefinitions
                 List.of("filter-a"), // changed: defaultFilters
+                oldConfig.routerDefinitions(),
                 List.of(vc("different-cluster")), // changed: virtualClusters
                 oldConfig.micrometer(),
                 oldConfig.useIoUring(),
@@ -205,7 +207,7 @@ class StaticSectionDifferTest {
 
     private static Configuration withManagement(Configuration base, ManagementConfiguration management) {
         return new Configuration(management, base.clusterDefinitions(), base.filterDefinitions(), base.defaultFilters(),
-                base.virtualClusters(), base.micrometer(),
+                base.routerDefinitions(), base.virtualClusters(), base.micrometer(),
                 base.useIoUring(), base.development(), base.network(), base.proxyProtocol());
     }
 
@@ -217,13 +219,13 @@ class StaticSectionDifferTest {
 
     private static Configuration withNetwork(Configuration base, NetworkDefinition network) {
         return new Configuration(base.management(), base.clusterDefinitions(), base.filterDefinitions(), base.defaultFilters(),
-                base.virtualClusters(), base.micrometer(),
+                base.routerDefinitions(), base.virtualClusters(), base.micrometer(),
                 base.useIoUring(), base.development(), network, base.proxyProtocol());
     }
 
     private static Configuration withProxyProtocol(Configuration base, ProxyProtocolConfig proxyProtocol) {
         return new Configuration(base.management(), base.clusterDefinitions(), base.filterDefinitions(), base.defaultFilters(),
-                base.virtualClusters(), base.micrometer(),
+                base.routerDefinitions(), base.virtualClusters(), base.micrometer(),
                 base.useIoUring(), base.development(), base.network(), proxyProtocol);
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/StaticSectionDifferTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/StaticSectionDifferTest.java
@@ -91,7 +91,7 @@ class StaticSectionDifferTest {
     @Test
     void differingUseIoUringIsDetected() {
         var oldConfig = baseConfig();
-        var newConfig = new Configuration(oldConfig.management(), oldConfig.filterDefinitions(),
+        var newConfig = new Configuration(oldConfig.management(), oldConfig.clusterDefinitions(), oldConfig.filterDefinitions(),
                 oldConfig.defaultFilters(), oldConfig.virtualClusters(), oldConfig.micrometer(),
                 !oldConfig.useIoUring(), // toggled
                 oldConfig.development(), oldConfig.network(), oldConfig.proxyProtocol());
@@ -108,7 +108,7 @@ class StaticSectionDifferTest {
     @Test
     void differingMicrometerIsDetected() {
         var oldConfig = baseConfig();
-        var newConfig = new Configuration(oldConfig.management(), oldConfig.filterDefinitions(),
+        var newConfig = new Configuration(oldConfig.management(), oldConfig.clusterDefinitions(), oldConfig.filterDefinitions(),
                 oldConfig.defaultFilters(), oldConfig.virtualClusters(),
                 List.of(new MicrometerDefinition("SomeMicrometerType", null)), // different from base's null
                 oldConfig.useIoUring(), oldConfig.development(), oldConfig.network(), oldConfig.proxyProtocol());
@@ -125,7 +125,7 @@ class StaticSectionDifferTest {
     @Test
     void differingDevelopmentIsDetected() {
         var oldConfig = baseConfig();
-        var newConfig = new Configuration(oldConfig.management(), oldConfig.filterDefinitions(),
+        var newConfig = new Configuration(oldConfig.management(), oldConfig.clusterDefinitions(), oldConfig.filterDefinitions(),
                 oldConfig.defaultFilters(), oldConfig.virtualClusters(), oldConfig.micrometer(),
                 oldConfig.useIoUring(),
                 Optional.of(Map.of("debug", "true")), // different from base's Optional.empty()
@@ -138,6 +138,7 @@ class StaticSectionDifferTest {
         var oldConfig = baseConfig();
         var newConfig = new Configuration(
                 new ManagementConfiguration(null, null, null), // changed: management
+                oldConfig.clusterDefinitions(),
                 oldConfig.filterDefinitions(),
                 oldConfig.defaultFilters(),
                 oldConfig.virtualClusters(),
@@ -157,6 +158,7 @@ class StaticSectionDifferTest {
         var oldConfig = baseConfig();
         var newConfig = new Configuration(
                 oldConfig.management(),
+                oldConfig.clusterDefinitions(),
                 List.of(new NamedFilterDefinition("filter-a", "SomeFilterType", null)), // changed: filterDefinitions
                 List.of("filter-a"), // changed: defaultFilters
                 List.of(vc("different-cluster")), // changed: virtualClusters
@@ -202,7 +204,7 @@ class StaticSectionDifferTest {
     }
 
     private static Configuration withManagement(Configuration base, ManagementConfiguration management) {
-        return new Configuration(management, base.filterDefinitions(), base.defaultFilters(),
+        return new Configuration(management, base.clusterDefinitions(), base.filterDefinitions(), base.defaultFilters(),
                 base.virtualClusters(), base.micrometer(),
                 base.useIoUring(), base.development(), base.network(), base.proxyProtocol());
     }
@@ -214,13 +216,13 @@ class StaticSectionDifferTest {
     }
 
     private static Configuration withNetwork(Configuration base, NetworkDefinition network) {
-        return new Configuration(base.management(), base.filterDefinitions(), base.defaultFilters(),
+        return new Configuration(base.management(), base.clusterDefinitions(), base.filterDefinitions(), base.defaultFilters(),
                 base.virtualClusters(), base.micrometer(),
                 base.useIoUring(), base.development(), network, base.proxyProtocol());
     }
 
     private static Configuration withProxyProtocol(Configuration base, ProxyProtocolConfig proxyProtocol) {
-        return new Configuration(base.management(), base.filterDefinitions(), base.defaultFilters(),
+        return new Configuration(base.management(), base.clusterDefinitions(), base.filterDefinitions(), base.defaultFilters(),
                 base.virtualClusters(), base.micrometer(),
                 base.useIoUring(), base.development(), base.network(), proxyProtocol);
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/VirtualClusterChangeDetectorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/VirtualClusterChangeDetectorTest.java
@@ -316,6 +316,7 @@ class VirtualClusterChangeDetectorTest {
                                                @Nullable Duration drainTimeout) {
         return new VirtualCluster(name,
                 new TargetCluster("kafka:9092", Optional.empty()),
+                null,
                 List.of(gateway("default", 9192)),
                 false, false, List.of(),
                 subjectBuilder, topicNameCache, drainTimeout);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/VirtualClusterChangeDetectorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/VirtualClusterChangeDetectorTest.java
@@ -118,12 +118,10 @@ class VirtualClusterChangeDetectorTest {
                 false, false,
                 List.of("filter-b", "filter-a"));
         // Build configs with the matching named filter definitions so Configuration validation passes.
-        var oldConfig = new Configuration(null,
-                List.of(filterDef("filter-a"), filterDef("filter-b")),
-                null, List.of(oldVc), null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null,
-                List.of(filterDef("filter-a"), filterDef("filter-b")),
-                null, List.of(newVc), null, false, Optional.empty(), null, null);
+        var oldConfig = new Configuration(null, null, List.of(filterDef("filter-a"), filterDef("filter-b")), null, null, List.of(oldVc), null, false, Optional.empty(),
+                null, null);
+        var newConfig = new Configuration(null, null, List.of(filterDef("filter-a"), filterDef("filter-b")), null, null, List.of(newVc), null, false, Optional.empty(),
+                null, null);
         var result = detector.detect(new ConfigurationChangeContext(oldConfig, newConfig));
         assertThat(result.clustersToModify()).containsExactly("cluster");
     }
@@ -149,8 +147,7 @@ class VirtualClusterChangeDetectorTest {
     }
 
     private static Configuration configWith(VirtualCluster... clusters) {
-        return new Configuration(null, null, null, List.of(clusters), null, false,
-                Optional.empty(), null, null);
+        return new Configuration(null, null, null, null, null, List.of(clusters), null, false, Optional.empty(), null, null);
     }
 
     /**
@@ -287,8 +284,8 @@ class VirtualClusterChangeDetectorTest {
                 List.of(gateway("default", 9192)),
                 false, false, List.of("filter-a"));
         // newConfig needs filter-a in filterDefinitions; old has no filter defs because filters list was empty.
-        var oldConfig = new Configuration(null, null, null, List.of(oldVc), null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, List.of(filterDef("filter-a")), null, List.of(newVc), null, false, Optional.empty(), null, null);
+        var oldConfig = new Configuration(null, null, null, null, null, List.of(oldVc), null, false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, null, List.of(filterDef("filter-a")), null, null, List.of(newVc), null, false, Optional.empty(), null, null);
         var result = detector.detect(new ConfigurationChangeContext(oldConfig, newConfig));
         assertThat(result.clustersToModify()).containsExactly("cluster");
     }
@@ -304,8 +301,8 @@ class VirtualClusterChangeDetectorTest {
                 new TargetCluster("kafka:9092", Optional.empty()),
                 List.of(gateway("default", 9192)),
                 false, false, List.of());
-        var oldConfig = new Configuration(null, List.of(filterDef("filter-a")), null, List.of(oldVc), null, false, Optional.empty(), null, null);
-        var newConfig = new Configuration(null, null, null, List.of(newVc), null, false, Optional.empty(), null, null);
+        var oldConfig = new Configuration(null, null, List.of(filterDef("filter-a")), null, null, List.of(oldVc), null, false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, null, null, null, null, List.of(newVc), null, false, Optional.empty(), null, null);
         var result = detector.detect(new ConfigurationChangeContext(oldConfig, newConfig));
         assertThat(result.clustersToModify()).containsExactly("cluster");
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/router/TestRouterFactory.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/router/TestRouterFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.router;
+
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.router.RouterContext;
+import io.kroxylicious.proxy.router.RouterFactory;
+import io.kroxylicious.proxy.router.RouterFactoryContext;
+import io.kroxylicious.proxy.router.RouterResponse;
+
+@Plugin(configType = Void.class)
+public class TestRouterFactory implements RouterFactory<Void, Void> {
+
+    @Override
+    public Void initialize(RouterFactoryContext context, Void config) {
+        return null;
+    }
+
+    @Override
+    public Router createRouter(RouterFactoryContext context, Void initializationData) {
+        return new Router() {
+            @Override
+            public CompletionStage<RouterResponse> onRequest(ApiKeys apiKey, short apiVersion,
+                                                             RequestHeaderData header, ApiMessage request,
+                                                             RouterContext routerContext) {
+                return routerContext.respondWithoutReply().withCloseConnection().completed();
+            }
+        };
+    }
+}

--- a/kroxylicious-runtime/src/test/resources/META-INF/services/io.kroxylicious.proxy.router.RouterFactory
+++ b/kroxylicious-runtime/src/test/resources/META-INF/services/io.kroxylicious.proxy.router.RouterFactory
@@ -1,0 +1,1 @@
+io.kroxylicious.proxy.internal.router.TestRouterFactory


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Implements the public API and configuration model for the Routing API ([design proposal 070](https://github.com/kroxylicious/design/pull/70)). This is the interface surface that router plugin authors will implement — the runtime engine is not yet wired up.

- Add io.kroxylicious.proxy.router package: Router, RouterFactory, RouterFactoryContext, RouterContext, RouterResponse, CloseOrTerminalStage, CloseStage, TerminalStage
- Add io.kroxylicious.proxy.topology package: VirtualNode, TopologyService, PartitionLeaders, Coordinators, PartitionInfo, BrokerInfo
- Add configuration model: ClusterDefinition, RouterDefinition, RouteDefinition, RouteTarget, with DAG validation via RouterGraphValidator
- Update VirtualCluster to support target (router or cluster) alongside the deprecated targetCluster
- Update Configuration to accept clusterDefinitions and routerDefinitions

Closes #4151

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
