### PR TITLE
fix(build): move Sonar JBang issue exclusions to root POM

### DIFF
--- a/kroxylicious-openmessaging-benchmarks/pom.xml
+++ b/kroxylicious-openmessaging-benchmarks/pom.xml
@@ -26,17 +26,6 @@
 
     <properties>
         <helm.chart.directory>${project.basedir}/helm/kroxylicious-benchmark</helm.chart.directory>
-        <!--
-            JBang entry-point files use //DEPS and //SOURCES directives that Sonar flags as
-            commented-out code (S125), and a ///usr/bin/env shebang that Sonar flags as a
-            malformed Markdown doc comment (S7476). These comments are not removable — they
-            are required JBang syntax. Exclude all JBang entry-point classes from analysis.
-        -->
-        <sonar.issue.ignore.multicriteria>jbang-s125,jbang-s7476</sonar.issue.ignore.multicriteria>
-        <sonar.issue.ignore.multicriteria.jbang-s125.ruleKey>java:S125</sonar.issue.ignore.multicriteria.jbang-s125.ruleKey>
-        <sonar.issue.ignore.multicriteria.jbang-s125.resourceKey>**/results/cli/*.java</sonar.issue.ignore.multicriteria.jbang-s125.resourceKey>
-        <sonar.issue.ignore.multicriteria.jbang-s7476.ruleKey>java:S7476</sonar.issue.ignore.multicriteria.jbang-s7476.ruleKey>
-        <sonar.issue.ignore.multicriteria.jbang-s7476.resourceKey>**/results/cli/*.java</sonar.issue.ignore.multicriteria.jbang-s7476.resourceKey>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1448,6 +1448,30 @@
                 <sonar.host.url>https://sonarcloud.io</sonar.host.url>
                 <sonar.projectName>Proxy Runtime</sonar.projectName>
                 <sonar.projectKey>kroxylicious_kroxylicious</sonar.projectKey>
+                <!--
+                    JBang entry-point files use //DEPS and //SOURCES directives that Sonar flags as
+                    commented-out code (S125), and a ///usr/bin/env shebang that Sonar flags as a
+                    malformed Markdown doc comment (S7476). These comments are not removable — they
+                    are required JBang syntax.
+                    Must be defined at root level: SonarCloud does not support module-level issue exclusions.
+                -->
+                <sonar.issue.ignore.multicriteria>jbang-s125-cli,jbang-s7476-cli,jbang-s125-webify,jbang-s7476-webify,jbang-s125-crds,jbang-s7476-crds,jbang-s125-release,jbang-s7476-release</sonar.issue.ignore.multicriteria>
+                <sonar.issue.ignore.multicriteria.jbang-s125-cli.ruleKey>java:S125</sonar.issue.ignore.multicriteria.jbang-s125-cli.ruleKey>
+                <sonar.issue.ignore.multicriteria.jbang-s125-cli.resourceKey>**/results/cli/*.java</sonar.issue.ignore.multicriteria.jbang-s125-cli.resourceKey>
+                <sonar.issue.ignore.multicriteria.jbang-s7476-cli.ruleKey>java:S7476</sonar.issue.ignore.multicriteria.jbang-s7476-cli.ruleKey>
+                <sonar.issue.ignore.multicriteria.jbang-s7476-cli.resourceKey>**/results/cli/*.java</sonar.issue.ignore.multicriteria.jbang-s7476-cli.resourceKey>
+                <sonar.issue.ignore.multicriteria.jbang-s125-webify.ruleKey>java:S125</sonar.issue.ignore.multicriteria.jbang-s125-webify.ruleKey>
+                <sonar.issue.ignore.multicriteria.jbang-s125-webify.resourceKey>**/Webify.java</sonar.issue.ignore.multicriteria.jbang-s125-webify.resourceKey>
+                <sonar.issue.ignore.multicriteria.jbang-s7476-webify.ruleKey>java:S7476</sonar.issue.ignore.multicriteria.jbang-s7476-webify.ruleKey>
+                <sonar.issue.ignore.multicriteria.jbang-s7476-webify.resourceKey>**/Webify.java</sonar.issue.ignore.multicriteria.jbang-s7476-webify.resourceKey>
+                <sonar.issue.ignore.multicriteria.jbang-s125-crds.ruleKey>java:S125</sonar.issue.ignore.multicriteria.jbang-s125-crds.ruleKey>
+                <sonar.issue.ignore.multicriteria.jbang-s125-crds.resourceKey>**/package_crds.java</sonar.issue.ignore.multicriteria.jbang-s125-crds.resourceKey>
+                <sonar.issue.ignore.multicriteria.jbang-s7476-crds.ruleKey>java:S7476</sonar.issue.ignore.multicriteria.jbang-s7476-crds.ruleKey>
+                <sonar.issue.ignore.multicriteria.jbang-s7476-crds.resourceKey>**/package_crds.java</sonar.issue.ignore.multicriteria.jbang-s7476-crds.resourceKey>
+                <sonar.issue.ignore.multicriteria.jbang-s125-release.ruleKey>java:S125</sonar.issue.ignore.multicriteria.jbang-s125-release.ruleKey>
+                <sonar.issue.ignore.multicriteria.jbang-s125-release.resourceKey>**/websiteReleaseAssets.java</sonar.issue.ignore.multicriteria.jbang-s125-release.resourceKey>
+                <sonar.issue.ignore.multicriteria.jbang-s7476-release.ruleKey>java:S7476</sonar.issue.ignore.multicriteria.jbang-s7476-release.ruleKey>
+                <sonar.issue.ignore.multicriteria.jbang-s7476-release.resourceKey>**/websiteReleaseAssets.java</sonar.issue.ignore.multicriteria.jbang-s7476-release.resourceKey>
                 <impsort-maven-plugin.goal>check</impsort-maven-plugin.goal>
                 <skip-validate-yaml-snippets>false</skip-validate-yaml-snippets>
             </properties>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Move `sonar.issue.ignore.multicriteria` properties from the OMB module POM to the root POM's `ci` profile, and extend coverage to all JBang entry-point files across the project.

### Additional Context

SonarCloud no longer supports `sonar.issue.ignore.multicriteria` at module level, producing the warning: *"Specifying issue exclusions at module level is not supported anymore."* The fix is to define these properties at the root/project level.

While moving the config, extended the exclusions to cover all 8 JBang files (not just the 4 OMB CLI ones): `Webify.java`, `package_crds.java`, and `websiteReleaseAssets.java`.

### Checklist

- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.