### PR TITLE
ci(sonar): opt out of actions/checkout fork PR protection

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -65,6 +65,7 @@ jobs:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{env.SANITIZED_HEAD_REF}}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
       - name: Checkout base branch
         if: env.SONAR_TOKEN_SET == 'true'
         run: |


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Adds `allow-unsafe-pr-checkout: true` to the `actions/checkout` step in the Sonar workflow.

A recent update to `actions/checkout` introduced a built-in protection that refuses to check out fork PR code from a `workflow_run` workflow by default, causing the Sonar scan to fail.

### Additional Context

The Sonar workflow uses `workflow_run` so it can access repository secrets (the Sonar token) when scanning fork PRs. `actions/checkout` now blocks this by default to prevent "pwn request" vulnerabilities.

The workflow already mitigates the key risks of this pattern:
- Branch names are validated against malicious characters before use
- PR metadata is fetched from the GitHub API rather than trusting the event payload

Opting out with `allow-unsafe-pr-checkout: true` is therefore safe here.

### Checklist

- [x] New tests written (where applicable).
- [x] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).