### PR TITLE
refactor(collections): use SequencedCollection accessors

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
@@ -111,7 +111,7 @@ class ProtobufSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
             if (messageTypes.isEmpty()) {
                 throw new IllegalArgumentException("Protobuf schema has no message types defined");
             }
-            return messageTypes.get(0);
+            return messageTypes.getFirst();
         }
         catch (IOException e) {
             throw new UncheckedIOException("Failed to resolve Protobuf schema", e);

--- a/kroxylicious-filters/kroxylicious-sasl-inspection/src/main/java/io/kroxylicious/filter/sasl/inspection/PlainSaslObserver.java
+++ b/kroxylicious-filters/kroxylicious-sasl-inspection/src/main/java/io/kroxylicious/filter/sasl/inspection/PlainSaslObserver.java
@@ -29,7 +29,7 @@ class PlainSaslObserver implements SaslObserver {
         Objects.requireNonNull(response, "response");
         if (authorizationId == null) {
             var tokens = parsePlainClient(new String(response, StandardCharsets.UTF_8));
-            var optionalAuthzid = tokens.get(0);
+            var optionalAuthzid = tokens.getFirst();
             var authcid = tokens.get(1);
             if (authcid.isEmpty()) {
                 throw new SaslException("PLAIN saw client initial response with empty authcid.");

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsV4SigningHttpRequestBuilder.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsV4SigningHttpRequestBuilder.java
@@ -377,7 +377,7 @@ public class AwsV4SigningHttpRequestBuilder implements Builder {
     private static Map<String, String> getSingleValuedHeaders(HttpRequest request) {
         return request.headers().map().entrySet().stream()
                 .filter(AwsV4SigningHttpRequestBuilder::hasSingleValue)
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().get(0)));
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getFirst()));
     }
 
     private static boolean hasSingleValue(Map.Entry<String, List<String>> e) {

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/credentials/CredentialsProviderFactory.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/credentials/CredentialsProviderFactory.java
@@ -42,7 +42,7 @@ public interface CredentialsProviderFactory {
             throw new KmsException(
                     "Config must define exactly one credential provider, found %s".formatted(List.copyOf(configured)));
         }
-        return switch (configured.get(0)) {
+        return switch (configured.getFirst()) {
             case "longTerm" -> new LongTermCredentialsProvider(creds.longTerm());
             case "ec2Metadata" -> new Ec2MetadataCredentialsProvider(creds.ec2Metadata());
             case "webIdentity" -> new WebIdentityCredentialsProvider(creds.webIdentity(), config.region());

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/WrappingKey.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/WrappingKey.java
@@ -62,7 +62,7 @@ public record WrappingKey(String keyName, String keyVersion, SupportedKeyType su
         String path = uri.getPath();
         validatePath(path);
         List<String> pathSegments = splitPath(path);
-        return pathSegments.get(pathSegments.size() - 1);
+        return pathSegments.getLast();
     }
 
     public static List<String> splitPath(String pathString) {

--- a/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/model/RetrieveApiKey.java
+++ b/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/model/RetrieveApiKey.java
@@ -30,6 +30,6 @@ public class RetrieveApiKey implements TemplateMethodModelEx {
 
     @Override
     public Object exec(List arguments) {
-        return retrieveApiKey((MessageSpecModel) arguments.get(0));
+        return retrieveApiKey((MessageSpecModel) arguments.getFirst());
     }
 }

--- a/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/model/VersionsModel.java
+++ b/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/model/VersionsModel.java
@@ -31,11 +31,11 @@ class VersionsModel implements TemplateHashModel, TemplateScalarModel, TemplateS
             case "highest" -> wrapper.wrap(versions.highest());
             case "lowest" -> wrapper.wrap(versions.lowest());
             case "intersect" -> wrapper.wrap((TemplateMethodModelEx) args -> {
-                Object o = args.get(0);
+                Object o = args.getFirst();
                 return versions.intersect(((VersionsModel) o).versions);
             });
             case "contains" -> wrapper.wrap((TemplateMethodModelEx) args -> {
-                Object o = args.get(0);
+                Object o = args.getFirst();
                 return versions.contains(((SimpleNumber) o).getAsNumber().shortValue());
             });
             default -> throw new TemplateModelException(versions.getClass().getSimpleName() + " doesn't have property " + key);

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
@@ -92,7 +92,7 @@ class PodMutator {
         try {
             ArrayNode patch = MAPPER.createArrayNode();
 
-            VirtualClusters vc = spec.getVirtualClusters().get(0);
+            VirtualClusters vc = spec.getVirtualClusters().getFirst();
             String targetClusterTrustStorePath = resolveTargetClusterTrustStorePath(vc);
             String proxyConfig = ProxyConfigGenerator.generateConfig(spec, targetClusterTrustStorePath);
             int bootstrapPort = ProxyConfigGenerator.resolveBootstrapPort(vc);
@@ -173,7 +173,7 @@ class PodMutator {
             addOp(patch, OP_ADD, "/spec/volumes", toJson(List.of(configVolume)));
         }
 
-        VirtualClusters vc = spec.getVirtualClusters().get(0);
+        VirtualClusters vc = spec.getVirtualClusters().getFirst();
         TargetClusterTls tls = vc.getTargetClusterTls();
         if (tls != null && tls.getTrustAnchorSecretRef() != null) {
             addOp(patch, OP_ADD, "/spec/volumes/-", toJson(buildTlsSecretVolume(tls)));
@@ -339,7 +339,7 @@ class PodMutator {
                 .withReadOnly(true)
                 .endVolumeMount();
 
-        VirtualClusters vcForTls = spec.getVirtualClusters().get(0);
+        VirtualClusters vcForTls = spec.getVirtualClusters().getFirst();
         if (vcForTls.getTargetClusterTls() != null && vcForTls.getTargetClusterTls().getTrustAnchorSecretRef() != null) {
             builder.addNewVolumeMount()
                     .withName(TARGET_CLUSTER_TLS_VOLUME_NAME)

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGenerator.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGenerator.java
@@ -67,7 +67,7 @@ class ProxyConfigGenerator {
     static String generateConfig(
                                  KroxyliciousSidecarConfigSpec spec,
                                  @Nullable String targetClusterTrustStorePath) {
-        VirtualClusters vc = spec.getVirtualClusters().get(0);
+        VirtualClusters vc = spec.getVirtualClusters().getFirst();
 
         int bootstrapPort = resolveBootstrapPort(vc);
         int managementPort = resolveManagementPort(spec);

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolver.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolver.java
@@ -240,7 +240,7 @@ class SidecarConfigResolver implements Closeable {
             return errors;
         }
 
-        var vc = spec.getVirtualClusters().get(0);
+        var vc = spec.getVirtualClusters().getFirst();
         if (vc.getTargetBootstrapServers() == null || vc.getTargetBootstrapServers().isBlank()) {
             errors.add("spec.virtualClusters[0].targetBootstrapServers is required");
         }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -189,7 +189,7 @@ public class ResourcesUtil {
         if (list.size() > 1) {
             throw new IllegalStateException("collection contained more than one resource named " + name);
         }
-        return list.isEmpty() ? Optional.empty() : Optional.of(list.get(0));
+        return list.isEmpty() ? Optional.empty() : Optional.of(list.getFirst());
     }
 
     /**

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/RouteHostDetails.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/RouteHostDetails.java
@@ -96,7 +96,7 @@ public record RouteHostDetails(
             return Optional.empty();
         }
 
-        return Optional.of(details.get(0).hostWithoutSubdomain());
+        return Optional.of(details.getFirst().hostWithoutSubdomain());
     }
 
     /**
@@ -133,7 +133,7 @@ public record RouteHostDetails(
             return Optional.empty();
         }
 
-        String hostWithSubdomain = ingress.get(0).getHost(); // one-bootstrap.apps-crc.testing
+        String hostWithSubdomain = ingress.getFirst().getHost(); // one-bootstrap.apps-crc.testing
         ArrayList<String> splitHostWithSubdomain = new ArrayList<>(Arrays.asList(hostWithSubdomain.split("\\.")));
         if (splitHostWithSubdomain.size() < 2) {
             return Optional.empty();

--- a/kroxylicious-openmessaging-benchmarks/src/main/java/io/kroxylicious/benchmarks/results/cli/CheckBackPressure.java
+++ b/kroxylicious-openmessaging-benchmarks/src/main/java/io/kroxylicious/benchmarks/results/cli/CheckBackPressure.java
@@ -104,7 +104,7 @@ public class CheckBackPressure implements Callable<Integer> {
         System.out.println("at the broker is masking overhead measurements.");
         System.out.println();
         System.out.println("Suggested rate sweep to find the saturation knee (adjust --min-rate/--max-rate as needed):");
-        Report first = saturated.get(0);
+        Report first = saturated.getFirst();
         System.out.println("  " + scriptsDir + "/rate-sweep.sh \\");
         if (resolvedWorkload != null) {
             System.out.println("    --workload " + resolvedWorkload + " \\");

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouterGraphValidator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouterGraphValidator.java
@@ -132,7 +132,7 @@ class RouterGraphValidator {
     }
 
     private static String formatCycle(List<String> path) {
-        int cycleStart = path.indexOf(path.get(path.size() - 1));
+        int cycleStart = path.indexOf(path.getLast());
         return String.join(" -> ", path.subList(cycleStart, path.size()));
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -432,7 +432,7 @@ public class KafkaProxyFrontendHandler
                                                   @Nullable Throwable errorCodeEx) {
         final Object triggerMsg;
         if (bufferedMsgs != null && !bufferedMsgs.isEmpty()) {
-            triggerMsg = bufferedMsgs.get(0);
+            triggerMsg = bufferedMsgs.getFirst();
         }
         else {
             triggerMsg = initialRequestForError;

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/subject/TlsCertificateExtractor.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/subject/TlsCertificateExtractor.java
@@ -35,7 +35,7 @@ public interface TlsCertificateExtractor extends Function<X509Certificate, Strea
         return x509Certificate -> {
             try {
                 return x509Certificate.getSubjectAlternativeNames().stream().flatMap(san -> {
-                    Integer asn1SanType = (Integer) san.get(0);
+                    Integer asn1SanType = (Integer) san.getFirst();
                     if (asn1SanType == targetType.asn1Value) {
                         return Stream.of((String) san.get(1));
                     }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
@@ -141,7 +141,7 @@ public class KafkaUtils {
     public static String getPodNameByLabel(String deployNamespace, String labelKey, String labelValue, Duration timeout) {
         List<Pod> pods = await().atMost(timeout).until(() -> kubeClient().listPods(deployNamespace, labelKey, labelValue),
                 p -> !p.isEmpty());
-        return pods.get(pods.size() - 1).getMetadata().getName();
+        return pods.getLast().getMetadata().getName();
     }
 
     /**
@@ -155,7 +155,7 @@ public class KafkaUtils {
     public static String getPodNameByPrefix(String deployNamespace, String prefix, Duration timeout) {
         List<Pod> pods = await().atMost(timeout).until(() -> kubeClient().listPodsByPrefixInName(deployNamespace, prefix),
                 p -> !p.isEmpty());
-        return pods.get(pods.size() - 1).getMetadata().getName();
+        return pods.getLast().getMetadata().getName();
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Replace `List` index access with `getFirst()` and `getLast()` where the surrounding code already establishes that the collection is non-empty.

`RunMetadata.java` call sites are intentionally unchanged because they use Jackson `JsonNode.get(int)`, not `List.get(int)`. `JsonNode` is not a `SequencedCollection` and does not provide `getFirst()` or `getLast()`.

### Additional Context
Closes #4218 
No user-facing changes; no docs or changelog update required.

Verification:
`mvn verify` was attempted. It fails in unrelated modules due to existing/local environment issues.

### Checklist

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [X ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).