### PR TITLE
chore(ci): prevent dependabot automatically rebasing

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,12 +6,14 @@
 version: 2
 updates:
   - package-ecosystem: "maven" # See documentation for possible values
+    rebase-strategy: "disabled" # Use manual rebasing to manage CI workload
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
     # Default limit is 5, which is tight for a large project with many dependencies
     open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
+    rebase-strategy: "disabled" # Use manual rebasing to manage CI workload
     directory: "/"
     schedule:
       # Check for updates to GitHub Actions every week
@@ -22,6 +24,7 @@ updates:
   # from the docs: For GitHub Actions, use the value /. Dependabot will search the /.github/workflows directory, as well as the action.yml/action.yaml file from the root directory.
   # we need custom configuration to scan the other directories that contain action.yaml files
   - package-ecosystem: "github-actions"
+    rebase-strategy: "disabled" # Use manual rebasing to manage CI workload
     # directories supports globbing
     directories: 
       - "/.github/actions/common/*"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Why:
We are currently limited by our CI resources and if a PR merge triggers 10 rebased dependabot PRs then our CI is overwhelmed for a long time. We would prefer to review the PRs in a controlled fashion, instructing dependabot to rebase them when we are prepared to merge them.

Note that existing dependa PRs won't obey this change.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
