### PR TITLE
fix(record-encryption): resolve TypeParameterUnusedInFormals warning

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/common/AbstractResolver.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/common/AbstractResolver.java
@@ -33,11 +33,11 @@ public abstract class AbstractResolver<E extends Enum<E>, T extends PersistedIde
         }
         // each T can have multiple names, but each name must uniquely identify a T
         // each T has a unique id
-        this.nameMapping = impls.stream().collect(Collectors.toMap(T::name, tx -> tx));
+        this.nameMapping = impls.stream().collect(Collectors.toMap(PersistedIdentifiable::name, tx -> tx));
 
-        this.idMapping = impls.stream().collect(Collectors.toMap(T::serializedId, tx -> tx));
+        this.idMapping = impls.stream().collect(Collectors.toMap(PersistedIdentifiable::serializedId, tx -> tx));
 
-        this.reverseIdMapping = impls.stream().collect(Collectors.toMap(tx -> tx, T::serializedId));
+        this.reverseIdMapping = impls.stream().collect(Collectors.toMap(tx -> tx, PersistedIdentifiable::serializedId));
     }
 
     /**


### PR DESCRIPTION
## Summary
Fixes error-prone `TypeParameterUnusedInFormals` warning that was flagged when upgrading to error-prone 2.50.0 in PR #4195.

## Changes
- Replace method references on type parameter `T` with explicit references to `PersistedIdentifiable` interface methods
- Affects three method references in `AbstractResolver` constructor

## Why
Error-prone 2.50.0 introduced stricter checking for method references on type parameters. The warning prevents potential ambiguity when a type parameter has multiple bounds by requiring explicit interface method references.

## Testing
- [x] Build passes with error-prone 2.50.0
- [x] No other occurrences of this pattern in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)