### PR TITLE
chore(ci): increase Dependabot open PR limit to 10

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    # Default limit is 5, which is tight for a large project with many dependencies
+    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
Increases the Dependabot open pull request limit from the default of 5 to 10.

I noticed whilst trying to work out why Micrometer hadn't been CVE fixed on main, that dependabot had hit an [error](https://github.com/kroxylicious/kroxylicious/network/updates/1420550353) a few days ago:

> Dependabot cannot open any more pull requests
> The open pull request limit has been exceeded. The current limit is: 5.
> Dependabot will open new pull requests once you merge or close the already open pull requests. You can also update this limit in the config file.

## Motivation
The default limit of 5 concurrent PRs is too restrictive for a large project with many dependencies. When the limit is reached, Dependabot stops creating new PRs until existing ones are merged or closed, which can cause important updates to be delayed.

## Changes
- Added `open-pull-requests-limit: 10` to the Maven ecosystem configuration in `.github/dependabot.yaml`
- Added explanatory comment about the default limit

## Test Plan
Once merged, Dependabot should be able to create up to 10 concurrent PRs for Maven dependencies instead of being blocked at 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)