### PR TITLE
[ST] add logging of env variables used in run and log collection in case of failure outisde of test itself scope

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -11,6 +11,9 @@ import java.io.UncheckedIOException;
 import java.util.Objects;
 import java.util.Properties;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.skodjob.testframe.enums.InstallType;
 import io.skodjob.testframe.environment.TestEnvironmentVariables;
 
@@ -18,6 +21,7 @@ import io.skodjob.testframe.environment.TestEnvironmentVariables;
  * The type Environment.
  */
 public class Environment {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Environment.class);
 
     private Environment() {
     }
@@ -213,5 +217,15 @@ public class Environment {
 
     private static String determineStrimziVersion() {
         return readMetadataProperty("strimzi.version");
+    }
+
+    static {
+        ENVIRONMENT_VARIABLES.logEnvironmentVariables();
+        try {
+            ENVIRONMENT_VARIABLES.saveConfigurationFile(CLUSTER_DUMP_DIR);
+        }
+        catch (IOException e) {
+            LOGGER.error("Failed to write environment configuration to {}: {}", CLUSTER_DUMP_DIR, e.getMessage());
+        }
     }
 }

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/extensions/KroxyliciousExtension.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/extensions/KroxyliciousExtension.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.LifecycleMethodExecutionExceptionHandler;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
@@ -35,7 +36,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 /**
  * The type Kroxylicious extension.
  */
-public class KroxyliciousExtension implements ParameterResolver, BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback {
+public class KroxyliciousExtension implements ParameterResolver, BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback,
+        LifecycleMethodExecutionExceptionHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(KroxyliciousExtension.class);
     private static final String K8S_NAMESPACE_KEY = "namespace";
     private static final String EXTENSION_STORE_NAME = "io.kroxylicious.systemtests";
@@ -129,5 +131,25 @@ public class KroxyliciousExtension implements ParameterResolver, BeforeAllCallba
 
     private String extractK8sNamespace(ExtensionContext extensionContext) {
         return extensionContext.getStore(junitNamespace).get(K8S_NAMESPACE_KEY, String.class);
+    }
+
+    @Override
+    public void handleBeforeAllMethodExecutionException(ExtensionContext extensionContext, Throwable throwable) throws Throwable {
+        LOGGER.error("{} - Exception {} has been thrown in @BeforeAll. Going to collect logs from components.",
+                extensionContext.getRequiredTestClass().getSimpleName(), throwable.getMessage());
+        if (!(throwable instanceof TestAbortedException)) {
+            logCollector.collectLogs(extensionContext.getRequiredTestClass().getName(), "setupBefore");
+        }
+        throw throwable;
+    }
+
+    @Override
+    public void handleAfterAllMethodExecutionException(ExtensionContext extensionContext, Throwable throwable) throws Throwable {
+        LOGGER.error("{} - Exception {} has been thrown in @AfterAll. Going to collect logs from components.",
+                extensionContext.getRequiredTestClass().getSimpleName(), throwable.getMessage());
+        if (!(throwable instanceof TestAbortedException)) {
+            logCollector.collectLogs(extensionContext.getRequiredTestClass().getName(), "teardownAfter");
+        }
+        throw throwable;
     }
 }


### PR DESCRIPTION

### Type of change

- Enhancement ST 

### Description

Add collecting of logs from used namespaces even in case of failure in beforeAll which is quite useful in case of problem with registries or access and other mostly test related issues. Currently the colleciton of logs from cluster is skipped in case of fiailures in before/afterAll etc. which in case of failure usually does not provide enogh information to find issue without need to re-run. 

Log but also collect (used) envrionment variables in ST, also useful for investigating failed runs.  This brings much more better confirmation about whether we run what we really intended to run but also useful information about propagation of parameters thus speeding up eventual debugging.



### Checklist


- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
