### PR TITLE
Add client certificate authentication to Thales CipherTrust Manager KMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#4182](https://github.com/kroxylicious/kroxylicious/pull/4182): build(deps): Add client certificate authentication to Thales CipherTrust Manager KMS
 * [#4144](https://github.com/kroxylicious/kroxylicious/pull/4144): build(deps): bump io.prometheus:prometheus-metrics-bom from 1.6.1 to 1.8.0
 * [#4207](https://github.com/kroxylicious/kroxylicious/pull/4207): build(deps): [record-validation] bump io.kiota:kiota-http-jdk from 0.0.35 to 0.0.36
 * [#4197](https://github.com/kroxylicious/kroxylicious/pull/4197): build(deps-dev): bump com.google.protobuf:protobuf-java from 4.35.0 to 4.35.1

--- a/kroxylicious-certificate-test-support/pom.xml
+++ b/kroxylicious-certificate-test-support/pom.xml
@@ -42,6 +42,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/kroxylicious-certificate-test-support/src/main/java/io/kroxylicious/testing/certificate/CertificateGenerator.java
+++ b/kroxylicious-certificate-test-support/src/main/java/io/kroxylicious/testing/certificate/CertificateGenerator.java
@@ -7,18 +7,20 @@
 package io.kroxylicious.testing.certificate;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.Instant;
@@ -31,21 +33,31 @@ import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.openssl.jcajce.JcePEMEncryptorBuilder;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Test utility to create key material in a variety of forms.
+ */
 public class CertificateGenerator {
 
     public static final String PKCS_12 = "PKCS12";
     public static final String JKS = "JKS";
     public static final String ALIAS = "alias";
+    @SuppressWarnings("java:S2068") // This is a test password. A constant is not inappropriate.
+    public static final String ENCRYPTED_KEY_PASSWORD = "keypass";
+
+    private CertificateGenerator() {
+        // utility class - do not construct
+    }
 
     public static KeyPair generateRsaKeyPair() {
         try {
             KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
-            generator.initialize(1024, new SecureRandom());
+            generator.initialize(2048, new SecureRandom());
             return generator.generateKeyPair();
         }
         catch (NoSuchAlgorithmException e) {
@@ -63,6 +75,21 @@ public class CertificateGenerator {
         }
     }
 
+    static Path writeEncryptedRsaPrivateKeyPem(KeyPair pair, String password) {
+        try {
+            var rsakey = createTempFile("encrypted-rsakey", ".pem");
+            try (var pemWriter = new JcaPEMWriter(Files.newBufferedWriter(rsakey.toPath(), StandardCharsets.UTF_8))) {
+                var encryptorBuilder = new JcePEMEncryptorBuilder("AES-256-CBC");
+                encryptorBuilder.setProvider(new BouncyCastleProvider());
+                pemWriter.writeObject(pair.getPrivate(), encryptorBuilder.build(password.toCharArray()));
+            }
+            return rsakey.toPath();
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @NonNull
     private static Path writeToPem(Object obj, File file) throws IOException {
         try (JcaPEMWriter pemWriter = new JcaPEMWriter(new FileWriter(file, StandardCharsets.UTF_8))) {
@@ -72,6 +99,7 @@ public class CertificateGenerator {
     }
 
     @NonNull
+    @SuppressWarnings("java:S5443") // These files are used exclusively on test path, file permissions aren't a concern
     private static File createTempFile(String prefix, String suffix) {
         try {
             File file = File.createTempFile(prefix, suffix);
@@ -139,9 +167,7 @@ public class CertificateGenerator {
             store.load(null, null);
             store.setCertificateEntry(ALIAS, cert);
             char[] pass = password != null ? password.toCharArray() : null;
-            try (FileOutputStream outputStream = new FileOutputStream(certFile)) {
-                store.store(outputStream, pass);
-            }
+            writeKeyStore(certFile, store, pass);
             return certFile.toPath();
         }
         catch (Exception e) {
@@ -160,6 +186,8 @@ public class CertificateGenerator {
 
     public record Keys(KeyPair serverKey,
                        Path privateKeyPem,
+                       Path encryptedPrivateKeyPem,
+                       String encryptedPrivateKeyPassword,
                        Path selfSignedCertificatePem,
                        TrustStore pkcs12ClientTruststore,
                        TrustStore jksClientTruststore,
@@ -171,8 +199,9 @@ public class CertificateGenerator {
         String password = "changeit";
         KeyPair pair = generateRsaKeyPair();
         Path privateKeyPem = writeRsaPrivateKeyPem(pair);
+        Path encryptedPrivateKeyPem = writeEncryptedRsaPrivateKeyPem(pair, ENCRYPTED_KEY_PASSWORD);
         X509Certificate x509Certificate = generateSelfSignedX509Certificate(pair);
-        KeyStore keyStore = createJksKeystore(pair, x509Certificate, password, "keypass");
+        KeyStore keyStore = createJksKeystore(pair, x509Certificate, password, ENCRYPTED_KEY_PASSWORD);
         Path serverCert = generateCertPem(x509Certificate);
         Path pkcs12Trust = buildPkcs12TrustStore(x509Certificate, password);
         Path noPasswordPkcs12Trust = buildPkcs12TrustStore(x509Certificate, null);
@@ -181,7 +210,8 @@ public class CertificateGenerator {
         TrustStore pkcs12ClientTruststore = new TrustStore(pkcs12Trust, PKCS_12, password, passwordFile);
         TrustStore pkcs12NoPasswordTruststore = new TrustStore(noPasswordPkcs12Trust, PKCS_12, null, null);
         TrustStore jksClientTruststore = new TrustStore(jksTrust, JKS, password, passwordFile);
-        return new Keys(pair, privateKeyPem, serverCert, pkcs12ClientTruststore, jksClientTruststore, pkcs12NoPasswordTruststore, keyStore);
+        return new Keys(pair, privateKeyPem, encryptedPrivateKeyPem, ENCRYPTED_KEY_PASSWORD, serverCert, pkcs12ClientTruststore, jksClientTruststore,
+                pkcs12NoPasswordTruststore, keyStore);
     }
 
     public static KeyStore createJksKeystore(KeyPair privateKeyPem, X509Certificate x509Certificate, String storePassword, String keyPassword) {
@@ -190,9 +220,7 @@ public class CertificateGenerator {
             java.security.KeyStore store = java.security.KeyStore.getInstance(JKS);
             store.load(null);
             store.setKeyEntry(ALIAS, privateKeyPem.getPrivate(), keyPassword.toCharArray(), new Certificate[]{ x509Certificate });
-            try (FileOutputStream stream = new FileOutputStream(tempFile)) {
-                store.store(stream, storePassword.toCharArray());
-            }
+            writeKeyStore(tempFile, store, storePassword.toCharArray());
             Path path = tempFile.toPath();
             Path storePasswordFile = writeToTempFile(storePassword);
             Path keyPasswordFile = writeToTempFile(keyPassword);
@@ -203,11 +231,18 @@ public class CertificateGenerator {
         }
     }
 
+    private static void writeKeyStore(File tempFile, java.security.KeyStore store, char[] storePassword)
+            throws IOException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
+        try (var stream = Files.newOutputStream(tempFile.toPath())) {
+            store.store(stream, storePassword);
+        }
+    }
+
     private static Path writeToTempFile(String password) {
         try {
             File tempFile = createTempFile("pass", "raw");
             Path path = tempFile.toPath();
-            java.nio.file.Files.writeString(path, password, StandardCharsets.UTF_8);
+            Files.writeString(path, password, StandardCharsets.UTF_8);
             return path;
         }
         catch (IOException e) {

--- a/kroxylicious-certificate-test-support/src/main/java/io/kroxylicious/testing/certificate/CertificateGenerator.java
+++ b/kroxylicious-certificate-test-support/src/main/java/io/kroxylicious/testing/certificate/CertificateGenerator.java
@@ -212,21 +212,36 @@ public class CertificateGenerator {
                 pkcs12NoPasswordTruststore, keyStore);
     }
 
-    public static KeyStore createJksKeystore(KeyPair privateKeyPem, X509Certificate x509Certificate, String storePassword, String keyPassword) {
+    /**
+     * Create a keystore containing the given key pair and certificate.
+     *
+     * @param privateKeyPem the private key
+     * @param x509Certificate the certificate
+     * @param storePassword password for the keystore
+     * @param keyPassword password for the key entry
+     * @param type the keystore type (e.g., "JKS", "PKCS12")
+     * @return KeyStore record containing path, type, passwords, and password files
+     */
+    public static KeyStore createKeystore(KeyPair privateKeyPem, X509Certificate x509Certificate, String storePassword, String keyPassword, String type) {
+        String suffix = PKCS_12.equals(type) ? ".p12" : ".jks";
         try {
-            File tempFile = createTempFile("keystore", "jks");
-            java.security.KeyStore store = java.security.KeyStore.getInstance(JKS);
+            File tempFile = createTempFile("keystore", suffix);
+            java.security.KeyStore store = java.security.KeyStore.getInstance(type);
             store.load(null);
             store.setKeyEntry(ALIAS, privateKeyPem.getPrivate(), keyPassword.toCharArray(), new Certificate[]{ x509Certificate });
             writeKeyStore(tempFile, store, storePassword.toCharArray());
             Path path = tempFile.toPath();
             Path storePasswordFile = writeToTempFile(storePassword);
             Path keyPasswordFile = writeToTempFile(keyPassword);
-            return new KeyStore(path, JKS, storePassword, storePasswordFile, keyPassword, keyPasswordFile);
+            return new KeyStore(path, type, storePassword, storePasswordFile, keyPassword, keyPasswordFile);
         }
         catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static KeyStore createJksKeystore(KeyPair privateKeyPem, X509Certificate x509Certificate, String storePassword, String keyPassword) {
+        return createKeystore(privateKeyPem, x509Certificate, storePassword, keyPassword, JKS);
     }
 
     private static void writeKeyStore(File tempFile, java.security.KeyStore store, char[] storePassword)

--- a/kroxylicious-certificate-test-support/src/main/java/io/kroxylicious/testing/certificate/CertificateGenerator.java
+++ b/kroxylicious-certificate-test-support/src/main/java/io/kroxylicious/testing/certificate/CertificateGenerator.java
@@ -151,17 +151,17 @@ public class CertificateGenerator {
         }
     }
 
-    private static Path buildPkcs12TrustStore(X509Certificate cert, @Nullable String password) {
-        return buildTrustStore(cert, password, ".p12", PKCS_12);
-    }
-
-    public static TrustStore buildJksTrustStore(X509Certificate cert, @Nullable String password) {
-        Path path = buildTrustStore(cert, password, ".jks", JKS);
-        return new TrustStore(path, JKS, password, null);
-    }
-
+    /**
+     * Create a trust store containing the given certificate.
+     *
+     * @param cert the certificate to include in the trust store
+     * @param password optional password for the trust store
+     * @param type the trust store type (e.g., "JKS", "PKCS12")
+     * @return TrustStore record containing path, type, password, and password file
+     */
     @NonNull
-    private static Path buildTrustStore(X509Certificate cert, @Nullable String password, String suffix, String type) {
+    public static TrustStore createTrustStore(X509Certificate cert, @Nullable String password, String type) {
+        String suffix = PKCS_12.equals(type) ? ".p12" : ".jks";
         try {
             File certFile = createTempFile("trust", suffix);
             java.security.KeyStore store = java.security.KeyStore.getInstance(type);
@@ -169,7 +169,8 @@ public class CertificateGenerator {
             store.setCertificateEntry(ALIAS, cert);
             char[] pass = password != null ? password.toCharArray() : null;
             writeKeyStore(certFile, store, pass);
-            return certFile.toPath();
+            Path passwordFile = password != null ? writeToTempFile(password) : null;
+            return new TrustStore(certFile.toPath(), type, password, passwordFile);
         }
         catch (Exception e) {
             throw new RuntimeException(e);
@@ -204,13 +205,9 @@ public class CertificateGenerator {
         X509Certificate x509Certificate = generateSelfSignedX509Certificate(pair);
         KeyStore keyStore = createJksKeystore(pair, x509Certificate, password, ENCRYPTED_KEY_PASSWORD);
         Path serverCert = generateCertPem(x509Certificate);
-        Path pkcs12Trust = buildPkcs12TrustStore(x509Certificate, password);
-        Path noPasswordPkcs12Trust = buildPkcs12TrustStore(x509Certificate, null);
-        TrustStore jksTrustStore = buildJksTrustStore(x509Certificate, password);
-        Path passwordFile = writeToTempFile(password);
-        TrustStore pkcs12ClientTruststore = new TrustStore(pkcs12Trust, PKCS_12, password, passwordFile);
-        TrustStore pkcs12NoPasswordTruststore = new TrustStore(noPasswordPkcs12Trust, PKCS_12, null, null);
-        TrustStore jksClientTruststore = new TrustStore(jksTrustStore.path(), JKS, password, passwordFile);
+        TrustStore pkcs12ClientTruststore = createTrustStore(x509Certificate, password, PKCS_12);
+        TrustStore pkcs12NoPasswordTruststore = createTrustStore(x509Certificate, null, PKCS_12);
+        TrustStore jksClientTruststore = createTrustStore(x509Certificate, password, JKS);
         return new Keys(pair, privateKeyPem, encryptedPrivateKeyPem, ENCRYPTED_KEY_PASSWORD, serverCert, pkcs12ClientTruststore, jksClientTruststore,
                 pkcs12NoPasswordTruststore, keyStore);
     }

--- a/kroxylicious-certificate-test-support/src/main/java/io/kroxylicious/testing/certificate/CertificateGenerator.java
+++ b/kroxylicious-certificate-test-support/src/main/java/io/kroxylicious/testing/certificate/CertificateGenerator.java
@@ -155,8 +155,9 @@ public class CertificateGenerator {
         return buildTrustStore(cert, password, ".p12", PKCS_12);
     }
 
-    private static Path buildJksTrustStore(X509Certificate cert, @Nullable String password) {
-        return buildTrustStore(cert, password, ".jks", JKS);
+    public static TrustStore buildJksTrustStore(X509Certificate cert, @Nullable String password) {
+        Path path = buildTrustStore(cert, password, ".jks", JKS);
+        return new TrustStore(path, JKS, password, null);
     }
 
     @NonNull
@@ -205,11 +206,11 @@ public class CertificateGenerator {
         Path serverCert = generateCertPem(x509Certificate);
         Path pkcs12Trust = buildPkcs12TrustStore(x509Certificate, password);
         Path noPasswordPkcs12Trust = buildPkcs12TrustStore(x509Certificate, null);
-        Path jksTrust = buildJksTrustStore(x509Certificate, password);
+        TrustStore jksTrustStore = buildJksTrustStore(x509Certificate, password);
         Path passwordFile = writeToTempFile(password);
         TrustStore pkcs12ClientTruststore = new TrustStore(pkcs12Trust, PKCS_12, password, passwordFile);
         TrustStore pkcs12NoPasswordTruststore = new TrustStore(noPasswordPkcs12Trust, PKCS_12, null, null);
-        TrustStore jksClientTruststore = new TrustStore(jksTrust, JKS, password, passwordFile);
+        TrustStore jksClientTruststore = new TrustStore(jksTrustStore.path(), JKS, password, passwordFile);
         return new Keys(pair, privateKeyPem, encryptedPrivateKeyPem, ENCRYPTED_KEY_PASSWORD, serverCert, pkcs12ClientTruststore, jksClientTruststore,
                 pkcs12NoPasswordTruststore, keyStore);
     }

--- a/kroxylicious-certificate-test-support/src/main/java/io/kroxylicious/testing/certificate/CertificateGenerator.java
+++ b/kroxylicious-certificate-test-support/src/main/java/io/kroxylicious/testing/certificate/CertificateGenerator.java
@@ -203,7 +203,7 @@ public class CertificateGenerator {
         Path privateKeyPem = writeRsaPrivateKeyPem(pair);
         Path encryptedPrivateKeyPem = writeEncryptedRsaPrivateKeyPem(pair, ENCRYPTED_KEY_PASSWORD);
         X509Certificate x509Certificate = generateSelfSignedX509Certificate(pair);
-        KeyStore keyStore = createJksKeystore(pair, x509Certificate, password, ENCRYPTED_KEY_PASSWORD);
+        KeyStore keyStore = createKeystore(pair, x509Certificate, password, ENCRYPTED_KEY_PASSWORD, JKS);
         Path serverCert = generateCertPem(x509Certificate);
         TrustStore pkcs12ClientTruststore = createTrustStore(x509Certificate, password, PKCS_12);
         TrustStore pkcs12NoPasswordTruststore = createTrustStore(x509Certificate, null, PKCS_12);
@@ -238,10 +238,6 @@ public class CertificateGenerator {
         catch (Exception e) {
             throw new RuntimeException(e);
         }
-    }
-
-    public static KeyStore createJksKeystore(KeyPair privateKeyPem, X509Certificate x509Certificate, String storePassword, String keyPassword) {
-        return createKeystore(privateKeyPem, x509Certificate, storePassword, keyPassword, JKS);
     }
 
     private static void writeKeyStore(File tempFile, java.security.KeyStore store, char[] storePassword)

--- a/kroxylicious-certificate-test-support/src/test/java/io/kroxylicious/testing/certificate/CertificateGeneratorTest.java
+++ b/kroxylicious-certificate-test-support/src/test/java/io/kroxylicious/testing/certificate/CertificateGeneratorTest.java
@@ -88,14 +88,6 @@ class CertificateGeneratorTest {
         });
     }
 
-    @Test
-    void createJksKeystore() throws Exception {
-        KeyPair keyPair = CertificateGenerator.generateRsaKeyPair();
-        X509Certificate x509Certificate = CertificateGenerator.generateSelfSignedX509Certificate(keyPair);
-        CertificateGenerator.KeyStore jksKeystore = CertificateGenerator.createJksKeystore(keyPair, x509Certificate, "storePazz", "keyPazz");
-        assertKeyStoreContains(jksKeystore, keyPair, x509Certificate, "keyPazz", "storePazz", CertificateGenerator.JKS);
-    }
-
     @ParameterizedTest
     @ValueSource(strings = { "JKS", "PKCS12" })
     void createKeystoreCreatesCorrectType(String type) throws Exception {

--- a/kroxylicious-certificate-test-support/src/test/java/io/kroxylicious/testing/certificate/CertificateGeneratorTest.java
+++ b/kroxylicious-certificate-test-support/src/test/java/io/kroxylicious/testing/certificate/CertificateGeneratorTest.java
@@ -30,6 +30,8 @@ import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -281,6 +283,52 @@ class CertificateGeneratorTest {
         catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "JKS", "PKCS12" })
+    void createTrustStoreCreatesCorrectType(String type) throws Exception {
+        // Given: a certificate and password
+        KeyPair keyPair = CertificateGenerator.generateRsaKeyPair();
+        X509Certificate certificate = CertificateGenerator.generateSelfSignedX509Certificate(keyPair);
+        String password = "trustpass";
+
+        // When: building trust store with specified type
+        CertificateGenerator.TrustStore trustStore = CertificateGenerator.createTrustStore(certificate, password, type);
+
+        // Then: trust store contains the certificate with correct type and password
+        assertTrustStore(trustStore, certificate, password, type);
+    }
+
+    @Test
+    void createTrustStoreHandlesNullPasswordForPkcs12() throws Exception {
+        // Given: a certificate with no password
+        KeyPair keyPair = CertificateGenerator.generateRsaKeyPair();
+        X509Certificate certificate = CertificateGenerator.generateSelfSignedX509Certificate(keyPair);
+
+        // When: building PKCS12 trust store without password
+        CertificateGenerator.TrustStore trustStore = CertificateGenerator.createTrustStore(certificate, null, "PKCS12");
+
+        // Then: trust store is created without password
+        assertThat(trustStore).isNotNull();
+        assertThat(trustStore.password()).isNull();
+        assertThat(trustStore.passwordFile()).isNull();
+        KeyStore keyStore = loadKeyStore(trustStore.path(), null, "PKCS12");
+        Certificate trustedCert = keyStore.getCertificate(CertificateGenerator.ALIAS);
+        assertThat(trustedCert).isNotNull().isEqualTo(certificate);
+    }
+
+    @Test
+    void createTrustStoreFailsWithInvalidType() {
+        // Given: a certificate
+        KeyPair keyPair = CertificateGenerator.generateRsaKeyPair();
+        X509Certificate certificate = CertificateGenerator.generateSelfSignedX509Certificate(keyPair);
+
+        // When/Then: building trust store with invalid type throws RuntimeException wrapping KeyStoreException
+        assertThatCode(() -> CertificateGenerator.createTrustStore(certificate, "pass", "INVALID_TYPE"))
+                .isInstanceOf(RuntimeException.class)
+                .hasCauseInstanceOf(java.security.KeyStoreException.class)
+                .hasMessageContaining("INVALID_TYPE");
     }
 
 }

--- a/kroxylicious-certificate-test-support/src/test/java/io/kroxylicious/testing/certificate/CertificateGeneratorTest.java
+++ b/kroxylicious-certificate-test-support/src/test/java/io/kroxylicious/testing/certificate/CertificateGeneratorTest.java
@@ -53,6 +53,21 @@ class CertificateGeneratorTest {
     }
 
     @Test
+    void writeEncryptedRsaPrivateKeyPem() throws IOException {
+        // Given: a key pair and password
+        KeyPair keyPair = CertificateGenerator.generateRsaKeyPair();
+        String password = "testpassword";
+
+        // When: writing encrypted PEM
+        Path path = CertificateGenerator.writeEncryptedRsaPrivateKeyPem(keyPair, password);
+
+        // Then: the private key can be decrypted with the password
+        byte[] pemBytes = Files.readAllBytes(path);
+        PrivateKey decrypted = PemParser.parsePrivateKey(pemBytes, password.toCharArray());
+        assertThat(decrypted).isEqualTo(keyPair.getPrivate());
+    }
+
+    @Test
     void generateSelfSignedX509Certificate() {
         KeyPair keyPair = CertificateGenerator.generateRsaKeyPair();
         X509Certificate x509Certificate = CertificateGenerator.generateSelfSignedX509Certificate(keyPair);
@@ -80,22 +95,93 @@ class CertificateGeneratorTest {
     }
 
     @Test
-    void generate() throws Exception {
+    void generateCreatesRsaKeyPair() {
+        // When: calling generate
         CertificateGenerator.Keys keys = CertificateGenerator.generate();
-        assertRsaKeyPairGenerated(keys.serverKey());
-        assertPemAtPathContainsPrivateKey(keys.privateKeyPem(), keys.serverKey());
 
+        // Then: should create a valid RSA key pair
+        assertRsaKeyPairGenerated(keys.serverKey());
+    }
+
+    @Test
+    void generateCreatesUnencryptedPrivateKeyPem() throws Exception {
+        // When: calling generate
+        CertificateGenerator.Keys keys = CertificateGenerator.generate();
+
+        // Then: should create unencrypted private key PEM matching the key pair
+        assertPemAtPathContainsPrivateKey(keys.privateKeyPem(), keys.serverKey());
+    }
+
+    @Test
+    void generateCreatesEncryptedPrivateKeyPem() throws Exception {
+        // When: calling generate
+        CertificateGenerator.Keys keys = CertificateGenerator.generate();
+
+        // Then: should create encrypted private key PEM with password
+        assertThat(keys.encryptedPrivateKeyPem()).isNotNull();
+        assertThat(keys.encryptedPrivateKeyPassword()).isEqualTo(CertificateGenerator.ENCRYPTED_KEY_PASSWORD);
+        byte[] encryptedPemBytes = Files.readAllBytes(keys.encryptedPrivateKeyPem());
+        PrivateKey decryptedKey = PemParser.parsePrivateKey(encryptedPemBytes, keys.encryptedPrivateKeyPassword().toCharArray());
+        assertThat(decryptedKey).isEqualTo(keys.serverKey().getPrivate());
+    }
+
+    @Test
+    void generateCreatesSelfSignedCertificatePem() throws Exception {
+        // When: calling generate
+        CertificateGenerator.Keys keys = CertificateGenerator.generate();
+
+        // Then: should create self-signed certificate PEM for the key pair
         assertThat(keys.selfSignedCertificatePem()).isNotNull();
         Object cert = new PEMParser(new FileReader(keys.selfSignedCertificatePem().toFile())).readObject();
         assertThat(cert).isInstanceOf(X509CertificateHolder.class);
         X509Certificate certificate = convertToJcaX509Cert((X509CertificateHolder) cert);
         assertSelfSignedCertGeneratedForKeyPair(certificate, keys.serverKey());
+    }
 
+    @Test
+    void generateCreatesJksServerKeystore() throws Exception {
+        // When: calling generate
+        CertificateGenerator.Keys keys = CertificateGenerator.generate();
+
+        // Then: should create JKS keystore containing the private key and certificate
+        X509Certificate certificate = loadCertificateFromPem(keys.selfSignedCertificatePem());
         assertKeyStoreContains(keys.jksServerKeystore(), keys.serverKey(), certificate, "keypass", "changeit");
+    }
 
+    @Test
+    void generateCreatesJksClientTruststore() throws Exception {
+        // When: calling generate
+        CertificateGenerator.Keys keys = CertificateGenerator.generate();
+
+        // Then: should create JKS truststore with password
+        X509Certificate certificate = loadCertificateFromPem(keys.selfSignedCertificatePem());
         assertTrustStore(keys.jksClientTruststore(), certificate, "changeit", "JKS");
+    }
+
+    @Test
+    void generateCreatesPkcs12ClientTruststore() throws Exception {
+        // When: calling generate
+        CertificateGenerator.Keys keys = CertificateGenerator.generate();
+
+        // Then: should create PKCS12 truststore with password
+        X509Certificate certificate = loadCertificateFromPem(keys.selfSignedCertificatePem());
         assertTrustStore(keys.pkcs12ClientTruststore(), certificate, "changeit", "PKCS12");
+    }
+
+    @Test
+    void generateCreatesPkcs12NoPasswordClientTruststore() throws Exception {
+        // When: calling generate
+        CertificateGenerator.Keys keys = CertificateGenerator.generate();
+
+        // Then: should create PKCS12 truststore without password
+        X509Certificate certificate = loadCertificateFromPem(keys.selfSignedCertificatePem());
         assertTrustStore(keys.pkcs12NoPasswordClientTruststore(), certificate, null, "PKCS12");
+    }
+
+    private X509Certificate loadCertificateFromPem(Path pemPath) throws Exception {
+        Object cert = new PEMParser(new FileReader(pemPath.toFile())).readObject();
+        assertThat(cert).isInstanceOf(X509CertificateHolder.class);
+        return convertToJcaX509Cert((X509CertificateHolder) cert);
     }
 
     private void assertTrustStore(CertificateGenerator.TrustStore trustStore, X509Certificate certificate, @Nullable String password, String type) throws Exception {
@@ -121,7 +207,7 @@ class CertificateGeneratorTest {
         PrivateKey privateKey = keyPair.getPrivate();
         assertThat(privateKey.getAlgorithm()).isEqualTo("RSA");
         assertThat(privateKey.getFormat()).isEqualTo("PKCS#8");
-        assertThat(privateKey).isInstanceOfSatisfying(RSAPrivateKey.class, rsaPrivateKey -> assertThat(rsaPrivateKey.getModulus().bitLength()).isEqualTo(1024));
+        assertThat(privateKey).isInstanceOfSatisfying(RSAPrivateKey.class, rsaPrivateKey -> assertThat(rsaPrivateKey.getModulus().bitLength()).isEqualTo(2048));
     }
 
     private static void assertPemAtPathContainsPrivateKey(Path path, KeyPair keyPair) throws IOException {

--- a/kroxylicious-certificate-test-support/src/test/java/io/kroxylicious/testing/certificate/CertificateGeneratorTest.java
+++ b/kroxylicious-certificate-test-support/src/test/java/io/kroxylicious/testing/certificate/CertificateGeneratorTest.java
@@ -93,7 +93,23 @@ class CertificateGeneratorTest {
         KeyPair keyPair = CertificateGenerator.generateRsaKeyPair();
         X509Certificate x509Certificate = CertificateGenerator.generateSelfSignedX509Certificate(keyPair);
         CertificateGenerator.KeyStore jksKeystore = CertificateGenerator.createJksKeystore(keyPair, x509Certificate, "storePazz", "keyPazz");
-        assertKeyStoreContains(jksKeystore, keyPair, x509Certificate, "keyPazz", "storePazz");
+        assertKeyStoreContains(jksKeystore, keyPair, x509Certificate, "keyPazz", "storePazz", CertificateGenerator.JKS);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "JKS", "PKCS12" })
+    void createKeystoreCreatesCorrectType(String type) throws Exception {
+        // Given: a key pair, certificate, and passwords
+        KeyPair keyPair = CertificateGenerator.generateRsaKeyPair();
+        X509Certificate certificate = CertificateGenerator.generateSelfSignedX509Certificate(keyPair);
+        String storePassword = "storePazz";
+        String keyPassword = "keyPazz";
+
+        // When: creating keystore with specified type
+        CertificateGenerator.KeyStore keyStore = CertificateGenerator.createKeystore(keyPair, certificate, storePassword, keyPassword, type);
+
+        // Then: keystore contains the key and certificate with correct type and passwords
+        assertKeyStoreContains(keyStore, keyPair, certificate, keyPassword, storePassword, type);
     }
 
     @Test
@@ -147,7 +163,7 @@ class CertificateGeneratorTest {
 
         // Then: should create JKS keystore containing the private key and certificate
         X509Certificate certificate = loadCertificateFromPem(keys.selfSignedCertificatePem());
-        assertKeyStoreContains(keys.jksServerKeystore(), keys.serverKey(), certificate, "keypass", "changeit");
+        assertKeyStoreContains(keys.jksServerKeystore(), keys.serverKey(), certificate, "keypass", "changeit", CertificateGenerator.JKS);
     }
 
     @Test
@@ -256,7 +272,7 @@ class CertificateGeneratorTest {
     }
 
     private static void assertKeyStoreContains(CertificateGenerator.KeyStore jksKeystore, KeyPair keyPair, X509Certificate x509Certificate, String keyPassword,
-                                               String storePassword)
+                                               String storePassword, String type)
             throws Exception {
         assertThat(jksKeystore).isNotNull();
         assertThat(jksKeystore.keyPassword()).isNotNull().isEqualTo(keyPassword);
@@ -266,8 +282,8 @@ class CertificateGeneratorTest {
         assertThat(jksKeystore.storePasswordFile()).isNotNull();
         assertThat(Files.readString(jksKeystore.storePasswordFile())).isEqualTo(storePassword);
         assertThat(jksKeystore.path()).isNotNull();
-        assertThat(jksKeystore.type()).isEqualTo("JKS");
-        KeyStore store = loadKeyStore(jksKeystore.path(), jksKeystore.storePassword(), "JKS");
+        assertThat(jksKeystore.type()).isEqualTo(type);
+        KeyStore store = loadKeyStore(jksKeystore.path(), jksKeystore.storePassword(), type);
         Key key = store.getKey(CertificateGenerator.ALIAS, jksKeystore.keyPassword().toCharArray());
         assertThat(key).isEqualTo(keyPair.getPrivate());
         Certificate certificate = store.getCertificate(CertificateGenerator.ALIAS);

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/pom.xml
@@ -22,6 +22,22 @@
     <name>Thales CipherTrust Manager KMS test support</name>
     <description>Test support code for Thales CipherTrust Manager KMS</description>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- https://junit-pioneer.org/docs/environment-variables/#warnings-for-reflective-access -->
+                    <argLine>
+                        @{jacoco.argline}
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <!-- Kroxylicious dependencies -->
         <dependency>
@@ -90,6 +106,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServer.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServer.java
@@ -7,7 +7,6 @@
 package io.kroxylicious.testing.kms.ciphertrust;
 
 import java.net.URLDecoder;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.SecureRandom;
@@ -225,31 +224,13 @@ public class CipherTrustMockServer implements AutoCloseable {
         }
     }
 
-    @SuppressWarnings({ "java:S5443", "java:S2068", "java:S6437" }) // S5443: createTempFile is safe for test trust stores. S2068: STORE_PASSWORD is a test constant.
     private CertificateGenerator.TrustStore createClientTrustStore() {
         // We need to generate the client certificate first, so we can add it to the trust store
         if (clientCertificate == null) {
             generateClientCertificate();
         }
 
-        try {
-            // Create a JKS truststore containing the client certificate
-            java.security.KeyStore trustStore = java.security.KeyStore.getInstance("JKS");
-            trustStore.load(null);
-            trustStore.setCertificateEntry("client-cert", clientCertificate);
-
-            // Write to temporary file
-            var tempFile = Files.createTempFile("client-truststore-", ".jks");
-            tempFile.toFile().deleteOnExit();
-            try (var stream = Files.newOutputStream(tempFile)) {
-                trustStore.store(stream, STORE_PASSWORD.toCharArray());
-            }
-
-            return new CertificateGenerator.TrustStore(tempFile, "JKS", STORE_PASSWORD, null);
-        }
-        catch (Exception e) {
-            throw new MockServerException("Failed to create client truststore", e);
-        }
+        return CertificateGenerator.buildJksTrustStore(clientCertificate, STORE_PASSWORD);
     }
 
     /**

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServer.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServer.java
@@ -131,13 +131,6 @@ public class CipherTrustMockServer implements AutoCloseable {
     private KeyPair clientKeyPair;
 
     /**
-     * Create a CipherTrust mock server using HTTP.
-     */
-    public CipherTrustMockServer() {
-        this(false, false);
-    }
-
-    /**
      * Create a CipherTrust mock server with optional TLS support.
      *
      * @param useTls if true, configure HTTPS with self-signed certificate; if false, use HTTP
@@ -151,8 +144,12 @@ public class CipherTrustMockServer implements AutoCloseable {
      *
      * @param useTls if true, configure HTTPS with self-signed certificate; if false, use HTTP
      * @param requireClientAuth if true, require client certificates during TLS handshake (mutual TLS)
+     * @throws IllegalArgumentException if requireClientAuth is true but useTls is false
      */
     public CipherTrustMockServer(boolean useTls, boolean requireClientAuth) {
+        if (requireClientAuth && !useTls) {
+            throw new IllegalArgumentException("Client certificate authentication requires TLS (useTls must be true)");
+        }
         this.useTls = useTls;
         this.requireClientAuth = requireClientAuth;
         SecureRandom secureRandom;
@@ -183,6 +180,7 @@ public class CipherTrustMockServer implements AutoCloseable {
 
         if (useTls) {
             config.dynamicHttpsPort();
+            config.httpDisabled(true);
             configureTls(config);
         }
         else {
@@ -374,6 +372,10 @@ public class CipherTrustMockServer implements AutoCloseable {
     @VisibleForTesting
     @Nullable
     Tls createTls(boolean includeClientCert) {
+        if (!isHttps()) {
+            return null;
+        }
+
         io.kroxylicious.proxy.config.tls.KeyPair keyPair = null;
         if (includeClientCert) {
             keyPair = new io.kroxylicious.proxy.config.tls.KeyPair(
@@ -382,15 +384,10 @@ public class CipherTrustMockServer implements AutoCloseable {
                     null);
         }
 
-        TrustProvider trustProvider = null;
-        if (isHttps()) {
-            Path caCertPem = getServerCertificatePem();
-            trustProvider = new TrustStore(caCertPem.toString(), null, Tls.PEM, null);
-        }
+        Path caCertPem = getServerCertificatePem();
+        TrustProvider trustProvider = new TrustStore(caCertPem.toString(), null, Tls.PEM, null);
 
-        return keyPair != null || trustProvider != null
-                ? new Tls(keyPair, trustProvider, null, null)
-                : null;
+        return new Tls(keyPair, trustProvider, null, null);
     }
 
     /**

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServer.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServer.java
@@ -230,7 +230,7 @@ public class CipherTrustMockServer implements AutoCloseable {
             generateClientCertificate();
         }
 
-        return CertificateGenerator.buildJksTrustStore(clientCertificate, STORE_PASSWORD);
+        return CertificateGenerator.createTrustStore(clientCertificate, STORE_PASSWORD, "JKS");
     }
 
     /**

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServer.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServer.java
@@ -214,7 +214,7 @@ public class CipherTrustMockServer implements AutoCloseable {
                 config.needClientAuth(true);
 
                 // Create trust store containing our test client certificate so WireMock will accept it
-                CertificateGenerator.TrustStore trustStore = createClientTrustStore();
+                CertificateGenerator.TrustStore trustStore = CertificateGenerator.createTrustStore(clientCertificate, STORE_PASSWORD, "JKS");
                 config.trustStorePath(trustStore.path().toString())
                         .trustStorePassword(trustStore.password());
             }
@@ -222,13 +222,6 @@ public class CipherTrustMockServer implements AutoCloseable {
         catch (Exception e) {
             throw new MockServerException("Failed to configure TLS", e);
         }
-    }
-
-    private CertificateGenerator.TrustStore createClientTrustStore() {
-        if (clientCertificate == null) {
-            generateClientCertificate();
-        }
-        return CertificateGenerator.createTrustStore(clientCertificate, STORE_PASSWORD, "JKS");
     }
 
     /**

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServer.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServer.java
@@ -194,15 +194,17 @@ public class CipherTrustMockServer implements AutoCloseable {
             KeyPair keyPair = CertificateGenerator.generateRsaKeyPair();
             X509Certificate certificate = CertificateGenerator.generateSelfSignedX509Certificate(keyPair);
             this.serverCertificate = certificate; // Store for later access
-            CertificateGenerator.KeyStore keyStore = CertificateGenerator.createJksKeystore(
+            CertificateGenerator.KeyStore keyStore = CertificateGenerator.createKeystore(
                     keyPair,
                     certificate,
                     STORE_PASSWORD,
-                    KEY_PASSWORD);
+                    KEY_PASSWORD,
+                    CertificateGenerator.PKCS_12);
 
             config.keystorePath(keyStore.path().toString())
                     .keystorePassword(STORE_PASSWORD)
-                    .keyManagerPassword(KEY_PASSWORD);
+                    .keyManagerPassword(KEY_PASSWORD)
+                    .keystoreType(CertificateGenerator.PKCS_12);
 
             if (requireClientAuth) {
                 // Configure mutual TLS: server will require client certificates during TLS handshake.
@@ -214,9 +216,10 @@ public class CipherTrustMockServer implements AutoCloseable {
                 config.needClientAuth(true);
 
                 // Create trust store containing our test client certificate so WireMock will accept it
-                CertificateGenerator.TrustStore trustStore = CertificateGenerator.createTrustStore(clientCertificate, STORE_PASSWORD, "JKS");
+                CertificateGenerator.TrustStore trustStore = CertificateGenerator.createTrustStore(clientCertificate, STORE_PASSWORD, CertificateGenerator.PKCS_12);
                 config.trustStorePath(trustStore.path().toString())
-                        .trustStorePassword(trustStore.password());
+                        .trustStorePassword(trustStore.password())
+                        .trustStoreType(CertificateGenerator.PKCS_12);
             }
         }
         catch (Exception e) {

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServer.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServer.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.testing.kms.ciphertrust;
 
 import java.net.URLDecoder;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.SecureRandom;
@@ -41,6 +42,10 @@ import io.kroxylicious.kms.provider.thales.ciphertrust.model.EncryptRequest;
 import io.kroxylicious.kms.provider.thales.ciphertrust.model.EncryptResponse;
 import io.kroxylicious.kms.provider.thales.ciphertrust.model.GetKeyResponse;
 import io.kroxylicious.kms.provider.thales.ciphertrust.model.RandomResponse;
+import io.kroxylicious.proxy.config.tls.Tls;
+import io.kroxylicious.proxy.config.tls.TrustProvider;
+import io.kroxylicious.proxy.config.tls.TrustStore;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
 import io.kroxylicious.testing.certificate.CertificateGenerator;
 import io.kroxylicious.testing.kms.ciphertrust.model.CreateKeyRequest;
 import io.kroxylicious.testing.kms.ciphertrust.model.CreateKeyResponse;
@@ -70,7 +75,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Stores KEKs in-memory and validates JWT tokens.
  * </p>
  */
-public class CipherTrustMockServer {
+public class CipherTrustMockServer implements AutoCloseable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CipherTrustMockServer.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -99,6 +104,10 @@ public class CipherTrustMockServer {
     public static final String TEST_USERNAME = "testuser";
 
     /**
+     * Test client ID for client certificate authentication.
+     */
+    public static final String TEST_CLIENT_ID = "test-client-1";
+    /**
      * Test password for mock authentication.
      */
     @SuppressWarnings("java:S2068") // Suppressed warning as this is a test password
@@ -110,15 +119,22 @@ public class CipherTrustMockServer {
     private static final String KEY_PASSWORD = "keypass";
     private final WireMockServer server;
     private final boolean useTls;
+    private final boolean requireClientAuth;
 
     @Nullable
     private X509Certificate serverCertificate;
+
+    @Nullable
+    private X509Certificate clientCertificate;
+
+    @Nullable
+    private KeyPair clientKeyPair;
 
     /**
      * Create a CipherTrust mock server using HTTP.
      */
     public CipherTrustMockServer() {
-        this(false);
+        this(false, false);
     }
 
     /**
@@ -127,13 +143,29 @@ public class CipherTrustMockServer {
      * @param useTls if true, configure HTTPS with self-signed certificate; if false, use HTTP
      */
     public CipherTrustMockServer(boolean useTls) {
+        this(useTls, false);
+    }
+
+    /**
+     * Create a CipherTrust mock server with optional TLS and mutual TLS support.
+     *
+     * @param useTls if true, configure HTTPS with self-signed certificate; if false, use HTTP
+     * @param requireClientAuth if true, require client certificates during TLS handshake (mutual TLS)
+     */
+    public CipherTrustMockServer(boolean useTls, boolean requireClientAuth) {
         this.useTls = useTls;
+        this.requireClientAuth = requireClientAuth;
         SecureRandom secureRandom;
         try {
             secureRandom = SecureRandom.getInstanceStrong();
         }
         catch (Exception e) {
             throw new MockServerException("Failed to initialize SecureRandom", e);
+        }
+
+        // Generate client certificate early if we'll need it for mTLS trust store configuration
+        if (useTls && requireClientAuth) {
+            generateClientCertificate();
         }
 
         VersionedKeyStore keyStore = new VersionedKeyStore();
@@ -174,9 +206,51 @@ public class CipherTrustMockServer {
             config.keystorePath(keyStore.path().toString())
                     .keystorePassword(STORE_PASSWORD)
                     .keyManagerPassword(KEY_PASSWORD);
+
+            if (requireClientAuth) {
+                // Configure mutual TLS: server will require client certificates during TLS handshake.
+                // Note: WireMock cannot validate which specific client certificate was presented
+                // (see https://github.com/wiremock/wiremock/issues/1812), but it WILL reject
+                // connections that don't present any client certificate. This is sufficient to
+                // test that TlsHttpClientConfigurator properly configures HttpClient to present
+                // client certificates during the TLS handshake.
+                config.needClientAuth(true);
+
+                // Create trust store containing our test client certificate so WireMock will accept it
+                CertificateGenerator.TrustStore trustStore = createClientTrustStore();
+                config.trustStorePath(trustStore.path().toString())
+                        .trustStorePassword(trustStore.password());
+            }
         }
         catch (Exception e) {
             throw new MockServerException("Failed to configure TLS", e);
+        }
+    }
+
+    @SuppressWarnings({ "java:S5443", "java:S2068", "java:S6437" }) // S5443: createTempFile is safe for test trust stores. S2068: STORE_PASSWORD is a test constant.
+    private CertificateGenerator.TrustStore createClientTrustStore() {
+        // We need to generate the client certificate first, so we can add it to the trust store
+        if (clientCertificate == null) {
+            generateClientCertificate();
+        }
+
+        try {
+            // Create a JKS truststore containing the client certificate
+            java.security.KeyStore trustStore = java.security.KeyStore.getInstance("JKS");
+            trustStore.load(null);
+            trustStore.setCertificateEntry("client-cert", clientCertificate);
+
+            // Write to temporary file
+            var tempFile = Files.createTempFile("client-truststore-", ".jks");
+            tempFile.toFile().deleteOnExit();
+            try (var stream = Files.newOutputStream(tempFile)) {
+                trustStore.store(stream, STORE_PASSWORD.toCharArray());
+            }
+
+            return new CertificateGenerator.TrustStore(tempFile, "JKS", STORE_PASSWORD, null);
+        }
+        catch (Exception e) {
+            throw new MockServerException("Failed to create client truststore", e);
         }
     }
 
@@ -184,8 +258,23 @@ public class CipherTrustMockServer {
      * Start the mock server and configure endpoints.
      */
     public void start() {
+        // Generate client certificate for testing client cert authentication (if not already done)
+        if (clientCertificate == null) {
+            generateClientCertificate();
+        }
+
         server.start();
         setupEndpoints();
+    }
+
+    private void generateClientCertificate() {
+        try {
+            this.clientKeyPair = CertificateGenerator.generateRsaKeyPair();
+            this.clientCertificate = CertificateGenerator.generateSelfSignedX509Certificate(clientKeyPair);
+        }
+        catch (Exception e) {
+            throw new MockServerException("Failed to generate client certificate", e);
+        }
     }
 
     /**
@@ -195,6 +284,11 @@ public class CipherTrustMockServer {
         if (server != null && server.isRunning()) {
             server.stop();
         }
+    }
+
+    @Override
+    public void close() {
+        stop();
     }
 
     /**
@@ -224,7 +318,8 @@ public class CipherTrustMockServer {
      * @throws IllegalStateException if TLS is not enabled
      */
     @Nullable
-    public X509Certificate getServerCertificate() {
+    @VisibleForTesting
+    X509Certificate getServerCertificate() {
         if (!useTls) {
             throw new IllegalStateException("Mock server not configured with TLS");
         }
@@ -237,8 +332,80 @@ public class CipherTrustMockServer {
      * @return path to temporary PEM file containing the server certificate
      * @throws IllegalStateException if TLS is not enabled
      */
-    public Path getServerCertificatePem() {
+    @VisibleForTesting
+    Path getServerCertificatePem() {
         return CertificateGenerator.generateCertPem(getServerCertificate());
+    }
+
+    /**
+     * Get the client certificate for testing client certificate authentication.
+     *
+     * @return the client X509 certificate
+     */
+    private X509Certificate getClientCertificate() {
+        return Objects.requireNonNull(clientCertificate, "Client certificate not initialized");
+    }
+
+    /**
+     * Get the client certificate as a PEM file.
+     *
+     * @return path to temporary PEM file containing the client certificate
+     */
+    private Path getClientCertificatePem() {
+        return CertificateGenerator.generateCertPem(getClientCertificate());
+    }
+
+    /**
+     * Get the client private key as a PEM file.
+     *
+     * @return path to temporary PEM file containing the client private key
+     */
+    private Path getClientPrivateKeyPem() {
+        KeyPair keyPair = Objects.requireNonNull(clientKeyPair, "Client key pair not initialized");
+        return CertificateGenerator.writeRsaPrivateKeyPem(keyPair);
+    }
+
+    /**
+     * Create TLS configuration for connecting to this mock server.
+     *
+     * @param includeClientCert whether to include client certificate for mTLS
+     * @return TLS configuration or null if TLS is not in use.
+     */
+    @VisibleForTesting
+    @Nullable
+    Tls createTls(boolean includeClientCert) {
+        io.kroxylicious.proxy.config.tls.KeyPair keyPair = null;
+        if (includeClientCert) {
+            keyPair = new io.kroxylicious.proxy.config.tls.KeyPair(
+                    getClientPrivateKeyPem().toString(),
+                    getClientCertificatePem().toString(),
+                    null);
+        }
+
+        TrustProvider trustProvider = null;
+        if (isHttps()) {
+            Path caCertPem = getServerCertificatePem();
+            trustProvider = new TrustStore(caCertPem.toString(), null, Tls.PEM, null);
+        }
+
+        return keyPair != null || trustProvider != null
+                ? new Tls(keyPair, trustProvider, null, null)
+                : null;
+    }
+
+    /**
+     * Create connection configuration for connecting to this mock server.
+     *
+     * @param useClientCert whether to use client certificate authentication
+     * @return connection configuration
+     */
+    ConnectionConfig createConnectionConfig(boolean useClientCert) {
+        final String username = useClientCert ? null : TEST_USERNAME;
+        final String password = useClientCert ? null : TEST_PASSWORD;
+        final String clientId = useClientCert ? TEST_CLIENT_ID : null;
+        final Tls tls = createTls(useClientCert);
+
+        return new ConnectionConfig(username, password, clientId, tls);
     }
 
     private void setupEndpoints() {
@@ -396,6 +563,7 @@ public class CipherTrustMockServer {
 
             String username = request.username();
             String password = request.password();
+            String clientId = request.clientId();
             String grantType = request.grantType();
 
             // Default to password grant type if not specified
@@ -405,6 +573,7 @@ public class CipherTrustMockServer {
 
             LOGGER.atDebug()
                     .addKeyValue("username", username)
+                    .addKeyValue("clientId", clientId)
                     .addKeyValue("grantType", grantType)
                     .log("Processing auth request");
 
@@ -418,6 +587,23 @@ public class CipherTrustMockServer {
                     ErrorResponse errorResponse = new ErrorResponse("Invalid credentials");
                     return jsonResponse(errorResponse, 401);
                 }
+                // Password authentication returns refresh token
+                AuthResponse response = new AuthResponse(MOCK_JWT_TOKEN, TOKEN_DURATION, MOCK_REFRESH_TOKEN);
+                return jsonResponse(response, 200);
+            }
+            else if ("client_credential".equals(grantType)) {
+                // Client certificate authentication (note: singular "client_credential")
+                if (!TEST_CLIENT_ID.equals(clientId)) {
+                    LOGGER.atDebug()
+                            .addKeyValue("clientId", clientId)
+                            .log("Authentication failed: unknown client ID");
+
+                    ErrorResponse errorResponse = new ErrorResponse("Unknown client ID");
+                    return jsonResponse(errorResponse, 401);
+                }
+                // Client certificate authentication does NOT return refresh token (real CTM behavior)
+                AuthResponse response = new AuthResponse(MOCK_JWT_TOKEN, TOKEN_DURATION, null);
+                return jsonResponse(response, 200);
             }
             else {
                 LOGGER.atWarn()
@@ -427,10 +613,6 @@ public class CipherTrustMockServer {
                 ErrorResponse errorResponse = new ErrorResponse("Unsupported grant type: " + grantType);
                 return jsonResponse(errorResponse, 400);
             }
-
-            // Successful authentication
-            AuthResponse response = new AuthResponse(MOCK_JWT_TOKEN, TOKEN_DURATION, MOCK_REFRESH_TOKEN);
-            return jsonResponse(response, 200);
         }
 
         @Override
@@ -665,7 +847,7 @@ public class CipherTrustMockServer {
             var name = getQueryParam(request, "name", null, Function.identity());
             var labelFilter = getQueryParam(request, "labels", null, Function.identity());
             var skip = Objects.requireNonNull(getQueryParam(request, "skip", 0, Integer::parseInt));
-            var limit = getQueryParam(request, "limit", 10, Integer::parseInt);
+            var limit = Objects.requireNonNull(getQueryParam(request, "limit", 10, Integer::parseInt));
 
             LOGGER.atDebug()
                     .addKeyValue("name", name)

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServer.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServer.java
@@ -344,7 +344,7 @@ public class CipherTrustMockServer implements AutoCloseable {
      */
     @VisibleForTesting
     @Nullable
-    Tls createTlsConfigForClient() {
+    Tls createClientTlsConfig() {
         if (!isHttps()) {
             return null;
         }
@@ -366,14 +366,13 @@ public class CipherTrustMockServer implements AutoCloseable {
     /**
      * Create connection configuration for connecting to this mock server.
      *
-     * @param useClientCert whether to use client certificate authentication
      * @return connection configuration
      */
-    ConnectionConfig createConnectionConfig(boolean useClientCert) {
-        final String username = useClientCert ? null : TEST_USERNAME;
-        final String password = useClientCert ? null : TEST_PASSWORD;
-        final String clientId = useClientCert ? TEST_CLIENT_ID : null;
-        final Tls tls = createTlsConfigForClient();
+    ConnectionConfig createClientConnectionConfig() {
+        final String username = requireClientAuth ? null : TEST_USERNAME;
+        final String password = requireClientAuth ? null : TEST_PASSWORD;
+        final String clientId = requireClientAuth ? TEST_CLIENT_ID : null;
+        final Tls tls = createClientTlsConfig();
 
         return new ConnectionConfig(username, password, clientId, tls);
     }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServer.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServer.java
@@ -225,11 +225,9 @@ public class CipherTrustMockServer implements AutoCloseable {
     }
 
     private CertificateGenerator.TrustStore createClientTrustStore() {
-        // We need to generate the client certificate first, so we can add it to the trust store
         if (clientCertificate == null) {
             generateClientCertificate();
         }
-
         return CertificateGenerator.createTrustStore(clientCertificate, STORE_PASSWORD, "JKS");
     }
 
@@ -237,11 +235,6 @@ public class CipherTrustMockServer implements AutoCloseable {
      * Start the mock server and configure endpoints.
      */
     public void start() {
-        // Generate client certificate for testing client cert authentication (if not already done)
-        if (clientCertificate == null) {
-            generateClientCertificate();
-        }
-
         server.start();
         setupEndpoints();
     }
@@ -347,18 +340,17 @@ public class CipherTrustMockServer implements AutoCloseable {
     /**
      * Create TLS configuration for connecting to this mock server.
      *
-     * @param includeClientCert whether to include client certificate for mTLS
      * @return TLS configuration or null if TLS is not in use.
      */
     @VisibleForTesting
     @Nullable
-    Tls createTls(boolean includeClientCert) {
+    Tls createTlsConfigForClient() {
         if (!isHttps()) {
             return null;
         }
 
         io.kroxylicious.proxy.config.tls.KeyPair keyPair = null;
-        if (includeClientCert) {
+        if (requireClientAuth) {
             keyPair = new io.kroxylicious.proxy.config.tls.KeyPair(
                     getClientPrivateKeyPem().toString(),
                     getClientCertificatePem().toString(),
@@ -381,7 +373,7 @@ public class CipherTrustMockServer implements AutoCloseable {
         final String username = useClientCert ? null : TEST_USERNAME;
         final String password = useClientCert ? null : TEST_PASSWORD;
         final String clientId = useClientCert ? TEST_CLIENT_ID : null;
-        final Tls tls = createTls(useClientCert);
+        final Tls tls = createTlsConfigForClient();
 
         return new ConnectionConfig(username, password, clientId, tls);
     }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustTestKmsFacade.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustTestKmsFacade.java
@@ -201,7 +201,7 @@ public class CipherTrustTestKmsFacade implements TestKmsFacade<Config, WrappingK
             mockServer.start();
             cipherTrustUrl = URI.create(mockServer.getBaseUrl());
 
-            connectionConfig = mockServer.createConnectionConfig(useClientCert);
+            connectionConfig = mockServer.createClientConnectionConfig();
         }
 
         // Build HttpClient with TLS config (common for both real and mock)

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustTestKmsFacade.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustTestKmsFacade.java
@@ -196,11 +196,11 @@ public class CipherTrustTestKmsFacade implements TestKmsFacade<Config, WrappingK
             connectionConfig = createConnectionConfigForReal();
         }
         else {
-            mockServer = new CipherTrustMockServer();
+            boolean useClientCert = authMode == AuthMode.CLIENT_CERT;
+            mockServer = new CipherTrustMockServer(true, useClientCert);
             mockServer.start();
             cipherTrustUrl = URI.create(mockServer.getBaseUrl());
 
-            boolean useClientCert = authMode == AuthMode.CLIENT_CERT;
             connectionConfig = mockServer.createConnectionConfig(useClientCert);
         }
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustTestKmsFacade.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustTestKmsFacade.java
@@ -12,7 +12,6 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +31,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kroxylicious.kms.provider.thales.ciphertrust.CipherTrustEdek;
 import io.kroxylicious.kms.provider.thales.ciphertrust.CipherTrustKmsService;
 import io.kroxylicious.kms.provider.thales.ciphertrust.WrappingKey;
+import io.kroxylicious.kms.provider.thales.ciphertrust.config.ClientCredentials;
 import io.kroxylicious.kms.provider.thales.ciphertrust.config.Config;
 import io.kroxylicious.kms.provider.thales.ciphertrust.config.UserCredentials;
 import io.kroxylicious.kms.provider.thales.ciphertrust.model.AuthRequest;
@@ -41,7 +41,9 @@ import io.kroxylicious.kms.service.KmsException;
 import io.kroxylicious.kms.service.UnknownAliasException;
 import io.kroxylicious.proxy.config.secret.InlinePassword;
 import io.kroxylicious.proxy.config.tls.InsecureTls;
+import io.kroxylicious.proxy.config.tls.KeyPair;
 import io.kroxylicious.proxy.config.tls.Tls;
+import io.kroxylicious.proxy.config.tls.TrustProvider;
 import io.kroxylicious.proxy.config.tls.TrustStore;
 import io.kroxylicious.testing.kms.TestKekManager;
 import io.kroxylicious.testing.kms.TestKmsFacade;
@@ -68,8 +70,52 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Both modes use HTTP calls for all operations including authentication,
  * ensuring identical behavior from a protocol perspective.
  * </p>
+ *
+ * <h2>Environment Variables</h2>
+ * <h3>Server Selection</h3>
+ * <ul>
+ * <li><b>KROXYLICIOUS_KMS_THALES_CIPHERTRUST_API_ENDPOINT</b> - URL of real CipherTrust Manager instance (if not set, uses mock server)</li>
+ * </ul>
+ *
+ * <h3>Authentication Mode</h3>
+ * <ul>
+ * <li><b>KROXYLICIOUS_KMS_THALES_CIPHERTRUST_AUTH_MODE</b> - Authentication mode: PASSWORD or CLIENT_CERT (default: CLIENT_CERT)</li>
+ * </ul>
+ *
+ * <h3>Password Authentication (when AUTH_MODE=PASSWORD)</h3>
+ * <ul>
+ * <li><b>KROXYLICIOUS_KMS_THALES_CIPHERTRUST_USERNAME</b> - Username (required for real server, ignored for mock)</li>
+ * <li><b>KROXYLICIOUS_KMS_THALES_CIPHERTRUST_PASSWORD</b> - Password (required for real server, ignored for mock)</li>
+ * </ul>
+ *
+ * <h3>Client Certificate Authentication (when AUTH_MODE=CLIENT_CERT)</h3>
+ * <ul>
+ * <li><b>KROXYLICIOUS_KMS_THALES_CIPHERTRUST_CLIENT_ID</b> - Client ID (required for real server, ignored for mock)</li>
+ * <li><b>KROXYLICIOUS_KMS_THALES_CIPHERTRUST_CLIENT_CERT</b> - Path to client certificate PEM file (required for real server, ignored for mock)</li>
+ * <li><b>KROXYLICIOUS_KMS_THALES_CIPHERTRUST_CLIENT_KEY</b> - Path to client private key PEM file (required for real server, ignored for mock)</li>
+ * </ul>
+ *
+ * <h3>TLS Configuration (optional, for real server only)</h3>
+ * <ul>
+ * <li><b>KROXYLICIOUS_KMS_THALES_CIPHERTRUST_TLS_INSECURE</b> - Disable certificate verification (default: false)</li>
+ * <li><b>KROXYLICIOUS_KMS_THALES_CIPHERTRUST_TLS_CA_CERT</b> - Path to custom CA certificate PEM file</li>
+ * </ul>
  */
 public class CipherTrustTestKmsFacade implements TestKmsFacade<Config, WrappingKey, CipherTrustEdek> {
+
+    /**
+     * Authentication mode for testing (applies to both real and mock servers).
+     */
+    enum AuthMode {
+        /**
+         * Username/password authentication.
+         */
+        PASSWORD,
+        /**
+         * Client certificate authentication.
+         */
+        CLIENT_CERT
+    }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CipherTrustTestKmsFacade.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -82,6 +128,10 @@ public class CipherTrustTestKmsFacade implements TestKmsFacade<Config, WrappingK
     private static final String ENV_URL = "KROXYLICIOUS_KMS_THALES_CIPHERTRUST_API_ENDPOINT";
     private static final String ENV_USERNAME = "KROXYLICIOUS_KMS_THALES_CIPHERTRUST_USERNAME";
     private static final String ENV_PASSWORD = "KROXYLICIOUS_KMS_THALES_CIPHERTRUST_PASSWORD";
+    private static final String ENV_CLIENT_ID = "KROXYLICIOUS_KMS_THALES_CIPHERTRUST_CLIENT_ID";
+    private static final String ENV_CLIENT_CERT = "KROXYLICIOUS_KMS_THALES_CIPHERTRUST_CLIENT_CERT";
+    private static final String ENV_CLIENT_KEY = "KROXYLICIOUS_KMS_THALES_CIPHERTRUST_CLIENT_KEY";
+    private static final String ENV_AUTH_MODE = "KROXYLICIOUS_KMS_THALES_CIPHERTRUST_AUTH_MODE";
     private static final String ENV_TLS_INSECURE = "KROXYLICIOUS_KMS_THALES_CIPHERTRUST_TLS_INSECURE";
     private static final String ENV_TLS_CA_CERT = "KROXYLICIOUS_KMS_THALES_CIPHERTRUST_TLS_CA_CERT";
     @SuppressWarnings("java:S1075") // Ignore URIs should not be hardcoded as this path is defined by API contact
@@ -95,11 +145,7 @@ public class CipherTrustTestKmsFacade implements TestKmsFacade<Config, WrappingK
     private static final String JSON_CONTENT_TYPE = "application/json";
 
     private final boolean useReal;
-    private final String username;
-    private final String password;
-    private final boolean tlsInsecure;
-    @Nullable
-    private final String tlsCaCertPath;
+    private final AuthMode authMode;
     private final String testRunInstance = UUID.randomUUID().toString();
 
     @Nullable
@@ -109,6 +155,9 @@ public class CipherTrustTestKmsFacade implements TestKmsFacade<Config, WrappingK
     private URI cipherTrustUrl;
 
     @Nullable
+    private ConnectionConfig connectionConfig;
+
+    @Nullable
     private HttpClient httpClient;
 
     @Nullable
@@ -116,30 +165,23 @@ public class CipherTrustTestKmsFacade implements TestKmsFacade<Config, WrappingK
 
     /**
      * Creates a CipherTrust test KMS facade.
+     * <p>
+     * See class-level Javadoc for complete list of environment variables.
+     * </p>
      */
     @SuppressWarnings("java:S2068") // Suppressed warning as this method uses a a test password
     public CipherTrustTestKmsFacade() {
         String urlStr = System.getenv(ENV_URL);
-        if (urlStr != null && !urlStr.isEmpty()) {
-            // Use real instance
-            this.useReal = true;
-            this.cipherTrustUrl = URI.create(urlStr);
-            this.username = System.getenv().getOrDefault(ENV_USERNAME, CipherTrustMockServer.TEST_USERNAME);
-            this.password = System.getenv().getOrDefault(ENV_PASSWORD, CipherTrustMockServer.TEST_PASSWORD);
-            this.tlsInsecure = Boolean.parseBoolean(System.getenv().getOrDefault(ENV_TLS_INSECURE, "false"));
-            this.tlsCaCertPath = System.getenv(ENV_TLS_CA_CERT);
-            this.mockServer = null;
-        }
-        else {
-            // Use mock
-            this.useReal = false;
-            this.cipherTrustUrl = null; // Will be set after mockServer.start()
-            this.username = CipherTrustMockServer.TEST_USERNAME;
-            this.password = CipherTrustMockServer.TEST_PASSWORD;
-            this.tlsInsecure = false;
-            this.tlsCaCertPath = null;
-            this.mockServer = null; // Will be created in start()
-        }
+        this.useReal = urlStr != null && !urlStr.isEmpty();
+        this.authMode = determineAuthMode();
+        this.cipherTrustUrl = useReal ? URI.create(urlStr) : null;
+        this.mockServer = null;
+        this.connectionConfig = null; // Will be created in start()
+    }
+
+    private static AuthMode determineAuthMode() {
+        // ENV_AUTH_MODE controls auth mode for both real and mock (defaults to CLIENT_CERT)
+        return AuthMode.valueOf(System.getenv().getOrDefault(ENV_AUTH_MODE, AuthMode.CLIENT_CERT.name()).toUpperCase());
     }
 
     @Override
@@ -151,51 +193,33 @@ public class CipherTrustTestKmsFacade implements TestKmsFacade<Config, WrappingK
     @Override
     public void start() {
         if (useReal) {
-            startReal();
+            connectionConfig = createConnectionConfigForReal();
         }
         else {
-            startMock();
+            mockServer = new CipherTrustMockServer();
+            mockServer.start();
+            cipherTrustUrl = URI.create(mockServer.getBaseUrl());
+
+            boolean useClientCert = authMode == AuthMode.CLIENT_CERT;
+            connectionConfig = mockServer.createConnectionConfig(useClientCert);
         }
-    }
 
-    private void startMock() {
-        mockServer = new CipherTrustMockServer();
-        mockServer.start();
-        cipherTrustUrl = URI.create(mockServer.getBaseUrl());
-
-        // Build HttpClient with TLS config if mock uses HTTPS
+        // Build HttpClient with TLS config (common for both real and mock)
         HttpClient.Builder clientBuilder = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(30));
 
-        if (mockServer.isHttps()) {
-            // Mock server uses self-signed certificate, so we need InsecureTls
-            TlsHttpClientConfigurator tlsConfigurator = new TlsHttpClientConfigurator(
-                    new Tls(null, new InsecureTls(true), null, null));
-            tlsConfigurator.apply(clientBuilder);
-        }
-
-        this.httpClient = clientBuilder.build();
-
-        // Authenticate to mock server via HTTP (same flow as real)
-        authenticateViaHttp();
-    }
-
-    private void startReal() {
-        // Build HttpClient with TLS config
-        HttpClient.Builder clientBuilder = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(30));
-
-        TlsHttpClientConfigurator tlsConfigurator = new TlsHttpClientConfigurator(getTlsConfig());
+        TlsHttpClientConfigurator tlsConfigurator = new TlsHttpClientConfigurator(connectionConfig.tls());
         tlsConfigurator.apply(clientBuilder);
 
         this.httpClient = clientBuilder.build();
 
-        // Authenticate to real instance via HTTP
+        // Authenticate via HTTP (common for both real and mock)
         authenticateViaHttp();
     }
 
     private void authenticateViaHttp() {
-        AuthRequest authRequest = AuthRequest.withPassword(username, password);
+        AuthRequest authRequest = buildAuthRequest();
+
         String requestBody = encodeJson(authRequest);
         HttpRequest request = buildAuthRequest(AUTH_TOKENS_PATH, requestBody);
         AuthResponse authResponse = sendRequest(request, AUTH_RESPONSE_TYPE_REF, null, 200);
@@ -203,7 +227,25 @@ public class CipherTrustTestKmsFacade implements TestKmsFacade<Config, WrappingK
 
         LOGGER.atDebug()
                 .addKeyValue("useReal", useReal)
+                .addKeyValue("authMode", authMode)
                 .log("Authenticated to CipherTrust Manager");
+    }
+
+    private AuthRequest buildAuthRequest() {
+        Objects.requireNonNull(connectionConfig);
+        return switch (authMode) {
+            case PASSWORD -> {
+                // Username/password authentication
+                var username = Objects.requireNonNull(connectionConfig.username());
+                var password = Objects.requireNonNull(connectionConfig.password());
+                yield AuthRequest.withPassword(username, password);
+            }
+            case CLIENT_CERT -> {
+                // Client certificate authentication
+                var clientId = Objects.requireNonNull(connectionConfig.clientId());
+                yield AuthRequest.withClientCredential(clientId);
+            }
+        };
     }
 
     @Override
@@ -236,11 +278,20 @@ public class CipherTrustTestKmsFacade implements TestKmsFacade<Config, WrappingK
 
     @Override
     public Config getKmsServiceConfig() {
-        if (cipherTrustUrl == null) {
+        if (cipherTrustUrl == null || connectionConfig == null) {
             throw new IllegalStateException("CipherTrust facade not started");
         }
-        UserCredentials userCredentials = new UserCredentials(username, new InlinePassword(password));
-        return new Config(cipherTrustUrl, userCredentials, getTlsConfig());
+        return switch (authMode) {
+            case PASSWORD -> {
+                var userCredentials = new UserCredentials(Objects.requireNonNull(connectionConfig.username()),
+                        new InlinePassword(Objects.requireNonNull(connectionConfig.password())));
+                yield new Config(cipherTrustUrl, userCredentials, null, connectionConfig.tls());
+            }
+            case CLIENT_CERT -> {
+                var clientCredentials = new ClientCredentials(Objects.requireNonNull(connectionConfig.clientId()));
+                yield new Config(cipherTrustUrl, null, clientCredentials, connectionConfig.tls());
+            }
+        };
     }
 
     @Override
@@ -248,35 +299,67 @@ public class CipherTrustTestKmsFacade implements TestKmsFacade<Config, WrappingK
         return new CipherTrustTestKekManager();
     }
 
+    /**
+     * Create connection configuration for real server (reads from environment variables).
+     *
+     * @return connection configuration
+     */
+    private ConnectionConfig createConnectionConfigForReal() {
+        final Tls tls = createTlsForReal();
+        return switch (authMode) {
+
+            case PASSWORD -> {
+                var username = System.getenv(ENV_USERNAME);
+                if (username == null) {
+                    throw new IllegalStateException("Environment variable " + ENV_USERNAME + " must be set for password authentication");
+                }
+                var password = System.getenv(ENV_PASSWORD);
+                if (password == null) {
+                    throw new IllegalStateException("Environment variable " + ENV_PASSWORD + " must be set for password authentication");
+                }
+                yield new ConnectionConfig(username, password, null, tls);
+            }
+            case CLIENT_CERT -> {
+                var clientId = System.getenv(ENV_CLIENT_ID);
+                if (clientId == null) {
+                    throw new IllegalStateException("Environment variable " + ENV_CLIENT_ID + " must be set for client certificate authentication");
+                }
+
+                yield new ConnectionConfig(null, null, clientId, tls);
+            }
+        };
+    }
+
     @Nullable
-    private Tls getTlsConfig() {
-        // Priority 1: Check for insecure mode (testing/development)
+    private Tls createTlsForReal() {
+        KeyPair keyPair = null;
+        if (authMode == AuthMode.CLIENT_CERT) {
+            String certPath = System.getenv(ENV_CLIENT_CERT);
+            String keyPath = System.getenv(ENV_CLIENT_KEY);
+            if (certPath != null && keyPath != null) {
+                keyPair = new KeyPair(keyPath, certPath, null);
+            }
+        }
+
+        TrustProvider trustProvider = createTrustProviderForReal();
+        return keyPair != null || trustProvider != null ? new Tls(keyPair, trustProvider, null, null) : null;
+    }
+
+    @Nullable
+    private TrustProvider createTrustProviderForReal() {
+        // Priority 1: Insecure mode
+        boolean tlsInsecure = Boolean.parseBoolean(System.getenv().getOrDefault(ENV_TLS_INSECURE, "false"));
         if (tlsInsecure) {
-            return new Tls(null, new InsecureTls(true), null, null);
+            return new InsecureTls(true);
         }
 
-        // Priority 2: For mock server, use its self-signed certificate
-        if (mockServer != null && mockServer.isHttps()) {
-            Path caCertPem = mockServer.getServerCertificatePem();
-            TrustStore trustStore = new TrustStore(
-                    caCertPem.toString(),
-                    null, // No password for PEM trust store
-                    Tls.PEM,
-                    null);
-            return new Tls(null, trustStore, null, null);
-        }
-
-        // Priority 3: For real server with custom CA cert (self-signed)
+        // Priority 2: Custom CA cert
+        String tlsCaCertPath = System.getenv(ENV_TLS_CA_CERT);
         if (tlsCaCertPath != null && !tlsCaCertPath.isEmpty()) {
-            TrustStore trustStore = new TrustStore(
-                    tlsCaCertPath,
-                    null, // No password for PEM trust store
-                    Tls.PEM,
-                    null);
-            return new Tls(null, trustStore, null, null);
+            return new TrustStore(tlsCaCertPath, null, Tls.PEM, null);
         }
 
-        // Priority 4: Use platform trust store (works with public CA certs)
+        // Priority 3: Platform trust store
         return null;
     }
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/ConnectionConfig.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/ConnectionConfig.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.testing.kms.ciphertrust;
+
+import io.kroxylicious.proxy.config.tls.Tls;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Connection configuration for CipherTrust Manager.
+ *
+ * @param username username for password authentication, or null for client cert auth
+ * @param password password for password authentication, or null for client cert auth
+ * @param clientId client ID for client certificate authentication, or null for password auth
+ * @param tls TLS configuration, or null if not needed
+ */
+record ConnectionConfig(
+                        @Nullable String username,
+                        @Nullable String password,
+                        @Nullable String clientId,
+                        @Nullable Tls tls) {}

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/test/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServerTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/test/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServerTest.java
@@ -62,7 +62,7 @@ class CipherTrustMockServerTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        mockServer = new CipherTrustMockServer();
+        mockServer = new CipherTrustMockServer(false);
         mockServer.start();
         baseUrl = mockServer.getBaseUrl();
         client = HttpClient.newHttpClient();
@@ -1007,7 +1007,7 @@ class CipherTrustMockServerTest {
     @SuppressWarnings("resource")
     void closeIsIdempotent() {
         // Given
-        CipherTrustMockServer server = new CipherTrustMockServer();
+        CipherTrustMockServer server = new CipherTrustMockServer(false);
         server.start();
 
         // When/Then

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/test/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServerTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/test/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServerTest.java
@@ -891,7 +891,7 @@ class CipherTrustMockServerTest {
             tlsServer.start();
             String tlsBaseUrl = tlsServer.getBaseUrl();
 
-            Tls tls = tlsServer.createTlsConfigForClient();
+            Tls tls = tlsServer.createClientTlsConfig();
             TlsHttpClientConfigurator tlsConfigurator = new TlsHttpClientConfigurator(tls);
             try (HttpClient tlsClient = tlsConfigurator.apply(HttpClient.newBuilder()).build()) {
 
@@ -925,7 +925,7 @@ class CipherTrustMockServerTest {
             tlsServer.start();
             String tlsBaseUrl = tlsServer.getBaseUrl();
 
-            Tls tls = tlsServer.createTlsConfigForClient();
+            Tls tls = tlsServer.createClientTlsConfig();
             TlsHttpClientConfigurator tlsConfigurator = new TlsHttpClientConfigurator(tls);
             try (HttpClient tlsClient = tlsConfigurator.apply(HttpClient.newBuilder()).build()) {
 
@@ -977,7 +977,7 @@ class CipherTrustMockServerTest {
             String mtlsBaseUrl = mtlsServer.getBaseUrl();
 
             // And: HttpClient configured with client certificate and server trust
-            Tls tls = mtlsServer.createTlsConfigForClient();
+            Tls tls = mtlsServer.createClientTlsConfig();
             TlsHttpClientConfigurator configurator = new TlsHttpClientConfigurator(tls);
             try (HttpClient mtlsClient = configurator.apply(HttpClient.newBuilder()).build()) {
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/test/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServerTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/test/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServerTest.java
@@ -887,11 +887,11 @@ class CipherTrustMockServerTest {
     @Test
     void clientCertificateAuthenticationWithTlsSucceeds() throws Exception {
         // Given
-        try (CipherTrustMockServer tlsServer = new CipherTrustMockServer(true)) {
+        try (CipherTrustMockServer tlsServer = new CipherTrustMockServer(true, true)) {
             tlsServer.start();
             String tlsBaseUrl = tlsServer.getBaseUrl();
 
-            Tls tls = tlsServer.createTls(true);
+            Tls tls = tlsServer.createTlsConfigForClient();
             TlsHttpClientConfigurator tlsConfigurator = new TlsHttpClientConfigurator(tls);
             try (HttpClient tlsClient = tlsConfigurator.apply(HttpClient.newBuilder()).build()) {
 
@@ -921,11 +921,11 @@ class CipherTrustMockServerTest {
     @Test
     void clientCertificateAuthenticationWithUnknownClientIdFails() throws Exception {
         // Given
-        try (CipherTrustMockServer tlsServer = new CipherTrustMockServer(true)) {
+        try (CipherTrustMockServer tlsServer = new CipherTrustMockServer(true, true)) {
             tlsServer.start();
             String tlsBaseUrl = tlsServer.getBaseUrl();
 
-            Tls tls = tlsServer.createTls(true);
+            Tls tls = tlsServer.createTlsConfigForClient();
             TlsHttpClientConfigurator tlsConfigurator = new TlsHttpClientConfigurator(tls);
             try (HttpClient tlsClient = tlsConfigurator.apply(HttpClient.newBuilder()).build()) {
 
@@ -977,7 +977,7 @@ class CipherTrustMockServerTest {
             String mtlsBaseUrl = mtlsServer.getBaseUrl();
 
             // And: HttpClient configured with client certificate and server trust
-            Tls tls = mtlsServer.createTls(true);
+            Tls tls = mtlsServer.createTlsConfigForClient();
             TlsHttpClientConfigurator configurator = new TlsHttpClientConfigurator(tls);
             try (HttpClient mtlsClient = configurator.apply(HttpClient.newBuilder()).build()) {
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/test/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServerTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/test/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServerTest.java
@@ -33,12 +33,14 @@ import io.kroxylicious.proxy.config.tls.InsecureTls;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.testing.kms.ciphertrust.model.CreateKeyRequest;
 import io.kroxylicious.testing.kms.ciphertrust.model.CreateKeyResponse;
+import io.kroxylicious.testing.kms.ciphertrust.model.ErrorResponse;
 import io.kroxylicious.testing.kms.ciphertrust.model.GetKeysResponse;
 import io.kroxylicious.testing.kms.ciphertrust.model.RotateKeyRequest;
 import io.kroxylicious.testing.kms.ciphertrust.model.RotateKeyResponse;
 import io.kroxylicious.testing.kms.tls.TlsHttpClientConfigurator;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
@@ -69,6 +71,9 @@ class CipherTrustMockServerTest {
 
     @AfterEach
     void tearDown() {
+        if (client != null) {
+            client.close();
+        }
         if (mockServer != null) {
             mockServer.stop();
         }
@@ -184,7 +189,7 @@ class CipherTrustMockServerTest {
         // Given
         var authRequestJson = "{\"username\":\"" + CipherTrustMockServer.TEST_USERNAME
                 + "\",\"password\":\"" + CipherTrustMockServer.TEST_PASSWORD
-                + "\",\"grant_type\":\"client_credentials\"}";
+                + "\",\"grant_type\":\"unknown_grant_type\"}";
 
         var request = HttpRequest.newBuilder()
                 .uri(URI.create(baseUrl + "/api/v1/auth/tokens/"))
@@ -200,9 +205,55 @@ class CipherTrustMockServerTest {
         assertThat(response.headers().firstValue("Content-Type"))
                 .hasValue("application/json");
 
-        var errorResponse = OBJECT_MAPPER.readValue(response.body(), io.kroxylicious.testing.kms.ciphertrust.model.ErrorResponse.class);
+        var errorResponse = OBJECT_MAPPER.readValue(response.body(), ErrorResponse.class);
         assertThat(errorResponse.error()).contains("Unsupported grant type");
-        assertThat(errorResponse.error()).contains("client_credentials");
+        assertThat(errorResponse.error()).contains("unknown_grant_type");
+    }
+
+    @Test
+    void clientCertificateAuthenticationSucceeds() throws Exception {
+        // Given - client certificate authentication request with pre-configured test client
+        var authRequest = AuthRequest.withClientCredential(CipherTrustMockServer.TEST_CLIENT_ID);
+
+        var request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + "/api/v1/auth/tokens/"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(authRequest)))
+                .build();
+
+        // When - authenticate with client_credential grant type
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        // Then - should return JWT without refresh token (matching real CTM behavior)
+        assertThat(response.statusCode())
+                .describedAs("Response status (body: %s)", response.body())
+                .isEqualTo(200);
+
+        var authResponse = OBJECT_MAPPER.readValue(response.body(), AuthResponse.class);
+        assertThat(authResponse.jwt()).isEqualTo(MOCK_JWT_TOKEN);
+        assertThat(authResponse.duration()).isEqualTo(300); // 5 minutes
+        // Client certificate authentication does NOT return refresh token (real CTM behavior)
+        assertThat(authResponse.refreshToken()).isNull();
+    }
+
+    @Test
+    void clientCertificateAuthenticationFailsWithUnknownClientId() throws Exception {
+        // Given - client certificate authentication request with unknown client ID
+        var authRequest = AuthRequest.withClientCredential("unknown-client-id");
+
+        var request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + "/api/v1/auth/tokens/"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(authRequest)))
+                .build();
+
+        // When - attempt to authenticate with unknown client
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        // Then - should return 401 unauthorized
+        assertThat(response.statusCode()).isEqualTo(401);
+        assertThat(response.headers().firstValue("Content-Type"))
+                .hasValue("application/json");
     }
 
     @Test
@@ -692,14 +743,10 @@ class CipherTrustMockServerTest {
 
     @Test
     void tlsMockServerStartsSuccessfully() {
-        CipherTrustMockServer tlsServer = new CipherTrustMockServer(true);
-        try {
+        try (CipherTrustMockServer tlsServer = new CipherTrustMockServer(true)) {
             tlsServer.start();
             assertThat(tlsServer.getBaseUrl()).startsWith("https://");
             assertThat(tlsServer.isHttps()).isTrue();
-        }
-        finally {
-            tlsServer.stop();
         }
     }
 
@@ -711,120 +758,113 @@ class CipherTrustMockServerTest {
 
     @Test
     void tlsAuthenticationSucceeds() throws Exception {
-        CipherTrustMockServer tlsServer = new CipherTrustMockServer(true);
-        try {
+        try (CipherTrustMockServer tlsServer = new CipherTrustMockServer(true)) {
             tlsServer.start();
             String tlsBaseUrl = tlsServer.getBaseUrl();
 
             // Create HttpClient with insecure TLS (to accept self-signed certificate)
             Tls tls = new Tls(null, new InsecureTls(true), null, null);
             TlsHttpClientConfigurator tlsConfigurator = new TlsHttpClientConfigurator(tls);
-            HttpClient tlsClient = tlsConfigurator.apply(HttpClient.newBuilder()).build();
+            try (HttpClient tlsClient = tlsConfigurator.apply(HttpClient.newBuilder()).build()) {
 
-            // Authenticate
-            var authReq = AuthRequest.withPassword(
-                    CipherTrustMockServer.TEST_USERNAME,
-                    CipherTrustMockServer.TEST_PASSWORD);
-            var request = HttpRequest.newBuilder()
-                    .uri(URI.create(tlsBaseUrl + "/api/v1/auth/tokens/"))
-                    .header("Content-Type", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(authReq)))
-                    .build();
+                // Authenticate
+                var authReq = AuthRequest.withPassword(
+                        CipherTrustMockServer.TEST_USERNAME,
+                        CipherTrustMockServer.TEST_PASSWORD);
+                var request = HttpRequest.newBuilder()
+                        .uri(URI.create(tlsBaseUrl + "/api/v1/auth/tokens/"))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(authReq)))
+                        .build();
 
-            var response = tlsClient.send(request, HttpResponse.BodyHandlers.ofString());
-            assertThat(response.statusCode()).isEqualTo(200);
+                var response = tlsClient.send(request, HttpResponse.BodyHandlers.ofString());
+                assertThat(response.statusCode()).isEqualTo(200);
 
-            var authResponse = OBJECT_MAPPER.readValue(response.body(), AuthResponse.class);
-            assertThat(authResponse.jwt()).isEqualTo(MOCK_JWT_TOKEN);
-            assertThat(authResponse.duration()).isEqualTo(300);
-        }
-        finally {
-            tlsServer.stop();
+                var authResponse = OBJECT_MAPPER.readValue(response.body(), AuthResponse.class);
+                assertThat(authResponse.jwt()).isEqualTo(MOCK_JWT_TOKEN);
+                assertThat(authResponse.duration()).isEqualTo(300);
+            }
         }
     }
 
     @Test
     void tlsEncryptionRoundTrip() throws Exception {
-        CipherTrustMockServer tlsServer = new CipherTrustMockServer(true);
-        try {
+        try (CipherTrustMockServer tlsServer = new CipherTrustMockServer(true)) {
             tlsServer.start();
             String tlsBaseUrl = tlsServer.getBaseUrl();
 
             // Create HttpClient with insecure TLS
             Tls tls = new Tls(null, new InsecureTls(true), null, null);
             TlsHttpClientConfigurator tlsConfigurator = new TlsHttpClientConfigurator(tls);
-            HttpClient tlsClient = tlsConfigurator.apply(HttpClient.newBuilder()).build();
+            try (HttpClient tlsClient = tlsConfigurator.apply(HttpClient.newBuilder()).build()) {
 
-            // Authenticate
-            var authReq = AuthRequest.withPassword(
-                    CipherTrustMockServer.TEST_USERNAME,
-                    CipherTrustMockServer.TEST_PASSWORD);
-            var authRequest = HttpRequest.newBuilder()
-                    .uri(URI.create(tlsBaseUrl + "/api/v1/auth/tokens/"))
-                    .header("Content-Type", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(authReq)))
-                    .build();
-            var authResponse = tlsClient.send(authRequest, HttpResponse.BodyHandlers.ofString());
-            var auth = OBJECT_MAPPER.readValue(authResponse.body(), AuthResponse.class);
-            String token = auth.jwt();
+                // Authenticate
+                var authReq = AuthRequest.withPassword(
+                        CipherTrustMockServer.TEST_USERNAME,
+                        CipherTrustMockServer.TEST_PASSWORD);
+                var authRequest = HttpRequest.newBuilder()
+                        .uri(URI.create(tlsBaseUrl + "/api/v1/auth/tokens/"))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(authReq)))
+                        .build();
+                var authResponse = tlsClient.send(authRequest, HttpResponse.BodyHandlers.ofString());
+                var auth = OBJECT_MAPPER.readValue(authResponse.body(), AuthResponse.class);
+                String token = auth.jwt();
 
-            // Create key
-            var keyRequest = new CreateKeyRequest("tls-test-key", "AES", 12, Map.of());
-            var createKeyReq = HttpRequest.newBuilder()
-                    .uri(URI.create(tlsBaseUrl + "/api/v1/vault/keys2/"))
-                    .header("Authorization", "Bearer " + token)
-                    .header("Content-Type", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(keyRequest)))
-                    .build();
-            var createKeyResp = tlsClient.send(createKeyReq, HttpResponse.BodyHandlers.ofString());
-            var createKeyResponse = OBJECT_MAPPER.readValue(createKeyResp.body(), CreateKeyResponse.class);
-            String keyName = createKeyResponse.name();
+                // Create key
+                var keyRequest = new CreateKeyRequest("tls-test-key", "AES", 12, Map.of());
+                var createKeyReq = HttpRequest.newBuilder()
+                        .uri(URI.create(tlsBaseUrl + "/api/v1/vault/keys2/"))
+                        .header("Authorization", "Bearer " + token)
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(keyRequest)))
+                        .build();
+                var createKeyResp = tlsClient.send(createKeyReq, HttpResponse.BodyHandlers.ofString());
+                var createKeyResponse = OBJECT_MAPPER.readValue(createKeyResp.body(), CreateKeyResponse.class);
+                String keyName = createKeyResponse.name();
 
-            // Encrypt
-            byte[] plaintext = "HTTPS test data".getBytes(StandardCharsets.UTF_8);
-            var encryptReq = new EncryptRequest(keyName, plaintext, "name");
-            var encryptHttpReq = HttpRequest.newBuilder()
-                    .uri(URI.create(tlsBaseUrl + "/api/v1/crypto/encrypt"))
-                    .header("Authorization", "Bearer " + token)
-                    .header("Content-Type", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(encryptReq)))
-                    .build();
-            var encryptResp = tlsClient.send(encryptHttpReq, HttpResponse.BodyHandlers.ofString());
-            var encryptResponse = OBJECT_MAPPER.readValue(encryptResp.body(), EncryptResponse.class);
+                // Encrypt
+                byte[] plaintext = "HTTPS test data".getBytes(StandardCharsets.UTF_8);
+                var encryptReq = new EncryptRequest(keyName, plaintext, "name");
+                var encryptHttpReq = HttpRequest.newBuilder()
+                        .uri(URI.create(tlsBaseUrl + "/api/v1/crypto/encrypt"))
+                        .header("Authorization", "Bearer " + token)
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(encryptReq)))
+                        .build();
+                var encryptResp = tlsClient.send(encryptHttpReq, HttpResponse.BodyHandlers.ofString());
+                var encryptResponse = OBJECT_MAPPER.readValue(encryptResp.body(), EncryptResponse.class);
 
-            // Decrypt
-            var decryptReq = new DecryptRequest(
-                    encryptResponse.ciphertext(),
-                    encryptResponse.tag(),
-                    encryptResponse.id(),
-                    encryptResponse.version(),
-                    encryptResponse.mode(),
-                    encryptResponse.iv());
-            var decryptHttpReq = HttpRequest.newBuilder()
-                    .uri(URI.create(tlsBaseUrl + "/api/v1/crypto/decrypt"))
-                    .header("Authorization", "Bearer " + token)
-                    .header("Content-Type", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(decryptReq)))
-                    .build();
-            HttpResponse<String> decryptResp;
+                // Decrypt
+                var decryptReq = new DecryptRequest(
+                        encryptResponse.ciphertext(),
+                        encryptResponse.tag(),
+                        encryptResponse.id(),
+                        encryptResponse.version(),
+                        encryptResponse.mode(),
+                        encryptResponse.iv());
+                var decryptHttpReq = HttpRequest.newBuilder()
+                        .uri(URI.create(tlsBaseUrl + "/api/v1/crypto/decrypt"))
+                        .header("Authorization", "Bearer " + token)
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(decryptReq)))
+                        .build();
+                HttpResponse<String> decryptResp;
 
-            decryptResp = tlsClient.send(decryptHttpReq, HttpResponse.BodyHandlers.ofString());
+                decryptResp = tlsClient.send(decryptHttpReq, HttpResponse.BodyHandlers.ofString());
 
-            var decryptResponse = OBJECT_MAPPER.readValue(decryptResp.body(), DecryptResponse.class);
+                var decryptResponse = OBJECT_MAPPER.readValue(decryptResp.body(), DecryptResponse.class);
 
-            // Verify round-trip
-            assertThat(decryptResponse.plaintext()).isEqualTo(plaintext);
-        }
-        finally {
-            tlsServer.stop();
+                // Verify round-trip
+                assertThat(decryptResponse.plaintext()).isEqualTo(plaintext);
+            }
         }
     }
 
     @Test
     void tlsServerProvidesCertificate() {
         // Given
-        CipherTrustMockServer tlsServer = new CipherTrustMockServer(true);
-        try {
+        try (CipherTrustMockServer tlsServer = new CipherTrustMockServer(true)) {
             tlsServer.start();
 
             // When
@@ -834,24 +874,86 @@ class CipherTrustMockServerTest {
             assertThat(certificate).isNotNull();
             assertThat(certificate.getSubjectX500Principal().getName()).contains("CN=localhost");
         }
-        finally {
-            tlsServer.stop();
-        }
     }
 
     @Test
     void httpServerThrowsWhenAccessingCertificate() {
         // When/Then
-        assertThatThrownBy(() -> mockServer.getServerCertificate())
+        assertThatThrownBy(() -> mockServer.getServerCertificatePem())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Mock server not configured with TLS");
     }
 
     @Test
+    void clientCertificateAuthenticationWithTlsSucceeds() throws Exception {
+        // Given
+        try (CipherTrustMockServer tlsServer = new CipherTrustMockServer(true)) {
+            tlsServer.start();
+            String tlsBaseUrl = tlsServer.getBaseUrl();
+
+            Tls tls = tlsServer.createTls(true);
+            TlsHttpClientConfigurator tlsConfigurator = new TlsHttpClientConfigurator(tls);
+            try (HttpClient tlsClient = tlsConfigurator.apply(HttpClient.newBuilder()).build()) {
+
+                var authRequest = AuthRequest.withClientCredential(CipherTrustMockServer.TEST_CLIENT_ID);
+                var request = HttpRequest.newBuilder()
+                        .uri(URI.create(tlsBaseUrl + "/api/v1/auth/tokens/"))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(authRequest)))
+                        .build();
+
+                // When
+                var response = tlsClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+                // Then
+                assertThat(response.statusCode())
+                        .describedAs("Response status (body: %s)", response.body())
+                        .isEqualTo(200);
+
+                var authResponse = OBJECT_MAPPER.readValue(response.body(), AuthResponse.class);
+                assertThat(authResponse.jwt()).isEqualTo(MOCK_JWT_TOKEN);
+                assertThat(authResponse.duration()).isEqualTo(300);
+                assertThat(authResponse.refreshToken()).isNull();
+            }
+        }
+    }
+
+    @Test
+    void clientCertificateAuthenticationWithUnknownClientIdFails() throws Exception {
+        // Given
+        try (CipherTrustMockServer tlsServer = new CipherTrustMockServer(true)) {
+            tlsServer.start();
+            String tlsBaseUrl = tlsServer.getBaseUrl();
+
+            Tls tls = tlsServer.createTls(true);
+            TlsHttpClientConfigurator tlsConfigurator = new TlsHttpClientConfigurator(tls);
+            try (HttpClient tlsClient = tlsConfigurator.apply(HttpClient.newBuilder()).build()) {
+
+                var authRequest = AuthRequest.withClientCredential("unknown-client-id");
+                var request = HttpRequest.newBuilder()
+                        .uri(URI.create(tlsBaseUrl + "/api/v1/auth/tokens/"))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(authRequest)))
+                        .build();
+
+                // When
+                var response = tlsClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+                // Then - should return 401 unauthorized (matching real CTM behavior)
+                assertThat(response.statusCode()).isEqualTo(401);
+                assertThat(response.headers().firstValue("Content-Type"))
+                        .hasValue("application/json");
+
+                var errorResponse = OBJECT_MAPPER.readValue(response.body(), ErrorResponse.class);
+                assertThat(errorResponse.error()).containsIgnoringCase("client");
+            }
+        }
+    }
+
+    @Test
     void tlsServerProvidesCertificatePem() {
         // Given
-        CipherTrustMockServer tlsServer = new CipherTrustMockServer(true);
-        try {
+        try (CipherTrustMockServer tlsServer = new CipherTrustMockServer(true)) {
             tlsServer.start();
 
             // When
@@ -865,9 +967,54 @@ class CipherTrustMockServerTest {
                     .startsWith("-----BEGIN CERTIFICATE-----")
                     .endsWith("-----END CERTIFICATE-----\n");
         }
-        finally {
-            tlsServer.stop();
+    }
+
+    @Test
+    void clientCertificatePresentedDuringTlsHandshake() throws Exception {
+        // Given: mock server requiring client certificates via needClientAuth(true)
+        try (CipherTrustMockServer mtlsServer = new CipherTrustMockServer(true, true)) {
+            mtlsServer.start();
+            String mtlsBaseUrl = mtlsServer.getBaseUrl();
+
+            // And: HttpClient configured with client certificate and server trust
+            Tls tls = mtlsServer.createTls(true);
+            TlsHttpClientConfigurator configurator = new TlsHttpClientConfigurator(tls);
+            try (HttpClient mtlsClient = configurator.apply(HttpClient.newBuilder()).build()) {
+
+                // When: we attempt to authenticate with client certificate
+                var authRequest = AuthRequest.withClientCredential(CipherTrustMockServer.TEST_CLIENT_ID);
+                var request = HttpRequest.newBuilder()
+                        .uri(URI.create(mtlsBaseUrl + "/api/v1/auth/tokens/"))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(authRequest)))
+                        .build();
+
+                var response = mtlsClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+                // Then: authentication succeeds, proving the client certificate was presented
+                // during the TLS handshake.
+                assertThat(response.statusCode())
+                        .describedAs("Response status (body: %s)", response.body())
+                        .isEqualTo(200);
+
+                var authResponse = OBJECT_MAPPER.readValue(response.body(), AuthResponse.class);
+                assertThat(authResponse.jwt()).isEqualTo(MOCK_JWT_TOKEN);
+            }
         }
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    void closeIsIdempotent() {
+        // Given
+        CipherTrustMockServer server = new CipherTrustMockServer();
+        server.start();
+
+        // When/Then
+        assertThatCode(() -> {
+            server.close();
+            server.close();
+        }).doesNotThrowAnyException();
     }
 
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/test/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustTestKmsFacadeTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/test/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustTestKmsFacadeTest.java
@@ -8,7 +8,10 @@ package io.kroxylicious.testing.kms.ciphertrust;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
 import io.kroxylicious.kms.provider.thales.ciphertrust.CipherTrustKmsService;
 import io.kroxylicious.kms.provider.thales.ciphertrust.config.Config;
@@ -50,11 +53,11 @@ class CipherTrustTestKmsFacadeTest {
         // When
         var config = facade.getKmsServiceConfig();
 
-        // Then
+        // Then (default is CLIENT_CERT mode)
         assertThat(config).isNotNull();
         assertThat(config.endpointUrl()).isNotNull();
-        assertThat(config.userCredentials()).isNotNull();
-        assertThat(config.userCredentials().username()).isNotEmpty();
+        assertThat(config.clientCredentials()).isNotNull();
+        assertThat(config.clientCredentials().clientId()).isNotEmpty();
     }
 
     @Test
@@ -100,6 +103,16 @@ class CipherTrustTestKmsFacadeTest {
     }
 
     @Test
+    void deleteKekNotFound() {
+        // Given
+        String nonExistentAlias = "non-existent-key";
+
+        // When/Then
+        assertThatThrownBy(() -> manager.deleteKek(nonExistentAlias))
+                .isInstanceOf(UnknownAliasException.class);
+    }
+
+    @Test
     void rotateKekWithSpacesInName() {
         // Given - Create a key with spaces in the name
         String aliasWithSpaces = "rotate test key";
@@ -117,5 +130,117 @@ class CipherTrustTestKmsFacadeTest {
 
         // When/Then - Should successfully delete (URI-encoding the name in the query parameter)
         assertThatNoException().isThrownBy(() -> manager.deleteKek(aliasWithSpaces));
+    }
+
+    @Nested
+    @DisabledIfEnvironmentVariable(named = "KROXYLICIOUS_KMS_THALES_CIPHERTRUST_API_ENDPOINT", matches = ".+", disabledReason = "Auth mode tests only apply to mock server")
+    class AuthenticationModes {
+
+        @Test
+        @SetEnvironmentVariable(key = "KROXYLICIOUS_KMS_THALES_CIPHERTRUST_AUTH_MODE", value = "PASSWORD")
+        void shouldConfigurePasswordAuthentication() {
+            // Given: facade configured for password auth
+            CipherTrustTestKmsFacade passwordFacade = new CipherTrustTestKmsFacade();
+
+            // When: facade started
+            passwordFacade.start();
+
+            try {
+                Config config = passwordFacade.getKmsServiceConfig();
+
+                // Then: config contains user credentials (not client credentials)
+                assertThat(config.userCredentials()).isNotNull();
+                assertThat(config.userCredentials().username()).isNotNull();
+                assertThat(config.userCredentials().password()).isNotNull();
+                assertThat(config.clientCredentials()).isNull();
+            }
+            finally {
+                passwordFacade.close();
+            }
+        }
+
+        @Test
+        @SetEnvironmentVariable(key = "KROXYLICIOUS_KMS_THALES_CIPHERTRUST_AUTH_MODE", value = "CLIENT_CERT")
+        void shouldConfigureClientCertificateAuthentication() {
+            // Given: facade configured for client cert auth
+            CipherTrustTestKmsFacade clientCertFacade = new CipherTrustTestKmsFacade();
+
+            // When: facade started
+            clientCertFacade.start();
+
+            try {
+                Config config = clientCertFacade.getKmsServiceConfig();
+
+                // Then: config contains client credentials (not user credentials)
+                assertThat(config.clientCredentials()).isNotNull();
+                assertThat(config.clientCredentials().clientId()).isNotEmpty();
+                assertThat(config.userCredentials()).isNull();
+
+                // And: TLS config includes client certificate
+                assertThat(config.tls()).isNotNull();
+                assertThat(config.tls().key()).isNotNull();
+            }
+            finally {
+                clientCertFacade.close();
+            }
+        }
+
+        @Test
+        void shouldDefaultToClientCertificateMode() {
+            // Given: no AUTH_MODE env var set (using default from outer test class setup)
+            Config config = facade.getKmsServiceConfig();
+
+            // Then: defaults to client cert mode
+            assertThat(config.clientCredentials()).isNotNull();
+            assertThat(config.userCredentials()).isNull();
+        }
+
+        @Test
+        @SetEnvironmentVariable(key = "KROXYLICIOUS_KMS_THALES_CIPHERTRUST_AUTH_MODE", value = "PASSWORD")
+        void shouldAuthenticateWithPasswordMode() {
+            // Given: facade with password auth
+            CipherTrustTestKmsFacade passwordFacade = new CipherTrustTestKmsFacade();
+            passwordFacade.start();
+
+            try {
+                TestKekManager passwordManager = passwordFacade.getTestKekManager();
+                String alias = "password-auth-test";
+
+                // When: KEK operation performed
+                passwordManager.generateKek(alias);
+
+                // Then: authentication succeeds and operation completes
+                assertThat(passwordManager.read(alias)).isNotNull();
+
+                passwordManager.deleteKek(alias);
+            }
+            finally {
+                passwordFacade.close();
+            }
+        }
+
+        @Test
+        @SetEnvironmentVariable(key = "KROXYLICIOUS_KMS_THALES_CIPHERTRUST_AUTH_MODE", value = "CLIENT_CERT")
+        void shouldAuthenticateWithClientCertMode() {
+            // Given: facade with client cert auth
+            CipherTrustTestKmsFacade clientCertFacade = new CipherTrustTestKmsFacade();
+            clientCertFacade.start();
+
+            try {
+                TestKekManager clientCertManager = clientCertFacade.getTestKekManager();
+                String alias = "client-cert-auth-test";
+
+                // When: KEK operation performed
+                clientCertManager.generateKek(alias);
+
+                // Then: authentication succeeds and operation completes
+                assertThat(clientCertManager.read(alias)).isNotNull();
+
+                clientCertManager.deleteKek(alias);
+            }
+            finally {
+                clientCertFacade.close();
+            }
+        }
     }
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/DEV_GUIDE.md
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/DEV_GUIDE.md
@@ -33,15 +33,14 @@ by following these instructions.
    ```
    This script updates the CipherTrust Manager's web interface certificate to use the EC2 hostname,
    allowing secure connections without bypassing SSL verification.
+   It restarts the web component within CTM to bring the change into effect. 
 10. Extract the CA certificate for TLS trust configuration:
    ```shell
-   ksctl interfaces certificate get --name web | \
-     jq -r '.certificates' | \
-     awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/ {print; if (/END CERTIFICATE/) {count++; if (count==2) exit}}' \
-     > /tmp/ctm-ca.pem
+    ksctl interfaces certificate get --name web |\
+      jq -r '.certificates | [scan("-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----"; "m")] | last' > /tmp/ctm-ca.pem
    ```
-   This extracts the CA certificate (second certificate in the chain) which is needed to 
-   configure secure TLS connections to the CipherTrust Manager.
+   This extracts the CA certificate (last certificate in the chain) which the client must trust 
+   to connect to CipherTrust Manager.
 
 ## Running the Integration Tests
 
@@ -54,7 +53,8 @@ To exercise the path where the KMS (and test facade) authenticate as a user, do 
 
 ```shell
 export KROXYLICIOUS_KMS_FACADE_FACTORY_CLASS_NAME_FILTER=".*Cipher.*"
-export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_API_ENDPOINT=<https://ec2-xx-xx-xx-xx.eu-west-1.compute.amazonaws.com>
+export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_API_ENDPOINT=https://ec2-xx-xx-xx-xx.eu-west-1.compute.amazonaws.com
+export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_AUTH_MODE=PASSWORD
 export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_USERNAME=admin
 export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_PASSWORD=your-password
 export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_TLS_CA_CERT=/tmp/ctm-ca.pem
@@ -63,36 +63,86 @@ export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_TLS_CA_CERT=/tmp/ctm-ca.pem
 Then run the integration tests:
 
 ```shell
-mvn verify -pl kroxylicious-integration-tests -am -Dfailsafe.failIfNoSpecifiedTests=false -DskipUTs=true -Derrorprone.skip=true -P-qa  -Dit.test=KmsIT 
+KROXYLICIOUS_KMS_FACADE_FACTORY_CLASS_NAME_FILTER='.*Cipher.*' mvn verify -pl kroxylicious-integration-tests -am -Dfailsafe.failIfNoSpecifiedTests=false -DskipUTs=true -Derrorprone.skip=true -P-qa  -Dit.test=KmsIT 
 ```
 
 ### Client authentication (using certificate)
 
-TODO
+Client certificate authentication is the recommended approach for service accounts like Kroxylicious, as it eliminates the need to manage passwords and provides stronger authentication.
+
+#### One-time setup: Register a client certificate
+
+Client registration is a one-time admin operation. The registered client can then be used for testing.
+
+Use the provided script to automate the registration process:
+
+```shell
+./kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/scripts/register-client-cert.sh /tmp
+```
+
+The script will:
+1. Create a local CA and self-sign it
+2. Generate a CSR and private key for the client
+3. Issue and sign the client certificate
+4. Register the client management profile with admin group
+5. Create a registration token tied to the profile
+6. Register the client, linking the token to the client certificate
+7. Make the web interface trust the new CA (and restart the web service)
+8. Save the credentials and IDs to `/tmp/kroxylicious-*` files
+
+The script outputs the environment variables you'll need - copy them for the next step.
+
+#### Running tests with client certificate authentication
+
+Once you have a registered client, configure the environment variables:
+
+```shell
+export KROXYLICIOUS_KMS_FACADE_FACTORY_CLASS_NAME_FILTER=".*Cipher.*"
+export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_API_ENDPOINT=https://ec2-xx-xx-xx-xx.eu-west-1.compute.amazonaws.com
+export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_AUTH_MODE=CLIENT_CERT
+export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_CLIENT_ID=$(cat /tmp/kroxylicious-client-id.txt)
+export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_CLIENT_CERT=/tmp/kroxylicious-client.crt
+export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_CLIENT_KEY=/tmp/kroxylicious-client.key
+export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_TLS_CA_CERT=/tmp/ctm-ca.pem
+```
+
+Then run the integration tests:
+
+```shell
+KROXYLICIOUS_KMS_FACADE_FACTORY_CLASS_NAME_FILTER='.*Cipher.*' mvn verify -pl kroxylicious-integration-tests -am -Dfailsafe.failIfNoSpecifiedTests=false -DskipUTs=true -Derrorprone.skip=true -P-qa -Dit.test=KmsIT
+```
+
+**Note:** The `AUTH_MODE` defaults to `CLIENT_CERT`, so you can omit that variable if desired.
 
 ## Tear down
 
-When you're finished with the CipherTrust Manager instance, clean up the AWS resources to avoid ongoing charges:
+When you're finished with the CipherTrust Manager instance, clean up the resources to avoid ongoing charges:
 
-1. Terminate the EC2 instance:
+1. Unregister the test client certificate (if you registered one):
+   ```shell
+   ./kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/scripts/unregister-client-cert.sh /tmp
+   ```
+   This removes the client, registration token, profile, and CA from CipherTrust Manager, removes the CA from the web interface trusted CAs list, and deletes the local credential files.
+
+2. Terminate the EC2 instance:
    - Navigate to the [EC2 Console](https://console.aws.amazon.com/ec2/)
    - Select your CipherTrust Manager instance
    - Click **Instance state** → **Terminate instance**
    - Confirm the termination
 
-2. Delete the security group (if you created a custom one):
+3. Delete the security group (if you created a custom one):
    - In the EC2 Console, navigate to **Security Groups**
    - Select the security group you created for the CTM instance
    - Click **Actions** → **Delete security groups**
    - Note: You cannot delete a security group while it's still attached to an instance. Wait for the instance to fully terminate first.
 
-3. Delete the SSH key pair (if you created one specifically for this):
+4. Delete the SSH key pair (if you created one specifically for this):
    - In the EC2 Console, navigate to **Key Pairs**
    - Select the key pair
    - Click **Actions** → **Delete**
    - Also delete the local `.pem` file from your `~/.ssh/` directory
 
-4. Unsubscribe from the CipherTrust Manager Community Edition (optional):
+5. Unsubscribe from the CipherTrust Manager Community Edition (optional):
    - Navigate to [AWS Marketplace Subscriptions](https://console.aws.amazon.com/marketplace/home#/subscriptions)
    - Find **CipherTrust Manager Community Edition**
    - Click **Manage** → **Cancel subscription**

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/scripts/register-client-cert.sh
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/scripts/register-client-cert.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# Register a client certificate with CipherTrust Manager for testing.
+# This is a one-time admin operation to create a client that can authenticate
+# using mutual TLS instead of username/password.
+#
+# Prerequisites:
+#   - ksctl must be installed and logged in (ksctl login ...)
+#   - jq must be installed
+#
+# Usage: register-client-cert.sh [output-directory]
+#
+# The script will:
+#   1. Create a Local CA and self-sign it
+#   2. Generate a CSR and Private Key for the Client
+#   3. Issue and sign the client certificate
+#   4. Register the client management profile
+#   5. Create a token for client based on the profile
+#   6. Register the client, linking the token to the client cert
+#   7. Make web interface trust the new CA
+#   8. Save the client certificate, key, CA ID, and client ID to the output directory
+#
+# Output files:
+#   - kroxylicious-client.key - Client private key
+#   - kroxylicious-client.crt - Client certificate
+#   - kroxylicious-client-id.txt - Client ID (for KROXYLICIOUS_KMS_THALES_CIPHERTRUST_CLIENT_ID)
+#   - kroxylicious-ca-id.txt - CA ID (for cleanup/reference)
+#   - kroxylicious-profile-id.txt - Profile ID (for cleanup/reference)
+#   - kroxylicious-token-id.txt - Registration token ID (for cleanup/reference)
+#
+# Example:
+#   ./register-client-cert.sh /tmp
+#   export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_CLIENT_ID=$(cat /tmp/kroxylicious-client-id.txt)
+#   export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_CLIENT_CERT=/tmp/kroxylicious-client.crt
+#   export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_CLIENT_KEY=/tmp/kroxylicious-client.key
+
+set -euo pipefail
+
+# Default output directory
+OUTPUT_DIR="${1:-/tmp}"
+
+# CA Common Name for the client certificate CA
+# Note: ksctl ca locals create only supports --cn, which creates a subject like /CN=...
+CA_CN="KroxyliciousClientCA"
+CA_SUBJECT="/CN=${CA_CN}"
+
+# Validate prerequisites
+if ! command -v ksctl &> /dev/null; then
+    echo "Error: ksctl is not installed or not in PATH" >&2
+    echo "Download from your CipherTrust Manager: API -> CLI" >&2
+    exit 1
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is not installed or not in PATH" >&2
+    echo "Install with: brew install jq (macOS) or apt-get install jq (Linux)" >&2
+    exit 1
+fi
+
+# Check if ksctl is logged in by attempting to list CAs
+if ! ksctl ca locals list &> /dev/null; then
+    echo "Error: Not logged in to CipherTrust Manager" >&2
+    echo "Run: ksctl login --url <ctm-url> --user admin --nosslverify" >&2
+    exit 1
+fi
+
+echo "==> Step 1: Creating Local CA and self-signing it..."
+echo "    CA Subject: $CA_SUBJECT"
+ksctl ca locals create --cn "$CA_CN" > /dev/null
+CA_ID=$(ksctl ca locals list | jq -r --arg subject "$CA_SUBJECT" '.resources[] | select(.subject==$subject) | .id')
+CA_URI=$(ksctl ca locals list | jq -r --arg subject "$CA_SUBJECT" '.resources[] | select(.subject==$subject) | .uri')
+if [ -z "$CA_ID" ] || [ "$CA_ID" = "null" ]; then
+    echo "Error: Failed to create Local CA" >&2
+    exit 1
+fi
+echo "    Created CA ID: $CA_ID"
+echo "    CA URI: $CA_URI"
+echo "$CA_ID" > "$OUTPUT_DIR/kroxylicious-ca-id.txt"
+
+ksctl ca locals self-sign --duration 3650 --id "${CA_ID}" > /dev/null
+echo "    CA self-signed with 3650 day duration"
+
+echo "==> Step 2: Generating CSR and Private Key for the Client..."
+ksctl ca csr \
+  --cn "my-auth-client" \
+  --csr-outfile "$OUTPUT_DIR/kroxylicious-client.csr" \
+  --key-outfile "$OUTPUT_DIR/kroxylicious-client.key" > /dev/null
+echo "    Private key: $OUTPUT_DIR/kroxylicious-client.key"
+echo "    CSR: $OUTPUT_DIR/kroxylicious-client.csr"
+
+echo "==> Step 3: Issuing and signing the Client Certificate..."
+ksctl ca locals certs issue \
+  --ca-id "${CA_ID}" \
+  --csr-infile "$OUTPUT_DIR/kroxylicious-client.csr" \
+  --cert-outfile "$OUTPUT_DIR/kroxylicious-client.crt" \
+  --duration 365 \
+  --purpose client > /dev/null
+echo "    Client certificate: $OUTPUT_DIR/kroxylicious-client.crt"
+
+echo "==> Step 4: Registering the Client Management Profile..."
+CLIENT_PROFILE_ID=$(ksctl clientmgmt profiles create --name 'kroxylicious-test' | jq -r .id)
+if [ -z "$CLIENT_PROFILE_ID" ] || [ "$CLIENT_PROFILE_ID" = "null" ]; then
+    echo "Error: Failed to create client management profile" >&2
+    exit 1
+fi
+echo "    Created profile ID: $CLIENT_PROFILE_ID"
+echo "$CLIENT_PROFILE_ID" > "$OUTPUT_DIR/kroxylicious-profile-id.txt"
+
+# Note, for some reason, creating the profile with groups/ca_id doesn't seem to work, but updating does.
+ksctl clientmgmt profiles update --profile-id "$CLIENT_PROFILE_ID" --ca_id "${CA_ID}" --groups 'admin' > /dev/null
+echo "    Profile updated with CA ID and groups"
+
+echo "==> Step 5: Creating token for client based on the profile..."
+TOKEN_RESPONSE=$(ksctl clientmgmt tokens create --ca-id "${CA_ID}" --cert-duration 365 --client-mgmt-profile-id "${CLIENT_PROFILE_ID}")
+REG_TOKEN=$(echo "$TOKEN_RESPONSE" | jq -r .token)
+TOKEN_ID=$(echo "$TOKEN_RESPONSE" | jq -r .id)
+if [ -z "$REG_TOKEN" ] || [ "$REG_TOKEN" = "null" ]; then
+    echo "Error: Failed to create registration token" >&2
+    exit 1
+fi
+echo "    Registration token created (ID: $TOKEN_ID)"
+echo "$TOKEN_ID" > "$OUTPUT_DIR/kroxylicious-token-id.txt"
+
+echo "==> Step 6: Registering the client, linking the token to the client cert..."
+CLIENT_ID=$(ksctl clientmgmt clients register --reg-token "${REG_TOKEN}" --cert-file "$OUTPUT_DIR/kroxylicious-client.crt" | jq -r .id)
+if [ -z "$CLIENT_ID" ] || [ "$CLIENT_ID" = "null" ]; then
+    echo "Error: Failed to register client" >&2
+    exit 1
+fi
+echo "    Client registered with ID: $CLIENT_ID"
+echo "$CLIENT_ID" > "$OUTPUT_DIR/kroxylicious-client-id.txt"
+
+echo "==> Step 7: Making web interface trust the new CA..."
+CURRENT_TRUSTED_CAS=$(ksctl interfaces get --name web | jq -r '.trusted_cas.local | join(",")')
+ksctl interfaces modify --name web --trusted-local-cas "${CURRENT_TRUSTED_CAS},${CA_URI}" > /dev/null
+echo "    Web interface updated to trust new CA"
+
+echo "==> Restarting web service to activate new certificate..."
+ksctl services restart --service-names web -y > /dev/null
+echo "    Web service restarted"
+
+# Clean up temporary files
+rm -f "$OUTPUT_DIR/kroxylicious-client.csr"
+
+echo ""
+echo "==> Client registration complete!"
+echo ""
+echo "Client ID: $CLIENT_ID"
+echo "CA ID: $CA_ID"
+echo "Profile ID: $CLIENT_PROFILE_ID"
+echo "Token ID: $TOKEN_ID"
+echo ""
+echo "Files created in $OUTPUT_DIR:"
+echo "  - kroxylicious-client.key (private key)"
+echo "  - kroxylicious-client.crt (certificate)"
+echo "  - kroxylicious-client-id.txt (client ID)"
+echo "  - kroxylicious-ca-id.txt (CA ID)"
+echo "  - kroxylicious-profile-id.txt (profile ID)"
+echo "  - kroxylicious-token-id.txt (token ID)"
+echo ""
+echo "To use with integration tests, set these environment variables:"
+echo ""
+echo "  export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_CLIENT_ID=$CLIENT_ID"
+echo "  export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_CLIENT_CERT=$OUTPUT_DIR/kroxylicious-client.crt"
+echo "  export KROXYLICIOUS_KMS_THALES_CIPHERTRUST_CLIENT_KEY=$OUTPUT_DIR/kroxylicious-client.key"
+echo ""

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/scripts/unregister-client-cert.sh
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/scripts/unregister-client-cert.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# Unregister a client certificate from CipherTrust Manager.
+# This removes the client, profile, and CA from CTM and optionally deletes local credential files.
+#
+# Prerequisites:
+#   - ksctl must be installed and logged in (ksctl login ...)
+#   - jq must be installed
+#
+# Usage: unregister-client-cert.sh [output-directory]
+#
+# Arguments:
+#   [output-directory]  - Directory containing kroxylicious-client-id.txt, kroxylicious-ca-id.txt,
+#                         and kroxylicious-profile-id.txt (default: /tmp)
+#
+# The script will:
+#   1. Delete the client from CipherTrust Manager
+#   2. Delete the client management profile
+#   3. Delete the local CA
+#   4. Optionally delete local credential files
+#
+# Examples:
+#   ./unregister-client-cert.sh /tmp
+
+set -euo pipefail
+
+# Default output directory
+OUTPUT_DIR="${1:-/tmp}"
+
+# Validate prerequisites
+if ! command -v ksctl &> /dev/null; then
+    echo "Error: ksctl is not installed or not in PATH" >&2
+    echo "Download from your CipherTrust Manager: API -> CLI" >&2
+    exit 1
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is not installed or not in PATH" >&2
+    echo "Install with: brew install jq (macOS) or apt-get install jq (Linux)" >&2
+    exit 1
+fi
+
+# Check if ksctl is logged in
+if ! ksctl ca locals list &> /dev/null; then
+    echo "Error: Not logged in to CipherTrust Manager" >&2
+    echo "Run: ksctl login --url <ctm-url> --user admin --nosslverify" >&2
+    exit 1
+fi
+
+# Read IDs from files
+if [ ! -f "$OUTPUT_DIR/kroxylicious-client-id.txt" ]; then
+    echo "Error: Client ID file not found: $OUTPUT_DIR/kroxylicious-client-id.txt" >&2
+    exit 1
+fi
+CLIENT_ID=$(cat "$OUTPUT_DIR/kroxylicious-client-id.txt")
+echo "Read client ID from file: $CLIENT_ID"
+
+if [ ! -f "$OUTPUT_DIR/kroxylicious-profile-id.txt" ]; then
+    echo "Warning: Profile ID file not found: $OUTPUT_DIR/kroxylicious-profile-id.txt" >&2
+    echo "         Profile cleanup will be skipped" >&2
+    PROFILE_ID=""
+else
+    PROFILE_ID=$(cat "$OUTPUT_DIR/kroxylicious-profile-id.txt")
+    echo "Read profile ID from file: $PROFILE_ID"
+fi
+
+if [ ! -f "$OUTPUT_DIR/kroxylicious-ca-id.txt" ]; then
+    echo "Warning: CA ID file not found: $OUTPUT_DIR/kroxylicious-ca-id.txt" >&2
+    echo "         CA cleanup will be skipped" >&2
+    CA_ID=""
+else
+    CA_ID=$(cat "$OUTPUT_DIR/kroxylicious-ca-id.txt")
+    echo "Read CA ID from file: $CA_ID"
+fi
+
+if [ ! -f "$OUTPUT_DIR/kroxylicious-token-id.txt" ]; then
+    echo "Warning: Token ID file not found: $OUTPUT_DIR/kroxylicious-token-id.txt" >&2
+    echo "         Token cleanup will be skipped" >&2
+    TOKEN_ID=""
+else
+    TOKEN_ID=$(cat "$OUTPUT_DIR/kroxylicious-token-id.txt")
+    echo "Read token ID from file: $TOKEN_ID"
+fi
+
+echo ""
+echo "==> Step 1: Deleting client from CipherTrust Manager..."
+if ksctl clientmgmt clients delete --client-id "$CLIENT_ID" --nowarning &> /dev/null; then
+    echo "    Client deleted (ID: $CLIENT_ID)"
+else
+    echo "Warning: Failed to delete client from CipherTrust Manager" >&2
+    echo "         Client may not exist or you may not have permission" >&2
+fi
+
+if [ -n "$TOKEN_ID" ]; then
+    echo "==> Step 2: Deleting registration token..."
+    if ksctl clientmgmt tokens delete --token-id "$TOKEN_ID" &> /dev/null; then
+        echo "    Token deleted (ID: $TOKEN_ID)"
+    else
+        echo "Warning: Failed to delete token from CipherTrust Manager" >&2
+        echo "         Token may not exist or you may not have permission" >&2
+    fi
+else
+    echo "==> Step 2: Skipping token deletion (no token ID found)"
+fi
+
+if [ -n "$PROFILE_ID" ]; then
+    echo "==> Step 3: Deleting client management profile..."
+    if ksctl clientmgmt profiles delete --profile-id "$PROFILE_ID" &> /dev/null; then
+        echo "    Profile deleted (ID: $PROFILE_ID)"
+    else
+        echo "Warning: Failed to delete profile from CipherTrust Manager" >&2
+        echo "         Profile may not exist or you may not have permission" >&2
+    fi
+else
+    echo "==> Step 3: Skipping profile deletion (no profile ID found)"
+fi
+
+if [ -n "$CA_ID" ]; then
+    echo "==> Step 4: Removing CA from web interface trusted CAs..."
+    # Get current trusted CAs
+    CA_URI=$(ksctl ca locals list | jq -r --arg id "$CA_ID" '.resources[] | select(.id==$id) | .uri')
+    if [ -n "$CA_URI" ] && [ "$CA_URI" != "null" ]; then
+        CURRENT_TRUSTED_CAS=$(ksctl interfaces get --name web | jq -r '.trusted_cas.local | join(",")')
+        # Remove our CA URI from the list
+        NEW_TRUSTED_CAS=$(echo "$CURRENT_TRUSTED_CAS" | tr ',' '\n' | grep -v "$CA_URI" | tr '\n' ',' | sed 's/,$//')
+
+        if [ "$CURRENT_TRUSTED_CAS" != "$NEW_TRUSTED_CAS" ]; then
+            ksctl interfaces modify --name web --trusted-local-cas "$NEW_TRUSTED_CAS" > /dev/null
+            echo "    CA removed from web interface"
+
+            echo "==> Restarting web service..."
+            ksctl services restart --service-names web -y > /dev/null
+            echo "    Web service restarted"
+        else
+            echo "    CA was not in web interface trusted CAs list"
+        fi
+    else
+        echo "    CA URI not found, skipping web interface update"
+    fi
+
+    echo "==> Step 5: Deleting local CA..."
+    if ksctl ca locals delete --id "$CA_ID" &> /dev/null; then
+        echo "    CA deleted (ID: $CA_ID)"
+    else
+        echo "Warning: Failed to delete CA from CipherTrust Manager" >&2
+        echo "         CA may not exist or you may not have permission" >&2
+    fi
+else
+    echo "==> Step 4: Skipping CA removal from web interface (no CA ID found)"
+    echo "==> Step 5: Skipping CA deletion (no CA ID found)"
+fi
+
+# Check for local files and offer to delete them
+FILES_TO_DELETE=(
+    "$OUTPUT_DIR/kroxylicious-client.key"
+    "$OUTPUT_DIR/kroxylicious-client.crt"
+    "$OUTPUT_DIR/kroxylicious-client-id.txt"
+    "$OUTPUT_DIR/kroxylicious-ca-id.txt"
+    "$OUTPUT_DIR/kroxylicious-profile-id.txt"
+    "$OUTPUT_DIR/kroxylicious-token-id.txt"
+)
+
+FILES_FOUND=()
+for file in "${FILES_TO_DELETE[@]}"; do
+    if [ -f "$file" ]; then
+        FILES_FOUND+=("$file")
+    fi
+done
+
+if [ ${#FILES_FOUND[@]} -gt 0 ]; then
+    echo ""
+    echo "==> Deleting local credential files from $OUTPUT_DIR:"
+    for file in "${FILES_FOUND[@]}"; do
+        rm -f "$file"
+        echo "    Deleted: $(basename "$file")"
+    done
+    echo ""
+    echo "==> Local files deleted"
+else
+    echo ""
+    echo "==> No local credential files found in $OUTPUT_DIR"
+fi
+
+echo ""
+echo "==> Client unregistration complete!"
+echo ""

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKmsService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKmsService.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 
 import io.kroxylicious.kms.provider.thales.ciphertrust.auth.BearerTokenService;
 import io.kroxylicious.kms.provider.thales.ciphertrust.auth.CachingBearerTokenService;
+import io.kroxylicious.kms.provider.thales.ciphertrust.auth.ClientCertificateTokenService;
 import io.kroxylicious.kms.provider.thales.ciphertrust.auth.UserAuthenticationTokenService;
 import io.kroxylicious.kms.provider.thales.ciphertrust.config.Config;
 import io.kroxylicious.kms.service.Kms;
@@ -72,18 +73,34 @@ public class CipherTrustKmsService implements KmsService<Config, WrappingKey, Ci
     }
 
     private BearerTokenService createTokenService(Config config) {
-        // User authentication
-        var userCreds = config.userCredentials();
         var tlsConfigurator = new TlsHttpClientConfigurator(config.tls());
+        BearerTokenService delegate;
 
-        BearerTokenService delegate = new UserAuthenticationTokenService(
-                config.endpointUrl(),
-                userCreds.username(),
-                userCreds.password().getProvidedPassword(),
-                DEFAULT_TIMEOUT,
-                tlsConfigurator);
+        if (config.userCredentials() != null) {
+            // User authentication with username/password
+            var userCreds = config.userCredentials();
+            delegate = new UserAuthenticationTokenService(
+                    config.endpointUrl(),
+                    userCreds.username(),
+                    userCreds.password().getProvidedPassword(),
+                    DEFAULT_TIMEOUT,
+                    tlsConfigurator);
+        }
+        else if (config.clientCredentials() != null) {
+            // Client certificate authentication
+            var clientCreds = config.clientCredentials();
+            delegate = new ClientCertificateTokenService(
+                    config.endpointUrl(),
+                    clientCreds.clientId(),
+                    DEFAULT_TIMEOUT,
+                    tlsConfigurator);
+        }
+        else {
+            // Cannot happen, the Config ctor makes the enforcement.
+            throw new IllegalStateException("Must supply either userCredentials or clientCredentials");
+        }
 
-        // Wrap with caching token service for automatic token refresh
+        // Wrap with caching token service for automatic token refresh/re-authentication
         return new CachingBearerTokenService(delegate, Clock.systemUTC());
     }
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/AbstractTokenService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/AbstractTokenService.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.thales.ciphertrust.auth;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.UnaryOperator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.kroxylicious.kms.provider.thales.ciphertrust.model.AuthRequest;
+import io.kroxylicious.kms.provider.thales.ciphertrust.model.AuthResponse;
+import io.kroxylicious.kms.service.KmsException;
+
+/**
+ * Abstract base class for CipherTrust Manager authentication token services.
+ * <p>
+ * Provides common HTTP request/response handling infrastructure for authentication.
+ * Subclasses implement specific authentication methods (client certificate, username/password).
+ * </p>
+ */
+abstract class AbstractTokenService implements BearerTokenService {
+
+    protected static final Logger LOGGER = LoggerFactory.getLogger(AbstractTokenService.class);
+    protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    protected final URI authEndpoint;
+    protected final HttpClient client;
+
+    /**
+     * Create an authentication token service.
+     *
+     * @param endpointUrl base URL of CipherTrust Manager instance
+     * @param timeout HTTP request timeout
+     * @param tlsConfigurator TLS configuration for HTTP client
+     */
+    protected AbstractTokenService(URI endpointUrl,
+                                   Duration timeout,
+                                   UnaryOperator<HttpClient.Builder> tlsConfigurator) {
+        Objects.requireNonNull(endpointUrl, "endpointUrl cannot be null");
+        Objects.requireNonNull(timeout, "timeout cannot be null");
+        Objects.requireNonNull(tlsConfigurator, "tlsConfigurator cannot be null");
+
+        this.authEndpoint = endpointUrl.resolve("/api/v1/auth/tokens/");
+        this.client = createClient(timeout, tlsConfigurator);
+    }
+
+    private HttpClient createClient(Duration timeout, UnaryOperator<HttpClient.Builder> tlsConfigurator) {
+        return tlsConfigurator.apply(HttpClient.newBuilder())
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .connectTimeout(timeout)
+                .build();
+    }
+
+    /**
+     * Perform authentication with the given request.
+     *
+     * @param authRequest the authentication request
+     * @param operationType description of the operation type for logging
+     * @return completion stage that completes with the bearer token
+     */
+    protected CompletionStage<BearerToken> authenticate(AuthRequest authRequest, String operationType) {
+        try {
+            String requestBody = OBJECT_MAPPER.writeValueAsString(authRequest);
+
+            HttpRequest httpRequest = HttpRequest.newBuilder()
+                    .uri(authEndpoint)
+                    .header("Content-Type", "application/json")
+                    .header("Accept", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8))
+                    .build();
+
+            return client.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofByteArray())
+                    .thenApply(response -> {
+                        if (response.statusCode() == 200) {
+                            return response;
+                        }
+                        else {
+                            String body = new String(response.body(), StandardCharsets.UTF_8);
+                            var logBuilder = LOGGER.atWarn()
+                                    .addKeyValue("operation", operationType)
+                                    .addKeyValue("statusCode", response.statusCode());
+                            if (LOGGER.isDebugEnabled()) {
+                                logBuilder = logBuilder.addKeyValue("responseBody", body);
+                            }
+                            logBuilder.log(LOGGER.isDebugEnabled()
+                                    ? "authentication operation failed"
+                                    : "authentication operation failed, increase log level to DEBUG for response body");
+                            throw new KmsException("%s failed with HTTP %d".formatted(operationType, response.statusCode()));
+                        }
+                    })
+                    .thenApply(HttpResponse::body)
+                    .thenApply(this::parseAuthResponse)
+                    .thenApply(authResponse -> createBearerToken(authResponse, operationType));
+        }
+        catch (IOException e) {
+            LOGGER.atWarn()
+                    .setCause(e)
+                    .log("failed to serialize authentication request");
+            return CompletableFuture.failedFuture(new KmsException("Failed to serialize authentication request", e));
+        }
+    }
+
+    /**
+     * Parse authentication response from JSON bytes.
+     *
+     * @param bytes response body bytes
+     * @return parsed authentication response
+     * @throws UncheckedIOException if parsing fails
+     */
+    protected AuthResponse parseAuthResponse(byte[] bytes) {
+        try {
+            return OBJECT_MAPPER.readValue(bytes, AuthResponse.class);
+        }
+        catch (IOException e) {
+            String responseBody = new String(bytes, StandardCharsets.UTF_8);
+            var logBuilder = LOGGER.atWarn()
+                    .setCause(e);
+            if (LOGGER.isDebugEnabled()) {
+                logBuilder = logBuilder.addKeyValue("responseBody", responseBody);
+            }
+            logBuilder.log(LOGGER.isDebugEnabled()
+                    ? "failed to parse authentication response"
+                    : "failed to parse authentication response, increase log level to DEBUG for response body");
+            throw new UncheckedIOException("Failed to parse authentication response", e);
+        }
+    }
+
+    /**
+     * Create a bearer token from the authentication response.
+     * Subclasses can override to extract refresh tokens or other data.
+     *
+     * @param authResponse the authentication response
+     * @param operationType description of the operation type for logging
+     * @return the bearer token
+     */
+    protected BearerToken createBearerToken(AuthResponse authResponse, String operationType) {
+        Instant now = Instant.now();
+        Instant expiresAt = now.plusSeconds(authResponse.duration());
+
+        LOGGER.atInfo()
+                .addKeyValue("expiresAt", expiresAt)
+                .log("{} succeeded", operationType);
+
+        return new BearerToken(authResponse.jwt(), now, expiresAt);
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+}

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/ClientCertificateTokenService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/ClientCertificateTokenService.java
@@ -18,7 +18,6 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
 
 import org.slf4j.Logger;
@@ -31,47 +30,50 @@ import io.kroxylicious.kms.provider.thales.ciphertrust.model.AuthResponse;
 import io.kroxylicious.kms.service.KmsException;
 
 /**
- * Bearer token service for CipherTrust Manager user authentication.
+ * Bearer token service for CipherTrust Manager client certificate authentication.
  * <p>
- * Handles initial authentication with username/password and subsequent token
- * refresh using refresh tokens. Intended to be wrapped with
- * {@link CachingBearerTokenService} for automatic token caching and refresh.
+ * Authenticates using client certificates presented during TLS handshake.
+ * Unlike user authentication, client certificate authentication does NOT support
+ * refresh tokens - the client must re-authenticate with the certificate each time
+ * the JWT expires.
+ * </p>
+ * <p>
+ * Intended to be wrapped with {@link CachingBearerTokenService} for automatic
+ * token caching and re-authentication.
  * </p>
  */
-public class UserAuthenticationTokenService implements BearerTokenService {
+public class ClientCertificateTokenService implements BearerTokenService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UserAuthenticationTokenService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClientCertificateTokenService.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final URI authEndpoint;
-    private final String username;
-    private final String password;
+    private final String clientId;
     private final HttpClient client;
-    private final AtomicReference<String> refreshToken = new AtomicReference<>();
 
     /**
-     * Create a user authentication token service.
+     * Create a client certificate authentication token service.
      *
      * @param endpointUrl base URL of CipherTrust Manager instance
-     * @param username username for authentication
-     * @param password password for authentication
+     * @param clientId client ID obtained during client registration
      * @param timeout HTTP request timeout
-     * @param tlsConfigurator TLS configuration for HTTP client
+     * @param tlsConfigurator TLS configuration for HTTP client (must include client certificate)
      */
-    public UserAuthenticationTokenService(URI endpointUrl,
-                                          String username,
-                                          String password,
-                                          Duration timeout,
-                                          UnaryOperator<HttpClient.Builder> tlsConfigurator) {
+    public ClientCertificateTokenService(URI endpointUrl,
+                                         String clientId,
+                                         Duration timeout,
+                                         UnaryOperator<HttpClient.Builder> tlsConfigurator) {
         Objects.requireNonNull(endpointUrl, "endpointUrl cannot be null");
-        Objects.requireNonNull(username, "username cannot be null");
-        Objects.requireNonNull(password, "password cannot be null");
+        Objects.requireNonNull(clientId, "clientId cannot be null");
         Objects.requireNonNull(timeout, "timeout cannot be null");
         Objects.requireNonNull(tlsConfigurator, "tlsConfigurator cannot be null");
 
+        if (clientId.isBlank()) {
+            throw new IllegalArgumentException("clientId cannot be blank");
+        }
+
         this.authEndpoint = endpointUrl.resolve("/api/v1/auth/tokens/");
-        this.username = username;
-        this.password = password;
+        this.clientId = clientId;
         this.client = createClient(timeout, tlsConfigurator);
     }
 
@@ -84,36 +86,15 @@ public class UserAuthenticationTokenService implements BearerTokenService {
 
     @Override
     public CompletionStage<BearerToken> getBearerToken() {
-        String currentRefreshToken = refreshToken.get();
-        if (currentRefreshToken != null) {
-            // Try refresh token first (avoids sending password)
-            return refreshWithToken(currentRefreshToken)
-                    .exceptionallyCompose(error -> {
-                        LOGGER.atDebug()
-                                .addKeyValue("error", error.getMessage())
-                                .log("refresh token failed, falling back to password authentication");
-                        // If refresh fails, clear token and fall back to password auth
-                        refreshToken.set(null);
-                        return authenticateWithPassword();
-                    });
-        }
-        else {
-            // Initial authentication with username/password
-            return authenticateWithPassword();
-        }
+        return authenticateWithCertificate();
     }
 
-    private CompletionStage<BearerToken> authenticateWithPassword() {
-        AuthRequest request = AuthRequest.withPassword(username, password);
-        return authenticate(request, "password authentication");
+    private CompletionStage<BearerToken> authenticateWithCertificate() {
+        AuthRequest request = AuthRequest.withClientCredential(clientId);
+        return authenticate(request);
     }
 
-    private CompletionStage<BearerToken> refreshWithToken(String token) {
-        AuthRequest request = AuthRequest.withRefreshToken(token);
-        return authenticate(request, "token refresh");
-    }
-
-    private CompletionStage<BearerToken> authenticate(AuthRequest authRequest, String operationType) {
+    private CompletionStage<BearerToken> authenticate(AuthRequest authRequest) {
         try {
             String requestBody = OBJECT_MAPPER.writeValueAsString(authRequest);
 
@@ -132,30 +113,26 @@ public class UserAuthenticationTokenService implements BearerTokenService {
                         else {
                             String body = new String(response.body(), StandardCharsets.UTF_8);
                             var logBuilder = LOGGER.atWarn()
-                                    .addKeyValue("operation", operationType)
                                     .addKeyValue("statusCode", response.statusCode());
                             if (LOGGER.isDebugEnabled()) {
                                 logBuilder = logBuilder.addKeyValue("responseBody", body);
                             }
                             logBuilder.log(LOGGER.isDebugEnabled()
-                                    ? "authentication operation failed"
-                                    : "authentication operation failed, increase log level to DEBUG for response body");
-                            throw new KmsException("%s failed with HTTP %d".formatted(operationType, response.statusCode()));
+                                    ? "client certificate authentication failed"
+                                    : "client certificate authentication failed, increase log level to DEBUG for response body");
+                            throw new KmsException("client certificate authentication failed with HTTP %d".formatted(response.statusCode()));
                         }
                     })
                     .thenApply(HttpResponse::body)
                     .thenApply(this::parseAuthResponse)
                     .thenApply(authResponse -> {
-                        // Store refresh token for future use
-                        refreshToken.set(authResponse.refreshToken());
-
                         // Calculate expiry time
                         Instant now = Instant.now();
                         Instant expiresAt = now.plusSeconds(authResponse.duration());
 
                         LOGGER.atInfo()
                                 .addKeyValue("expiresAt", expiresAt)
-                                .log("{} succeeded", operationType);
+                                .log("client certificate authentication succeeded");
 
                         return new BearerToken(authResponse.jwt(), now, expiresAt);
                     });

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/ClientCertificateTokenService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/ClientCertificateTokenService.java
@@ -6,28 +6,14 @@
 
 package io.kroxylicious.kms.provider.thales.ciphertrust.auth;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.UnaryOperator;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.kroxylicious.kms.provider.thales.ciphertrust.model.AuthRequest;
-import io.kroxylicious.kms.provider.thales.ciphertrust.model.AuthResponse;
-import io.kroxylicious.kms.service.KmsException;
 
 /**
  * Bearer token service for CipherTrust Manager client certificate authentication.
@@ -42,14 +28,9 @@ import io.kroxylicious.kms.service.KmsException;
  * token caching and re-authentication.
  * </p>
  */
-public class ClientCertificateTokenService implements BearerTokenService {
+public class ClientCertificateTokenService extends AbstractTokenService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ClientCertificateTokenService.class);
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-    private final URI authEndpoint;
     private final String clientId;
-    private final HttpClient client;
 
     /**
      * Create a client certificate authentication token service.
@@ -63,25 +44,14 @@ public class ClientCertificateTokenService implements BearerTokenService {
                                          String clientId,
                                          Duration timeout,
                                          UnaryOperator<HttpClient.Builder> tlsConfigurator) {
-        Objects.requireNonNull(endpointUrl, "endpointUrl cannot be null");
-        Objects.requireNonNull(clientId, "clientId cannot be null");
-        Objects.requireNonNull(timeout, "timeout cannot be null");
-        Objects.requireNonNull(tlsConfigurator, "tlsConfigurator cannot be null");
+        super(endpointUrl, timeout, tlsConfigurator);
 
+        Objects.requireNonNull(clientId, "clientId cannot be null");
         if (clientId.isBlank()) {
             throw new IllegalArgumentException("clientId cannot be blank");
         }
 
-        this.authEndpoint = endpointUrl.resolve("/api/v1/auth/tokens/");
         this.clientId = clientId;
-        this.client = createClient(timeout, tlsConfigurator);
-    }
-
-    private HttpClient createClient(Duration timeout, UnaryOperator<HttpClient.Builder> tlsConfigurator) {
-        return tlsConfigurator.apply(HttpClient.newBuilder())
-                .followRedirects(HttpClient.Redirect.NORMAL)
-                .connectTimeout(timeout)
-                .build();
     }
 
     @Override
@@ -91,80 +61,6 @@ public class ClientCertificateTokenService implements BearerTokenService {
 
     private CompletionStage<BearerToken> authenticateWithCertificate() {
         AuthRequest request = AuthRequest.withClientCredential(clientId);
-        return authenticate(request);
-    }
-
-    private CompletionStage<BearerToken> authenticate(AuthRequest authRequest) {
-        try {
-            String requestBody = OBJECT_MAPPER.writeValueAsString(authRequest);
-
-            HttpRequest httpRequest = HttpRequest.newBuilder()
-                    .uri(authEndpoint)
-                    .header("Content-Type", "application/json")
-                    .header("Accept", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8))
-                    .build();
-
-            return client.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofByteArray())
-                    .thenApply(response -> {
-                        if (response.statusCode() == 200) {
-                            return response;
-                        }
-                        else {
-                            String body = new String(response.body(), StandardCharsets.UTF_8);
-                            var logBuilder = LOGGER.atWarn()
-                                    .addKeyValue("statusCode", response.statusCode());
-                            if (LOGGER.isDebugEnabled()) {
-                                logBuilder = logBuilder.addKeyValue("responseBody", body);
-                            }
-                            logBuilder.log(LOGGER.isDebugEnabled()
-                                    ? "client certificate authentication failed"
-                                    : "client certificate authentication failed, increase log level to DEBUG for response body");
-                            throw new KmsException("client certificate authentication failed with HTTP %d".formatted(response.statusCode()));
-                        }
-                    })
-                    .thenApply(HttpResponse::body)
-                    .thenApply(this::parseAuthResponse)
-                    .thenApply(authResponse -> {
-                        // Calculate expiry time
-                        Instant now = Instant.now();
-                        Instant expiresAt = now.plusSeconds(authResponse.duration());
-
-                        LOGGER.atInfo()
-                                .addKeyValue("expiresAt", expiresAt)
-                                .log("client certificate authentication succeeded");
-
-                        return new BearerToken(authResponse.jwt(), now, expiresAt);
-                    });
-        }
-        catch (IOException e) {
-            LOGGER.atWarn()
-                    .setCause(e)
-                    .log("failed to serialize authentication request");
-            return CompletableFuture.failedFuture(new KmsException("Failed to serialize authentication request", e));
-        }
-    }
-
-    private AuthResponse parseAuthResponse(byte[] bytes) {
-        try {
-            return OBJECT_MAPPER.readValue(bytes, AuthResponse.class);
-        }
-        catch (IOException e) {
-            String responseBody = new String(bytes, StandardCharsets.UTF_8);
-            var logBuilder = LOGGER.atWarn()
-                    .setCause(e);
-            if (LOGGER.isDebugEnabled()) {
-                logBuilder = logBuilder.addKeyValue("responseBody", responseBody);
-            }
-            logBuilder.log(LOGGER.isDebugEnabled()
-                    ? "failed to parse authentication response"
-                    : "failed to parse authentication response, increase log level to DEBUG for response body");
-            throw new UncheckedIOException("Failed to parse authentication response", e);
-        }
-    }
-
-    @Override
-    public void close() {
-        client.close();
+        return authenticate(request, "client certificate authentication");
     }
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/UserAuthenticationTokenService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/UserAuthenticationTokenService.java
@@ -6,29 +6,17 @@
 
 package io.kroxylicious.kms.provider.thales.ciphertrust.auth;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.kroxylicious.kms.provider.thales.ciphertrust.model.AuthRequest;
 import io.kroxylicious.kms.provider.thales.ciphertrust.model.AuthResponse;
-import io.kroxylicious.kms.service.KmsException;
 
 /**
  * Bearer token service for CipherTrust Manager user authentication.
@@ -38,15 +26,10 @@ import io.kroxylicious.kms.service.KmsException;
  * {@link CachingBearerTokenService} for automatic token caching and refresh.
  * </p>
  */
-public class UserAuthenticationTokenService implements BearerTokenService {
+public class UserAuthenticationTokenService extends AbstractTokenService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UserAuthenticationTokenService.class);
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-    private final URI authEndpoint;
     private final String username;
     private final String password;
-    private final HttpClient client;
     private final AtomicReference<String> refreshToken = new AtomicReference<>();
 
     /**
@@ -63,23 +46,13 @@ public class UserAuthenticationTokenService implements BearerTokenService {
                                           String password,
                                           Duration timeout,
                                           UnaryOperator<HttpClient.Builder> tlsConfigurator) {
-        Objects.requireNonNull(endpointUrl, "endpointUrl cannot be null");
+        super(endpointUrl, timeout, tlsConfigurator);
+
         Objects.requireNonNull(username, "username cannot be null");
         Objects.requireNonNull(password, "password cannot be null");
-        Objects.requireNonNull(timeout, "timeout cannot be null");
-        Objects.requireNonNull(tlsConfigurator, "tlsConfigurator cannot be null");
 
-        this.authEndpoint = endpointUrl.resolve("/api/v1/auth/tokens/");
         this.username = username;
         this.password = password;
-        this.client = createClient(timeout, tlsConfigurator);
-    }
-
-    private HttpClient createClient(Duration timeout, UnaryOperator<HttpClient.Builder> tlsConfigurator) {
-        return tlsConfigurator.apply(HttpClient.newBuilder())
-                .followRedirects(HttpClient.Redirect.NORMAL)
-                .connectTimeout(timeout)
-                .build();
     }
 
     @Override
@@ -113,81 +86,17 @@ public class UserAuthenticationTokenService implements BearerTokenService {
         return authenticate(request, "token refresh");
     }
 
-    private CompletionStage<BearerToken> authenticate(AuthRequest authRequest, String operationType) {
-        try {
-            String requestBody = OBJECT_MAPPER.writeValueAsString(authRequest);
-
-            HttpRequest httpRequest = HttpRequest.newBuilder()
-                    .uri(authEndpoint)
-                    .header("Content-Type", "application/json")
-                    .header("Accept", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8))
-                    .build();
-
-            return client.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofByteArray())
-                    .thenApply(response -> {
-                        if (response.statusCode() == 200) {
-                            return response;
-                        }
-                        else {
-                            String body = new String(response.body(), StandardCharsets.UTF_8);
-                            var logBuilder = LOGGER.atWarn()
-                                    .addKeyValue("operation", operationType)
-                                    .addKeyValue("statusCode", response.statusCode());
-                            if (LOGGER.isDebugEnabled()) {
-                                logBuilder = logBuilder.addKeyValue("responseBody", body);
-                            }
-                            logBuilder.log(LOGGER.isDebugEnabled()
-                                    ? "authentication operation failed"
-                                    : "authentication operation failed, increase log level to DEBUG for response body");
-                            throw new KmsException("%s failed with HTTP %d".formatted(operationType, response.statusCode()));
-                        }
-                    })
-                    .thenApply(HttpResponse::body)
-                    .thenApply(this::parseAuthResponse)
-                    .thenApply(authResponse -> {
-                        // Store refresh token for future use
-                        refreshToken.set(authResponse.refreshToken());
-
-                        // Calculate expiry time
-                        Instant now = Instant.now();
-                        Instant expiresAt = now.plusSeconds(authResponse.duration());
-
-                        LOGGER.atInfo()
-                                .addKeyValue("expiresAt", expiresAt)
-                                .log("{} succeeded", operationType);
-
-                        return new BearerToken(authResponse.jwt(), now, expiresAt);
-                    });
-        }
-        catch (IOException e) {
-            LOGGER.atWarn()
-                    .setCause(e)
-                    .log("failed to serialize authentication request");
-            return CompletableFuture.failedFuture(new KmsException("Failed to serialize authentication request", e));
-        }
-    }
-
-    private AuthResponse parseAuthResponse(byte[] bytes) {
-        try {
-            return OBJECT_MAPPER.readValue(bytes, AuthResponse.class);
-        }
-        catch (IOException e) {
-            String responseBody = new String(bytes, StandardCharsets.UTF_8);
-            var logBuilder = LOGGER.atWarn()
-                    .setCause(e);
-            if (LOGGER.isDebugEnabled()) {
-                logBuilder = logBuilder.addKeyValue("responseBody", responseBody);
-            }
-            logBuilder.log(LOGGER.isDebugEnabled()
-                    ? "failed to parse authentication response"
-                    : "failed to parse authentication response, increase log level to DEBUG for response body");
-            throw new UncheckedIOException("Failed to parse authentication response", e);
-        }
-    }
-
     @Override
-    public void close() {
-        client.close();
+    protected BearerToken createBearerToken(AuthResponse authResponse, String operationType) {
+        refreshToken.set(authResponse.refreshToken());
+
+        Instant now = Instant.now();
+        Instant expiresAt = now.plusSeconds(authResponse.duration());
+
+        LOGGER.atInfo()
+                .addKeyValue("expiresAt", expiresAt)
+                .log("{} succeeded", operationType);
+
+        return new BearerToken(authResponse.jwt(), now, expiresAt);
     }
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/config/ClientCredentials.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/config/ClientCredentials.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.thales.ciphertrust.config;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Client certificate authentication credentials for CipherTrust Manager.
+ * <p>
+ * The client certificate must be configured in the TLS configuration ({@code tls.key}).
+ * The client ID is obtained during client registration with the CipherTrust Manager.
+ * </p>
+ *
+ * @param clientId client ID obtained during client registration
+ */
+public record ClientCredentials(
+                                @JsonProperty(value = "clientId", required = true) String clientId) {
+
+    /**
+     * Constructs client certificate authentication credentials.
+     */
+    public ClientCredentials {
+        Objects.requireNonNull(clientId, "clientId cannot be null");
+        if (clientId.isBlank()) {
+            throw new IllegalArgumentException("clientId cannot be blank");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ClientCredentials{clientId='***'}";
+    }
+}

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/config/Config.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/config/Config.java
@@ -17,21 +17,51 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Configuration for the Thales CipherTrust Manager KMS service.
+ * <p>
+ * Supports two authentication methods (mutually exclusive):
+ * <ul>
+ *   <li>User authentication: requires {@code userCredentials}</li>
+ *   <li>Client certificate authentication: requires {@code clientCredentials} and {@code tls.key}</li>
+ * </ul>
  *
  * @param endpointUrl URL of the CipherTrust Manager instance e.g. {@code https://ctm.example.com}
- * @param userCredentials user credentials for authentication
- * @param tls TLS configuration
+ * @param userCredentials user credentials for username/password authentication (optional)
+ * @param clientCredentials client credentials for client certificate authentication (optional)
+ * @param tls TLS configuration including optional client certificate
  */
 public record Config(
                      @JsonProperty(value = "endpointUrl", required = true) URI endpointUrl,
-                     @JsonProperty(value = "userCredentials", required = true) UserCredentials userCredentials,
+                     @JsonProperty(value = "userCredentials", required = false) @Nullable UserCredentials userCredentials,
+                     @JsonProperty(value = "clientCredentials", required = false) @Nullable ClientCredentials clientCredentials,
                      @JsonProperty(value = "tls", required = false) @Nullable Tls tls) {
 
     /**
      * Constructs a CipherTrust Manager KMS configuration.
+     * <p>
+     * Validates that exactly one authentication method is configured:
+     * either userCredentials OR clientCredentials (with client certificate in TLS).
+     * </p>
      */
     public Config {
         Objects.requireNonNull(endpointUrl, "endpointUrl cannot be null");
-        Objects.requireNonNull(userCredentials, "userCredentials cannot be null");
+
+        boolean hasUserCredentials = userCredentials != null;
+        boolean hasClientCredentials = clientCredentials != null;
+        boolean hasClientCertificate = tls != null && tls.key() != null;
+
+        // Validate mutual exclusivity of authentication methods
+        if (hasUserCredentials && hasClientCredentials) {
+            throw new IllegalArgumentException("Cannot configure both userCredentials and clientCredentials");
+        }
+
+        // Validate that at least one authentication method is configured
+        if (!hasUserCredentials && !hasClientCredentials) {
+            throw new IllegalArgumentException("Must configure either userCredentials or clientCredentials");
+        }
+
+        // Validate client certificate authentication configuration
+        if (hasClientCredentials && !hasClientCertificate) {
+            throw new IllegalArgumentException("clientCredentials requires a client certificate (tls.key must be configured)");
+        }
     }
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/config/UserCredentials.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/config/UserCredentials.java
@@ -31,4 +31,10 @@ public record UserCredentials(
             throw new IllegalArgumentException("username cannot be empty");
         }
     }
+
+    @Override
+    @SuppressWarnings("java:S2068") // The masked password is a not a password
+    public String toString() {
+        return "UserCredentials{username='" + username + "', password='***'}";
+    }
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/model/AuthRequest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/model/AuthRequest.java
@@ -15,7 +15,12 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Request model for CipherTrust Manager authentication.
- * Supports both initial authentication (username/password) and token refresh (refresh_token).
+ * Supports:
+ * <ul>
+ *   <li>User authentication with username/password (grant_type=password)</li>
+ *   <li>Token refresh (grant_type=refresh_token)</li>
+ *   <li>Client certificate authentication (grant_type=client_credential)</li>
+ * </ul>
  *
  * @param username username for initial authentication
  * @param password password for initial authentication
@@ -25,7 +30,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * @param refreshTokenRevokeUnusedIn optional refresh token revoke unused duration
  * @param renewRefreshToken optional flag to renew refresh token
  * @param authDomain optional auth domain
- * @param clientId optional client ID
+ * @param clientId client ID for client certificate authentication
  * @param connection optional connection
  * @param cookies optional cookies flag
  * @param domain optional domain
@@ -66,6 +71,20 @@ public record AuthRequest(
      */
     public static AuthRequest withRefreshToken(String refreshToken) {
         return new AuthRequest(null, null, refreshToken, "refresh_token", null, null, null, null, null, null, null, null, null);
+    }
+
+    /**
+     * Create an auth request for client certificate authentication.
+     * <p>
+     * The client certificate must be presented during the TLS handshake.
+     * The grant_type is set to "client_credential" (singular, as required by CTM API).
+     * </p>
+     *
+     * @param clientId the client ID obtained during client registration
+     * @return auth request
+     */
+    public static AuthRequest withClientCredential(String clientId) {
+        return new AuthRequest(null, null, null, "client_credential", null, null, null, null, clientId, null, null, null, null);
     }
 
     @Override

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/model/AuthResponse.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/model/AuthResponse.java
@@ -11,24 +11,26 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 /**
  * Response model for CipherTrust Manager authentication.
  *
  * @param jwt the JWT token
  * @param duration the token duration in seconds
- * @param refreshToken the refresh token for obtaining new JWTs
+ * @param refreshToken the refresh token for obtaining new JWTs (null for client certificate authentication)
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record AuthResponse(
                            @JsonProperty("jwt") String jwt,
                            @JsonProperty("duration") int duration,
-                           @JsonProperty("refresh_token") String refreshToken) {
+                           @JsonProperty("refresh_token") @Nullable String refreshToken) {
 
     /**
      * Constructs an authentication response.
      */
     public AuthResponse {
         Objects.requireNonNull(jwt, "jwt cannot be null");
-        Objects.requireNonNull(refreshToken, "refreshToken cannot be null");
+        // refreshToken is nullable for client certificate authentication
     }
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKmsServiceTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKmsServiceTest.java
@@ -37,16 +37,17 @@ class CipherTrustKmsServiceTest {
     }
 
     @Test
-    void initializeStoresConfig() {
+    void initializeWithUserCredentials() {
         // Given
         service = new CipherTrustKmsService();
         var config = new Config(
                 URI.create("https://ctm.example.com"),
                 new UserCredentials("user", new InlinePassword("pass")),
+                null,
                 null);
+        service.initialize(config);
 
         // When
-        service.initialize(config);
         var kms = service.buildKms();
 
         // Then
@@ -55,7 +56,9 @@ class CipherTrustKmsServiceTest {
 
     @Test
     void detectsMissingInitialization() {
+        // Given
         service = new CipherTrustKmsService();
+        // When/Then
         assertThatThrownBy(() -> service.buildKms())
                 .isInstanceOf(NullPointerException.class);
     }
@@ -67,6 +70,7 @@ class CipherTrustKmsServiceTest {
         var config = new Config(
                 URI.create("https://ctm.example.com"),
                 new UserCredentials("user", new InlinePassword("pass")),
+                null,
                 null);
         service.initialize(config);
 
@@ -79,17 +83,21 @@ class CipherTrustKmsServiceTest {
 
     @Test
     void appliesTlsConfiguration() {
+        // Given
         var validButUnusualCipherSuite = "TLS_EMPTY_RENEGOTIATION_INFO_SCSV";
         var config = new Config(
                 URI.create("https://ctm.example.com"),
                 new UserCredentials("user", new InlinePassword("pass")),
+                null,
                 new Tls(null, null, new AllowDeny<>(
                         List.of(validButUnusualCipherSuite), null), null, null));
 
         service = new CipherTrustKmsService();
         service.initialize(config);
+        // When
         var kms = service.buildKms();
 
+        // Then
         var client = ((CipherTrustKms) kms).getHttpClient();
         assertThat(client)
                 .extracting(HttpClient::sslParameters)

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKmsTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKmsTest.java
@@ -73,6 +73,7 @@ class CipherTrustKmsTest {
         var config = new Config(
                 URI.create(server.baseUrl()),
                 new UserCredentials("testuser", new InlinePassword("testpass")),
+                null,
                 null);
 
         service = new CipherTrustKmsService();

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/ClientCertificateTokenServiceTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/ClientCertificateTokenServiceTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.thales.ciphertrust.auth;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.time.Duration;
+import java.util.function.UnaryOperator;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+
+import io.kroxylicious.kms.provider.thales.ciphertrust.model.AuthResponse;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link ClientCertificateTokenService}.
+ */
+class ClientCertificateTokenServiceTest {
+
+    public static final UnaryOperator<HttpClient.Builder> NOOP_TLS_CONFIGURATOR = builder -> builder;
+    private static final String TEST_CLIENT_ID = "test-client-1";
+    private static final String INITIAL_JWT = "initial-jwt-token";
+    private static final Duration TEST_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration ASYNC_TIMEOUT = Duration.ofSeconds(5);
+    private static final URI VALID_ENDPOINT = URI.create("http://localhost");
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static WireMockServer server;
+    private ClientCertificateTokenService service;
+
+    @BeforeAll
+    static void initMockServer() {
+        server = new WireMockServer(wireMockConfig().dynamicPort());
+        server.start();
+    }
+
+    @AfterAll
+    static void shutdownMockServer() {
+        server.shutdown();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        server.resetAll();
+        URI endpoint = URI.create(server.baseUrl());
+        service = new ClientCertificateTokenService(
+                endpoint,
+                TEST_CLIENT_ID,
+                TEST_TIMEOUT,
+                builder -> builder); // No TLS configuration for test
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (service != null) {
+            service.close();
+        }
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    void constructorRejectsNullEndpoint() {
+        // Given/When/Then
+        assertThatThrownBy(() -> new ClientCertificateTokenService(null, TEST_CLIENT_ID, TEST_TIMEOUT, NOOP_TLS_CONFIGURATOR))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("endpointUrl cannot be null");
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    void constructorRejectsNullClientId() {
+        // Given/When/Then
+        assertThatThrownBy(() -> new ClientCertificateTokenService(VALID_ENDPOINT, null, TEST_TIMEOUT, NOOP_TLS_CONFIGURATOR))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("clientId cannot be null");
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    void constructorRejectsBlankClientId() {
+        // Given/When/Then
+        assertThatThrownBy(() -> new ClientCertificateTokenService(VALID_ENDPOINT, "", TEST_TIMEOUT, NOOP_TLS_CONFIGURATOR))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("clientId cannot be blank");
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    void constructorRejectsNullTimeout() {
+        // Given/When/Then
+        assertThatThrownBy(() -> new ClientCertificateTokenService(VALID_ENDPOINT, TEST_CLIENT_ID, null, NOOP_TLS_CONFIGURATOR))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("timeout cannot be null");
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    void constructorRejectsNullTlsConfigurator() {
+        // Given/When/Then
+        assertThatThrownBy(() -> new ClientCertificateTokenService(VALID_ENDPOINT, TEST_CLIENT_ID, TEST_TIMEOUT, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("tlsConfigurator cannot be null");
+    }
+
+    @Test
+    void authenticationSucceeds() {
+        // Given
+        stubClientCertAuth(INITIAL_JWT);
+
+        // When
+        var tokenStage = service.getBearerToken();
+
+        // Then
+        assertThat(tokenStage)
+                .succeedsWithin(ASYNC_TIMEOUT)
+                .satisfies(token -> {
+                    assertThat(token.token()).isEqualTo(INITIAL_JWT);
+                    assertThat(token.expires()).isAfter(token.created());
+                });
+
+        // Verify client_credentials grant was used
+        server.verify(postRequestedFor(urlPathEqualTo("/api/v1/auth/tokens/"))
+                .withRequestBody(matchingClientCredentialAuth()));
+    }
+
+    @Test
+    void subsequentAuthUsesClientCredentials() {
+        // Given
+        stubClientCertAuth(INITIAL_JWT);
+        assertThat(service.getBearerToken())
+                .succeedsWithin(ASYNC_TIMEOUT)
+                .satisfies(token -> assertThat(token.token()).isEqualTo(INITIAL_JWT));
+        server.resetRequests();
+
+        // When
+        var secondTokenStage = service.getBearerToken();
+
+        // Then
+        assertThat(secondTokenStage)
+                .succeedsWithin(ASYNC_TIMEOUT)
+                .satisfies(token -> assertThat(token.token()).isEqualTo(INITIAL_JWT));
+
+        // Verify client_credentials was used again (no refresh token)
+        server.verify(postRequestedFor(urlPathEqualTo("/api/v1/auth/tokens/"))
+                .withRequestBody(matchingClientCredentialAuth()));
+    }
+
+    @Test
+    void authenticationFailsWithInvalidClient() {
+        // Given
+        stubClientCertAuthFailure();
+
+        // When
+        var tokenStage = service.getBearerToken();
+
+        // Then
+        assertThat(tokenStage)
+                .failsWithin(ASYNC_TIMEOUT)
+                .withThrowableThat()
+                .havingRootCause()
+                .withMessageContaining("client certificate authentication failed with HTTP 401");
+    }
+
+    @Test
+    void authenticationFailsWithInvalidJsonResponse() {
+        // Given
+        stubClientCertAuthWithInvalidJson();
+
+        // When
+        var tokenStage = service.getBearerToken();
+
+        // Then
+        assertThat(tokenStage)
+                .failsWithin(ASYNC_TIMEOUT)
+                .withThrowableThat()
+                .withMessageContaining("Failed to parse authentication response");
+    }
+
+    // Helper methods for stubbing
+
+    private void stubClientCertAuth(String jwt) {
+        // Note: Client certificate auth does NOT return a refresh_token
+        AuthResponse response = new AuthResponse(jwt, 300, null);
+
+        server.stubFor(
+                post(urlPathEqualTo("/api/v1/auth/tokens/"))
+                        .withRequestBody(matchingClientCredentialAuth())
+                        .willReturn(aResponse()
+                                .withStatus(200)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(toJson(response))));
+    }
+
+    private void stubClientCertAuthFailure() {
+        String errorResponse = """
+                {
+                    "code": 5,
+                    "codeDesc": "NCERRUnauthorizedAccess",
+                    "message": "Invalid Client",
+                    "requestID": "test-request-id"
+                }
+                """;
+
+        server.stubFor(
+                post(urlPathEqualTo("/api/v1/auth/tokens/"))
+                        .withRequestBody(matchingClientCredentialAuth())
+                        .willReturn(aResponse()
+                                .withStatus(401)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(errorResponse)));
+    }
+
+    private void stubClientCertAuthWithInvalidJson() {
+        String invalidResponse = "This is not JSON";
+
+        server.stubFor(
+                post(urlPathEqualTo("/api/v1/auth/tokens/"))
+                        .withRequestBody(matchingClientCredentialAuth())
+                        .willReturn(aResponse()
+                                .withStatus(200)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(invalidResponse)));
+    }
+
+    // Helper methods for request matching
+
+    private StringValuePattern matchingClientCredentialAuth() {
+        return containing("\"grant_type\":\"client_credential\"")
+                .and(containing("\"client_id\":\"" + TEST_CLIENT_ID + "\""));
+    }
+
+    private String toJson(Object object) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(object);
+        }
+        catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize object to JSON", e);
+        }
+    }
+}

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/config/ClientCredentialsTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/config/ClientCredentialsTest.java
@@ -13,44 +13,38 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import io.kroxylicious.proxy.config.secret.InlinePassword;
-import io.kroxylicious.proxy.config.secret.PasswordProvider;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class UserCredentialsTest {
+class ClientCredentialsTest {
 
     @ParameterizedTest
     @MethodSource("invalidConstructorArguments")
-    void constructorValidation(String username, PasswordProvider password, Class<? extends Exception> expectedExceptionType, String expectedMessage) {
+    void constructorValidation(String clientId, Class<? extends Exception> expectedExceptionType, String expectedMessage) {
         // When/Then
-        assertThatThrownBy(() -> new UserCredentials(username, password))
+        assertThatThrownBy(() -> new ClientCredentials(clientId))
                 .isInstanceOf(expectedExceptionType)
                 .hasMessageContaining(expectedMessage);
     }
 
     static Stream<Arguments> invalidConstructorArguments() {
-        PasswordProvider validPassword = new InlinePassword("validPassword");
         return Stream.of(
-                Arguments.of(null, validPassword, NullPointerException.class, "username cannot be null"),
-                Arguments.of("validUser", null, NullPointerException.class, "password cannot be null"),
-                Arguments.of("", validPassword, IllegalArgumentException.class, "username cannot be empty"));
+                Arguments.of(null, NullPointerException.class, "clientId cannot be null"),
+                Arguments.of("", IllegalArgumentException.class, "clientId cannot be blank"),
+                Arguments.of("   ", IllegalArgumentException.class, "clientId cannot be blank"));
     }
 
     @Test
-    void toStringMasksPassword() {
+    void toStringMasksClientId() {
         // Given
-        var credentials = new UserCredentials("testuser", new InlinePassword("secret"));
+        var credentials = new ClientCredentials("secret-client-id-123");
 
         // When
         String result = credentials.toString();
 
         // Then
         assertThat(result)
-                .contains("testuser")
                 .contains("***")
-                .doesNotContain("secret");
+                .doesNotContain("secret-client-id-123");
     }
-
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/config/ConfigParseTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/config/ConfigParseTest.java
@@ -16,15 +16,18 @@ import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 
 import io.kroxylicious.proxy.config.tls.InsecureTls;
+import io.kroxylicious.proxy.config.tls.Tls;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
 class ConfigParseTest {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Test
     void endpointUrlAndUserCredentials() throws IOException {
+        // Given
         String json = """
                 {
                     "endpointUrl": "https://ctm.example.com",
@@ -34,7 +37,11 @@ class ConfigParseTest {
                     }
                 }
                 """;
+
+        // When
         Config config = readConfig(json);
+
+        // Then
         assertThat(config.endpointUrl()).isEqualTo(URI.create("https://ctm.example.com"));
         assertThat(config.userCredentials()).isNotNull();
         assertThat(config.userCredentials().username()).isEqualTo("testuser");
@@ -43,50 +50,60 @@ class ConfigParseTest {
 
     @Test
     void endpointUrlRequired() {
-        assertThatThrownBy(() -> {
-            String json = """
-                    {
-                        "userCredentials": {
-                            "username": "testuser",
-                            "password": { "password": "testpass" }
-                        }
+        // Given
+        String json = """
+                {
+                    "userCredentials": {
+                        "username": "testuser",
+                        "password": { "password": "testpass" }
                     }
-                    """;
-            readConfig(json);
-        }).isInstanceOf(MismatchedInputException.class).hasMessageContaining("endpointUrl");
+                }
+                """;
+
+        // When/Then
+        assertThatThrownBy(() -> readConfig(json))
+                .isInstanceOf(MismatchedInputException.class)
+                .hasMessageContaining("endpointUrl");
     }
 
     @Test
     void endpointUrlShouldNotBeNull() {
-        assertThatThrownBy(() -> {
-            String json = """
-                    {
-                        "endpointUrl": null,
-                        "userCredentials": {
-                            "username": "testuser",
-                            "password": { "password": "testpass" }
-                        }
+        // Given
+        String json = """
+                {
+                    "endpointUrl": null,
+                    "userCredentials": {
+                        "username": "testuser",
+                        "password": { "password": "testpass" }
                     }
-                    """;
-            readConfig(json);
-        }).isInstanceOf(ValueInstantiationException.class).cause().isInstanceOf(NullPointerException.class);
+                }
+                """;
+
+        // When/Then
+        assertThatThrownBy(() -> readConfig(json))
+                .isInstanceOf(ValueInstantiationException.class)
+                .cause()
+                .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void credentialsRequired() {
-        assertThatThrownBy(() -> {
-            String json = """
-                    {
-                        "endpointUrl": "https://ctm.example.com"
-                    }
-                    """;
-            readConfig(json);
-        }).isInstanceOf(MismatchedInputException.class)
-                .hasMessageContaining("userCredentials");
+        // Given
+        String json = """
+                {
+                    "endpointUrl": "https://ctm.example.com"
+                }
+                """;
+
+        // When/Then
+        assertThatThrownBy(() -> readConfig(json))
+                .isInstanceOf(ValueInstantiationException.class)
+                .hasMessageContaining("Must configure either userCredentials or clientCredentials");
     }
 
     @Test
     void emptyTls() throws Exception {
+        // Given
         String json = """
                 {
                     "endpointUrl": "https://ctm.example.com",
@@ -97,13 +114,18 @@ class ConfigParseTest {
                     "tls": {}
                 }
                 """;
+
+        // When
         Config config = readConfig(json);
+
+        // Then
         assertThat(config.tls()).isNotNull();
         assertThat(config.tls().trust()).isNull();
     }
 
     @Test
     void missingTls() throws Exception {
+        // Given
         String json = """
                 {
                     "endpointUrl": "https://ctm.example.com",
@@ -113,12 +135,17 @@ class ConfigParseTest {
                     }
                 }
                 """;
+
+        // When
         Config config = readConfig(json);
+
+        // Then
         assertThat(config.tls()).isNull();
     }
 
     @Test
-    void testTlsTrust() throws Exception {
+    void tlsTrustInsecure() throws Exception {
+        // Given
         String json = """
                 {
                     "endpointUrl": "https://ctm.example.com",
@@ -133,10 +160,117 @@ class ConfigParseTest {
                     }
                 }
                 """;
+
+        // When
         Config config = readConfig(json);
+
+        // Then
+        assertThat(config)
+                .isNotNull()
+                .extracting(Config::tls)
+                .isNotNull()
+                .satisfies(tls -> assertThat(tls)
+                        .extracting(Tls::trust)
+                        .asInstanceOf(type(InsecureTls.class))
+                        .extracting(InsecureTls::insecure)
+                        .isEqualTo(true));
+    }
+
+    @Test
+    void endpointUrlAndClientCredentials() throws IOException {
+        // Given
+        String json = """
+                {
+                    "endpointUrl": "https://ctm.example.com",
+                    "clientCredentials": {
+                        "clientId": "test-client-123"
+                    },
+                    "tls": {
+                        "key": {
+                            "storeFile": "/path/to/keystore.p12",
+                            "storePassword": { "password": "storepass" }
+                        }
+                    }
+                }
+                """;
+
+        // When
+        Config config = readConfig(json);
+
+        // Then
+        assertThat(config.endpointUrl()).isEqualTo(URI.create("https://ctm.example.com"));
+        assertThat(config.clientCredentials()).isNotNull();
+        assertThat(config.clientCredentials().clientId()).isEqualTo("test-client-123");
         assertThat(config.tls()).isNotNull();
-        assertThat(config.tls().trust()).isInstanceOf(InsecureTls.class);
-        assertThat(((InsecureTls) config.tls().trust()).insecure()).isTrue();
+        assertThat(config.tls().key()).isNotNull();
+    }
+
+    @Test
+    void clientCredentialsRequireClientCertificate() {
+        // Given
+        String json = """
+                {
+                    "endpointUrl": "https://ctm.example.com",
+                    "clientCredentials": {
+                        "clientId": "test-client-123"
+                    }
+                }
+                """;
+
+        // When/Then
+        assertThatThrownBy(() -> readConfig(json))
+                .isInstanceOf(ValueInstantiationException.class)
+                .hasMessageContaining("clientCredentials requires a client certificate");
+    }
+
+    @Test
+    void clientCredentialsRequireClientId() {
+        // Given
+        String json = """
+                {
+                    "endpointUrl": "https://ctm.example.com",
+                    "clientCredentials": {},
+                    "tls": {
+                        "key": {
+                            "storeFile": "/path/to/keystore.p12",
+                            "storePassword": { "password": "storepass" }
+                        }
+                    }
+                }
+                """;
+
+        // When/Then
+        assertThatThrownBy(() -> readConfig(json))
+                .isInstanceOf(MismatchedInputException.class)
+                .hasMessageContaining("clientId");
+    }
+
+    @Test
+    void cannotConfigureBothUserAndClientCredentials() {
+        // Given
+        String json = """
+                {
+                    "endpointUrl": "https://ctm.example.com",
+                    "userCredentials": {
+                        "username": "testuser",
+                        "password": { "password": "testpass" }
+                    },
+                    "clientCredentials": {
+                        "clientId": "test-client-123"
+                    },
+                    "tls": {
+                        "key": {
+                            "storeFile": "/path/to/keystore.p12",
+                            "storePassword": { "password": "storepass" }
+                        }
+                    }
+                }
+                """;
+
+        // When/Then
+        assertThatThrownBy(() -> readConfig(json))
+                .isInstanceOf(ValueInstantiationException.class)
+                .hasMessageContaining("Cannot configure both userCredentials and clientCredentials");
     }
 
     private Config readConfig(String json) throws IOException {

--- a/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/testing/kms/tls/TlsHttpClientConfigurator.java
+++ b/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/testing/kms/tls/TlsHttpClientConfigurator.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
@@ -84,9 +85,6 @@ public class TlsHttpClientConfigurator implements UnaryOperator<HttpClient.Build
      * @param tls tls parameters
      */
     public TlsHttpClientConfigurator(@Nullable Tls tls) {
-        if (tls != null && tls.key() != null) {
-            LOGGER.warn("TLS key material is currently not supported by this client");
-        }
         this.tls = tls;
     }
 
@@ -116,8 +114,15 @@ public class TlsHttpClientConfigurator implements UnaryOperator<HttpClient.Build
         }
     }
 
-    private SSLParameters sslParameters() {
-        var defaultSslParameters = PLATFORM_SSL_CONTEXT.getDefaultSSLParameters();
+    @VisibleForTesting
+    SSLParameters sslParameters() {
+        // Use the configured SSL context (which may have client certificates) rather than
+        // the platform default. This ensures client certificates are properly configured
+        // in the SSLParameters returned by HttpClient.
+        SSLContext contextToUse = (tls == null || (tls.trust() == null && tls.key() == null))
+                ? PLATFORM_SSL_CONTEXT
+                : sslContext();
+        var defaultSslParameters = contextToUse.getDefaultSSLParameters();
 
         // Disable hostname verification if using insecure TLS
         if (isInsecureTls()) {
@@ -128,7 +133,7 @@ public class TlsHttpClientConfigurator implements UnaryOperator<HttpClient.Build
             return defaultSslParameters;
         }
 
-        var supportedSSLParameters = PLATFORM_SSL_CONTEXT.getSupportedSSLParameters();
+        var supportedSSLParameters = contextToUse.getSupportedSSLParameters();
 
         var protocols = applyRestriction("protocol", tls.protocols(), defaultSslParameters, supportedSSLParameters, SSLParameters::getProtocols);
         var cipherSuites = applyRestriction("cipher suite", tls.cipherSuites(), defaultSslParameters, supportedSSLParameters, SSLParameters::getCipherSuites);
@@ -207,9 +212,37 @@ public class TlsHttpClientConfigurator implements UnaryOperator<HttpClient.Build
     @VisibleForTesting
     static KeyManager[] getKeyManagers(KeyProvider key) {
         return key.accept(new KeyProviderVisitor<>() {
+            @SuppressFBWarnings({ "PATH_TRAVERSAL_IN", "HARD_CODE_PASSWORD" })
             @Override
             public KeyManager[] visit(KeyPair keyPair) {
-                throw new SslConfigurationException("KeyPair is not supported by this client");
+                try {
+                    // Read private key and certificate from PEM files
+                    byte[] keyBytes = Files.readAllBytes(Paths.get(keyPair.privateKeyFile()));
+                    byte[] certBytes = Files.readAllBytes(Paths.get(keyPair.certificateFile()));
+
+                    char[] keypassword = keyPair.keyPasswordProvider() != null
+                            ? keyPair.keyPasswordProvider().getProvidedPassword().toCharArray()
+                            : null;
+                    PrivateKey privateKey = PemParser.parsePrivateKey(keyBytes, keypassword);
+                    X509Certificate[] certs = PemParser.parseCertificateChain(certBytes);
+
+                    // Create in-memory KeyStore
+                    KeyStore ks = KeyStore.getInstance("JKS");
+                    ks.load(null, null);
+                    // Use empty password for both store and key entry for in-memory keystore
+                    char[] storePassword = "".toCharArray();
+                    ks.setKeyEntry("key", privateKey, storePassword, certs);
+
+                    KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                    kmf.init(ks, storePassword);
+                    return kmf.getKeyManagers();
+                }
+                catch (IOException e) {
+                    throw new SslConfigurationException("Failed to read PEM key material from " + keyPair.certificateFile() + " or " + keyPair.privateKeyFile(), e);
+                }
+                catch (Exception e) {
+                    throw new SslConfigurationException("Failed to load PEM key material", e);
+                }
             }
 
             @SuppressFBWarnings("PATH_TRAVERSAL_IN")

--- a/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/testing/kms/tls/TlsHttpClientConfigurator.java
+++ b/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/testing/kms/tls/TlsHttpClientConfigurator.java
@@ -114,34 +114,27 @@ public class TlsHttpClientConfigurator implements UnaryOperator<HttpClient.Build
         }
     }
 
-    @VisibleForTesting
-    SSLParameters sslParameters() {
-        // Use the configured SSL context (which may have client certificates) rather than
-        // the platform default. This ensures client certificates are properly configured
-        // in the SSLParameters returned by HttpClient.
-        SSLContext contextToUse = (tls == null || (tls.trust() == null && tls.key() == null))
-                ? PLATFORM_SSL_CONTEXT
-                : sslContext();
-        var defaultSslParameters = contextToUse.getDefaultSSLParameters();
+    private SSLParameters sslParameters(SSLContext context) {
+        var copy = context.getDefaultSSLParameters();
 
         // Disable hostname verification if using insecure TLS
         if (isInsecureTls()) {
-            defaultSslParameters.setEndpointIdentificationAlgorithm(null);
+            copy.setEndpointIdentificationAlgorithm(null);
         }
 
         if (tls == null || (tls.protocols() == null && tls.cipherSuites() == null)) {
-            return defaultSslParameters;
+            return copy;
         }
 
-        var supportedSSLParameters = contextToUse.getSupportedSSLParameters();
+        var supportedSSLParameters = context.getSupportedSSLParameters();
 
-        var protocols = applyRestriction("protocol", tls.protocols(), defaultSslParameters, supportedSSLParameters, SSLParameters::getProtocols);
-        var cipherSuites = applyRestriction("cipher suite", tls.cipherSuites(), defaultSslParameters, supportedSSLParameters, SSLParameters::getCipherSuites);
+        var protocols = applyRestriction("protocol", tls.protocols(), copy, supportedSSLParameters, SSLParameters::getProtocols);
+        var cipherSuites = applyRestriction("cipher suite", tls.cipherSuites(), copy, supportedSSLParameters, SSLParameters::getCipherSuites);
 
-        defaultSslParameters.setProtocols(protocols);
-        defaultSslParameters.setCipherSuites(cipherSuites);
+        copy.setProtocols(protocols);
+        copy.setCipherSuites(cipherSuites);
 
-        return defaultSslParameters;
+        return copy;
     }
 
     private boolean isInsecureTls() {
@@ -358,8 +351,9 @@ public class TlsHttpClientConfigurator implements UnaryOperator<HttpClient.Build
     @Override
     public HttpClient.Builder apply(@NonNull HttpClient.Builder builder) {
         Objects.requireNonNull(builder);
-        builder.sslContext(sslContext())
-                .sslParameters(sslParameters());
+        SSLContext context = sslContext();
+        builder.sslContext(context)
+                .sslParameters(sslParameters(context));
         return builder;
     }
 }

--- a/kroxylicious-kms-tls-support/src/test/java/io/kroxylicious/testing/kms/tls/TlsHttpClientConfiguratorTest.java
+++ b/kroxylicious-kms-tls-support/src/test/java/io/kroxylicious/testing/kms/tls/TlsHttpClientConfiguratorTest.java
@@ -9,6 +9,7 @@ package io.kroxylicious.testing.kms.tls;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.http.HttpClient;
+import java.nio.file.NoSuchFileException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -22,8 +23,10 @@ import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -33,6 +36,7 @@ import io.kroxylicious.proxy.config.secret.InlinePassword;
 import io.kroxylicious.proxy.config.tls.AllowDeny;
 import io.kroxylicious.proxy.config.tls.InsecureTls;
 import io.kroxylicious.proxy.config.tls.KeyPair;
+import io.kroxylicious.proxy.config.tls.KeyProvider;
 import io.kroxylicious.proxy.config.tls.KeyStore;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.config.tls.TrustStore;
@@ -134,10 +138,36 @@ class TlsHttpClientConfiguratorTest {
     }
 
     @Test
-    void testFileNotFound() {
+    void shouldDetectMissingTrustMaterialFile() {
         TrustStore store = new TrustStore("/tmp/" + UUID.randomUUID(), new InlinePassword("changeit"), null, null);
-        assertThatThrownBy(() -> TlsHttpClientConfigurator.getTrustManagers(store)).isInstanceOf(SslConfigurationException.class).cause()
+        assertThatThrownBy(() -> TlsHttpClientConfigurator.getTrustManagers(store))
+                .isInstanceOf(SslConfigurationException.class).cause()
                 .isInstanceOf(FileNotFoundException.class);
+    }
+
+    static Stream<Arguments> missingKeyMaterialFiles() {
+        String nonExistentPath = "/tmp/nonexistent-" + UUID.randomUUID();
+        CertificateGenerator.Keys validKeys = CertificateGenerator.generate();
+        return Stream.of(
+                argumentSet("KeyPair with missing private key file",
+                        new KeyPair(nonExistentPath + "-key.pem", validKeys.selfSignedCertificatePem().toString(), null)),
+                argumentSet("KeyPair with missing certificate file",
+                        new KeyPair(validKeys.privateKeyPem().toString(), nonExistentPath + "-cert.pem", null)),
+                argumentSet("KeyStore with missing store file",
+                        new io.kroxylicious.proxy.config.tls.KeyStore(nonExistentPath + ".jks", new InlinePassword("changeit"), null, null)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("missingKeyMaterialFiles")
+    void shouldDetectMissingKeyMaterialFile(KeyProvider keyProvider) {
+        // Given: a KeyProvider pointing to non-existent file(s)
+
+        // When: attempting to get key managers
+        // Then: should throw SslConfigurationException with IOException cause
+        assertThatThrownBy(() -> TlsHttpClientConfigurator.getKeyManagers(keyProvider))
+                .isInstanceOf(SslConfigurationException.class)
+                .cause()
+                .isInstanceOfAny(FileNotFoundException.class, NoSuchFileException.class);
     }
 
     @Test
@@ -150,12 +180,21 @@ class TlsHttpClientConfiguratorTest {
     }
 
     @Test
-    void testPemSupported() {
-        CertificateGenerator.Keys keys = CertificateGenerator.generate();
-        java.nio.file.Path certPem = keys.selfSignedCertificatePem();
-        TrustStore store = new TrustStore(certPem.toString(), null, "PEM", null);
-        TrustManager[] trustManagers = TlsHttpClientConfigurator.getTrustManagers(store);
-        assertThat(trustManagers).isNotEmpty();
+    void shouldAcceptPemTrust() {
+        // Given
+        var keys = CertificateGenerator.generate();
+        var certPem = keys.selfSignedCertificatePem();
+        var store = new TrustStore(certPem.toString(), null, "PEM", null);
+
+        // When
+        var trustManagers = TlsHttpClientConfigurator.getTrustManagers(store);
+
+        // Then
+        assertThat(trustManagers)
+                .singleElement()
+                .asInstanceOf(InstanceOfAssertFactories.type(X509TrustManager.class))
+                .extracting(X509TrustManager::getAcceptedIssuers, InstanceOfAssertFactories.array(X509Certificate[].class))
+                .hasSize(1);
     }
 
     @Test
@@ -200,11 +239,54 @@ class TlsHttpClientConfiguratorTest {
     }
 
     @Test
-    void testKeyPairNotSupported() {
-        KeyPair store = new KeyPair("/tmp/keypair", "/tmp/cert", null);
-        assertThatThrownBy(() -> {
-            TlsHttpClientConfigurator.getKeyManagers(store);
-        }).isInstanceOf(SslConfigurationException.class).hasMessageContaining("KeyPair is not supported by this client");
+    void shouldAcceptPemKeyPair() {
+        // Given
+        var keys = CertificateGenerator.generate();
+        var privateKeyPem = keys.privateKeyPem().toString();
+        var certPem = keys.selfSignedCertificatePem().toString();
+        var keyPair = new KeyPair(privateKeyPem, certPem, null);
+
+        // When
+        var keyManagers = TlsHttpClientConfigurator.getKeyManagers(keyPair);
+
+        // Then
+        assertThat(keyManagers)
+                .singleElement()
+                .asInstanceOf(InstanceOfAssertFactories.type(X509KeyManager.class))
+                .extracting(x -> x.getPrivateKey("key"))
+                .isEqualTo(keys.serverKey().getPrivate());
+    }
+
+    @Test
+    void shouldAcceptEncryptedPemKeyPairWithPassword() {
+        // Given: an encrypted PEM private key with the correct password
+        var keys = CertificateGenerator.generate();
+        KeyPair keyPair = new KeyPair(keys.encryptedPrivateKeyPem().toString(), keys.selfSignedCertificatePem().toString(),
+                new InlinePassword(keys.encryptedPrivateKeyPassword()));
+
+        // When: attempting to get key managers with the password
+        var keyManagers = TlsHttpClientConfigurator.getKeyManagers(keyPair);
+
+        // Then: should succeed and return the correct private key
+        assertThat(keyManagers)
+                .singleElement()
+                .asInstanceOf(InstanceOfAssertFactories.type(X509KeyManager.class))
+                .extracting(x -> x.getPrivateKey("key"))
+                .isEqualTo(keys.serverKey().getPrivate());
+    }
+
+    @Test
+    void shouldRejectEncryptedPemKeyPairWithoutPassword() {
+        // Given: an encrypted PEM private key without a password
+        var keys = CertificateGenerator.generate();
+        KeyPair keyPair = new KeyPair(keys.encryptedPrivateKeyPem().toString(), keys.selfSignedCertificatePem().toString(), null);
+
+        // When: attempting to get key managers without a password
+        // Then: should throw SslConfigurationException with clear message
+        assertThatThrownBy(() -> TlsHttpClientConfigurator.getKeyManagers(keyPair))
+                .isInstanceOf(SslConfigurationException.class)
+                .cause()
+                .hasMessageContaining("Encrypted private key requires a password");
     }
 
     @Test

--- a/kroxylicious-kms-tls-support/src/test/java/io/kroxylicious/testing/kms/tls/TlsHttpClientConfiguratorTest.java
+++ b/kroxylicious-kms-tls-support/src/test/java/io/kroxylicious/testing/kms/tls/TlsHttpClientConfiguratorTest.java
@@ -42,7 +42,6 @@ import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.config.tls.TrustStore;
 import io.kroxylicious.testing.certificate.CertificateGenerator;
 
-import static io.kroxylicious.testing.certificate.CertificateGenerator.createJksKeystore;
 import static io.kroxylicious.testing.certificate.CertificateGenerator.generateRsaKeyPair;
 import static io.kroxylicious.testing.certificate.CertificateGenerator.generateSelfSignedX509Certificate;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -231,7 +230,7 @@ class TlsHttpClientConfiguratorTest {
         java.security.KeyPair pair = generateRsaKeyPair();
         X509Certificate x509Certificate = generateSelfSignedX509Certificate(pair);
         String password = "password";
-        CertificateGenerator.KeyStore keyStore = createJksKeystore(pair, x509Certificate, password, password);
+        CertificateGenerator.KeyStore keyStore = CertificateGenerator.createKeystore(pair, x509Certificate, password, password, CertificateGenerator.PKCS_12);
         KeyStore store = new KeyStore(keyStore.path().toString(), new InlinePassword(keyStore.storePassword()), null,
                 keyStore.type());
         KeyManager[] trustManagers = TlsHttpClientConfigurator.getKeyManagers(store);


### PR DESCRIPTION
## Summary

Adds client certificate authentication support to the Thales CipherTrust Manager (CTM) KMS provider as an alternative to username/password authentication, as recommended by Thales for 'service account' use-cases.

**Key Changes:**
- Added `ClientCertificateTokenService` which handles client certificate authentication
- Updated `Config` to support either `userCredentials` OR `clientCredentials`
- Updated mock server to handle `client_credential` grant type
- Updated TlsHttpClientConfigurator to handle private-key/cert pairs. CTM natively uses key material expressed in PEM files, so the most natural way to configure the CTM KMS for client-certificate is to accept the same key material.
- Update the DEV_GUIDE to show you how to configure CTM for client certificate authentication.

## Configuration Example

```yaml
endpointUrl: https://ctm.example.com
clientCredentials:
  clientId: uuid-from-registration
tls:
  key:
    privateKeyFile: /path/to/private.pem
    certificateFile: /path/to/cert.pem
  trust:
    storeFile: /path/to/ca.jks
```

## Related

Relates-to: #4117