### PR TITLE
fix: redact sensitive fields in CipherTrustEdek#toString()

### DIFF
--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsEdek.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsEdek.java
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright Kroxylicious Authors.
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsEdek.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsEdek.java
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright Kroxylicious Authors.
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
@@ -64,7 +64,7 @@ public record AwsKmsEdek(String kekRef,
     public String toString() {
         return "AwsKmsEdek{" +
                 "keyRef=" + kekRef +
-                ", edek=" + Arrays.toString(edek) +
+                ", edek=<redacted>" +
                 '}';
     }
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsEdekTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsEdekTest.java
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright Kroxylicious Authors.
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsEdekTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsEdekTest.java
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright Kroxylicious Authors.
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
@@ -40,6 +40,6 @@ class AwsKmsEdekTest {
     @Test
     void toStringFormation() {
         var edek = new AwsKmsEdek("keyref", new byte[]{ (byte) 1, (byte) 2, (byte) 3 });
-        assertThat(edek).hasToString("AwsKmsEdek{keyRef=keyref, edek=[1, 2, 3]}");
+        assertThat(edek).hasToString("AwsKmsEdek{keyRef=keyref, edek=<redacted>}");
     }
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/AzureKeyVaultEdek.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/AzureKeyVaultEdek.java
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright Kroxylicious Authors.
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/AzureKeyVaultEdek.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/AzureKeyVaultEdek.java
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright Kroxylicious Authors.
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
@@ -123,7 +123,7 @@ public record AzureKeyVaultEdek(String keyName,
                 ", vaultName=" + vaultName +
                 ", supportedKeyType=" + supportedKeyType +
                 ", keyVersion=" + keyVersion +
-                ", edek=" + Arrays.toString(edek) +
+                ", edek=<redacted>" +
                 '}';
     }
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/AzureKeyVaultEdekTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/AzureKeyVaultEdekTest.java
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright Kroxylicious Authors.
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/AzureKeyVaultEdekTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/AzureKeyVaultEdekTest.java
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright Kroxylicious Authors.
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
@@ -45,6 +45,13 @@ class AzureKeyVaultEdekTest {
         AzureKeyVaultEdek azureKeyVaultEdek = createEdek(KEY_NAME, repeatString(32, "z"), EDEK, VAULT_NAME, KEY_TYPE);
         Optional<byte[]> bytes = azureKeyVaultEdek.keyVersion128bit();
         assertThat(bytes).isEmpty();
+    }
+
+    @Test
+    void toStringFormation() {
+        AzureKeyVaultEdek edek = createEdek(KEY_NAME, KEY_VERSION, EDEK, VAULT_NAME, KEY_TYPE);
+        assertThat(edek).hasToString("AzureKeyVaultEdek{keyName=" + KEY_NAME + ", vaultName=" + VAULT_NAME
+                + ", supportedKeyType=" + KEY_TYPE + ", keyVersion=" + KEY_VERSION + ", edek=<redacted>}");
     }
 
     static Stream<Arguments> validEdek() {

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/main/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKmsEdek.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/main/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKmsEdek.java
@@ -72,9 +72,9 @@ public record FortanixDsmKmsEdek(String kekRef,
     @Override
     public String toString() {
         return "FortanixDsmKmsEdek{" +
-                "keyRef=" + kekRef +
-                ", iv=" + Arrays.toString(iv) +
-                ", edek=" + Arrays.toString(edek) +
+                "keyId=" + kekRef +
+                ", iv=<redacted>" +
+                ", edek=<redacted>" +
                 '}';
     }
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/main/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKmsEdek.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/main/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKmsEdek.java
@@ -72,7 +72,7 @@ public record FortanixDsmKmsEdek(String kekRef,
     @Override
     public String toString() {
         return "FortanixDsmKmsEdek{" +
-                "keyId=" + kekRef +
+                "keyRef=" + kekRef +
                 ", iv=<redacted>" +
                 ", edek=<redacted>" +
                 '}';

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/main/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKmsEdek.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/main/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKmsEdek.java
@@ -72,7 +72,7 @@ public record FortanixDsmKmsEdek(String kekRef,
     @Override
     public String toString() {
         return "FortanixDsmKmsEdek{" +
-                "keyRef=" + kekRef +
+                "kekRef=" + kekRef +
                 ", iv=<redacted>" +
                 ", edek=<redacted>" +
                 '}';

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/test/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKmsEdekTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/test/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKmsEdekTest.java
@@ -71,6 +71,6 @@ class FortanixDsmKmsEdekTest {
     @Test
     void toStringFormation() {
         var edek = new FortanixDsmKmsEdek("keyref", IV, new byte[]{ (byte) 1, (byte) 2, (byte) 3 });
-        assertThat(edek).hasToString("FortanixDsmKmsEdek{keyRef=keyref, iv=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], edek=[1, 2, 3]}");
+        assertThat(edek).hasToString("FortanixDsmKmsEdek{kekRef=keyref, iv=<redacted>, edek=<redacted>}");
     }
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdek.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdek.java
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright Kroxylicious Authors.
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdek.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdek.java
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright Kroxylicious Authors.
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
@@ -68,7 +68,7 @@ public record VaultEdek(String kekRef,
     public String toString() {
         return "VaultEdek{" +
                 "keyRef=" + kekRef +
-                ", edek=" + Arrays.toString(edek) +
+                ", edek=<redacted>" +
                 '}';
     }
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekTest.java
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright Kroxylicious Authors.
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekTest.java
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright Kroxylicious Authors.
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
@@ -34,6 +34,6 @@ class VaultEdekTest {
     @Test
     void toStringFormation() {
         var edek = new VaultEdek("keyref", new byte[]{ (byte) 1, (byte) 2, (byte) 3 });
-        assertThat(edek).hasToString("VaultEdek{keyRef=keyref, edek=[1, 2, 3]}");
+        assertThat(edek).hasToString("VaultEdek{keyRef=keyref, edek=<redacted>}");
     }
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustEdek.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustEdek.java
@@ -104,11 +104,11 @@ public record CipherTrustEdek(
     public String toString() {
         return "CipherTrustEdek{" +
                 "id='" + id + '\'' +
-                ", ciphertext=" + Arrays.toString(ciphertext) +
-                ", tag=" + Arrays.toString(tag) +
+                ", ciphertext=<redacted>" +
+                ", tag=<redacted>" +
                 ", version=" + version +
                 ", mode='" + mode + '\'' +
-                ", iv=" + Arrays.toString(iv) +
+                ", iv=<redacted>" +
                 '}';
     }
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustEdekSerdeTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustEdekSerdeTest.java
@@ -204,7 +204,10 @@ class CipherTrustEdekSerdeTest {
         assertThat(toString)
                 .contains(KEY_ID)
                 .contains("gcm")
-                .contains("version=1");
+                .contains("version=1")
+                .contains("<redacted>")
+                .doesNotContain("1, 2")
+                .doesNotContain("4, 5");
     }
 
 }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
x Refactoring
- Documentation

### Description

Redact sensitive fields (ciphertext, tag, iv) in CipherTrustEdek#toString() to prevent accidental exposure of encrypted key material in logs.

### Additional Context

Fixes #4173. Even though the fields are encrypted, there is no justification for logging them.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
