### PR TITLE
test(webhook): wait for pod termination in fail-closed phase of MinikubeWebhookInstallKT

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-admission/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/pom.xml
@@ -180,6 +180,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
@@ -43,6 +43,7 @@ import io.kroxylicious.testing.integration.ShellUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Tests that the webhook can be installed from YAML manifests and that sidecar
@@ -406,29 +407,19 @@ abstract class AbstractWebhookInstallKT {
                 .withName("kroxylicious-webhook")
                 .scale(0);
 
-        client.apps().deployments()
-                .inNamespace(WEBHOOK_NS)
-                .withName("kroxylicious-webhook")
-                .waitUntilCondition(
-                        d -> d != null
-                                && d.getStatus() != null
-                                && (d.getStatus().getReadyReplicas() == null
-                                        || d.getStatus().getReadyReplicas() == 0),
-                        60, TimeUnit.SECONDS);
-
-        // Wait for the Service endpoints to be drained so the API server
-        // considers the webhook unreachable
-        client.endpoints()
-                .inNamespace(WEBHOOK_NS)
-                .withName("kroxylicious-webhook")
-                .waitUntilCondition(
-                        ep -> ep == null
-                                || ep.getSubsets() == null
-                                || ep.getSubsets().isEmpty()
-                                || ep.getSubsets().stream()
-                                        .allMatch(s -> s.getAddresses() == null
-                                                || s.getAddresses().isEmpty()),
-                        60, TimeUnit.SECONDS);
+        // Wait for webhook pods to actually terminate. The Kubernetes API server maintains
+        // persistent HTTP connection pools to webhook endpoints. Existing socket connections
+        // to terminating pods remain open and can continue servicing requests during the
+        // termination grace period (default 30s). The 60s timeout is chosen to be well-clear
+        // of the default terminationGracePeriodSeconds.
+        LOGGER.info("Waiting for webhook pods to terminate");
+        await().atMost(60, TimeUnit.SECONDS)
+                .until(() -> client.pods()
+                        .inNamespace(WEBHOOK_NS)
+                        .withLabel("app", "kroxylicious-webhook")
+                        .list()
+                        .getItems()
+                        .isEmpty());
 
         LOGGER.info("Webhook scaled to 0, attempting pod creation (expecting rejection)");
         var pod = new PodBuilder()


### PR DESCRIPTION
## Summary

Fixes flaky test failure in `MinikubeWebhookInstallKT` where the `verifyFailClosed()` method incorrectly allowed pod creation to succeed when it should have been rejected.

Fixes #4068

## Problem

The test method `shouldInstallAndInjectSidecar` verifies fail-closed behavior by calling `verifyFailClosed()` which:
1. Scales webhook deployment to 0 replicas
2. Waits for `readyReplicas=0`
3. Waits for Service endpoints to drain
4. Attempts to create a pod (expecting rejection due to `failurePolicy: Fail`)

However, the pod creation **succeeded** instead of being rejected, causing the test to fail with:
```
Expecting code to raise a throwable.
	at AbstractWebhookInstallKT.verifyFailClosed(AbstractWebhookInstallKT.java:449)
```

## Root Cause

**Working theory:** The Kubernetes API server maintains **persistent HTTP connection pools** to webhook endpoints. Draining Service endpoints only prevents **new connections** from being established, but doesn't close **existing socket connections**.

When the test runs:
1. Webhook pods enter Terminating state (default 30s grace period)
2. `readyReplicas` updates to 0
3. Service endpoints are drained
4. **But webhook pods are still running and existing HTTP/2 connections remain open**
5. API server's webhook client finds an existing connection in its pool
6. Sends admission review over that connection
7. Webhook responds successfully
8. Pod creation succeeds ❌

This creates a race condition between:
- How quickly pods terminate (up to 30s grace period)
- When existing HTTP connections timeout/close
- Network timing in the CI environment

## Solution

Wait for webhook **pods to actually terminate**, not just for endpoints to drain. This ensures all HTTP connections are definitively closed before testing fail-closed behavior.

Removed the intermediate checks for `readyReplicas=0` and endpoint drainage - they were insufficient and added complexity. Now directly wait for pod termination using Awaitility.

## Test Plan

- [x] Local testing (MinikubeWebhookInstallKT passes)
- [ ] CI validation

## Checklist

- [x] Commits follow conventional commit format
- [x] Commits include `Assisted-by:` trailer
- [x] Changes include explanatory comments
- [x] Fixes issue reference included