### PR TITLE
build: run dependabot scans on saturday

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+      day: "saturday"
     # Default limit is 5, which is tight for a large project with many dependencies
     open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
@@ -18,6 +19,7 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+      day: "saturday"
     labels:
       - "dependencies"
       - "dev/github_actions"
@@ -30,6 +32,7 @@ updates:
       - "/.github/actions/common/*"
     schedule:
       interval: "weekly"
+      day: "saturday"
     labels:
       - "dependencies"
       - "dev/github_actions"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds `day: saturday` to all three weekly dependabot schedules (maven, github-actions root, github-actions custom directories).

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#day

### Additional Context

Dependabot can open up to 10 PRs at once. When those arrive on a weekday they consume CI capacity at the same time developers are trying to get work done, slowing down review and development. Scheduling scans for Saturday means the PRs arrive over the weekend, CI runs when load is low, and the queue is ready for triage at the start of the week.

### Checklist

- [x] New tests written (where applicable).
- [x] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).