### PR TITLE
feat(routing): node ID virtualization and per-broker connections for static routing

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingPassThroughIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingPassThroughIT.java
@@ -221,7 +221,7 @@ class RoutingPassThroughIT {
             while (collected.size() < 10 && System.currentTimeMillis() < deadline) {
                 consumer.poll(Duration.ofSeconds(1)).forEach(collected::add);
             }
-            assertThat(collected).hasSize(10);
+            assertThat(collected).isNotEmpty().hasSize(10);
         }
     }
 
@@ -288,7 +288,7 @@ class RoutingPassThroughIT {
             while (collected.size() < 10 && System.currentTimeMillis() < deadline) {
                 consumer.poll(Duration.ofSeconds(1)).forEach(collected::add);
             }
-            assertThat(collected).hasSize(10);
+            assertThat(collected).isNotEmpty().hasSize(10);
         }
 
         // Then: all data is on the selected cluster, none on the other

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingPassThroughIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingPassThroughIT.java
@@ -21,6 +21,9 @@ import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.FetchRequestData;
 import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseBroker;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -93,7 +96,7 @@ class RoutingPassThroughIT {
     }
 
     @Test
-    void shouldProduceAndConsumeViaPassThroughRouter(KafkaCluster cluster, Topic topic) throws Exception {
+    void shouldProduceAndConsumeViaPassThroughRouter(KafkaCluster cluster, Topic topic) {
         var config = routingConfig(cluster);
 
         try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
@@ -193,8 +196,7 @@ class RoutingPassThroughIT {
 
     @Test
     void shouldProduceAndConsumeViaPassThroughRouterWithMultiNodeCluster(
-                                                                         @BrokerCluster(numBrokers = 3) KafkaCluster cluster, Topic topic)
-            throws Exception {
+                                                                         @BrokerCluster(numBrokers = 3) KafkaCluster cluster, Topic topic) {
         // Given: a pass-through router backed by a 3-node cluster; the partition leader
         // may be on any broker (not necessarily the bootstrap node), so the proxy must
         // resolve the correct upstream broker via the METADATA-based address registry.
@@ -298,7 +300,7 @@ class RoutingPassThroughIT {
     }
 
     @Test
-    void shouldStaticallyRouteDifferentApiKeysToDifferentUpstreams() throws Exception {
+    void shouldStaticallyRouteDifferentApiKeysToDifferentUpstreams() {
         // Given: two mock upstreams and a router that splits API_VERSIONS to upstream A
         // and FETCH to upstream B. Uses the low-level KafkaClient to bypass the Kafka
         // client's metadata assumptions — it just sends whatever frames we tell it to.
@@ -349,6 +351,174 @@ class RoutingPassThroughIT {
                         .extracting(Request::apiKeys)
                         .containsExactly(ApiKeys.FETCH);
             }
+        }
+    }
+
+    @Test
+    void shouldRouteConnectionsToCorrectUpstreamBrokerBasedOnVirtualNodeId() {
+        // Given: two mock servers representing upstream broker 0 and broker 1 of a single route.
+        // With IdentityNodeIdMapping (single route), virtual node 0 = upstream broker 0 and
+        // virtual node 1 = upstream broker 1, exposed on proxy ports 9193 and 9194 respectively.
+        try (var mockBroker0 = MockServer.startOnRandomPort();
+                var mockBroker1 = MockServer.startOnRandomPort()) {
+
+            var apiVersionsResponse = new ApiVersionsResponseData();
+            mockBroker0.addMockResponseForApiKey(new ResponsePayload(ApiKeys.API_VERSIONS, (short) 3, apiVersionsResponse));
+            mockBroker1.addMockResponseForApiKey(new ResponsePayload(ApiKeys.API_VERSIONS, (short) 3, apiVersionsResponse));
+
+            // METADATA from broker 0 (the route bootstrap) advertises both upstream brokers.
+            // Once the proxy processes this response, the EndpointReconciler creates
+            // BrokerEndpointBindings: port 9193 → mockBroker0, port 9194 → mockBroker1.
+            var md = new MetadataResponseData().setControllerId(0);
+            md.brokers().add(new MetadataResponseBroker().setNodeId(0).setHost("localhost").setPort(mockBroker0.port()));
+            md.brokers().add(new MetadataResponseBroker().setNodeId(1).setHost("localhost").setPort(mockBroker1.port()));
+            mockBroker0.addMockResponseForApiKey(new ResponsePayload(ApiKeys.METADATA, (short) 12, md));
+
+            var clusterDef = new ClusterDefinition(TARGET_CLUSTER_NAME, "localhost:" + mockBroker0.port(), null);
+            var route = new RouteDefinition(ROUTE_NAME, 0, List.of(), new RouteTarget(TARGET_CLUSTER_NAME, null));
+            var routerDef = new RouterDefinition(ROUTER_NAME,
+                    PassThroughRouterFactory.class.getName(), new PassThroughRouterFactory.Config(ROUTE_NAME), List.of(route));
+            var vc = new VirtualClusterBuilder()
+                    .withName("demo")
+                    .withTarget(new RouteTarget(null, ROUTER_NAME))
+                    .addToGateways(defaultGatewayBuilder()
+                            .withNewPortIdentifiesNode()
+                            .withBootstrapAddress(HostPort.parse("localhost:9192"))
+                            .withNodeIdRanges(new NamedRange("nodes", 0, 1))
+                            .endPortIdentifiesNode()
+                            .build())
+                    .build();
+            var config = baseConfigurationBuilder()
+                    .addToClusterDefinitions(clusterDef)
+                    .addToRouterDefinitions(routerDef)
+                    .addToVirtualClusters(vc);
+
+            try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester()) {
+                // Fetch METADATA via the bootstrap to trigger reconciliation. After getSync returns,
+                // the BrokerAddressFilter has completed reconciliation so ports 9193/9194 are bound
+                // to their respective upstream addresses.
+                try (var bootstrap = tester.simpleTestClient()) {
+                    bootstrap.getSync(new Request(ApiKeys.METADATA, (short) 12, "client", new MetadataRequestData()));
+                }
+
+                // Clear reconciliation traffic before the per-broker phase so assertions only
+                // reflect requests that arrive through specific virtual-node connections.
+                // Re-add the API_VERSIONS responses that were cleared along with the request history.
+                mockBroker0.clear();
+                mockBroker1.clear();
+                mockBroker0.addMockResponseForApiKey(new ResponsePayload(ApiKeys.API_VERSIONS, (short) 3, new ApiVersionsResponseData()));
+                mockBroker1.addMockResponseForApiKey(new ResponsePayload(ApiKeys.API_VERSIONS, (short) 3, new ApiVersionsResponseData()));
+
+                // When: connect to virtual-node-0-port and send a request
+                try (var nodeZero = tester.simpleTestClient("localhost:9193", false)) {
+                    nodeZero.getSync(new Request(ApiKeys.API_VERSIONS, (short) 3, "client", new ApiVersionsRequestData()));
+                }
+
+                // When: connect to virtual-node-1-port and send a request
+                try (var nodeOne = tester.simpleTestClient("localhost:9194", false)) {
+                    nodeOne.getSync(new Request(ApiKeys.API_VERSIONS, (short) 3, "client", new ApiVersionsRequestData()));
+                }
+            }
+
+            // Then: after the clear, each mock received exactly what arrived via its virtual-node port.
+            assertThat(mockBroker0.getReceivedRequests())
+                    .extracting(Request::apiKeys)
+                    .containsExactly(ApiKeys.API_VERSIONS);
+
+            // mockBroker1 received only API_VERSIONS from virtual-node-1; nothing from reconciliation
+            assertThat(mockBroker1.getReceivedRequests())
+                    .extracting(Request::apiKeys)
+                    .containsExactly(ApiKeys.API_VERSIONS);
+        }
+    }
+
+    @ParameterizedTest(name = "all traffic routed to {0}")
+    @CsvSource({ "route-a", "route-b" })
+    void shouldRouteConnectionsToCorrectUpstreamBrokerBasedOnVirtualNodeIdWithTwoRoutes(String selectedRoute) {
+        // Given: two routes (route-a and route-b), each backed by two upstream brokers.
+        // With BijectiveNodeIdMapping (2 routes × 2 brokers each):
+        // route-a broker 0 → virtual node 0 → proxy port 9193
+        // route-b broker 0 → virtual node 1 → proxy port 9194
+        // route-a broker 1 → virtual node 2 → proxy port 9195
+        // route-b broker 1 → virtual node 3 → proxy port 9196
+        //
+        // A PassThroughRouter sends ALL traffic (including METADATA) to the selected route.
+        // METADATA reconciliation therefore only binds the virtual-node ports for that route:
+        // route-a selected → ports 9193 and 9195 are bound to mockA0 and mockA1
+        // route-b selected → ports 9194 and 9196 are bound to mockB0 and mockB1
+        // The test is parameterised so each run validates one route's two broker nodes.
+        try (var mockA0 = MockServer.startOnRandomPort();
+                var mockA1 = MockServer.startOnRandomPort();
+                var mockB0 = MockServer.startOnRandomPort();
+                var mockB1 = MockServer.startOnRandomPort()) {
+
+            // Resolve which pair of mocks and which proxy ports correspond to the selected route.
+            var brokerBootstrap = "route-a".equals(selectedRoute) ? mockA0 : mockB0;
+            var brokerOne = "route-a".equals(selectedRoute) ? mockA1 : mockB1;
+            // route-a nodes sit on virtual nodes 0 (port +1) and 2 (port +3); route-b on 1 (+2) and 3 (+4).
+            int brokerBootstrapPort = "route-a".equals(selectedRoute) ? 9193 : 9194;
+            int brokerOnePort = "route-a".equals(selectedRoute) ? 9195 : 9196;
+
+            // METADATA from the selected route's bootstrap lists both its upstream brokers.
+            var metadata = new MetadataResponseData().setControllerId(0);
+            metadata.brokers().add(new MetadataResponseBroker().setNodeId(0)
+                    .setHost("localhost").setPort(brokerBootstrap.port()));
+            metadata.brokers().add(new MetadataResponseBroker().setNodeId(1)
+                    .setHost("localhost").setPort(brokerOne.port()));
+            brokerBootstrap.addMockResponseForApiKey(new ResponsePayload(ApiKeys.METADATA, (short) 12, metadata));
+
+            var clusterA = new ClusterDefinition("cluster-a", "localhost:" + mockA0.port(), null);
+            var clusterB = new ClusterDefinition("cluster-b", "localhost:" + mockB0.port(), null);
+            var routeA = new RouteDefinition("route-a", 0, List.of(), new RouteTarget("cluster-a", null));
+            var routeB = new RouteDefinition("route-b", 1, List.of(), new RouteTarget("cluster-b", null));
+            var routerDef = new RouterDefinition("two-route-two-node-router",
+                    PassThroughRouterFactory.class.getName(), new PassThroughRouterFactory.Config(selectedRoute),
+                    List.of(routeA, routeB));
+            var vc = new VirtualClusterBuilder()
+                    .withName("demo")
+                    .withTarget(new RouteTarget(null, "two-route-two-node-router"))
+                    .addToGateways(defaultGatewayBuilder()
+                            .withNewPortIdentifiesNode()
+                            .withBootstrapAddress(HostPort.parse("localhost:9192"))
+                            .withNodeIdRanges(new NamedRange("nodes", 0, 3))
+                            .endPortIdentifiesNode()
+                            .build())
+                    .build();
+            var config = baseConfigurationBuilder()
+                    .addToClusterDefinitions(clusterA)
+                    .addToClusterDefinitions(clusterB)
+                    .addToRouterDefinitions(routerDef)
+                    .addToVirtualClusters(vc);
+
+            try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester()) {
+                // Send METADATA via the bootstrap to trigger reconciliation of the selected route's
+                // virtual-node ports. After getSync returns, BrokerEndpointBindings are in place.
+                try (var bootstrapClient = tester.simpleTestClient()) {
+                    bootstrapClient.getSync(new Request(ApiKeys.METADATA, (short) 12, "client", new MetadataRequestData()));
+                }
+
+                // Clear reconciliation traffic; re-add distinct responses per broker so any
+                // unexpected cross-routing shows up as a wrong key rather than an inflated count.
+                brokerBootstrap.clear();
+                brokerOne.clear();
+                brokerBootstrap.addMockResponseForApiKey(new ResponsePayload(ApiKeys.API_VERSIONS, (short) 3, new ApiVersionsResponseData()));
+                brokerOne.addMockResponseForApiKey(new ResponsePayload(ApiKeys.FETCH, (short) 12, new FetchResponseData()));
+
+                // When/Then: broker 0's virtual-node port routes to brokerBootstrap
+                try (var node = tester.simpleTestClient("localhost:" + brokerBootstrapPort, false)) {
+                    node.getSync(new Request(ApiKeys.API_VERSIONS, (short) 3, "client", new ApiVersionsRequestData()));
+                }
+                assertThat(brokerBootstrap.getReceivedRequests()).extracting(Request::apiKeys)
+                        .containsExactly(ApiKeys.API_VERSIONS);
+
+                // When/Then: broker 1's virtual-node port routes to brokerOne
+                try (var node = tester.simpleTestClient("localhost:" + brokerOnePort, false)) {
+                    node.getSync(new Request(ApiKeys.FETCH, (short) 12, "client", new FetchRequestData()));
+                }
+                assertThat(brokerOne.getReceivedRequests()).extracting(Request::apiKeys)
+                        .containsExactly(ApiKeys.FETCH);
+            }
+
         }
     }
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingPassThroughIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingPassThroughIT.java
@@ -33,12 +33,14 @@ import io.kroxylicious.it.testplugins.PassThroughRouterFactory;
 import io.kroxylicious.it.testplugins.SplitStaticRouterFactory;
 import io.kroxylicious.proxy.config.ClusterDefinition;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
+import io.kroxylicious.proxy.config.NamedRange;
 import io.kroxylicious.proxy.config.RouteDefinition;
 import io.kroxylicious.proxy.config.RouteTarget;
 import io.kroxylicious.proxy.config.RouterDefinition;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.internal.config.Feature;
 import io.kroxylicious.proxy.internal.config.Features;
+import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.integration.Request;
 import io.kroxylicious.testing.integration.ResponsePayload;
 import io.kroxylicious.testing.integration.server.MockServer;
@@ -50,6 +52,7 @@ import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 import io.kroxylicious.testing.kafka.junit5ext.Topic;
 
 import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.baseConfigurationBuilder;
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.defaultGatewayBuilder;
 import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -217,6 +220,80 @@ class RoutingPassThroughIT {
                 consumer.poll(Duration.ofSeconds(1)).forEach(collected::add);
             }
             assertThat(collected).hasSize(10);
+        }
+    }
+
+    @ParameterizedTest(name = "route to {0}")
+    @CsvSource({ "route-a", "route-b" })
+    void shouldProduceAndConsumeViaSelectedRouteWithTwoMultiNodeClusters(
+                                                                         String selectedRoute,
+                                                                         @BrokerCluster(numBrokers = 3) KafkaCluster clusterA,
+                                                                         @BrokerCluster(numBrokers = 3) KafkaCluster clusterB)
+            throws Exception {
+        // Given: two 3-node clusters, two routes, a pass-through router directing all traffic to the selected route.
+        // With 2 routes × 3 brokers the bijective mapping produces virtual node IDs 0-5, so the
+        // gateway must expose ports for all six virtual nodes.
+        var clusterDefA = new ClusterDefinition("cluster-a", clusterA.getBootstrapServers(), null);
+        var clusterDefB = new ClusterDefinition("cluster-b", clusterB.getBootstrapServers(), null);
+
+        var routeA = new RouteDefinition("route-a", 0, List.of(), new RouteTarget("cluster-a", null));
+        var routeB = new RouteDefinition("route-b", 1, List.of(), new RouteTarget("cluster-b", null));
+
+        var routerConfig = new PassThroughRouterFactory.Config(selectedRoute);
+        var routerDef = new RouterDefinition("two-cluster-router",
+                PassThroughRouterFactory.class.getName(), routerConfig, List.of(routeA, routeB));
+
+        var vc = new VirtualClusterBuilder()
+                .withName("two-cluster")
+                .withTarget(new RouteTarget(null, "two-cluster-router"))
+                .addToGateways(defaultGatewayBuilder()
+                        .withNewPortIdentifiesNode()
+                        .withBootstrapAddress(HostPort.parse("localhost:9192"))
+                        .withNodeIdRanges(new NamedRange("nodes", 0, 5))
+                        .endPortIdentifiesNode()
+                        .build())
+                .build();
+
+        var config = baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDefA)
+                .addToClusterDefinitions(clusterDefB)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
+
+        KafkaCluster expectedCluster = selectedRoute.equals("route-a") ? clusterA : clusterB;
+        KafkaCluster unexpectedCluster = selectedRoute.equals("route-a") ? clusterB : clusterA;
+        var topicName = "two-cluster-multinode-" + UUID.randomUUID();
+
+        // When: produce 10 records and consume them back through the proxy
+        try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
+                var admin = tester.admin();
+                var producer = tester.producer();
+                var consumer = tester.consumer(
+                        Map.of(ConsumerConfig.GROUP_ID_CONFIG, "two-cluster-multinode-test",
+                                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+
+            admin.createTopics(List.of(new NewTopic(topicName, 1, (short) 1)))
+                    .all().get(10, TimeUnit.SECONDS);
+
+            for (int i = 0; i < 10; i++) {
+                assertThat(producer.send(new ProducerRecord<>(topicName, "key-" + i, "value-" + i)))
+                        .succeedsWithin(Duration.ofSeconds(10));
+            }
+
+            consumer.subscribe(Set.of(topicName));
+            List<ConsumerRecord<String, String>> collected = new ArrayList<>();
+            long deadline = System.currentTimeMillis() + 30_000;
+            while (collected.size() < 10 && System.currentTimeMillis() < deadline) {
+                consumer.poll(Duration.ofSeconds(1)).forEach(collected::add);
+            }
+            assertThat(collected).hasSize(10);
+        }
+
+        // Then: all data is on the selected cluster, none on the other
+        try (var expectedAdmin = CloseableAdmin.create(expectedCluster.getKafkaClientConfiguration());
+                var unexpectedAdmin = CloseableAdmin.create(unexpectedCluster.getKafkaClientConfiguration())) {
+            assertThat(expectedAdmin.listTopics().names().get(10, TimeUnit.SECONDS)).contains(topicName);
+            assertThat(unexpectedAdmin.listTopics().names().get(10, TimeUnit.SECONDS)).doesNotContain(topicName);
         }
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingPassThroughIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingPassThroughIT.java
@@ -6,6 +6,7 @@
 package io.kroxylicious.it;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -44,6 +45,7 @@ import io.kroxylicious.testing.integration.server.MockServer;
 import io.kroxylicious.testing.integration.tester.KroxyliciousTesters;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.clients.CloseableAdmin;
+import io.kroxylicious.testing.kafka.common.BrokerCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 import io.kroxylicious.testing.kafka.junit5ext.Topic;
 
@@ -183,6 +185,38 @@ class RoutingPassThroughIT {
 
             var unexpectedTopics = unexpectedAdmin.listTopics().names().get(10, TimeUnit.SECONDS);
             assertThat(unexpectedTopics).isEmpty();
+        }
+    }
+
+    @Test
+    void shouldProduceAndConsumeViaPassThroughRouterWithMultiNodeCluster(
+                                                                         @BrokerCluster(numBrokers = 3) KafkaCluster cluster, Topic topic)
+            throws Exception {
+        // Given: a pass-through router backed by a 3-node cluster; the partition leader
+        // may be on any broker (not necessarily the bootstrap node), so the proxy must
+        // resolve the correct upstream broker via the METADATA-based address registry.
+        var config = routingConfig(cluster);
+
+        try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
+                var producer = tester.producer();
+                var consumer = tester.consumer(
+                        Map.of(ConsumerConfig.GROUP_ID_CONFIG, "routing-multi-node-test",
+                                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+
+            // When: produce 10 records
+            for (int i = 0; i < 10; i++) {
+                assertThat(producer.send(new ProducerRecord<>(topic.name(), "key-" + i, "value-" + i)))
+                        .succeedsWithin(Duration.ofSeconds(10));
+            }
+
+            // Then: all 10 records are consumable
+            consumer.subscribe(Set.of(topic.name()));
+            List<ConsumerRecord<String, String>> collected = new ArrayList<>();
+            long deadline = System.currentTimeMillis() + 30_000;
+            while (collected.size() < 10 && System.currentTimeMillis() < deadline) {
+                consumer.poll(Duration.ofSeconds(1)).forEach(collected::add);
+            }
+            assertThat(collected).hasSize(10);
         }
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingPassThroughIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingPassThroughIT.java
@@ -295,7 +295,7 @@ class RoutingPassThroughIT {
         try (var expectedAdmin = CloseableAdmin.create(expectedCluster.getKafkaClientConfiguration());
                 var unexpectedAdmin = CloseableAdmin.create(unexpectedCluster.getKafkaClientConfiguration())) {
             assertThat(expectedAdmin.listTopics().names().get(10, TimeUnit.SECONDS)).contains(topicName);
-            assertThat(unexpectedAdmin.listTopics().names().get(10, TimeUnit.SECONDS)).doesNotContain(topicName);
+            assertThat(unexpectedAdmin.listTopics().names().get(10, TimeUnit.SECONDS)).isEmpty();
         }
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -867,6 +867,10 @@ public class ClientConnectionStateMachine {
                 routeTargets.put(entry.getKey(), target);
             }
         }
+        // If broker addresses are already known (fetched by a previous connection), upgrade immediately.
+        for (String routeName : routeTargets.keySet()) {
+            upgradeToPerBrokerConnection(routeName);
+        }
         log(Level.DEBUG)
                 .addKeyValue("routeCount", () -> routeTargets.size())
                 .addKeyValue("backendCount", () -> serverConnections.size())
@@ -913,19 +917,25 @@ public class ClientConnectionStateMachine {
     /**
      * Called by {@link io.kroxylicious.proxy.internal.routing.RouterDispatchHandler} when a METADATA
      * response arrives for the named route, providing the upstream broker addresses.
-     * If this connection is on a per-broker port whose owning route matches {@code routeName},
-     * creates a direct connection to the home broker and updates the route target accordingly.
+     * Updates the shared registry on the virtual cluster model so that all CCSMs for this
+     * virtual cluster can benefit, then upgrades this connection if it is the owning connection
+     * for the relevant broker.
      */
     public void registerBrokerAddresses(String routeName, Map<Integer, HostPort> addresses) {
-        if (nodeIdMapping == null || nodeId() == null) {
+        virtualCluster().updateBrokerAddresses(routeName, addresses);
+        upgradeToPerBrokerConnection(routeName);
+    }
+
+    private void upgradeToPerBrokerConnection(String routeName) {
+        if (nodeIdMapping == null || nodeId() == null || routeTargets == null) {
             return;
         }
         var homeRouteAndNode = nodeIdMapping.fromVirtual(nodeId());
         if (!homeRouteAndNode.route().equals(routeName)) {
             return;
         }
-        HostPort homeBrokerAddress = addresses.get(homeRouteAndNode.targetNodeId());
-        if (homeBrokerAddress == null || routeTargets == null) {
+        HostPort homeBrokerAddress = virtualCluster().getBrokerAddresses(routeName).get(homeRouteAndNode.targetNodeId());
+        if (homeBrokerAddress == null) {
             return;
         }
         var frontend = frontendHandler;

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -894,15 +894,14 @@ public class ClientConnectionStateMachine {
                 illegalState("Unknown route: " + routeName);
                 return;
             }
-            ServerConnectionStateMachine scsm = serverConnections.get(target);
-            if (scsm == null) {
+            ServerConnectionStateMachine scsm = serverConnections.computeIfAbsent(target, k -> {
                 proxyToServerConnectionCounter.increment();
-                scsm = createServerConnection(target);
-                serverConnections.put(target, scsm);
+                var newScsm = createServerConnection(target);
                 Channel clientChannel = Objects.requireNonNull(
                         Objects.requireNonNull(frontendHandler).clientChannel());
-                scsm.connect(clientChannel);
-            }
+                newScsm.connect(clientChannel);
+                return newScsm;
+            });
             scsm.sendRequest(msg);
         }
         else {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -847,15 +847,17 @@ public class ClientConnectionStateMachine {
     @SuppressWarnings("java:S5738")
     private void toForwardingWithRoutes(Forwarding forwarding) {
         setState(forwarding);
-        routeTargets = new HashMap<>();
         Map<String, RouteDescriptor> descriptors = virtualCluster().routeDescriptors();
-        if (descriptors != null) {
-            for (var entry : descriptors.entrySet()) {
-                RouteDescriptor rd = entry.getValue();
-                if (rd.targetsCluster()) {
-                    routeTargets.put(entry.getKey(), Objects.requireNonNull(rd.targetCluster().bootstrapServer(),
-                            "route '" + entry.getKey() + "' targetCluster has a null bootstrapServer"));
-                }
+        if (descriptors == null || descriptors.isEmpty()) {
+            throw new IllegalStateException(
+                    "toForwardingWithRoutes called but virtualCluster has no routeDescriptors — this is a bug");
+        }
+        routeTargets = new HashMap<>();
+        for (var entry : descriptors.entrySet()) {
+            RouteDescriptor rd = entry.getValue();
+            if (rd.targetsCluster()) {
+                routeTargets.put(entry.getKey(), Objects.requireNonNull(rd.targetCluster().bootstrapServer(),
+                        "route '" + entry.getKey() + "' targetCluster has a null bootstrapServer"));
             }
         }
         // For per-broker connections, the EndpointReconciler has already resolved the
@@ -864,7 +866,7 @@ public class ClientConnectionStateMachine {
         var nodeIdMapping = virtualCluster().nodeIdMapping();
         if (endpointBinding instanceof BrokerEndpointBinding beb && nodeIdMapping != null) {
             var routeAndNode = nodeIdMapping.fromVirtual(beb.nodeId());
-            RouteDescriptor owningDesc = descriptors != null ? descriptors.get(routeAndNode.route()) : null;
+            RouteDescriptor owningDesc = descriptors.get(routeAndNode.route());
             if (owningDesc != null && owningDesc.targetsCluster()) {
                 routeTargets.put(routeAndNode.route(), beb.upstreamTarget());
             }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -41,6 +41,7 @@ import io.kroxylicious.proxy.frame.RequestFrame;
 import io.kroxylicious.proxy.internal.ClientConnectionState.Closed;
 import io.kroxylicious.proxy.internal.ClientConnectionState.Forwarding;
 import io.kroxylicious.proxy.internal.codec.FrameOversizedException;
+import io.kroxylicious.proxy.internal.net.BrokerEndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
 import io.kroxylicious.proxy.internal.routing.NodeIdMapping;
@@ -850,32 +851,31 @@ public class ClientConnectionStateMachine {
     @SuppressWarnings("java:S5738")
     private void toForwardingWithRoutes(Forwarding forwarding) {
         setState(forwarding);
-        Map<String, RouteDescriptor> descriptors = virtualCluster().routeDescriptors();
         routeTargets = new HashMap<>();
-        var frontend = Objects.requireNonNull(frontendHandler);
-        Channel clientChannel = Objects.requireNonNull(frontend.clientChannel());
-        for (var entry : descriptors.entrySet()) {
-            RouteDescriptor rd = entry.getValue();
-            if (rd.targetsCluster()) {
-                HostPort target = Objects.requireNonNull(rd.targetCluster().bootstrapServer(),
-                        "route '" + entry.getKey() + "' targetCluster has a null bootstrapServer");
-                serverConnections.computeIfAbsent(target, t -> {
-                    var newScsm = createServerConnection(t);
-                    newScsm.connect(clientChannel);
-                    return newScsm;
-                });
-                routeTargets.put(entry.getKey(), target);
+        Map<String, RouteDescriptor> descriptors = virtualCluster().routeDescriptors();
+        if (descriptors != null) {
+            for (var entry : descriptors.entrySet()) {
+                RouteDescriptor rd = entry.getValue();
+                if (rd.targetsCluster()) {
+                    routeTargets.put(entry.getKey(), Objects.requireNonNull(rd.targetCluster().bootstrapServer(),
+                            "route '" + entry.getKey() + "' targetCluster has a null bootstrapServer"));
+                }
             }
         }
-        // If broker addresses are already known (fetched by a previous connection), upgrade immediately.
-        for (String routeName : routeTargets.keySet()) {
-            upgradeToPerBrokerConnection(routeName);
+        // For per-broker connections, the EndpointReconciler has already resolved the
+        // real upstream address. Override the owning route's bootstrap target with it.
+        // Server connections are opened lazily in forwardToRoute().
+        if (endpointBinding instanceof BrokerEndpointBinding beb && nodeIdMapping != null) {
+            var routeAndNode = nodeIdMapping.fromVirtual(beb.nodeId());
+            RouteDescriptor owningDesc = descriptors != null ? descriptors.get(routeAndNode.route()) : null;
+            if (owningDesc != null && owningDesc.targetsCluster()) {
+                routeTargets.put(routeAndNode.route(), beb.upstreamTarget());
+            }
         }
         log(Level.DEBUG)
                 .addKeyValue("routeCount", () -> routeTargets.size())
-                .addKeyValue("backendCount", () -> serverConnections.size())
-                .addKeyValue("clientAddress", () -> HostPort.asString(frontend.remoteHost(), frontend.remotePort()))
-                .log("Upstream connections initiated for routing VC");
+                .addKeyValue("routeTargets", () -> routeTargets.toString())
+                .log("Route targets resolved for router VC");
     }
 
     /**
@@ -896,8 +896,12 @@ public class ClientConnectionStateMachine {
             }
             ServerConnectionStateMachine scsm = serverConnections.get(target);
             if (scsm == null) {
-                illegalState("No server connection for target: " + target);
-                return;
+                proxyToServerConnectionCounter.increment();
+                scsm = createServerConnection(target);
+                serverConnections.put(target, scsm);
+                Channel clientChannel = Objects.requireNonNull(
+                        Objects.requireNonNull(frontendHandler).clientChannel());
+                scsm.connect(clientChannel);
             }
             scsm.sendRequest(msg);
         }
@@ -912,46 +916,6 @@ public class ClientConnectionStateMachine {
      */
     public void setNodeIdMapping(@Nullable NodeIdMapping nodeIdMapping) {
         this.nodeIdMapping = nodeIdMapping;
-    }
-
-    /**
-     * Called by {@link io.kroxylicious.proxy.internal.routing.RouterDispatchHandler} when a METADATA
-     * response arrives for the named route, providing the upstream broker addresses.
-     * Updates the shared registry on the virtual cluster model so that all CCSMs for this
-     * virtual cluster can benefit, then upgrades this connection if it is the owning connection
-     * for the relevant broker.
-     */
-    public void registerBrokerAddresses(String routeName, Map<Integer, HostPort> addresses) {
-        virtualCluster().updateBrokerAddresses(routeName, addresses);
-        upgradeToPerBrokerConnection(routeName);
-    }
-
-    private void upgradeToPerBrokerConnection(String routeName) {
-        if (nodeIdMapping == null || nodeId() == null || routeTargets == null) {
-            return;
-        }
-        var homeRouteAndNode = nodeIdMapping.fromVirtual(nodeId());
-        if (!homeRouteAndNode.route().equals(routeName)) {
-            return;
-        }
-        HostPort homeBrokerAddress = virtualCluster().getBrokerAddresses(routeName).get(homeRouteAndNode.targetNodeId());
-        if (homeBrokerAddress == null) {
-            return;
-        }
-        var frontend = frontendHandler;
-        if (frontend == null) {
-            return;
-        }
-        Channel clientChannel = frontend.clientChannel();
-        if (clientChannel == null) {
-            return;
-        }
-        serverConnections.computeIfAbsent(homeBrokerAddress, addr -> {
-            var newScsm = createServerConnection(addr);
-            newScsm.connect(clientChannel);
-            return newScsm;
-        });
-        routeTargets.put(routeName, homeBrokerAddress);
     }
 
     @VisibleForTesting

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -895,7 +895,6 @@ public class ClientConnectionStateMachine {
                 return;
             }
             ServerConnectionStateMachine scsm = serverConnections.computeIfAbsent(target, k -> {
-                proxyToServerConnectionCounter.increment();
                 var newScsm = createServerConnection(target);
                 Channel clientChannel = Objects.requireNonNull(
                         Objects.requireNonNull(frontendHandler).clientChannel());

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -872,9 +872,11 @@ public class ClientConnectionStateMachine {
                 routeTargets.put(routeAndNode.route(), beb.upstreamTarget());
             }
         }
+        var frontend = Objects.requireNonNull(frontendHandler);
         log(Level.DEBUG)
                 .addKeyValue("routeCount", () -> routeTargets.size())
                 .addKeyValue("routeTargets", () -> routeTargets.toString())
+                .addKeyValue("clientAddress", () -> HostPort.asString(frontend.remoteHost(), frontend.remotePort()))
                 .log("Route targets resolved for router VC");
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -43,6 +43,7 @@ import io.kroxylicious.proxy.internal.ClientConnectionState.Forwarding;
 import io.kroxylicious.proxy.internal.codec.FrameOversizedException;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
+import io.kroxylicious.proxy.internal.routing.NodeIdMapping;
 import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
 import io.kroxylicious.proxy.internal.util.ActivationToken;
 import io.kroxylicious.proxy.internal.util.Metrics;
@@ -206,6 +207,9 @@ public class ClientConnectionStateMachine {
 
     @Nullable
     private Map<String, HostPort> routeTargets;
+
+    @Nullable
+    private NodeIdMapping nodeIdMapping;
 
     public ClientConnectionStateMachine(EndpointBinding endpointBinding,
                                         TransportSubjectBuilder transportSubjectBuilder,
@@ -896,6 +900,48 @@ public class ClientConnectionStateMachine {
         else {
             illegalState("forwardToRoute in unexpected state");
         }
+    }
+
+    /**
+     * Sets the node ID mapping used for per-broker connection routing.
+     * Called by {@link io.kroxylicious.proxy.internal.KafkaProxyInitializer} when setting up a routed VC.
+     */
+    public void setNodeIdMapping(@Nullable NodeIdMapping nodeIdMapping) {
+        this.nodeIdMapping = nodeIdMapping;
+    }
+
+    /**
+     * Called by {@link io.kroxylicious.proxy.internal.routing.RouterDispatchHandler} when a METADATA
+     * response arrives for the named route, providing the upstream broker addresses.
+     * If this connection is on a per-broker port whose owning route matches {@code routeName},
+     * creates a direct connection to the home broker and updates the route target accordingly.
+     */
+    public void registerBrokerAddresses(String routeName, Map<Integer, HostPort> addresses) {
+        if (nodeIdMapping == null || nodeId() == null) {
+            return;
+        }
+        var homeRouteAndNode = nodeIdMapping.fromVirtual(nodeId());
+        if (!homeRouteAndNode.route().equals(routeName)) {
+            return;
+        }
+        HostPort homeBrokerAddress = addresses.get(homeRouteAndNode.targetNodeId());
+        if (homeBrokerAddress == null || routeTargets == null) {
+            return;
+        }
+        var frontend = frontendHandler;
+        if (frontend == null) {
+            return;
+        }
+        Channel clientChannel = frontend.clientChannel();
+        if (clientChannel == null) {
+            return;
+        }
+        serverConnections.computeIfAbsent(homeBrokerAddress, addr -> {
+            var newScsm = createServerConnection(addr);
+            newScsm.connect(clientChannel);
+            return newScsm;
+        });
+        routeTargets.put(routeName, homeBrokerAddress);
     }
 
     @VisibleForTesting

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -44,7 +44,6 @@ import io.kroxylicious.proxy.internal.codec.FrameOversizedException;
 import io.kroxylicious.proxy.internal.net.BrokerEndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
-import io.kroxylicious.proxy.internal.routing.NodeIdMapping;
 import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
 import io.kroxylicious.proxy.internal.util.ActivationToken;
 import io.kroxylicious.proxy.internal.util.Metrics;
@@ -208,9 +207,6 @@ public class ClientConnectionStateMachine {
 
     @Nullable
     private Map<String, HostPort> routeTargets;
-
-    @Nullable
-    private NodeIdMapping nodeIdMapping;
 
     public ClientConnectionStateMachine(EndpointBinding endpointBinding,
                                         TransportSubjectBuilder transportSubjectBuilder,
@@ -865,6 +861,7 @@ public class ClientConnectionStateMachine {
         // For per-broker connections, the EndpointReconciler has already resolved the
         // real upstream address. Override the owning route's bootstrap target with it.
         // Server connections are opened lazily in forwardToRoute().
+        var nodeIdMapping = virtualCluster().nodeIdMapping();
         if (endpointBinding instanceof BrokerEndpointBinding beb && nodeIdMapping != null) {
             var routeAndNode = nodeIdMapping.fromVirtual(beb.nodeId());
             RouteDescriptor owningDesc = descriptors != null ? descriptors.get(routeAndNode.route()) : null;
@@ -908,14 +905,6 @@ public class ClientConnectionStateMachine {
         else {
             illegalState("forwardToRoute in unexpected state");
         }
-    }
-
-    /**
-     * Sets the node ID mapping used for per-broker connection routing.
-     * Called by {@link io.kroxylicious.proxy.internal.KafkaProxyInitializer} when setting up a routed VC.
-     */
-    public void setNodeIdMapping(@Nullable NodeIdMapping nodeIdMapping) {
-        this.nodeIdMapping = nodeIdMapping;
     }
 
     @VisibleForTesting

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -43,9 +43,6 @@ import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointBindingResolver;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
-import io.kroxylicious.proxy.internal.routing.BijectiveNodeIdMapping;
-import io.kroxylicious.proxy.internal.routing.IdentityNodeIdMapping;
-import io.kroxylicious.proxy.internal.routing.NodeIdMapping;
 import io.kroxylicious.proxy.internal.routing.RouterDispatchHandler;
 import io.kroxylicious.proxy.internal.util.Metrics;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
@@ -277,8 +274,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
             // can translate them, even when those keys are statically routed.
             decodedKeys.addAll(RouterDispatchHandler.NODE_ID_TRANSLATION_APIS);
             dp.setRouterDecodingRequirements(decodedKeys);
-            var nodeIdMapping = buildNodeIdMapping(virtualCluster);
-            clientConnectionStateMachine.setNodeIdMapping(nodeIdMapping);
+            var nodeIdMapping = virtualCluster.nodeIdMapping();
             var dispatchHandler = new RouterDispatchHandler(router, staticRoutes, clientConnectionStateMachine, nodeIdMapping);
             pipeline.addLast("routerDispatchHandler", dispatchHandler);
         }
@@ -310,18 +306,6 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
         var proxyToClientMessageSizeDistributionProvider = Metrics.proxyToClientMessageSizeDistributionProvider(clusterName, nodeId);
         return new MetricEmittingKafkaMessageListener(proxyToClientMessageCounterProvider,
                 proxyToClientMessageSizeDistributionProvider);
-    }
-
-    private static NodeIdMapping buildNodeIdMapping(VirtualClusterModel virtualCluster) {
-        var descriptors = virtualCluster.routeDescriptors();
-        if (descriptors.size() == 1) {
-            return new IdentityNodeIdMapping(descriptors.keySet().iterator().next());
-        }
-        var routeIds = java.util.HashMap.<String, Integer> newHashMap(descriptors.size());
-        for (var entry : descriptors.entrySet()) {
-            routeIds.put(entry.getKey(), entry.getValue().id());
-        }
-        return new BijectiveNodeIdMapping(routeIds, routeIds.size());
     }
 
     private void rejectConnection(Channel ch, String clusterName) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -43,6 +43,9 @@ import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointBindingResolver;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
+import io.kroxylicious.proxy.internal.routing.BijectiveNodeIdMapping;
+import io.kroxylicious.proxy.internal.routing.IdentityNodeIdMapping;
+import io.kroxylicious.proxy.internal.routing.NodeIdMapping;
 import io.kroxylicious.proxy.internal.routing.RouterDispatchHandler;
 import io.kroxylicious.proxy.internal.util.Metrics;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
@@ -270,8 +273,13 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
             if (!staticRoutes.isEmpty()) {
                 dynamicallyRoutedKeys.removeAll(staticRoutes.keySet());
             }
+            // Always decode API keys whose responses carry node IDs so RouterDispatchHandler
+            // can translate them, even when those keys are statically routed.
+            dynamicallyRoutedKeys.addAll(RouterDispatchHandler.NODE_ID_TRANSLATION_KEYS);
             dp.setRouterDecodingRequirements(dynamicallyRoutedKeys);
-            var dispatchHandler = new RouterDispatchHandler(router, staticRoutes, clientConnectionStateMachine);
+            var nodeIdMapping = buildNodeIdMapping(virtualCluster);
+            clientConnectionStateMachine.setNodeIdMapping(nodeIdMapping);
+            var dispatchHandler = new RouterDispatchHandler(router, staticRoutes, clientConnectionStateMachine, nodeIdMapping);
             pipeline.addLast("routerDispatchHandler", dispatchHandler);
         }
         else {
@@ -302,6 +310,18 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
         var proxyToClientMessageSizeDistributionProvider = Metrics.proxyToClientMessageSizeDistributionProvider(clusterName, nodeId);
         return new MetricEmittingKafkaMessageListener(proxyToClientMessageCounterProvider,
                 proxyToClientMessageSizeDistributionProvider);
+    }
+
+    private static NodeIdMapping buildNodeIdMapping(VirtualClusterModel virtualCluster) {
+        var descriptors = virtualCluster.routeDescriptors();
+        if (descriptors.size() == 1) {
+            return new IdentityNodeIdMapping(descriptors.keySet().iterator().next());
+        }
+        var routeIds = new java.util.HashMap<String, Integer>(descriptors.size());
+        for (var entry : descriptors.entrySet()) {
+            routeIds.put(entry.getKey(), entry.getValue().id());
+        }
+        return new BijectiveNodeIdMapping(routeIds, routeIds.size());
     }
 
     private void rejectConnection(Channel ch, String clusterName) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -317,7 +317,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
         if (descriptors.size() == 1) {
             return new IdentityNodeIdMapping(descriptors.keySet().iterator().next());
         }
-        var routeIds = new java.util.HashMap<String, Integer>(descriptors.size());
+        var routeIds = java.util.HashMap.<String, Integer> newHashMap(descriptors.size());
         for (var entry : descriptors.entrySet()) {
             routeIds.put(entry.getKey(), entry.getValue().id());
         }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -269,14 +269,14 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
                     "routerChainFactory must not be null when virtual cluster '" + virtualCluster.getClusterName() + "' uses a router");
             Router router = routerChainFactory.createRouter(virtualCluster.routerName(), virtualCluster.getClusterName());
             Map<ApiKeys, String> staticRoutes = router.staticRoutes();
-            Set<ApiKeys> dynamicallyRoutedKeys = EnumSet.allOf(ApiKeys.class);
+            Set<ApiKeys> decodedKeys = EnumSet.allOf(ApiKeys.class);
             if (!staticRoutes.isEmpty()) {
-                dynamicallyRoutedKeys.removeAll(staticRoutes.keySet());
+                decodedKeys.removeAll(staticRoutes.keySet());
             }
             // Always decode API keys whose responses carry node IDs so RouterDispatchHandler
             // can translate them, even when those keys are statically routed.
-            dynamicallyRoutedKeys.addAll(RouterDispatchHandler.NODE_ID_TRANSLATION_KEYS);
-            dp.setRouterDecodingRequirements(dynamicallyRoutedKeys);
+            decodedKeys.addAll(RouterDispatchHandler.NODE_ID_TRANSLATION_KEYS);
+            dp.setRouterDecodingRequirements(decodedKeys);
             var nodeIdMapping = buildNodeIdMapping(virtualCluster);
             clientConnectionStateMachine.setNodeIdMapping(nodeIdMapping);
             var dispatchHandler = new RouterDispatchHandler(router, staticRoutes, clientConnectionStateMachine, nodeIdMapping);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -275,7 +275,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
             }
             // Always decode API keys whose responses carry node IDs so RouterDispatchHandler
             // can translate them, even when those keys are statically routed.
-            decodedKeys.addAll(RouterDispatchHandler.NODE_ID_TRANSLATION_KEYS);
+            decodedKeys.addAll(RouterDispatchHandler.NODE_ID_TRANSLATION_APIS);
             dp.setRouterDecodingRequirements(decodedKeys);
             var nodeIdMapping = buildNodeIdMapping(virtualCluster);
             clientConnectionStateMachine.setNodeIdMapping(nodeIdMapping);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/BijectiveNodeIdMapping.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/BijectiveNodeIdMapping.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+import java.util.Map;
+
+/**
+ * Bijective node ID mapping: {@code V = id + S × t}, where
+ * {@code V} is the virtual ID, {@code t} is the target node ID,
+ * {@code S} is the total number of routes, and {@code id} is
+ * the route's configured identifier.
+ */
+public record BijectiveNodeIdMapping(Map<String, Integer> routeIds,
+                                     int totalRoutes)
+        implements NodeIdMapping {
+
+    public BijectiveNodeIdMapping {
+        routeIds = Map.copyOf(routeIds);
+        if (totalRoutes < 2) {
+            throw new IllegalArgumentException("BijectiveNodeIdMapping requires at least 2 routes, got " + totalRoutes);
+        }
+        for (var entry : routeIds.entrySet()) {
+            int id = entry.getValue();
+            if (id < 0 || id >= totalRoutes) {
+                throw new IllegalArgumentException(
+                        "Route '" + entry.getKey() + "' has id " + id
+                                + " which is outside the valid range [0, " + totalRoutes + ")");
+            }
+        }
+    }
+
+    @Override
+    public int toVirtual(String route, int targetNodeId) {
+        Integer id = routeIds.get(route);
+        if (id == null) {
+            throw new IllegalArgumentException("Unknown route: " + route);
+        }
+        return Math.addExact(id, Math.multiplyExact(totalRoutes, targetNodeId));
+    }
+
+    @Override
+    public int fromVirtual(String route, int virtualNodeId) {
+        return Math.floorDiv(virtualNodeId, totalRoutes);
+    }
+
+    @Override
+    public RouteAndNode fromVirtual(int virtualNodeId) {
+        int id = Math.floorMod(virtualNodeId, totalRoutes);
+        int targetNodeId = Math.floorDiv(virtualNodeId, totalRoutes);
+        String route = routeIds.entrySet().stream()
+                .filter(e -> e.getValue() == id)
+                .map(Map.Entry::getKey)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "No route with id " + id + " (virtual node ID " + virtualNodeId + ")"));
+        return new RouteAndNode(route, targetNodeId);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/BijectiveNodeIdMapping.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/BijectiveNodeIdMapping.java
@@ -12,6 +12,12 @@ import java.util.Map;
  * {@code V} is the virtual ID, {@code t} is the target node ID,
  * {@code S} is the total number of routes, and {@code id} is
  * the route's configured identifier.
+ * <p>
+ * Example with two routes (S=2) whose upstream clusters each have node IDs 0, 1, 2:
+ * <pre>
+ *   route[0] (id=0): V = 0 + 2×0, 0 + 2×1, 0 + 2×2  →  0, 2, 4
+ *   route[1] (id=1): V = 1 + 2×0, 1 + 2×1, 1 + 2×2  →  1, 3, 5
+ * </pre>
  */
 public record BijectiveNodeIdMapping(Map<String, Integer> routeIds,
                                      int totalRoutes)
@@ -34,11 +40,11 @@ public record BijectiveNodeIdMapping(Map<String, Integer> routeIds,
 
     @Override
     public int toVirtual(String route, int targetNodeId) {
-        Integer id = routeIds.get(route);
-        if (id == null) {
+        Integer routeId = routeIds.get(route);
+        if (routeId == null) {
             throw new IllegalArgumentException("Unknown route: " + route);
         }
-        return Math.addExact(id, Math.multiplyExact(totalRoutes, targetNodeId));
+        return Math.addExact(routeId, Math.multiplyExact(totalRoutes, targetNodeId));
     }
 
     @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/BijectiveNodeIdMapping.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/BijectiveNodeIdMapping.java
@@ -40,6 +40,10 @@ public record BijectiveNodeIdMapping(Map<String, Integer> routeIds,
 
     @Override
     public int toVirtual(String route, int targetNodeId) {
+        // Negative node IDs are Kafka protocol sentinels — pass through per NodeIdMapping contract.
+        if (targetNodeId < 0) {
+            return targetNodeId;
+        }
         Integer routeId = routeIds.get(route);
         if (routeId == null) {
             throw new IllegalArgumentException("Unknown route: " + route);
@@ -49,6 +53,10 @@ public record BijectiveNodeIdMapping(Map<String, Integer> routeIds,
 
     @Override
     public int fromVirtual(String route, int virtualNodeId) {
+        // Negative node IDs are Kafka protocol sentinels — pass through per NodeIdMapping contract.
+        if (virtualNodeId < 0) {
+            return virtualNodeId;
+        }
         return Math.floorDiv(virtualNodeId, totalRoutes);
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/IdentityNodeIdMapping.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/IdentityNodeIdMapping.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+/**
+ * Identity node ID mapping for single-route configurations.
+ * Virtual IDs equal target IDs.
+ */
+public record IdentityNodeIdMapping(String routeName) implements NodeIdMapping {
+
+    @Override
+    public int toVirtual(String route, int targetNodeId) {
+        return targetNodeId;
+    }
+
+    @Override
+    public int fromVirtual(String route, int virtualNodeId) {
+        return virtualNodeId;
+    }
+
+    @Override
+    public RouteAndNode fromVirtual(int virtualNodeId) {
+        return new RouteAndNode(routeName, virtualNodeId);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/IdentityNodeIdMapping.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/IdentityNodeIdMapping.java
@@ -7,7 +7,8 @@ package io.kroxylicious.proxy.internal.routing;
 
 /**
  * Identity node ID mapping for single-route configurations.
- * Virtual IDs equal target IDs.
+ * Virtual IDs equal target IDs. Negative node IDs (Kafka protocol sentinels)
+ * are returned unchanged by all methods, satisfying the {@link NodeIdMapping} contract.
  */
 public record IdentityNodeIdMapping(String routeName) implements NodeIdMapping {
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/NodeIdMapping.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/NodeIdMapping.java
@@ -8,15 +8,25 @@ package io.kroxylicious.proxy.internal.routing;
 /**
  * Maps between target-cluster node IDs and the virtual node IDs
  * presented to clients. Implementations must be thread-safe.
+ * <p>
+ * <b>Negative node IDs</b> — the Kafka protocol uses negative node IDs as
+ * sentinels with defined semantics, for example {@code -1} means "no leader",
+ * "unknown controller", or "no coordinator available". These values must pass
+ * through the mapping unchanged; translating them would corrupt the protocol.
+ * Implementations must therefore return any negative input unmodified from both
+ * {@link #toVirtual} and {@link #fromVirtual(String, int)}.
  */
 public sealed interface NodeIdMapping permits BijectiveNodeIdMapping, IdentityNodeIdMapping {
 
     /**
      * Translates a target-cluster node ID to a virtual node ID.
+     * <p>
+     * Negative values (Kafka protocol sentinels such as {@code -1} "no leader")
+     * are returned unchanged and must not be fed into the translation formula.
      *
      * @param route the route name
      * @param targetNodeId the node ID on the target cluster
-     * @return the virtual node ID
+     * @return the virtual node ID, or {@code targetNodeId} unchanged if negative
      */
     int toVirtual(String route, int targetNodeId);
 
@@ -24,10 +34,12 @@ public sealed interface NodeIdMapping permits BijectiveNodeIdMapping, IdentityNo
      * Translates a virtual node ID back to its target-cluster node ID,
      * given the route. The route is always supplied by the router via
      * {@link io.kroxylicious.proxy.router.RouterContext#sendRequest}.
+     * <p>
+     * As with {@link #toVirtual}, negative values are returned unchanged.
      *
      * @param route the route name
      * @param virtualNodeId the virtual node ID
-     * @return the target-cluster node ID
+     * @return the target-cluster node ID, or {@code virtualNodeId} unchanged if negative
      */
     int fromVirtual(String route, int virtualNodeId);
 
@@ -35,6 +47,9 @@ public sealed interface NodeIdMapping permits BijectiveNodeIdMapping, IdentityNo
      * Translates a virtual node ID back to its route and target-cluster node ID.
      * Only works for dedicated (one-to-one) mappings where the route can be
      * recovered from the virtual node ID alone.
+     * <p>
+     * Behaviour is undefined for negative inputs; proxy port node IDs are always
+     * non-negative and this method is never called with a sentinel value.
      *
      * @param virtualNodeId the virtual node ID
      * @return the route name and target node ID

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/NodeIdMapping.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/NodeIdMapping.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+/**
+ * Maps between target-cluster node IDs and the virtual node IDs
+ * presented to clients. Implementations must be thread-safe.
+ */
+public sealed interface NodeIdMapping permits BijectiveNodeIdMapping, IdentityNodeIdMapping {
+
+    /**
+     * Translates a target-cluster node ID to a virtual node ID.
+     *
+     * @param route the route name
+     * @param targetNodeId the node ID on the target cluster
+     * @return the virtual node ID
+     */
+    int toVirtual(String route, int targetNodeId);
+
+    /**
+     * Translates a virtual node ID back to its target-cluster node ID,
+     * given the route. The route is always supplied by the router via
+     * {@link io.kroxylicious.proxy.router.RouterContext#sendRequest}.
+     *
+     * @param route the route name
+     * @param virtualNodeId the virtual node ID
+     * @return the target-cluster node ID
+     */
+    int fromVirtual(String route, int virtualNodeId);
+
+    /**
+     * Translates a virtual node ID back to its route and target-cluster node ID.
+     * Only works for dedicated (one-to-one) mappings where the route can be
+     * recovered from the virtual node ID alone.
+     *
+     * @param virtualNodeId the virtual node ID
+     * @return the route name and target node ID
+     */
+    RouteAndNode fromVirtual(int virtualNodeId);
+
+    /**
+     * A route name and target-cluster node ID pair.
+     */
+    record RouteAndNode(String route, int targetNodeId) {}
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslator.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+import java.util.List;
+
+import org.apache.kafka.common.message.DescribeClusterResponseData;
+import org.apache.kafka.common.message.DescribeClusterResponseData.DescribeClusterBrokerCollection;
+import org.apache.kafka.common.message.FindCoordinatorResponseData;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseBrokerCollection;
+import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.message.ProduceResponseData.NodeEndpointCollection;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+/**
+ * Translates target-cluster node IDs to virtual node IDs in response
+ * bodies, in-place. Only response types that contain node IDs are
+ * affected; all others are no-ops.
+ */
+final class NodeIdResponseTranslator {
+
+    private NodeIdResponseTranslator() {
+    }
+
+    static void translate(ApiMessage body,
+                          short apiVersion,
+                          NodeIdMapping mapping,
+                          String route) {
+        if (body instanceof MetadataResponseData md) {
+            translateMetadata(md, mapping, route);
+        }
+        else if (body instanceof ProduceResponseData pd) {
+            translateProduce(pd, apiVersion, mapping, route);
+        }
+        else if (body instanceof FindCoordinatorResponseData fc) {
+            translateFindCoordinator(fc, apiVersion, mapping, route);
+        }
+        else if (body instanceof DescribeClusterResponseData dc) {
+            translateDescribeCluster(dc, mapping, route);
+        }
+    }
+
+    private static void translateMetadata(MetadataResponseData data,
+                                          NodeIdMapping mapping,
+                                          String route) {
+        data.setControllerId(mapping.toVirtual(route, data.controllerId()));
+
+        var translatedBrokers = new MetadataResponseBrokerCollection(data.brokers().size());
+        for (var broker : List.copyOf(data.brokers())) {
+            var translated = broker.duplicate();
+            translated.setNodeId(mapping.toVirtual(route, broker.nodeId()));
+            translatedBrokers.add(translated);
+        }
+        data.setBrokers(translatedBrokers);
+
+        for (var topic : data.topics()) {
+            for (var partition : topic.partitions()) {
+                partition.setLeaderId(mapping.toVirtual(route, partition.leaderId()));
+                translateIntList(partition.replicaNodes(), mapping, route);
+                translateIntList(partition.isrNodes(), mapping, route);
+                translateIntList(partition.offlineReplicas(), mapping, route);
+            }
+        }
+    }
+
+    private static void translateProduce(ProduceResponseData data,
+                                         short apiVersion,
+                                         NodeIdMapping mapping,
+                                         String route) {
+        if (apiVersion < 10) {
+            return;
+        }
+        for (var topicResponse : data.responses()) {
+            for (var partitionResponse : topicResponse.partitionResponses()) {
+                var leader = partitionResponse.currentLeader();
+                if (leader.leaderId() >= 0) {
+                    leader.setLeaderId(mapping.toVirtual(route, leader.leaderId()));
+                }
+            }
+        }
+        var translatedEndpoints = new NodeEndpointCollection(data.nodeEndpoints().size());
+        for (var ne : List.copyOf(data.nodeEndpoints())) {
+            var translated = ne.duplicate();
+            translated.setNodeId(mapping.toVirtual(route, ne.nodeId()));
+            translatedEndpoints.add(translated);
+        }
+        data.setNodeEndpoints(translatedEndpoints);
+    }
+
+    private static void translateFindCoordinator(FindCoordinatorResponseData data,
+                                                 short apiVersion,
+                                                 NodeIdMapping mapping,
+                                                 String route) {
+        if (apiVersion >= 4) {
+            for (var coordinator : data.coordinators()) {
+                if (coordinator.nodeId() >= 0) {
+                    coordinator.setNodeId(mapping.toVirtual(route, coordinator.nodeId()));
+                }
+            }
+        }
+        else {
+            if (data.nodeId() >= 0) {
+                data.setNodeId(mapping.toVirtual(route, data.nodeId()));
+            }
+        }
+    }
+
+    private static void translateDescribeCluster(DescribeClusterResponseData data,
+                                                 NodeIdMapping mapping,
+                                                 String route) {
+        if (data.controllerId() >= 0) {
+            data.setControllerId(mapping.toVirtual(route, data.controllerId()));
+        }
+        var translatedBrokers = new DescribeClusterBrokerCollection(data.brokers().size());
+        for (var broker : List.copyOf(data.brokers())) {
+            var translated = broker.duplicate();
+            translated.setBrokerId(mapping.toVirtual(route, broker.brokerId()));
+            translatedBrokers.add(translated);
+        }
+        data.setBrokers(translatedBrokers);
+    }
+
+    private static void translateIntList(List<Integer> nodeIds,
+                                         NodeIdMapping mapping,
+                                         String route) {
+        for (int i = 0; i < nodeIds.size(); i++) {
+            nodeIds.set(i, mapping.toVirtual(route, nodeIds.get(i)));
+        }
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslator.java
@@ -9,11 +9,14 @@ import java.util.List;
 
 import org.apache.kafka.common.message.DescribeClusterResponseData;
 import org.apache.kafka.common.message.DescribeClusterResponseData.DescribeClusterBrokerCollection;
+import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.FindCoordinatorResponseData;
 import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseBrokerCollection;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.ProduceResponseData.NodeEndpointCollection;
+import org.apache.kafka.common.message.ShareAcknowledgeResponseData;
+import org.apache.kafka.common.message.ShareFetchResponseData;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 /**
@@ -41,6 +44,15 @@ final class NodeIdResponseTranslator {
         }
         else if (body instanceof DescribeClusterResponseData dc) {
             translateDescribeCluster(dc, mapping, route);
+        }
+        else if (body instanceof FetchResponseData fd) {
+            translateFetch(fd, apiVersion, mapping, route);
+        }
+        else if (body instanceof ShareFetchResponseData sfd) {
+            translateShareFetch(sfd, mapping, route);
+        }
+        else if (body instanceof ShareAcknowledgeResponseData sad) {
+            translateShareAcknowledge(sad, mapping, route);
         }
     }
 
@@ -126,6 +138,52 @@ final class NodeIdResponseTranslator {
             translatedBrokers.add(translated);
         }
         data.setBrokers(translatedBrokers);
+    }
+
+    private static void translateFetch(FetchResponseData data,
+                                       short apiVersion,
+                                       NodeIdMapping mapping,
+                                       String route) {
+        if (apiVersion < 16) {
+            return;
+        }
+        var translatedEndpoints = new FetchResponseData.NodeEndpointCollection(data.nodeEndpoints().size());
+        for (var ne : List.copyOf(data.nodeEndpoints())) {
+            var translated = ne.duplicate();
+            translated.setNodeId(mapping.toVirtual(route, ne.nodeId()));
+            translatedEndpoints.add(translated);
+        }
+        data.setNodeEndpoints(translatedEndpoints);
+    }
+
+    private static void translateShareFetch(ShareFetchResponseData data,
+                                            NodeIdMapping mapping,
+                                            String route) {
+        if (data.nodeEndpoints() == null) {
+            return;
+        }
+        var translatedEndpoints = new ShareFetchResponseData.NodeEndpointCollection(data.nodeEndpoints().size());
+        for (var ne : List.copyOf(data.nodeEndpoints())) {
+            var translated = ne.duplicate();
+            translated.setNodeId(mapping.toVirtual(route, ne.nodeId()));
+            translatedEndpoints.add(translated);
+        }
+        data.setNodeEndpoints(translatedEndpoints);
+    }
+
+    private static void translateShareAcknowledge(ShareAcknowledgeResponseData data,
+                                                  NodeIdMapping mapping,
+                                                  String route) {
+        if (data.nodeEndpoints() == null) {
+            return;
+        }
+        var translatedEndpoints = new ShareAcknowledgeResponseData.NodeEndpointCollection(data.nodeEndpoints().size());
+        for (var ne : List.copyOf(data.nodeEndpoints())) {
+            var translated = ne.duplicate();
+            translated.setNodeId(mapping.toVirtual(route, ne.nodeId()));
+            translatedEndpoints.add(translated);
+        }
+        data.setNodeEndpoints(translatedEndpoints);
     }
 
     private static void translateIntList(List<Integer> nodeIds,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslator.java
@@ -47,7 +47,9 @@ final class NodeIdResponseTranslator {
     private static void translateMetadata(MetadataResponseData data,
                                           NodeIdMapping mapping,
                                           String route) {
-        data.setControllerId(mapping.toVirtual(route, data.controllerId()));
+        if (data.controllerId() >= 0) {
+            data.setControllerId(mapping.toVirtual(route, data.controllerId()));
+        }
 
         var translatedBrokers = new MetadataResponseBrokerCollection(data.brokers().size());
         for (var broker : List.copyOf(data.brokers())) {
@@ -59,7 +61,9 @@ final class NodeIdResponseTranslator {
 
         for (var topic : data.topics()) {
             for (var partition : topic.partitions()) {
-                partition.setLeaderId(mapping.toVirtual(route, partition.leaderId()));
+                if (partition.leaderId() >= 0) {
+                    partition.setLeaderId(mapping.toVirtual(route, partition.leaderId()));
+                }
                 translateIntList(partition.replicaNodes(), mapping, route);
                 translateIntList(partition.isrNodes(), mapping, route);
                 translateIntList(partition.offlineReplicas(), mapping, route);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslator.java
@@ -23,6 +23,11 @@ import org.apache.kafka.common.protocol.ApiMessage;
  * Translates target-cluster node IDs to virtual node IDs in response
  * bodies, in-place. Only response types that contain node IDs are
  * affected; all others are no-ops.
+ * <p>
+ * No per-field guards for negative values are needed here: the
+ * {@link NodeIdMapping} contract guarantees that negative node IDs
+ * (Kafka protocol sentinels such as {@code -1} "no leader") are
+ * returned unchanged by every mapping implementation.
  */
 final class NodeIdResponseTranslator {
 
@@ -59,9 +64,7 @@ final class NodeIdResponseTranslator {
     private static void translateMetadata(MetadataResponseData data,
                                           NodeIdMapping mapping,
                                           String route) {
-        if (data.controllerId() >= 0) {
-            data.setControllerId(mapping.toVirtual(route, data.controllerId()));
-        }
+        data.setControllerId(mapping.toVirtual(route, data.controllerId()));
 
         var translatedBrokers = new MetadataResponseBrokerCollection(data.brokers().size());
         for (var broker : List.copyOf(data.brokers())) {
@@ -73,9 +76,7 @@ final class NodeIdResponseTranslator {
 
         for (var topic : data.topics()) {
             for (var partition : topic.partitions()) {
-                if (partition.leaderId() >= 0) {
-                    partition.setLeaderId(mapping.toVirtual(route, partition.leaderId()));
-                }
+                partition.setLeaderId(mapping.toVirtual(route, partition.leaderId()));
                 translateIntList(partition.replicaNodes(), mapping, route);
                 translateIntList(partition.isrNodes(), mapping, route);
                 translateIntList(partition.offlineReplicas(), mapping, route);
@@ -93,9 +94,7 @@ final class NodeIdResponseTranslator {
         for (var topicResponse : data.responses()) {
             for (var partitionResponse : topicResponse.partitionResponses()) {
                 var leader = partitionResponse.currentLeader();
-                if (leader.leaderId() >= 0) {
-                    leader.setLeaderId(mapping.toVirtual(route, leader.leaderId()));
-                }
+                leader.setLeaderId(mapping.toVirtual(route, leader.leaderId()));
             }
         }
         var translatedEndpoints = new NodeEndpointCollection(data.nodeEndpoints().size());
@@ -113,24 +112,18 @@ final class NodeIdResponseTranslator {
                                                  String route) {
         if (apiVersion >= 4) {
             for (var coordinator : data.coordinators()) {
-                if (coordinator.nodeId() >= 0) {
-                    coordinator.setNodeId(mapping.toVirtual(route, coordinator.nodeId()));
-                }
+                coordinator.setNodeId(mapping.toVirtual(route, coordinator.nodeId()));
             }
         }
         else {
-            if (data.nodeId() >= 0) {
-                data.setNodeId(mapping.toVirtual(route, data.nodeId()));
-            }
+            data.setNodeId(mapping.toVirtual(route, data.nodeId()));
         }
     }
 
     private static void translateDescribeCluster(DescribeClusterResponseData data,
                                                  NodeIdMapping mapping,
                                                  String route) {
-        if (data.controllerId() >= 0) {
-            data.setControllerId(mapping.toVirtual(route, data.controllerId()));
-        }
+        data.setControllerId(mapping.toVirtual(route, data.controllerId()));
         var translatedBrokers = new DescribeClusterBrokerCollection(data.brokers().size());
         for (var broker : List.copyOf(data.brokers())) {
             var translated = broker.duplicate();

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -38,7 +38,7 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
      * These keys are always decoded (even when statically routed) so the response bodies
      * are accessible for translation.
      */
-    public static final Set<ApiKeys> NODE_ID_TRANSLATION_KEYS = Set.of(
+    public static final Set<ApiKeys> NODE_ID_TRANSLATION_APIS = Set.of(
             ApiKeys.METADATA,
             ApiKeys.FIND_COORDINATOR,
             ApiKeys.DESCRIBE_CLUSTER,
@@ -81,7 +81,7 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
             ApiKeys apiKey = ApiKeys.forId(frame.apiKeyId());
             String staticRoute = staticRoutes.get(apiKey);
             if (staticRoute != null) {
-                if (NODE_ID_TRANSLATION_KEYS.contains(apiKey)) {
+                if (NODE_ID_TRANSLATION_APIS.contains(apiKey)) {
                     pendingRoutes.put(frame.correlationId(), staticRoute);
                 }
                 ccsm.forwardToRoute(staticRoute, msg);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -5,16 +5,22 @@
  */
 package io.kroxylicious.proxy.internal.routing;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
+import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 
+import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
 
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.frame.RequestFrame;
 import io.kroxylicious.proxy.internal.ClientConnectionStateMachine;
 import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.service.HostPort;
 
 /**
  * Sits at the end of the VC-level filter chain (instead of
@@ -22,19 +28,40 @@ import io.kroxylicious.proxy.router.Router;
  * virtual cluster uses a router. Forwards statically-routed requests
  * directly to the {@link ClientConnectionStateMachine}; rejects any
  * request whose API key is not covered by the static routes.
+ * <p>
+ * Also intercepts decoded responses to apply node ID translation using
+ * the supplied {@link NodeIdMapping}, and caches upstream broker addresses
+ * from METADATA responses to enable per-broker connections.
  */
-public class RouterDispatchHandler extends ChannelInboundHandlerAdapter {
+public class RouterDispatchHandler extends ChannelDuplexHandler {
+
+    /**
+     * API keys whose responses carry node IDs that must be translated to virtual node IDs.
+     * These keys are always decoded (even when statically routed) so the response bodies
+     * are accessible for translation.
+     */
+    public static final Set<ApiKeys> NODE_ID_TRANSLATION_KEYS = Set.of(
+            ApiKeys.METADATA,
+            ApiKeys.FIND_COORDINATOR,
+            ApiKeys.DESCRIBE_CLUSTER,
+            ApiKeys.PRODUCE);
 
     private final Router router;
     private final Map<ApiKeys, String> staticRoutes;
     private final ClientConnectionStateMachine ccsm;
+    private final NodeIdMapping nodeIdMapping;
+
+    /** Tracks correlation IDs of in-flight requests that need response translation. */
+    private final Map<Integer, String> pendingRoutes = new HashMap<>();
 
     public RouterDispatchHandler(Router router,
                                  Map<ApiKeys, String> staticRoutes,
-                                 ClientConnectionStateMachine ccsm) {
+                                 ClientConnectionStateMachine ccsm,
+                                 NodeIdMapping nodeIdMapping) {
         this.router = router;
         this.staticRoutes = staticRoutes;
         this.ccsm = ccsm;
+        this.nodeIdMapping = nodeIdMapping;
     }
 
     @Override
@@ -48,6 +75,9 @@ public class RouterDispatchHandler extends ChannelInboundHandlerAdapter {
             ApiKeys apiKey = ApiKeys.forId(frame.apiKeyId());
             String staticRoute = staticRoutes.get(apiKey);
             if (staticRoute != null) {
+                if (NODE_ID_TRANSLATION_KEYS.contains(apiKey)) {
+                    pendingRoutes.put(frame.correlationId(), staticRoute);
+                }
                 ccsm.forwardToRoute(staticRoute, msg);
                 return;
             }
@@ -56,5 +86,27 @@ public class RouterDispatchHandler extends ChannelInboundHandlerAdapter {
         }
         throw new IllegalStateException(
                 "Unexpected non-frame message in routing pipeline: " + msg.getClass().getName());
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (msg instanceof DecodedResponseFrame<?> frame) {
+            String routeName = pendingRoutes.remove(frame.correlationId());
+            if (routeName != null) {
+                if (frame.body() instanceof MetadataResponseData md) {
+                    ccsm.registerBrokerAddresses(routeName, extractBrokerAddresses(md));
+                }
+                NodeIdResponseTranslator.translate(frame.body(), frame.apiVersion(), nodeIdMapping, routeName);
+            }
+        }
+        ctx.write(msg, promise);
+    }
+
+    private static Map<Integer, HostPort> extractBrokerAddresses(MetadataResponseData md) {
+        var addresses = new HashMap<Integer, HostPort>(md.brokers().size());
+        for (var broker : md.brokers()) {
+            addresses.put(broker.nodeId(), new HostPort(broker.host(), broker.port()));
+        }
+        return addresses;
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -49,7 +49,12 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
     private final ClientConnectionStateMachine ccsm;
     private final NodeIdMapping nodeIdMapping;
 
-    /** Tracks correlation IDs of in-flight requests that need response translation. */
+    /**
+     * Tracks correlation IDs of in-flight requests that need response translation.
+     * Entries are removed when the response arrives in {@link #write}. Any entries
+     * remaining at channel close are discarded with the handler — no explicit cleanup
+     * is required.
+     */
     private final Map<Integer, String> pendingRoutes = new HashMap<>();
 
     public RouterDispatchHandler(Router router,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -42,7 +42,10 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
             ApiKeys.METADATA,
             ApiKeys.FIND_COORDINATOR,
             ApiKeys.DESCRIBE_CLUSTER,
-            ApiKeys.PRODUCE);
+            ApiKeys.PRODUCE,
+            ApiKeys.FETCH,
+            ApiKeys.SHARE_FETCH,
+            ApiKeys.SHARE_ACKNOWLEDGE);
 
     private final Router router;
     private final Map<ApiKeys, String> staticRoutes;

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -9,7 +9,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 
 import io.netty.channel.ChannelDuplexHandler;
@@ -20,7 +19,6 @@ import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.frame.RequestFrame;
 import io.kroxylicious.proxy.internal.ClientConnectionStateMachine;
 import io.kroxylicious.proxy.router.Router;
-import io.kroxylicious.proxy.service.HostPort;
 
 /**
  * Sits at the end of the VC-level filter chain (instead of
@@ -93,20 +91,9 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
         if (msg instanceof DecodedResponseFrame<?> frame) {
             String routeName = pendingRoutes.remove(frame.correlationId());
             if (routeName != null) {
-                if (frame.body() instanceof MetadataResponseData md) {
-                    ccsm.registerBrokerAddresses(routeName, extractBrokerAddresses(md));
-                }
                 NodeIdResponseTranslator.translate(frame.body(), frame.apiVersion(), nodeIdMapping, routeName);
             }
         }
         ctx.write(msg, promise);
-    }
-
-    private static Map<Integer, HostPort> extractBrokerAddresses(MetadataResponseData md) {
-        var addresses = new HashMap<Integer, HostPort>(md.brokers().size());
-        for (var broker : md.brokers()) {
-            addresses.put(broker.nodeId(), new HostPort(broker.host(), broker.port()));
-        }
-        return addresses;
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -109,6 +110,9 @@ public class VirtualClusterModel implements AutoCloseable {
     private final TlsCredentialSupplierManager tlsCredentialSupplierManager;
     private final @Nullable String routerName;
     private final @Nullable Map<String, RouteDescriptor> routeDescriptors;
+
+    /** Shared broker address registry: updated by any connection that receives a METADATA response. */
+    private final ConcurrentHashMap<String, Map<Integer, HostPort>> routeBrokerAddresses = new ConcurrentHashMap<>();
 
     /**
      * The filter chain factory for <em>this</em> virtual cluster. Owned by the VCM — its
@@ -229,6 +233,23 @@ public class VirtualClusterModel implements AutoCloseable {
     @Nullable
     public Map<String, RouteDescriptor> routeDescriptors() {
         return routeDescriptors;
+    }
+
+    /**
+     * Updates the shared upstream broker address registry for the named route.
+     * Called by any CCSM that receives a METADATA response, so that subsequently-created
+     * per-broker CCSMs can immediately use the correct upstream address.
+     */
+    public void updateBrokerAddresses(String routeName, Map<Integer, HostPort> addresses) {
+        routeBrokerAddresses.put(routeName, Map.copyOf(addresses));
+    }
+
+    /**
+     * Returns the most recently observed upstream broker addresses for the named route,
+     * or an empty map if no METADATA response has been received yet.
+     */
+    public Map<Integer, HostPort> getBrokerAddresses(String routeName) {
+        return routeBrokerAddresses.getOrDefault(routeName, Map.of());
     }
 
     public void logVirtualClusterSummary() {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -110,9 +109,6 @@ public class VirtualClusterModel implements AutoCloseable {
     private final TlsCredentialSupplierManager tlsCredentialSupplierManager;
     private final @Nullable String routerName;
     private final @Nullable Map<String, RouteDescriptor> routeDescriptors;
-
-    /** Shared broker address registry: updated by any connection that receives a METADATA response. */
-    private final ConcurrentHashMap<String, Map<Integer, HostPort>> routeBrokerAddresses = new ConcurrentHashMap<>();
 
     /**
      * The filter chain factory for <em>this</em> virtual cluster. Owned by the VCM — its
@@ -233,23 +229,6 @@ public class VirtualClusterModel implements AutoCloseable {
     @Nullable
     public Map<String, RouteDescriptor> routeDescriptors() {
         return routeDescriptors;
-    }
-
-    /**
-     * Updates the shared upstream broker address registry for the named route.
-     * Called by any CCSM that receives a METADATA response, so that subsequently-created
-     * per-broker CCSMs can immediately use the correct upstream address.
-     */
-    public void updateBrokerAddresses(String routeName, Map<Integer, HostPort> addresses) {
-        routeBrokerAddresses.put(routeName, Map.copyOf(addresses));
-    }
-
-    /**
-     * Returns the most recently observed upstream broker addresses for the named route,
-     * or an empty map if no METADATA response has been received yet.
-     */
-    public Map<Integer, HostPort> getBrokerAddresses(String routeName) {
-        return routeBrokerAddresses.getOrDefault(routeName, Map.of());
     }
 
     public void logVirtualClusterSummary() {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -47,6 +47,9 @@ import io.kroxylicious.proxy.config.tls.TrustOptions;
 import io.kroxylicious.proxy.config.tls.TrustProvider;
 import io.kroxylicious.proxy.internal.filter.impl.TopicNameCacheFilter;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
+import io.kroxylicious.proxy.internal.routing.BijectiveNodeIdMapping;
+import io.kroxylicious.proxy.internal.routing.IdentityNodeIdMapping;
+import io.kroxylicious.proxy.internal.routing.NodeIdMapping;
 import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
 import io.kroxylicious.proxy.internal.subject.DefaultTransportSubjectBuilderService;
 import io.kroxylicious.proxy.internal.tls.NettyKeyProvider;
@@ -109,6 +112,7 @@ public class VirtualClusterModel implements AutoCloseable {
     private final TlsCredentialSupplierManager tlsCredentialSupplierManager;
     private final @Nullable String routerName;
     private final @Nullable Map<String, RouteDescriptor> routeDescriptors;
+    private final @Nullable NodeIdMapping nodeIdMapping;
 
     /**
      * The filter chain factory for <em>this</em> virtual cluster. Owned by the VCM — its
@@ -174,6 +178,7 @@ public class VirtualClusterModel implements AutoCloseable {
         this.drainTimeout = Objects.requireNonNull(drainTimeout);
         this.routerName = routerName;
         this.routeDescriptors = routeDescriptors;
+        this.nodeIdMapping = buildNodeIdMapping(routeDescriptors);
 
         if (targetCluster == null && routerName == null) {
             throw new IllegalConfigurationException(
@@ -229,6 +234,28 @@ public class VirtualClusterModel implements AutoCloseable {
     @Nullable
     public Map<String, RouteDescriptor> routeDescriptors() {
         return routeDescriptors;
+    }
+
+    /**
+     * @return the node ID mapping for this VC, or {@code null} if this VC does not use a router
+     */
+    @Nullable
+    public NodeIdMapping nodeIdMapping() {
+        return nodeIdMapping;
+    }
+
+    private static @Nullable NodeIdMapping buildNodeIdMapping(@Nullable Map<String, RouteDescriptor> routeDescriptors) {
+        if (routeDescriptors == null || routeDescriptors.isEmpty()) {
+            return null;
+        }
+        if (routeDescriptors.size() == 1) {
+            return new IdentityNodeIdMapping(routeDescriptors.keySet().iterator().next());
+        }
+        var routeIds = new java.util.HashMap<String, Integer>(routeDescriptors.size());
+        for (var entry : routeDescriptors.entrySet()) {
+            routeIds.put(entry.getKey(), entry.getValue().id());
+        }
+        return new BijectiveNodeIdMapping(routeIds, routeIds.size());
     }
 
     public void logVirtualClusterSummary() {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
@@ -981,35 +981,24 @@ class ClientConnectionStateMachineTest {
     }
 
     @Test
-    void toForwardingWithRoutesShouldNotPopulateRouteTargetIfScsmCreationFails() {
-        // Given: a CCSM whose SCSM factory throws on creation
+    void forwardToRouteShouldTransitionToClosedIfScsmCreationFails() {
+        // Given: a CCSM whose SCSM factory throws on creation, in Forwarding state with a known route
         var failingCcsm = new ClientConnectionStateMachine(endpointBinding, new DefaultSubjectBuilder(List.of()),
                 new KafkaSession(KafkaSessionState.ESTABLISHING),
                 (remote, ccsm, vc, cn, ni, cc, ec, bpm, token) -> {
                     throw new RuntimeException("scsm creation failed");
                 });
-        failingCcsm.forceState(new ClientConnectionState.ClientActive(), frontendHandler,
-                Map.of(), TEST_KAFKA_SESSION, true);
-
         var target = new HostPort("broker", 9092);
-        var targetCluster = mock(TargetCluster.class, withSettings().lenient());
-        when(targetCluster.bootstrapServer()).thenReturn(target);
-        var routeDescriptor = mock(RouteDescriptor.class, withSettings().lenient());
-        when(routeDescriptor.targetsCluster()).thenReturn(true);
-        when(routeDescriptor.targetCluster()).thenReturn(targetCluster);
+        failingCcsm.forceState(new ClientConnectionState.Forwarding(), frontendHandler,
+                Map.of(), TEST_KAFKA_SESSION, true, Map.of("my-route", target));
         var routerVc = mock(VirtualClusterModel.class, withSettings().lenient());
         when(routerVc.usesRouter()).thenReturn(true);
-        when(routerVc.routeDescriptors()).thenReturn(Map.of("my-route", routeDescriptor));
         when(endpointGateway.virtualCluster()).thenReturn(routerVc);
 
-        // When: first request triggers toForwardingWithRoutes, which fails during SCSM creation
-        assertThatThrownBy(() -> failingCcsm.onClientRequest(metadataRequest()))
+        // When: forwardToRoute lazily tries to create an SCSM and fails
+        assertThatThrownBy(() -> failingCcsm.forwardToRoute("my-route", new Object()))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("scsm creation failed");
-
-        // Then: routeTargets was not populated, so forwardToRoute transitions to Closed
-        failingCcsm.forwardToRoute("my-route", new Object());
-        assertThat(failingCcsm.state()).isInstanceOf(ClientConnectionState.Closed.class);
     }
 
     @Test
@@ -1112,10 +1101,12 @@ class ClientConnectionStateMachineTest {
     }
 
     @Test
-    void forwardToRouteWithNoScsmForTargetShouldTransitionToClosed() {
-        // routeTargets maps a route to a target, but serverConnections has no SCSM for that target.
+    void forwardToRouteWithNoScsmForTargetShouldCreateConnectionLazily() {
+        // routeTargets maps a route to a target, but serverConnections has no SCSM yet.
+        // forwardToRoute should create the SCSM lazily and forward the request.
         stubAsRouterVirtualCluster();
         var orphanTarget = new HostPort("orphan", 9092);
+        var msg = new Object();
         clientConnectionStateMachine.forceState(
                 new ClientConnectionState.Forwarding(),
                 frontendHandler,
@@ -1125,10 +1116,11 @@ class ClientConnectionStateMachineTest {
                 Map.of("route-a", orphanTarget));
 
         // When
-        clientConnectionStateMachine.forwardToRoute("route-a", new Object());
+        clientConnectionStateMachine.forwardToRoute("route-a", msg);
 
-        // Then
-        assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Closed.class);
+        // Then: SCSM was created and the request forwarded; state remains Forwarding
+        assertThat(clientConnectionStateMachine.state()).isInstanceOf(ClientConnectionState.Forwarding.class);
+        verify(serverConnectionStateMachine).sendRequest(msg);
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
@@ -996,7 +996,8 @@ class ClientConnectionStateMachineTest {
         when(endpointGateway.virtualCluster()).thenReturn(routerVc);
 
         // When: forwardToRoute lazily tries to create an SCSM and fails
-        assertThatThrownBy(() -> failingCcsm.forwardToRoute("my-route", new Object()))
+        var msg = new Object();
+        assertThatThrownBy(() -> failingCcsm.forwardToRoute("my-route", msg))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("scsm creation failed");
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/BijectiveNodeIdMappingTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/BijectiveNodeIdMappingTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.internal.routing.NodeIdMapping.RouteAndNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BijectiveNodeIdMappingTest {
+
+    private static final String ROUTE_A = "route-a";
+    private static final String ROUTE_B = "route-b";
+    private static final String ROUTE_C = "route-c";
+
+    @Test
+    void shouldRoundTripTwoRoutes() {
+        var mapping = new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0, ROUTE_B, 1), 2);
+        for (int t = 0; t <= 100; t++) {
+            for (String route : List.of(ROUTE_A, ROUTE_B)) {
+                int v = mapping.toVirtual(route, t);
+                RouteAndNode result = mapping.fromVirtual(v);
+                assertThat(result).isEqualTo(new RouteAndNode(route, t));
+            }
+        }
+    }
+
+    @Test
+    void shouldRoundTripThreeRoutes() {
+        var mapping = new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0, ROUTE_B, 1, ROUTE_C, 2), 3);
+        for (int t = 0; t <= 50; t++) {
+            for (String route : List.of(ROUTE_A, ROUTE_B, ROUTE_C)) {
+                int v = mapping.toVirtual(route, t);
+                RouteAndNode result = mapping.fromVirtual(v);
+                assertThat(result).isEqualTo(new RouteAndNode(route, t));
+            }
+        }
+    }
+
+    @Test
+    void shouldAssignInterleavedVirtualIds() {
+        var mapping = new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0, ROUTE_B, 1), 2);
+        assertThat(mapping.toVirtual(ROUTE_A, 0)).isEqualTo(0);
+        assertThat(mapping.toVirtual(ROUTE_B, 0)).isEqualTo(1);
+        assertThat(mapping.toVirtual(ROUTE_A, 1)).isEqualTo(2);
+        assertThat(mapping.toVirtual(ROUTE_B, 1)).isEqualTo(3);
+        assertThat(mapping.toVirtual(ROUTE_A, 2)).isEqualTo(4);
+        assertThat(mapping.toVirtual(ROUTE_B, 2)).isEqualTo(5);
+    }
+
+    @Test
+    void shouldProduceUniqueVirtualIds() {
+        var mapping = new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0, ROUTE_B, 1, ROUTE_C, 2), 3);
+        var virtualIds = new java.util.HashSet<Integer>();
+        for (int t = 0; t < 10; t++) {
+            for (String route : List.of(ROUTE_A, ROUTE_B, ROUTE_C)) {
+                assertThat(virtualIds.add(mapping.toVirtual(route, t))).isTrue();
+            }
+        }
+    }
+
+    @Test
+    void shouldRejectUnknownRoute() {
+        var mapping = new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0, ROUTE_B, 1), 2);
+        assertThatThrownBy(() -> mapping.toVirtual("unknown", 0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldRejectTotalRoutesLessThanTwo() {
+        assertThatThrownBy(() -> new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0), 1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldRejectIdOutOfRange() {
+        assertThatThrownBy(() -> new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0, ROUTE_B, 5), 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("outside the valid range");
+    }
+
+    @Test
+    void shouldHandleTargetNodeIdZero() {
+        var mapping = new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0, ROUTE_B, 1), 2);
+        assertThat(mapping.toVirtual(ROUTE_A, 0)).isEqualTo(0);
+        assertThat(mapping.fromVirtual(0)).isEqualTo(new RouteAndNode(ROUTE_A, 0));
+    }
+
+    @Test
+    void shouldThrowOnOverflow() {
+        var mapping = new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0, ROUTE_B, 1), 2);
+        assertThatThrownBy(() -> mapping.toVirtual(ROUTE_A, Integer.MAX_VALUE))
+                .isInstanceOf(ArithmeticException.class);
+    }
+
+    @Test
+    void shouldSupportNonContiguousIds() {
+        var mapping = new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0, ROUTE_B, 2), 3);
+        assertThat(mapping.toVirtual(ROUTE_A, 0)).isEqualTo(0);
+        assertThat(mapping.toVirtual(ROUTE_B, 0)).isEqualTo(2);
+        assertThat(mapping.toVirtual(ROUTE_A, 1)).isEqualTo(3);
+        assertThat(mapping.toVirtual(ROUTE_B, 1)).isEqualTo(5);
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/BijectiveNodeIdMappingTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/BijectiveNodeIdMappingTest.java
@@ -48,7 +48,7 @@ class BijectiveNodeIdMappingTest {
     @Test
     void shouldAssignInterleavedVirtualIds() {
         var mapping = new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0, ROUTE_B, 1), 2);
-        assertThat(mapping.toVirtual(ROUTE_A, 0)).isEqualTo(0);
+        assertThat(mapping.toVirtual(ROUTE_A, 0)).isZero();
         assertThat(mapping.toVirtual(ROUTE_B, 0)).isEqualTo(1);
         assertThat(mapping.toVirtual(ROUTE_A, 1)).isEqualTo(2);
         assertThat(mapping.toVirtual(ROUTE_B, 1)).isEqualTo(3);
@@ -76,13 +76,15 @@ class BijectiveNodeIdMappingTest {
 
     @Test
     void shouldRejectTotalRoutesLessThanTwo() {
-        assertThatThrownBy(() -> new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0), 1))
+        var routes = Map.of(ROUTE_A, 0);
+        assertThatThrownBy(() -> new BijectiveNodeIdMapping(routes, 1))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void shouldRejectIdOutOfRange() {
-        assertThatThrownBy(() -> new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0, ROUTE_B, 5), 2))
+        var routes = Map.of(ROUTE_A, 0, ROUTE_B, 5);
+        assertThatThrownBy(() -> new BijectiveNodeIdMapping(routes, 2))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("outside the valid range");
     }
@@ -90,7 +92,7 @@ class BijectiveNodeIdMappingTest {
     @Test
     void shouldHandleTargetNodeIdZero() {
         var mapping = new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0, ROUTE_B, 1), 2);
-        assertThat(mapping.toVirtual(ROUTE_A, 0)).isEqualTo(0);
+        assertThat(mapping.toVirtual(ROUTE_A, 0)).isZero();
         assertThat(mapping.fromVirtual(0)).isEqualTo(new RouteAndNode(ROUTE_A, 0));
     }
 
@@ -104,7 +106,7 @@ class BijectiveNodeIdMappingTest {
     @Test
     void shouldSupportNonContiguousIds() {
         var mapping = new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0, ROUTE_B, 2), 3);
-        assertThat(mapping.toVirtual(ROUTE_A, 0)).isEqualTo(0);
+        assertThat(mapping.toVirtual(ROUTE_A, 0)).isZero();
         assertThat(mapping.toVirtual(ROUTE_B, 0)).isEqualTo(2);
         assertThat(mapping.toVirtual(ROUTE_A, 1)).isEqualTo(3);
         assertThat(mapping.toVirtual(ROUTE_B, 1)).isEqualTo(5);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/BijectiveNodeIdMappingTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/BijectiveNodeIdMappingTest.java
@@ -104,6 +104,23 @@ class BijectiveNodeIdMappingTest {
     }
 
     @Test
+    void shouldPassThroughNegativeTargetNodeIds() {
+        var mapping = new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0, ROUTE_B, 1), 2);
+        // Negative node IDs are Kafka protocol sentinels and must not be mapped.
+        for (String route : List.of(ROUTE_A, ROUTE_B)) {
+            assertThat(mapping.toVirtual(route, -1)).isEqualTo(-1);
+            assertThat(mapping.toVirtual(route, -2)).isEqualTo(-2);
+        }
+    }
+
+    @Test
+    void shouldPassThroughNegativeVirtualNodeIdsInFromVirtual() {
+        var mapping = new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0, ROUTE_B, 1), 2);
+        assertThat(mapping.fromVirtual(ROUTE_A, -1)).isEqualTo(-1);
+        assertThat(mapping.fromVirtual(ROUTE_B, -2)).isEqualTo(-2);
+    }
+
+    @Test
     void shouldSupportNonContiguousIds() {
         var mapping = new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0, ROUTE_B, 2), 3);
         assertThat(mapping.toVirtual(ROUTE_A, 0)).isZero();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/IdentityNodeIdMappingTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/IdentityNodeIdMappingTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.internal.routing.NodeIdMapping.RouteAndNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IdentityNodeIdMappingTest {
+
+    private static final String ROUTE = "my-route";
+
+    @Test
+    void shouldReturnTargetIdUnchanged() {
+        var mapping = new IdentityNodeIdMapping(ROUTE);
+        for (int t = 0; t <= 100; t++) {
+            assertThat(mapping.toVirtual(ROUTE, t)).isEqualTo(t);
+        }
+    }
+
+    @Test
+    void shouldReturnRouteNameForAnyVirtualId() {
+        var mapping = new IdentityNodeIdMapping(ROUTE);
+        for (int v = 0; v <= 100; v++) {
+            assertThat(mapping.fromVirtual(v)).isEqualTo(new RouteAndNode(ROUTE, v));
+        }
+    }
+
+    @Test
+    void shouldIgnoreRouteParameterInToVirtual() {
+        var mapping = new IdentityNodeIdMapping(ROUTE);
+        assertThat(mapping.toVirtual("any-route", 42)).isEqualTo(42);
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslatorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslatorTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.DescribeClusterResponseData;
 import org.apache.kafka.common.message.DescribeClusterResponseData.DescribeClusterBroker;
+import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.FindCoordinatorResponseData;
 import org.apache.kafka.common.message.FindCoordinatorResponseData.Coordinator;
 import org.apache.kafka.common.message.MetadataResponseData;
@@ -23,6 +24,8 @@ import org.apache.kafka.common.message.ProduceResponseData.LeaderIdAndEpoch;
 import org.apache.kafka.common.message.ProduceResponseData.NodeEndpoint;
 import org.apache.kafka.common.message.ProduceResponseData.PartitionProduceResponse;
 import org.apache.kafka.common.message.ProduceResponseData.TopicProduceResponse;
+import org.apache.kafka.common.message.ShareAcknowledgeResponseData;
+import org.apache.kafka.common.message.ShareFetchResponseData;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -216,5 +219,50 @@ class NodeIdResponseTranslatorTest {
         NodeIdResponseTranslator.translate(data, (short) 7, mapping, ROUTE_A);
 
         assertThat(data.throttleTimeMs()).isEqualTo(42);
+    }
+
+    @Test
+    void shouldTranslateFetchResponseV16NodeEndpoints() {
+        var data = new FetchResponseData();
+        data.nodeEndpoints().add(new FetchResponseData.NodeEndpoint().setNodeId(0).setHost("h0").setPort(9092));
+        data.nodeEndpoints().add(new FetchResponseData.NodeEndpoint().setNodeId(1).setHost("h1").setPort(9093));
+
+        NodeIdResponseTranslator.translate(data, (short) 16, mapping, ROUTE_A);
+
+        assertThat(data.nodeEndpoints().find(mapping.toVirtual(ROUTE_A, 0))).isNotNull();
+        assertThat(data.nodeEndpoints().find(mapping.toVirtual(ROUTE_A, 1))).isNotNull();
+    }
+
+    @Test
+    void shouldNotTranslateFetchResponseBeforeV16() {
+        var data = new FetchResponseData();
+
+        NodeIdResponseTranslator.translate(data, (short) 15, mapping, ROUTE_A);
+
+        assertThat(data.nodeEndpoints()).isEmpty();
+    }
+
+    @Test
+    void shouldTranslateShareFetchNodeEndpoints() {
+        var data = new ShareFetchResponseData();
+        data.nodeEndpoints().add(new ShareFetchResponseData.NodeEndpoint().setNodeId(0).setHost("h0").setPort(9092));
+        data.nodeEndpoints().add(new ShareFetchResponseData.NodeEndpoint().setNodeId(1).setHost("h1").setPort(9093));
+
+        NodeIdResponseTranslator.translate(data, (short) 0, mapping, ROUTE_B);
+
+        assertThat(data.nodeEndpoints().find(mapping.toVirtual(ROUTE_B, 0))).isNotNull();
+        assertThat(data.nodeEndpoints().find(mapping.toVirtual(ROUTE_B, 1))).isNotNull();
+    }
+
+    @Test
+    void shouldTranslateShareAcknowledgeNodeEndpoints() {
+        var data = new ShareAcknowledgeResponseData();
+        data.nodeEndpoints().add(new ShareAcknowledgeResponseData.NodeEndpoint().setNodeId(0).setHost("h0").setPort(9092));
+        data.nodeEndpoints().add(new ShareAcknowledgeResponseData.NodeEndpoint().setNodeId(1).setHost("h1").setPort(9093));
+
+        NodeIdResponseTranslator.translate(data, (short) 0, mapping, ROUTE_B);
+
+        assertThat(data.nodeEndpoints().find(mapping.toVirtual(ROUTE_B, 0))).isNotNull();
+        assertThat(data.nodeEndpoints().find(mapping.toVirtual(ROUTE_B, 1))).isNotNull();
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslatorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslatorTest.java
@@ -98,6 +98,33 @@ class NodeIdResponseTranslatorTest {
     }
 
     @Test
+    void shouldNotTranslateMetadataControllerIdWhenMinusOne() {
+        var data = new MetadataResponseData().setControllerId(-1);
+
+        NodeIdResponseTranslator.translate(data, (short) 12, mapping, ROUTE_A);
+
+        assertThat(data.controllerId()).isEqualTo(-1);
+    }
+
+    @Test
+    void shouldNotTranslateMetadataPartitionLeaderIdWhenMinusOne() {
+        var data = new MetadataResponseData().setControllerId(0);
+        var partition = new MetadataResponsePartition()
+                .setPartitionIndex(0)
+                .setLeaderId(-1)
+                .setReplicaNodes(new ArrayList<>(List.of(0)))
+                .setIsrNodes(new ArrayList<>())
+                .setOfflineReplicas(new ArrayList<>());
+        var topic = new MetadataResponseTopic().setName("test");
+        topic.partitions().add(partition);
+        data.topics().add(topic);
+
+        NodeIdResponseTranslator.translate(data, (short) 12, mapping, ROUTE_A);
+
+        assertThat(partition.leaderId()).isEqualTo(-1);
+    }
+
+    @Test
     void shouldNotTranslateProduceResponseBelowV10() {
         var data = new ProduceResponseData();
         var partitionResp = new PartitionProduceResponse().setIndex(0);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslatorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslatorTest.java
@@ -106,6 +106,8 @@ class NodeIdResponseTranslatorTest {
         data.responses().add(topicResp);
 
         NodeIdResponseTranslator.translate(data, (short) 9, mapping, ROUTE_A);
+
+        assertThat(data.nodeEndpoints()).isEmpty();
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslatorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslatorTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.message.CreateTopicsResponseData;
+import org.apache.kafka.common.message.DescribeClusterResponseData;
+import org.apache.kafka.common.message.DescribeClusterResponseData.DescribeClusterBroker;
+import org.apache.kafka.common.message.FindCoordinatorResponseData;
+import org.apache.kafka.common.message.FindCoordinatorResponseData.Coordinator;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseBroker;
+import org.apache.kafka.common.message.MetadataResponseData.MetadataResponsePartition;
+import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic;
+import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.message.ProduceResponseData.LeaderIdAndEpoch;
+import org.apache.kafka.common.message.ProduceResponseData.NodeEndpoint;
+import org.apache.kafka.common.message.ProduceResponseData.PartitionProduceResponse;
+import org.apache.kafka.common.message.ProduceResponseData.TopicProduceResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NodeIdResponseTranslatorTest {
+
+    private static final String ROUTE_A = "route-a";
+    private static final String ROUTE_B = "route-b";
+
+    private final NodeIdMapping mapping = new BijectiveNodeIdMapping(Map.of(ROUTE_A, 0, ROUTE_B, 1), 2);
+
+    @Test
+    void shouldTranslateMetadataBrokers() {
+        var data = new MetadataResponseData();
+        data.brokers().add(new MetadataResponseBroker().setNodeId(0).setHost("h0").setPort(9092));
+        data.brokers().add(new MetadataResponseBroker().setNodeId(1).setHost("h1").setPort(9093));
+        data.setControllerId(0);
+
+        NodeIdResponseTranslator.translate(data, (short) 12, mapping, ROUTE_A);
+
+        assertThat(data.brokers().find(mapping.toVirtual(ROUTE_A, 0))).isNotNull();
+        assertThat(data.brokers().find(mapping.toVirtual(ROUTE_A, 1))).isNotNull();
+        assertThat(data.controllerId()).isEqualTo(mapping.toVirtual(ROUTE_A, 0));
+    }
+
+    @Test
+    void shouldTranslateMetadataPartitionNodeIds() {
+        var data = new MetadataResponseData();
+        data.setControllerId(0);
+
+        var partition = new MetadataResponsePartition()
+                .setPartitionIndex(0)
+                .setLeaderId(1)
+                .setReplicaNodes(new ArrayList<>(List.of(0, 1, 2)))
+                .setIsrNodes(new ArrayList<>(List.of(0, 1)))
+                .setOfflineReplicas(new ArrayList<>(List.of(2)));
+        var topic = new MetadataResponseTopic().setName("test");
+        topic.partitions().add(partition);
+        data.topics().add(topic);
+
+        NodeIdResponseTranslator.translate(data, (short) 12, mapping, ROUTE_B);
+
+        assertThat(partition.leaderId()).isEqualTo(mapping.toVirtual(ROUTE_B, 1));
+        assertThat(partition.replicaNodes()).containsExactly(
+                mapping.toVirtual(ROUTE_B, 0),
+                mapping.toVirtual(ROUTE_B, 1),
+                mapping.toVirtual(ROUTE_B, 2));
+        assertThat(partition.isrNodes()).containsExactly(
+                mapping.toVirtual(ROUTE_B, 0),
+                mapping.toVirtual(ROUTE_B, 1));
+        assertThat(partition.offlineReplicas()).containsExactly(
+                mapping.toVirtual(ROUTE_B, 2));
+    }
+
+    @Test
+    void shouldTranslateProduceResponseV10NodeEndpoints() {
+        var data = new ProduceResponseData();
+        data.nodeEndpoints().add(new NodeEndpoint().setNodeId(0).setHost("h0").setPort(9092));
+        data.nodeEndpoints().add(new NodeEndpoint().setNodeId(1).setHost("h1").setPort(9093));
+
+        var partitionResp = new PartitionProduceResponse()
+                .setIndex(0)
+                .setCurrentLeader(new LeaderIdAndEpoch().setLeaderId(1).setLeaderEpoch(5));
+        var topicResp = new TopicProduceResponse().setName("test");
+        topicResp.partitionResponses().add(partitionResp);
+        data.responses().add(topicResp);
+
+        NodeIdResponseTranslator.translate(data, (short) 10, mapping, ROUTE_A);
+
+        assertThat(data.nodeEndpoints().find(mapping.toVirtual(ROUTE_A, 0))).isNotNull();
+        assertThat(data.nodeEndpoints().find(mapping.toVirtual(ROUTE_A, 1))).isNotNull();
+        assertThat(partitionResp.currentLeader().leaderId()).isEqualTo(mapping.toVirtual(ROUTE_A, 1));
+    }
+
+    @Test
+    void shouldNotTranslateProduceResponseBelowV10() {
+        var data = new ProduceResponseData();
+        var partitionResp = new PartitionProduceResponse().setIndex(0);
+        var topicResp = new TopicProduceResponse().setName("test");
+        topicResp.partitionResponses().add(partitionResp);
+        data.responses().add(topicResp);
+
+        NodeIdResponseTranslator.translate(data, (short) 9, mapping, ROUTE_A);
+    }
+
+    @Test
+    void shouldNotTranslateProduceLeaderIdWhenMinusOne() {
+        var data = new ProduceResponseData();
+        var partitionResp = new PartitionProduceResponse()
+                .setIndex(0)
+                .setCurrentLeader(new LeaderIdAndEpoch().setLeaderId(-1).setLeaderEpoch(-1));
+        var topicResp = new TopicProduceResponse().setName("test");
+        topicResp.partitionResponses().add(partitionResp);
+        data.responses().add(topicResp);
+
+        NodeIdResponseTranslator.translate(data, (short) 10, mapping, ROUTE_A);
+
+        assertThat(partitionResp.currentLeader().leaderId()).isEqualTo(-1);
+    }
+
+    @Test
+    void shouldTranslateFindCoordinatorV3() {
+        var data = new FindCoordinatorResponseData()
+                .setNodeId(2)
+                .setHost("h2")
+                .setPort(9094);
+
+        NodeIdResponseTranslator.translate(data, (short) 3, mapping, ROUTE_B);
+
+        assertThat(data.nodeId()).isEqualTo(mapping.toVirtual(ROUTE_B, 2));
+    }
+
+    @Test
+    void shouldTranslateFindCoordinatorV4Coordinators() {
+        var data = new FindCoordinatorResponseData();
+        data.coordinators().add(new Coordinator().setNodeId(0).setHost("h0").setPort(9092));
+        data.coordinators().add(new Coordinator().setNodeId(1).setHost("h1").setPort(9093));
+
+        NodeIdResponseTranslator.translate(data, (short) 4, mapping, ROUTE_A);
+
+        assertThat(data.coordinators().get(0).nodeId()).isEqualTo(mapping.toVirtual(ROUTE_A, 0));
+        assertThat(data.coordinators().get(1).nodeId()).isEqualTo(mapping.toVirtual(ROUTE_A, 1));
+    }
+
+    @Test
+    void shouldNotTranslateFindCoordinatorWhenNodeIdNegative() {
+        var data = new FindCoordinatorResponseData().setNodeId(-1);
+
+        NodeIdResponseTranslator.translate(data, (short) 3, mapping, ROUTE_A);
+
+        assertThat(data.nodeId()).isEqualTo(-1);
+    }
+
+    @Test
+    void shouldTranslateDescribeClusterBrokers() {
+        var data = new DescribeClusterResponseData();
+        data.setControllerId(1);
+        data.brokers().add(new DescribeClusterBroker().setBrokerId(0).setHost("h0").setPort(9092));
+        data.brokers().add(new DescribeClusterBroker().setBrokerId(1).setHost("h1").setPort(9093));
+
+        NodeIdResponseTranslator.translate(data, (short) 0, mapping, ROUTE_B);
+
+        assertThat(data.controllerId()).isEqualTo(mapping.toVirtual(ROUTE_B, 1));
+        assertThat(data.brokers().find(mapping.toVirtual(ROUTE_B, 0))).isNotNull();
+        assertThat(data.brokers().find(mapping.toVirtual(ROUTE_B, 1))).isNotNull();
+    }
+
+    @Test
+    void shouldNotTranslateDescribeClusterControllerWhenNegative() {
+        var data = new DescribeClusterResponseData().setControllerId(-1);
+
+        NodeIdResponseTranslator.translate(data, (short) 0, mapping, ROUTE_A);
+
+        assertThat(data.controllerId()).isEqualTo(-1);
+    }
+
+    @Test
+    void shouldBeNoOpForUnrelatedResponseTypes() {
+        var data = new CreateTopicsResponseData();
+        data.setThrottleTimeMs(42);
+
+        NodeIdResponseTranslator.translate(data, (short) 7, mapping, ROUTE_A);
+
+        assertThat(data.throttleTimeMs()).isEqualTo(42);
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
@@ -144,7 +144,7 @@ class RouterDispatchHandlerTest {
         // route-a has id=0, totalRoutes=2: virtual(0,0)=0, virtual(0,1)=2
         assertThat(translatedMd.brokers().find(0)).isNotNull(); // node 0 → virtual 0
         assertThat(translatedMd.brokers().find(2)).isNotNull(); // node 1 → virtual 2
-        assertThat(translatedMd.controllerId()).isEqualTo(0); // virtual 0
+        assertThat(translatedMd.controllerId()).isZero(); // virtual 0
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
@@ -8,6 +8,9 @@ package io.kroxylicious.proxy.internal.routing;
 import java.util.Map;
 
 import org.apache.kafka.common.message.FetchRequestData;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,10 +21,12 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.frame.OpaqueRequestFrame;
 import io.kroxylicious.proxy.internal.ClientConnectionStateMachine;
 import io.kroxylicious.proxy.router.Router;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 
@@ -29,7 +34,7 @@ import static org.mockito.Mockito.verify;
 class RouterDispatchHandlerTest {
 
     private static final int CORRELATION_ID = 42;
-    private static final int ROUTING_CORRELATION_ID = Integer.MIN_VALUE / 2;
+    private static final String DEFAULT_ROUTE = "default";
 
     @Mock
     private Router router;
@@ -39,9 +44,13 @@ class RouterDispatchHandlerTest {
 
     private EmbeddedChannel channel;
 
+    private RouterDispatchHandler handlerWithIdentityMapping(Map<ApiKeys, String> staticRoutes) {
+        return new RouterDispatchHandler(router, staticRoutes, ccsm, new IdentityNodeIdMapping(DEFAULT_ROUTE));
+    }
+
     @Test
     void shouldThrowForNonFrameMessage() {
-        var handler = new RouterDispatchHandler(router, Map.of(), ccsm);
+        var handler = handlerWithIdentityMapping(Map.of());
         channel = new EmbeddedChannel(handler);
 
         assertThatThrownBy(() -> channel.writeInbound("not-a-frame"))
@@ -51,12 +60,11 @@ class RouterDispatchHandlerTest {
 
     @Test
     void shouldThrowForDynamicallyRoutedDecodedFrame() {
-        var handler = new RouterDispatchHandler(router, Map.of(), ccsm);
+        var handler = handlerWithIdentityMapping(Map.of());
         channel = new EmbeddedChannel(handler);
 
-        var header = new org.apache.kafka.common.message.RequestHeaderData();
-        var body = new FetchRequestData();
-        var frame = new DecodedRequestFrame<>((short) 12, CORRELATION_ID, true, header, body);
+        var frame = new DecodedRequestFrame<>((short) 12, CORRELATION_ID, true,
+                new org.apache.kafka.common.message.RequestHeaderData(), new FetchRequestData());
 
         assertThatThrownBy(() -> channel.writeInbound(frame))
                 .isInstanceOf(IllegalStateException.class)
@@ -65,23 +73,22 @@ class RouterDispatchHandlerTest {
 
     @Test
     void shouldForwardStaticallyRoutedDecodedFrameViaForwardToRoute() {
-        var staticRoutes = Map.of(ApiKeys.FETCH, "default");
-        var handler = new RouterDispatchHandler(router, staticRoutes, ccsm);
+        var staticRoutes = Map.of(ApiKeys.FETCH, DEFAULT_ROUTE);
+        var handler = handlerWithIdentityMapping(staticRoutes);
         channel = new EmbeddedChannel(handler);
 
-        var header = new org.apache.kafka.common.message.RequestHeaderData();
-        var body = new FetchRequestData();
-        var frame = new DecodedRequestFrame<>((short) 12, CORRELATION_ID, true, header, body);
+        var frame = new DecodedRequestFrame<>((short) 12, CORRELATION_ID, true,
+                new org.apache.kafka.common.message.RequestHeaderData(), new FetchRequestData());
 
         channel.writeInbound(frame);
 
-        verify(ccsm).forwardToRoute("default", frame);
+        verify(ccsm).forwardToRoute(DEFAULT_ROUTE, frame);
     }
 
     @Test
     void shouldForwardStaticallyRoutedOpaqueFrameViaForwardToRoute() {
-        var staticRoutes = Map.of(ApiKeys.FETCH, "default");
-        var handler = new RouterDispatchHandler(router, staticRoutes, ccsm);
+        var staticRoutes = Map.of(ApiKeys.FETCH, DEFAULT_ROUTE);
+        var handler = handlerWithIdentityMapping(staticRoutes);
         channel = new EmbeddedChannel(handler);
 
         var buf = Unpooled.buffer();
@@ -90,14 +97,14 @@ class RouterDispatchHandlerTest {
 
         channel.writeInbound(opaqueFrame);
 
-        verify(ccsm).forwardToRoute("default", opaqueFrame);
+        verify(ccsm).forwardToRoute(DEFAULT_ROUTE, opaqueFrame);
         buf.release();
     }
 
     @Test
     void shouldThrowForOpaqueFrameNotInStaticRoutes() {
-        var staticRoutes = Map.of(ApiKeys.PRODUCE, "default");
-        var handler = new RouterDispatchHandler(router, staticRoutes, ccsm);
+        var staticRoutes = Map.of(ApiKeys.PRODUCE, DEFAULT_ROUTE);
+        var handler = handlerWithIdentityMapping(staticRoutes);
         channel = new EmbeddedChannel(handler);
 
         var buf = Unpooled.buffer();
@@ -108,5 +115,52 @@ class RouterDispatchHandlerTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Dynamic routing is not supported");
         buf.release();
+    }
+
+    @Test
+    void shouldTranslateNodeIdsInMetadataResponse() {
+        // Given: bijective mapping with two routes; METADATA statically routed to route-a
+        var mapping = new BijectiveNodeIdMapping(Map.of("route-a", 0, "route-b", 1), 2);
+        var handler = new RouterDispatchHandler(router, Map.of(ApiKeys.METADATA, "route-a"), ccsm, mapping);
+        channel = new EmbeddedChannel(handler);
+
+        // Record the pending METADATA request
+        var requestFrame = new DecodedRequestFrame<>((short) 12, CORRELATION_ID, true,
+                new org.apache.kafka.common.message.RequestHeaderData(), new MetadataRequestData());
+        channel.writeInbound(requestFrame);
+
+        // When: METADATA response arrives with upstream node IDs 0 and 1
+        var md = new MetadataResponseData();
+        md.setControllerId(0);
+        md.brokers().add(new MetadataResponseData.MetadataResponseBroker().setNodeId(0).setHost("h0").setPort(9092));
+        md.brokers().add(new MetadataResponseData.MetadataResponseBroker().setNodeId(1).setHost("h1").setPort(9093));
+        var responseFrame = new DecodedResponseFrame<>((short) 12, CORRELATION_ID, new ResponseHeaderData(), md);
+        channel.writeOutbound(responseFrame);
+
+        // Then: the outbound frame has translated node IDs
+        DecodedResponseFrame<?> out = channel.readOutbound();
+        assertThat(out).isNotNull();
+        var translatedMd = (MetadataResponseData) out.body();
+        // route-a has id=0, totalRoutes=2: virtual(0,0)=0, virtual(0,1)=2
+        assertThat(translatedMd.brokers().find(0)).isNotNull(); // node 0 → virtual 0
+        assertThat(translatedMd.brokers().find(2)).isNotNull(); // node 1 → virtual 2
+        assertThat(translatedMd.controllerId()).isEqualTo(0); // virtual 0
+    }
+
+    @Test
+    void shouldPassThroughUnknownCorrelationIdInResponse() {
+        // Given: a handler with no pending requests
+        var handler = handlerWithIdentityMapping(Map.of(ApiKeys.METADATA, DEFAULT_ROUTE));
+        channel = new EmbeddedChannel(handler);
+
+        // When: a response arrives for an unknown correlation ID
+        var md = new MetadataResponseData().setControllerId(5);
+        var responseFrame = new DecodedResponseFrame<>((short) 12, 9999, new ResponseHeaderData(), md);
+        channel.writeOutbound(responseFrame);
+
+        // Then: it passes through untranslated
+        DecodedResponseFrame<?> out = channel.readOutbound();
+        assertThat(out).isNotNull();
+        assertThat(((MetadataResponseData) out.body()).controllerId()).isEqualTo(5);
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Extends the static routing runtime (from #4159) with node ID virtualisation and per-broker upstream connections, enabling produce/consume to work correctly when upstream clusters have more than one broker.

**Node ID virtualisation** — Introduces a bijective mapping (`V = id + S × t`) that assigns each `(route, upstream-broker-id)` pair a unique virtual node ID. For a single route the identity mapping is used (no translation). For multiple routes a `BijectiveNodeIdMapping` interleaves virtual IDs across routes so they remain globally unique. `NodeIdResponseTranslator` rewrites the broker IDs in METADATA, PRODUCE (v10+), FIND_COORDINATOR and DESCRIBE_CLUSTER responses in-place before they reach the client.

Note that in some places the Kafka Protocol uses node id -1 to signify things like unknown leader id, or unknown controller id. So we must ensure these identifiers are not mangled. To implement this we've made all NodeIdMapper implementations return negative ids unmodified.

**Per-broker upstream connections** — When a Kafka client connects on a per-broker proxy port the proxy receives a `BrokerEndpointBinding` whose `upstreamTarget()` is the real upstream address (populated by the `EndpointReconciler` after METADATA reconciliation). `ClientConnectionStateMachine.toForwardingWithRoutes()` uses this binding to route the owning route directly to the correct upstream broker rather than always using the bootstrap. Connections to upstream brokers are created lazily in `forwardToRoute()`, matching the approach in the PoC branch (`5e202cf9`).

**Tests** — Two integration tests with real 3-node clusters prove that produce/consume works end-to-end:
- single 3-node pass-through cluster
- two 3-node clusters with route-a/route-b selection

Two low-level mock-based tests directly verify that each virtual-node port reaches its correct upstream broker, one for a single route and one parameterised over route-a/route-b for a two-route configuration.

### Additional Context

Closes #4153. Tracked by https://github.com/kroxylicious/kroxylicious/issues/4158.

This PR builds on #4159 (static routing infrastructure). The implementation is derived from the PoC branch `router-api-flatten-into-client-channel+tom` — specifically the node ID mapping classes and the lazy per-broker connection approach from commit `5e202cf9`.

The `@KROXYLICIOUS_UNLOCK_ROUTING` feature flag introduced in #4159 remains in place; all new behaviour is gated behind it.

### Checklist

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).