### PR TITLE
feat(routing): integrate RouterChainFactory with hot reload

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ClusterDefinitionChangeHotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ClusterDefinitionChangeHotReloadIT.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.it;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.proxy.config.ClusterDefinition;
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
+import io.kroxylicious.proxy.config.RouteTarget;
+import io.kroxylicious.proxy.config.VirtualCluster;
+import io.kroxylicious.proxy.service.HostPort;
+import io.kroxylicious.testing.integration.config.NamedFilterDefinitionBuilder;
+import io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils;
+import io.kroxylicious.testing.integration.tester.KroxyliciousTester;
+import io.kroxylicious.testing.integration.tester.KroxyliciousTesters;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.BrokerCluster;
+
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end integration tests for cluster definition changes via hot reload. Each test
+ * exercises {@code KafkaProxy#reconfigure(Configuration)} with a delta that mutates a
+ * cluster definition, then asserts on the observable lifecycle effects via
+ * {@link InvocationCountingFilterFactory}'s per-UUID initialize/close counters.
+ * <p>
+ * A cluster definition change is detected by {@code ClusterDefinitionChangeDetector} as a
+ * virtual cluster {@code modify}, planned as a {@code ReplaceCluster} operation, and executed
+ * as {@code RemoveCluster + AddCluster}. The affected VC's filter chain is torn down and
+ * rebuilt, producing an observable increment in the filter's initialize and close counters.
+ */
+class ClusterDefinitionChangeHotReloadIT extends BaseIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterDefinitionChangeHotReloadIT.class);
+
+    private static final int PORT_BLOCK_BASE = 23000 + ThreadLocalRandom.current().nextInt(2000);
+    private static final int PORT_CLUSTER_DEF_CHANGE = PORT_BLOCK_BASE;
+    private static final int PORT_CROSS_VC_A = PORT_BLOCK_BASE + 100;
+    private static final int PORT_CROSS_VC_B = PORT_BLOCK_BASE + 110;
+
+    private static final Duration RECONFIGURE_TIMEOUT = Duration.ofSeconds(15);
+
+    static {
+        LoggerFactory.getLogger(ClusterDefinitionChangeHotReloadIT.class)
+                .atInfo()
+                .addKeyValue("portBlockBase", PORT_BLOCK_BASE)
+                .log("ClusterDefinitionChangeHotReloadIT: per-JVM port block base chosen");
+    }
+
+    @AfterEach
+    void afterEach() {
+        InvocationCountingFilterFactory.assertAllClosedAndResetCounts();
+    }
+
+    @Test
+    void shouldRestartVcWhenNamedClusterDefinitionChanges(@BrokerCluster KafkaCluster cluster) throws Exception {
+        // Changing a cluster definition's bootstrapServers triggers ClusterDefinitionChangeDetector
+        // to flag the referencing VC as modified. ReplaceCluster tears down and rebuilds the VC,
+        // which is observable via the filter's initialize/close counts.
+        UUID filterId = UUID.randomUUID();
+        var filterDef = invocationCounterDef("counter", filterId);
+
+        var clusterDefV1 = new ClusterDefinition("upstream", cluster.getBootstrapServers(), null);
+        // Duplicate the bootstrap entry — different string, same connectivity.
+        var clusterDefV2 = new ClusterDefinition("upstream", cluster.getBootstrapServers() + "," + cluster.getBootstrapServers(), null);
+
+        var vc = namedClusterVc("vc-cluster-change", PORT_CLUSTER_DEF_CHANGE, "upstream", "counter");
+
+        var startingBuilder = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToFilterDefinitions(filterDef)
+                .addToClusterDefinitions(clusterDefV1)
+                .addToVirtualClusters(vc);
+
+        var afterConfig = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToFilterDefinitions(filterDef)
+                .addToClusterDefinitions(clusterDefV2)
+                .addToVirtualClusters(vc)
+                .build();
+
+        try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(startingBuilder)
+                .createDefaultKroxyliciousTester()) {
+
+            // Given: VC serving traffic via a named cluster definition
+            String topic = tester.createTopic("vc-cluster-change");
+            assertProduceConsumeRoundTrip(tester, "vc-cluster-change", topic, "before-reconfigure");
+
+            // When: the cluster definition's bootstrapServers changes
+            LOGGER.info("Reconfiguring: updating cluster definition bootstrapServers");
+            assertThat(tester.reconfigure(afterConfig))
+                    .succeedsWithin(RECONFIGURE_TIMEOUT)
+                    .satisfies(rr -> assertThat(rr.hasErrors())
+                            .as("ReconfigureResult should have no errors for a clean cluster definition update")
+                            .isFalse());
+
+            // Then: the VC was restarted — filter was initialized at startup and again after the
+            // cluster definition change; the old init result was closed once by ReplaceCluster.
+            assertThat(InvocationCountingFilterFactory.initializationCountFor(filterId))
+                    .as("filter should have been initialized at startup and once more after the cluster def change")
+                    .isEqualTo(2);
+            assertThat(InvocationCountingFilterFactory.closeCountFor(filterId))
+                    .as("old filter init result should have been closed exactly once by ReplaceCluster")
+                    .isEqualTo(1);
+
+            // Then: traffic still flows after the reload
+            assertProduceConsumeRoundTrip(tester, "vc-cluster-change", topic, "after-reconfigure");
+        }
+    }
+
+    @Test
+    void shouldNotRestartUnaffectedVcWhenDifferentClusterDefinitionChanges(
+                                                                           @BrokerCluster KafkaCluster cluster)
+            throws Exception {
+        // Per-VC isolation: changing cluster-a's definition restarts vc-a but leaves vc-b untouched,
+        // even though both use the same underlying Kafka cluster.
+        UUID filterAId = UUID.randomUUID();
+        UUID filterBId = UUID.randomUUID();
+        var filterADef = invocationCounterDef("counter-a", filterAId);
+        var filterBDef = invocationCounterDef("counter-b", filterBId);
+
+        var clusterDefAv1 = new ClusterDefinition("cluster-a", cluster.getBootstrapServers(), null);
+        var clusterDefAv2 = new ClusterDefinition("cluster-a", cluster.getBootstrapServers() + "," + cluster.getBootstrapServers(), null);
+        var clusterDefB = new ClusterDefinition("cluster-b", cluster.getBootstrapServers(), null);
+
+        var vcA = namedClusterVc("vc-a", PORT_CROSS_VC_A, "cluster-a", "counter-a");
+        var vcB = namedClusterVc("vc-b", PORT_CROSS_VC_B, "cluster-b", "counter-b");
+
+        var startingBuilder = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToFilterDefinitions(filterADef)
+                .addToFilterDefinitions(filterBDef)
+                .addToClusterDefinitions(clusterDefAv1)
+                .addToClusterDefinitions(clusterDefB)
+                .addToVirtualClusters(vcA, vcB);
+
+        var afterConfig = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToFilterDefinitions(filterADef)
+                .addToFilterDefinitions(filterBDef)
+                .addToClusterDefinitions(clusterDefAv2)
+                .addToClusterDefinitions(clusterDefB)
+                .addToVirtualClusters(vcA, vcB)
+                .build();
+
+        try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(startingBuilder)
+                .createDefaultKroxyliciousTester()) {
+
+            // Given: both VCs serving traffic
+            String topicA = tester.createTopic("vc-a");
+            String topicB = tester.createTopic("vc-b");
+            assertProduceConsumeRoundTrip(tester, "vc-a", topicA, "before-vc-a");
+            assertProduceConsumeRoundTrip(tester, "vc-b", topicB, "before-vc-b");
+            int vcBInitBefore = InvocationCountingFilterFactory.initializationCountFor(filterBId);
+            int vcBCloseBefore = InvocationCountingFilterFactory.closeCountFor(filterBId);
+
+            // When: only cluster-a's definition changes; cluster-b's is identical
+            LOGGER.info("Reconfiguring: updating cluster-a definition only");
+            assertThat(tester.reconfigure(afterConfig))
+                    .succeedsWithin(RECONFIGURE_TIMEOUT)
+                    .satisfies(rr -> assertThat(rr.hasErrors()).isFalse());
+
+            // Then: vc-a's filter was restarted
+            assertThat(InvocationCountingFilterFactory.initializationCountFor(filterAId))
+                    .as("vc-a filter should have been initialized twice (startup + after cluster-a change)")
+                    .isEqualTo(2);
+            assertThat(InvocationCountingFilterFactory.closeCountFor(filterAId))
+                    .as("vc-a old filter init result should have been closed once by ReplaceCluster")
+                    .isEqualTo(1);
+
+            // Then: vc-b's filter was not touched — per-VC isolation holds
+            assertThat(InvocationCountingFilterFactory.initializationCountFor(filterBId))
+                    .as("vc-b's filter must not be re-initialized when only cluster-a's definition changes")
+                    .isEqualTo(vcBInitBefore);
+            assertThat(InvocationCountingFilterFactory.closeCountFor(filterBId))
+                    .as("vc-b's filter must not be closed when only cluster-a's definition changes")
+                    .isEqualTo(vcBCloseBefore);
+
+            // Then: both VCs still serve traffic
+            assertProduceConsumeRoundTrip(tester, "vc-a", topicA, "after-vc-a");
+            assertProduceConsumeRoundTrip(tester, "vc-b", topicB, "after-vc-b");
+        }
+    }
+
+    // ---- fixture helpers ----
+
+    private static VirtualCluster namedClusterVc(String name, int port, String clusterDefName, String... filterNames) {
+        return new io.kroxylicious.proxy.config.VirtualClusterBuilder()
+                .withName(name)
+                .withTarget(new RouteTarget(clusterDefName, null))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(new HostPort("localhost", port)).build())
+                .addToFilters(filterNames)
+                .build();
+    }
+
+    private static NamedFilterDefinition invocationCounterDef(String name, UUID uuid) {
+        return new NamedFilterDefinitionBuilder(name, InvocationCountingFilterFactory.class.getSimpleName())
+                .withConfig("configInstanceId", uuid)
+                .build();
+    }
+
+    private static void assertProduceConsumeRoundTrip(KroxyliciousTester tester, String vc, String topic,
+                                                      String marker)
+            throws Exception {
+        int messageCount = 5;
+        try (var producer = tester.producer(vc, Map.of(ProducerConfig.LINGER_MS_CONFIG, 0))) {
+            for (int i = 0; i < messageCount; i++) {
+                producer.send(new ProducerRecord<>(topic, marker + "-" + i, marker + "-v-" + i))
+                        .get(10, TimeUnit.SECONDS);
+            }
+        }
+
+        try (var consumer = tester.consumer(vc, Map.of(
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
+                ConsumerConfig.GROUP_ID_CONFIG, "cluster-def-change-it-" + vc + "-" + marker))) {
+            consumer.subscribe(List.of(topic));
+            var seenKeys = new HashSet<String>();
+            String keyPrefix = marker + "-";
+            long deadline = System.currentTimeMillis() + 10_000;
+            while (System.currentTimeMillis() < deadline && seenKeys.size() < messageCount) {
+                var batch = consumer.poll(Duration.ofMillis(500));
+                for (var record : batch) {
+                    if (record.key() != null && record.key().startsWith(keyPrefix)) {
+                        seenKeys.add(record.key());
+                    }
+                }
+            }
+            assertThat(seenKeys)
+                    .as("consumer should observe all %d records produced with marker '%s' via VC '%s'",
+                            messageCount, marker, vc)
+                    .hasSize(messageCount);
+        }
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouterChangeHotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouterChangeHotReloadIT.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.it;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.it.testplugins.InvocationCountingRouterFactory;
+import io.kroxylicious.proxy.config.ClusterDefinition;
+import io.kroxylicious.proxy.config.RouteDefinition;
+import io.kroxylicious.proxy.config.RouteTarget;
+import io.kroxylicious.proxy.config.RouterDefinition;
+import io.kroxylicious.proxy.config.VirtualCluster;
+import io.kroxylicious.proxy.config.VirtualClusterBuilder;
+import io.kroxylicious.proxy.internal.config.Feature;
+import io.kroxylicious.proxy.internal.config.Features;
+import io.kroxylicious.proxy.service.HostPort;
+import io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils;
+import io.kroxylicious.testing.integration.tester.KroxyliciousTester;
+import io.kroxylicious.testing.integration.tester.KroxyliciousTesters;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.BrokerCluster;
+
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end integration tests for router definition changes via hot reload. Each test exercises
+ * {@code KafkaProxy#reconfigure(Configuration)} with a delta that mutates a router definition,
+ * then asserts on the observable lifecycle effects via
+ * {@link InvocationCountingRouterFactory}'s per-UUID initialize/close counters.
+ * <p>
+ * A router definition change is detected by {@code RouterChangeDetector} as a virtual cluster
+ * {@code modify}, planned as a {@code ReplaceCluster} operation, and executed as
+ * {@code RemoveCluster + AddCluster}. The affected VC's old {@code RouterChainFactory} is closed
+ * (firing {@code RouterFactory.close()} on the old initResult) and a new one is built (firing
+ * {@code RouterFactory.initialize()} with the updated config).
+ */
+class RouterChangeHotReloadIT extends BaseIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RouterChangeHotReloadIT.class);
+
+    private static final int PORT_BLOCK_BASE = 29000 + ThreadLocalRandom.current().nextInt(1000);
+    private static final int PORT_ROUTER_CHANGE = PORT_BLOCK_BASE;
+    private static final int PORT_CROSS_VC_A = PORT_BLOCK_BASE + 100;
+    private static final int PORT_CROSS_VC_B = PORT_BLOCK_BASE + 110;
+
+    private static final Duration RECONFIGURE_TIMEOUT = Duration.ofSeconds(15);
+
+    private static final Features ROUTING_ENABLED = Features.builder().enable(Feature.ROUTING).build();
+
+    private static final String ROUTE_NAME = "backing";
+    private static final String CLUSTER_DEF_NAME = "backing";
+
+    static {
+        LoggerFactory.getLogger(RouterChangeHotReloadIT.class)
+                .atInfo()
+                .addKeyValue("portBlockBase", PORT_BLOCK_BASE)
+                .log("RouterChangeHotReloadIT: per-JVM port block base chosen");
+    }
+
+    @AfterEach
+    void afterEach() {
+        InvocationCountingRouterFactory.assertAllClosedAndResetCounts();
+    }
+
+    @Test
+    void shouldCloseOldRouterInitResultAndInitNewOneWhenRouterDefinitionChangesViaReload(
+                                                                                         @BrokerCluster KafkaCluster cluster)
+            throws Exception {
+        // The central test for router-change hot reload: changing a router definition triggers
+        // ReplaceCluster, which closes the old RouterChainFactory (firing close on the old
+        // initResult) and builds a new one (firing initialize with the updated config).
+        UUID oldConfigId = UUID.randomUUID();
+        UUID newConfigId = UUID.randomUUID();
+
+        var clusterDef = clusterDefinition(cluster);
+        var vc = routerVc("vc-router-change", PORT_ROUTER_CHANGE, "my-router");
+
+        var startingBuilder = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDef)
+                .addToRouterDefinitions(routerDef("my-router", oldConfigId))
+                .addToVirtualClusters(vc);
+
+        var afterConfig = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDef)
+                .addToRouterDefinitions(routerDef("my-router", newConfigId))
+                .addToVirtualClusters(vc)
+                .build();
+
+        try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(startingBuilder)
+                .setFeatures(ROUTING_ENABLED)
+                .createDefaultKroxyliciousTester()) {
+
+            // Given: VC serving traffic through the router with old config.
+            String topic = tester.createTopic("vc-router-change");
+            assertProduceConsumeRoundTrip(tester, "vc-router-change", topic, "before-reconfigure");
+
+            // When: proxy reconfigured with the same router name but different config UUID.
+            LOGGER.info("Reconfiguring vc-router-change: routerDef config {} -> {}", oldConfigId, newConfigId);
+            assertThat(tester.reconfigure(afterConfig))
+                    .succeedsWithin(RECONFIGURE_TIMEOUT)
+                    .satisfies(rr -> assertThat(rr.hasErrors())
+                            .as("ReconfigureResult should have no errors for a clean router-definition swap")
+                            .isFalse());
+
+            // Then: the old initResult was closed exactly once (RemoveCluster tore down the old
+            // RouterChainFactory), and the new config was initialized exactly once (AddCluster
+            // built a fresh RouterChainFactory).
+            assertThat(InvocationCountingRouterFactory.closeCountFor(oldConfigId))
+                    .as("old router's initResult should have been closed exactly once during ReplaceCluster")
+                    .isEqualTo(1);
+            assertThat(InvocationCountingRouterFactory.initializationCountFor(newConfigId))
+                    .as("new router config should have been initialized exactly once")
+                    .isEqualTo(1);
+            assertThat(InvocationCountingRouterFactory.closeCountFor(newConfigId))
+                    .as("new router's initResult is part of the live chain, not yet closed")
+                    .isZero();
+
+            // Then: real traffic confirms the VC is still serving correctly after the reload.
+            assertProduceConsumeRoundTrip(tester, "vc-router-change", topic, "after-reconfigure");
+        }
+    }
+
+    @Test
+    void shouldNotAffectUnchangedVcRouterStateWhenAnotherVcsRouterDefinitionChanges(
+                                                                                    @BrokerCluster KafkaCluster cluster)
+            throws Exception {
+        // Per-VC isolation: changing VC-A's router definition does not touch VC-B's router
+        // state, even though both use the same router factory type.
+        UUID vcAOldId = UUID.randomUUID();
+        UUID vcANewId = UUID.randomUUID();
+        UUID vcBId = UUID.randomUUID();
+
+        var clusterDef = clusterDefinition(cluster);
+        var vcA = routerVc("vc-a", PORT_CROSS_VC_A, "router-a");
+        var vcB = routerVc("vc-b", PORT_CROSS_VC_B, "router-b");
+
+        var startingBuilder = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDef)
+                .addToRouterDefinitions(routerDef("router-a", vcAOldId), routerDef("router-b", vcBId))
+                .addToVirtualClusters(vcA, vcB);
+
+        var afterConfig = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDef)
+                .addToRouterDefinitions(routerDef("router-a", vcANewId), routerDef("router-b", vcBId))
+                .addToVirtualClusters(vcA, vcB)
+                .build();
+
+        try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(startingBuilder)
+                .setFeatures(ROUTING_ENABLED)
+                .createDefaultKroxyliciousTester()) {
+
+            // Given: both VCs serving traffic. Capture VC-B's counts before reconfigure so
+            // the Then can assert "unchanged" via delta.
+            String topicA = tester.createTopic("vc-a");
+            String topicB = tester.createTopic("vc-b");
+            assertProduceConsumeRoundTrip(tester, "vc-a", topicA, "before-reconfigure-vc-a");
+            assertProduceConsumeRoundTrip(tester, "vc-b", topicB, "before-reconfigure-vc-b");
+            int vcBInitBefore = InvocationCountingRouterFactory.initializationCountFor(vcBId);
+            int vcBCloseBefore = InvocationCountingRouterFactory.closeCountFor(vcBId);
+
+            // When: proxy reconfigured to change only VC-A's router definition; VC-B's is identical.
+            LOGGER.info("Reconfiguring to change router-a only");
+            assertThat(tester.reconfigure(afterConfig))
+                    .succeedsWithin(RECONFIGURE_TIMEOUT)
+                    .satisfies(rr -> assertThat(rr.hasErrors()).isFalse());
+
+            // Then: VC-A's old router is closed and the new one is initialised.
+            assertThat(InvocationCountingRouterFactory.closeCountFor(vcAOldId))
+                    .as("VC-A's old router should have been closed exactly once")
+                    .isEqualTo(1);
+            assertThat(InvocationCountingRouterFactory.initializationCountFor(vcANewId))
+                    .as("VC-A's new router should have been initialized exactly once")
+                    .isEqualTo(1);
+
+            // Then: VC-B's counts are unchanged — per-VC isolation holds.
+            assertThat(InvocationCountingRouterFactory.initializationCountFor(vcBId))
+                    .as("VC-B's router init count must not change during VC-A's reconfigure")
+                    .isEqualTo(vcBInitBefore);
+            assertThat(InvocationCountingRouterFactory.closeCountFor(vcBId))
+                    .as("VC-B's router close count must not change during VC-A's reconfigure")
+                    .isEqualTo(vcBCloseBefore);
+
+            // Then: both VCs still serve traffic.
+            assertProduceConsumeRoundTrip(tester, "vc-a", topicA, "after-reconfigure-vc-a");
+            assertProduceConsumeRoundTrip(tester, "vc-b", topicB, "after-reconfigure-vc-b");
+        }
+    }
+
+    // ---- fixture helpers ----
+
+    private static ClusterDefinition clusterDefinition(KafkaCluster cluster) {
+        return new ClusterDefinition(CLUSTER_DEF_NAME, cluster.getBootstrapServers(), null);
+    }
+
+    private static RouterDefinition routerDef(String name, UUID configId) {
+        var route = new RouteDefinition(ROUTE_NAME, 0, List.of(), new RouteTarget(CLUSTER_DEF_NAME, null));
+        var config = new InvocationCountingRouterFactory.Config(configId, ROUTE_NAME);
+        return new RouterDefinition(name, InvocationCountingRouterFactory.class.getName(), config, List.of(route));
+    }
+
+    private static VirtualCluster routerVc(String name, int port, String routerName) {
+        return new VirtualClusterBuilder()
+                .withName(name)
+                .withTarget(new RouteTarget(null, routerName))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(new HostPort("localhost", port)).build())
+                .build();
+    }
+
+    private static void assertProduceConsumeRoundTrip(KroxyliciousTester tester, String vc, String topic,
+                                                      String marker)
+            throws Exception {
+        int messageCount = 5;
+        try (var producer = tester.producer(vc, Map.of(ProducerConfig.LINGER_MS_CONFIG, 0))) {
+            for (int i = 0; i < messageCount; i++) {
+                producer.send(new ProducerRecord<>(topic, marker + "-" + i, marker + "-v-" + i))
+                        .get(10, TimeUnit.SECONDS);
+            }
+        }
+
+        try (var consumer = tester.consumer(vc, Map.of(
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
+                ConsumerConfig.GROUP_ID_CONFIG, "router-change-it-" + vc + "-" + marker))) {
+            consumer.subscribe(List.of(topic));
+            var seenKeys = new HashSet<String>();
+            String keyPrefix = marker + "-";
+            long deadline = System.currentTimeMillis() + 10_000;
+            while (System.currentTimeMillis() < deadline && seenKeys.size() < messageCount) {
+                var batch = consumer.poll(Duration.ofMillis(500));
+                for (var record : batch) {
+                    if (record.key() != null && record.key().startsWith(keyPrefix)) {
+                        seenKeys.add(record.key());
+                    }
+                }
+            }
+            assertThat(seenKeys)
+                    .as("consumer should observe all %d records produced with marker '%s' via VC '%s'",
+                            messageCount, marker, vc)
+                    .hasSize(messageCount);
+        }
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouterChangeHotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouterChangeHotReloadIT.java
@@ -38,6 +38,7 @@ import io.kroxylicious.testing.integration.tester.KroxyliciousTesters;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
 
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.baseVirtualClusterBuilder;
 import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -61,6 +62,7 @@ class RouterChangeHotReloadIT extends BaseIT {
     private static final int PORT_ROUTER_CHANGE = PORT_BLOCK_BASE;
     private static final int PORT_CROSS_VC_A = PORT_BLOCK_BASE + 100;
     private static final int PORT_CROSS_VC_B = PORT_BLOCK_BASE + 110;
+    private static final int PORT_ROUTING_DISABLED = PORT_BLOCK_BASE + 200;
 
     private static final Duration RECONFIGURE_TIMEOUT = Duration.ofSeconds(15);
 
@@ -202,6 +204,56 @@ class RouterChangeHotReloadIT extends BaseIT {
             // Then: both VCs still serve traffic.
             assertProduceConsumeRoundTrip(tester, "vc-a", topicA, "after-reconfigure-vc-a");
             assertProduceConsumeRoundTrip(tester, "vc-b", topicB, "after-reconfigure-vc-b");
+        }
+    }
+
+    @Test
+    void shouldNotInitializeRouterWhenRoutingFeatureIsDisabledAndRouterDefinitionSubmittedViaHotReload(
+                                                                                                       @BrokerCluster KafkaCluster cluster)
+            throws Exception {
+        // routerDefinitions is in the RECONCILABLE set, so the static-section differ permits
+        // the change. RouterChangeDetector detects the new router, but since no VC references
+        // it, no VC operations are planned and the reconfigure completes without errors.
+        // The factory is never initialized.
+        UUID routerId = UUID.randomUUID();
+
+        var clusterDef = clusterDefinition(cluster);
+        var vc = baseVirtualClusterBuilder(cluster, "vc-routing-disabled")
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(new HostPort("localhost", PORT_ROUTING_DISABLED)).build())
+                .build();
+
+        var startingBuilder = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDef)
+                .addToVirtualClusters(vc);
+
+        var afterConfig = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDef)
+                .addToVirtualClusters(vc)
+                .addToRouterDefinitions(routerDef("unused-router", routerId))
+                .build();
+
+        try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(startingBuilder)
+                // Intentionally no setFeatures(ROUTING_ENABLED)
+                .createDefaultKroxyliciousTester()) {
+
+            // Given: proxy serving traffic via a plain VC (no router)
+            String topic = tester.createTopic("vc-routing-disabled");
+            assertProduceConsumeRoundTrip(tester, "vc-routing-disabled", topic, "before-reconfigure");
+
+            // When: reconfigure submits routerDefinitions despite ROUTING being disabled
+            assertThat(tester.reconfigure(afterConfig))
+                    .succeedsWithin(RECONFIGURE_TIMEOUT)
+                    .satisfies(rr -> assertThat(rr.hasErrors())
+                            .as("routerDefinitions change is reconcilable, no VC uses the router, so no errors expected")
+                            .isFalse());
+
+            // Then: the factory is never initialized — no VC references the router
+            assertThat(InvocationCountingRouterFactory.initializationCountFor(routerId))
+                    .as("factory must not be initialized when no VC references the router")
+                    .isZero();
+
+            // Then: plain VC continues serving traffic after reconfigure
+            assertProduceConsumeRoundTrip(tester, "vc-routing-disabled", topic, "after-reconfigure");
         }
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/InvocationCountingRouterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/InvocationCountingRouterFactory.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.it.testplugins;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.router.RouterContext;
+import io.kroxylicious.proxy.router.RouterFactory;
+import io.kroxylicious.proxy.router.RouterFactoryContext;
+import io.kroxylicious.proxy.router.RouterResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A router factory that tracks {@code initialize()} and {@code close()} invocations per
+ * config UUID and routes all requests statically to the configured route. Intended for use
+ * in hot-reload integration tests that need to assert on router factory lifecycle events.
+ */
+@Plugin(configType = InvocationCountingRouterFactory.Config.class)
+public class InvocationCountingRouterFactory implements RouterFactory<InvocationCountingRouterFactory.Config, InvocationCountingRouterFactory.Config> {
+
+    /**
+     * @param configInstanceId unique identifier for this config instance, used to correlate
+     *        initialize/close events across hot-reload cycles
+     * @param route the route name to which all requests are forwarded statically
+     */
+    public record Config(UUID configInstanceId, String route) {}
+
+    private static final Map<UUID, AtomicInteger> initializeCounts = new ConcurrentHashMap<>();
+    private static final Map<UUID, AtomicInteger> closeCounts = new ConcurrentHashMap<>();
+
+    @Override
+    public Config initialize(RouterFactoryContext context, Config config) {
+        initializeCounts.computeIfAbsent(config.configInstanceId(), uuid -> new AtomicInteger(0)).incrementAndGet();
+        return config;
+    }
+
+    @Override
+    public Router createRouter(RouterFactoryContext context, Config initData) {
+        var allStatic = Arrays.stream(ApiKeys.values())
+                .collect(Collectors.toUnmodifiableMap(k -> k, k -> initData.route()));
+        return new Router() {
+            @Override
+            public CompletionStage<RouterResponse> onRequest(ApiKeys apiKey, short apiVersion,
+                                                             RequestHeaderData header, ApiMessage request,
+                                                             RouterContext routerContext) {
+                throw new IllegalStateException("Dynamic routing not supported by InvocationCountingRouterFactory");
+            }
+
+            @Override
+            public Map<ApiKeys, String> staticRoutes() {
+                return allStatic;
+            }
+        };
+    }
+
+    @Override
+    public void close(Config initData) {
+        closeCounts.computeIfAbsent(initData.configInstanceId(), uuid -> new AtomicInteger(0)).incrementAndGet();
+    }
+
+    public static int initializationCountFor(UUID configId) {
+        var counter = initializeCounts.get(configId);
+        return counter == null ? 0 : counter.get();
+    }
+
+    public static int closeCountFor(UUID configId) {
+        var counter = closeCounts.get(configId);
+        return counter == null ? 0 : counter.get();
+    }
+
+    public static void assertAllClosedAndResetCounts() {
+        for (var entry : initializeCounts.entrySet()) {
+            UUID uuid = entry.getKey();
+            assertThat(closeCounts.get(uuid))
+                    .as("every initialize() call for %s must have a matching close()", uuid)
+                    .hasValue(entry.getValue().intValue());
+        }
+        assertThat(closeCounts.keySet()).isEqualTo(initializeCounts.keySet());
+        initializeCounts.clear();
+        closeCounts.clear();
+    }
+}

--- a/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.router.RouterFactory
+++ b/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.router.RouterFactory
@@ -3,6 +3,7 @@
 #
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
+io.kroxylicious.it.testplugins.InvocationCountingRouterFactory
 io.kroxylicious.it.testplugins.PassThroughRouterFactory
 io.kroxylicious.it.testplugins.RouterContractCapturingFactory
 io.kroxylicious.it.testplugins.SplitStaticRouterFactory

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -48,7 +48,6 @@ import io.netty.channel.uring.IoUringIoHandler;
 import io.netty.channel.uring.IoUringServerSocketChannel;
 import io.netty.util.concurrent.Future;
 
-import io.kroxylicious.proxy.bootstrap.RouterChainFactory;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.IllegalConfigurationException;
 import io.kroxylicious.proxy.config.MicrometerDefinition;
@@ -205,7 +204,6 @@ public final class KafkaProxy implements AutoCloseable {
     private final PluginFactoryRegistry pfr;
     private final VirtualClusterRegistry virtualClusterRegistry;
     private @Nullable MeterRegistries meterRegistries;
-    private @Nullable RouterChainFactory routerChainFactory;
 
     private @Nullable ConfigurationReloadOrchestrator reconfigureOrchestrator;
     private @Nullable EventGroupConfig managementEventGroup;
@@ -327,7 +325,6 @@ public final class KafkaProxy implements AutoCloseable {
 
             var overrideMap = getApiKeyMaxVersionOverride(config);
             ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl(overrideMap);
-            this.routerChainFactory = new RouterChainFactory(pfr, config.virtualClusters(), config.routerDefinitions());
             this.reconfigureOrchestrator = new ConfigurationReloadOrchestrator(
                     config, virtualClusterRegistry, endpointRegistry,
                     ConfigurationReloadOrchestrator.defaultDetectors());
@@ -335,13 +332,11 @@ public final class KafkaProxy implements AutoCloseable {
             Optional<NettySettings> proxyNettySettings = getNettySettings(config, NetworkDefinition::proxy);
             var proxyProtocolMode = config.proxyProtocolMode();
             var tlsServerBootstrap = buildServerBootstrap(proxyEventGroup,
-                    new KafkaProxyInitializer(routerChainFactory,
-                            pfr, true, endpointRegistry, endpointRegistry,
+                    new KafkaProxyInitializer(pfr, true, endpointRegistry, endpointRegistry,
                             proxyProtocolMode, apiVersionsService,
                             proxyNettySettings, virtualClusterRegistry));
             var plainServerBootstrap = buildServerBootstrap(proxyEventGroup,
-                    new KafkaProxyInitializer(routerChainFactory,
-                            pfr, false, endpointRegistry, endpointRegistry,
+                    new KafkaProxyInitializer(pfr, false, endpointRegistry, endpointRegistry,
                             proxyProtocolMode, apiVersionsService,
                             proxyNettySettings, virtualClusterRegistry));
 
@@ -562,9 +557,6 @@ public final class KafkaProxy implements AutoCloseable {
 
             shutdownNetty();
 
-            if (routerChainFactory != null) {
-                routerChainFactory.close();
-            }
             if (meterRegistries != null) {
                 meterRegistries.close();
             }
@@ -587,7 +579,6 @@ public final class KafkaProxy implements AutoCloseable {
             managementEventGroup = null;
             proxyEventGroup = null;
             meterRegistries = null;
-            routerChainFactory = null;
             reconfigureOrchestrator = null;
             if (shutdownFailure != null) {
                 closeFailures.forEach(shutdownFailure::addSuppressed);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/RouterChainFactory.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/RouterChainFactory.java
@@ -87,6 +87,22 @@ public class RouterChainFactory implements AutoCloseable {
     private final Map<VcRouter, Wrapper> initialized;
     private final PluginFactoryRegistry pfr;
 
+    /**
+     * Creates a {@link RouterChainFactory} for a single virtual cluster. The factory
+     * initialises only the routers reachable from {@code vc}'s router graph.
+     *
+     * @param pfr the plugin factory registry
+     * @param vc the virtual cluster whose router graph to initialise
+     * @param routersByName all router definitions by name (the graph may reference any of them)
+     * @return a new factory whose lifetime should match that of the virtual cluster
+     */
+    public static RouterChainFactory forVirtualCluster(PluginFactoryRegistry pfr,
+                                                       VirtualCluster vc,
+                                                       @Nullable Map<String, RouterDefinition> routersByName) {
+        List<RouterDefinition> defs = routersByName == null ? null : new ArrayList<>(routersByName.values());
+        return new RouterChainFactory(pfr, List.of(vc), defs);
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public RouterChainFactory(PluginFactoryRegistry pfr,
                               List<VirtualCluster> virtualClusters,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/RouterChainFactory.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/RouterChainFactory.java
@@ -41,7 +41,8 @@ public class RouterChainFactory implements AutoCloseable {
     private static final class Wrapper {
 
         private final RouterFactory<? super Object, ? super Object> routerFactory;
-        private final RouterDefinition routerDefinition;
+        private final String routerName;
+        private final RouterFactoryContext context;
         private final Object initResult;
         private final AtomicBoolean closed = new AtomicBoolean(false);
 
@@ -49,7 +50,8 @@ public class RouterChainFactory implements AutoCloseable {
                         RouterDefinition routerDefinition,
                         RouterFactory<? super Object, ? super Object> routerFactory) {
             this.routerFactory = routerFactory;
-            this.routerDefinition = routerDefinition;
+            this.routerName = routerDefinition.name();
+            this.context = context;
             Object config = routerDefinition.config();
             try {
                 initResult = routerFactory.initialize(context, config);
@@ -62,16 +64,16 @@ public class RouterChainFactory implements AutoCloseable {
             }
         }
 
-        private Router create(RouterFactoryContext context) {
+        private Router create() {
             if (closed.get()) {
-                throw new IllegalStateException("Router factory " + routerDefinition.name() + " is closed");
+                throw new IllegalStateException("Router factory " + routerName + " is closed");
             }
             try {
                 return routerFactory.createRouter(context, initResult);
             }
             catch (Exception e) {
                 throw new PluginConfigurationException(
-                        "Exception instantiating router " + routerDefinition.name()
+                        "Exception instantiating router " + routerName
                                 + " using factory " + routerFactory,
                         e);
             }
@@ -182,11 +184,7 @@ public class RouterChainFactory implements AutoCloseable {
                     "No router definition found for name: " + routerName
                             + " in virtual cluster: " + virtualClusterName);
         }
-        var routeNames = wrapper.routerDefinition.routes().stream()
-                .map(RouteDefinition::name)
-                .collect(Collectors.toUnmodifiableSet());
-        RouterFactoryContext context = createContext(virtualClusterName, routerName, routeNames);
-        return wrapper.create(context);
+        return wrapper.create();
     }
 
     private RouterFactoryContext createContext(String vcName, String routerName, Set<String> routeNames) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import io.kroxylicious.proxy.bootstrap.RouterChainFactory;
 import io.kroxylicious.proxy.config.admin.ManagementConfiguration;
 import io.kroxylicious.proxy.internal.routing.DirectRouting;
 import io.kroxylicious.proxy.internal.routing.DynamicRouting;
@@ -261,9 +262,13 @@ public record Configuration(
                                                       Map<String, ClusterDefinition> clustersByName,
                                                       PluginFactoryRegistry pfr) {
         RoutingModel routing;
+        RouterChainFactory routerChainFactory = null;
         if (virtualCluster.router() != null) {
             routing = new DynamicRouting(virtualCluster.router(),
                     resolveRouteDescriptors(virtualCluster, filterDefinitionsByName, routersByName, clustersByName));
+            if (pfr != null) {
+                routerChainFactory = RouterChainFactory.forVirtualCluster(pfr, virtualCluster, routersByName);
+            }
         }
         else {
             routing = new DirectRouting(resolveDirectTargetCluster(virtualCluster, clustersByName));
@@ -277,7 +282,8 @@ public record Configuration(
                 virtualCluster.topicNameCacheConfig(),
                 virtualCluster.subjectBuilder(),
                 virtualCluster.effectiveDrainTimeout(),
-                pfr);
+                pfr,
+                routerChainFactory);
 
         addGateways(virtualCluster.gateways(), virtualClusterModel);
         virtualClusterModel.logVirtualClusterSummary();

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -262,13 +262,10 @@ public record Configuration(
                                                       Map<String, ClusterDefinition> clustersByName,
                                                       PluginFactoryRegistry pfr) {
         RoutingModel routing;
-        RouterChainFactory routerChainFactory = null;
         if (virtualCluster.router() != null) {
-            routing = new DynamicRouting(virtualCluster.router(),
-                    resolveRouteDescriptors(virtualCluster, filterDefinitionsByName, routersByName, clustersByName));
-            if (pfr != null) {
-                routerChainFactory = RouterChainFactory.forVirtualCluster(pfr, virtualCluster, routersByName);
-            }
+            var routeDescriptors = resolveRouteDescriptors(virtualCluster, filterDefinitionsByName, routersByName, clustersByName);
+            var routerChainFactory = RouterChainFactory.forVirtualCluster(pfr, virtualCluster, routersByName);
+            routing = new DynamicRouting(virtualCluster.router(), routeDescriptors, routerChainFactory);
         }
         else {
             routing = new DirectRouting(resolveDirectTargetCluster(virtualCluster, clustersByName));
@@ -282,8 +279,7 @@ public record Configuration(
                 virtualCluster.topicNameCacheConfig(),
                 virtualCluster.subjectBuilder(),
                 virtualCluster.effectiveDrainTimeout(),
-                pfr,
-                routerChainFactory);
+                pfr);
 
         addGateways(virtualCluster.gateways(), virtualClusterModel);
         virtualClusterModel.logVirtualClusterSummary();

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -260,9 +260,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
         pipeline.addLast("frontendHandler", frontendHandler);
         switch (virtualCluster.routing()) {
             case DynamicRouting dr -> {
-                var routerChainFactory = Objects.requireNonNull(virtualCluster.routerChainFactory(),
-                        "routerChainFactory must not be null when virtual cluster '" + virtualCluster.getClusterName() + "' uses a router");
-                Router router = routerChainFactory.createRouter(dr.routerName(), virtualCluster.getClusterName());
+                Router router = dr.routerChainFactory().createRouter(dr.routerName(), virtualCluster.getClusterName());
                 Map<ApiKeys, String> staticRoutes = router.staticRoutes();
                 Set<ApiKeys> decodedKeys = EnumSet.allOf(ApiKeys.class);
                 if (!staticRoutes.isEmpty()) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -260,7 +260,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
         pipeline.addLast("frontendHandler", frontendHandler);
         switch (virtualCluster.routing()) {
             case DynamicRouting dr -> {
-                Router router = dr.routerChainFactory().createRouter(dr.routerName(), virtualCluster.getClusterName());
+                Router router = virtualCluster.createRouter();
                 Map<ApiKeys, String> staticRoutes = router.staticRoutes();
                 Set<ApiKeys> decodedKeys = EnumSet.allOf(ApiKeys.class);
                 if (!staticRoutes.isEmpty()) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -31,7 +31,6 @@ import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.concurrent.Future;
 
 import io.kroxylicious.proxy.authentication.TransportSubjectBuilder;
-import io.kroxylicious.proxy.bootstrap.RouterChainFactory;
 import io.kroxylicious.proxy.config.NettySettings;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.config.ProxyProtocolMode;
@@ -68,8 +67,6 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
     private final EndpointBindingResolver bindingResolver;
     private final EndpointReconciler endpointReconciler;
     private final PluginFactoryRegistry pfr;
-    @Nullable
-    private final RouterChainFactory routerChainFactory;
     private final ApiVersionsServiceImpl apiVersionsService;
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private final Optional<NettySettings> proxyNettySettings;
@@ -79,8 +76,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
     private final VirtualClusterRegistry virtualClusterRegistry;
 
     @SuppressWarnings({ "OptionalUsedAsFieldOrParameterType", "java:S107" })
-    public KafkaProxyInitializer(@Nullable RouterChainFactory routerChainFactory,
-                                 PluginFactoryRegistry pfr,
+    public KafkaProxyInitializer(PluginFactoryRegistry pfr,
                                  boolean tls,
                                  EndpointBindingResolver bindingResolver,
                                  EndpointReconciler endpointReconciler,
@@ -93,7 +89,6 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
         this.proxyProtocolMode = proxyProtocolMode;
         this.tls = tls;
         this.bindingResolver = bindingResolver;
-        this.routerChainFactory = routerChainFactory;
         this.apiVersionsService = apiVersionsService;
         this.proxyNettySettings = proxyNettySettings;
         this.clientToProxyErrorCounter = Metrics.clientToProxyErrorCounter("", null).withTags();
@@ -265,7 +260,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
         pipeline.addLast("frontendHandler", frontendHandler);
         switch (virtualCluster.routing()) {
             case DynamicRouting dr -> {
-                Objects.requireNonNull(routerChainFactory,
+                var routerChainFactory = Objects.requireNonNull(virtualCluster.routerChainFactory(),
                         "routerChainFactory must not be null when virtual cluster '" + virtualCluster.getClusterName() + "' uses a router");
                 Router router = routerChainFactory.createRouter(dr.routerName(), virtualCluster.getClusterName());
                 Map<ApiKeys, String> staticRoutes = router.staticRoutes();

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ClusterDefinitionChangeDetector.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ClusterDefinitionChangeDetector.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.reload;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.kroxylicious.proxy.config.ClusterDefinition;
+import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.VirtualCluster;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Identifies virtual clusters that need to be restarted because a cluster definition they
+ * directly reference has changed.
+ * <p>
+ * A cluster is affected if it names a cluster definition (via {@code target.cluster()}) whose
+ * content — bootstrap servers or TLS config — differs between the old and new configuration.
+ * <p>
+ * VCs that target a router (via {@code target.router()}) or use an inline {@code targetCluster}
+ * are not affected by this detector. Walking the router DAG to find cluster definitions
+ * referenced transitively through routers is deferred.
+ * <p>
+ * This detector only produces {@code clustersToModify} entries. Added and removed clusters
+ * are the concern of {@link VirtualClusterChangeDetector}.
+ */
+final class ClusterDefinitionChangeDetector implements ChangeDetector {
+
+    @Override
+    public ChangeResult detect(ConfigurationChangeContext context) {
+        Configuration oldConfig = context.oldConfig();
+        Configuration newConfig = context.newConfig();
+
+        Set<String> changedClusterNames = changedClusterNames(oldConfig, newConfig);
+        if (changedClusterNames.isEmpty()) {
+            return ChangeResult.EMPTY;
+        }
+
+        Map<String, VirtualCluster> newByName = newConfig.virtualClusters().stream()
+                .collect(Collectors.toMap(VirtualCluster::name, Function.identity()));
+
+        Set<String> toModify = new HashSet<>();
+        for (VirtualCluster oldCluster : oldConfig.virtualClusters()) {
+            VirtualCluster newCluster = newByName.get(oldCluster.name());
+            if (newCluster == null) {
+                // Removed — VirtualClusterChangeDetector will flag this as clustersToRemove.
+                continue;
+            }
+            String namedTarget = newCluster.namedTargetCluster();
+            if (namedTarget != null && changedClusterNames.contains(namedTarget)) {
+                toModify.add(newCluster.name());
+            }
+        }
+
+        return new ChangeResult(Set.of(), Set.of(), toModify);
+    }
+
+    /**
+     * Names of cluster definitions whose content changed between old and new config.
+     * Additions and removals are treated as changes because any VC referencing that
+     * name needs to be restarted to pick up the updated connection parameters.
+     */
+    private static Set<String> changedClusterNames(Configuration oldConfig, Configuration newConfig) {
+        Map<String, ClusterDefinition> oldByName = indexByName(oldConfig.clusterDefinitions());
+        Map<String, ClusterDefinition> newByName = indexByName(newConfig.clusterDefinitions());
+
+        Set<String> changed = new HashSet<>();
+        Stream.concat(oldByName.keySet().stream(), newByName.keySet().stream())
+                .distinct()
+                .forEach(name -> {
+                    if (!Objects.equals(oldByName.get(name), newByName.get(name))) {
+                        changed.add(name);
+                    }
+                });
+        return changed;
+    }
+
+    private static Map<String, ClusterDefinition> indexByName(@Nullable List<ClusterDefinition> defs) {
+        return defs == null ? Map.of()
+                : defs.stream().collect(Collectors.toMap(ClusterDefinition::name, Function.identity()));
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
@@ -99,7 +99,7 @@ public class ConfigurationReloadOrchestrator {
      * {@link VirtualClusterChangeDetector} and {@link FilterChangeDetector}.
      */
     public static List<ChangeDetector> defaultDetectors() {
-        return List.of(new VirtualClusterChangeDetector(), new FilterChangeDetector());
+        return List.of(new VirtualClusterChangeDetector(), new FilterChangeDetector(), new RouterChangeDetector());
     }
 
     /**

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
@@ -99,7 +99,7 @@ public class ConfigurationReloadOrchestrator {
      * {@link VirtualClusterChangeDetector} and {@link FilterChangeDetector}.
      */
     public static List<ChangeDetector> defaultDetectors() {
-        return List.of(new VirtualClusterChangeDetector(), new FilterChangeDetector(), new RouterChangeDetector());
+        return List.of(new VirtualClusterChangeDetector(), new FilterChangeDetector(), new RouterChangeDetector(), new ClusterDefinitionChangeDetector());
     }
 
     /**

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/RouterChangeDetector.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/RouterChangeDetector.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.reload;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.RouteDefinition;
+import io.kroxylicious.proxy.config.RouterDefinition;
+import io.kroxylicious.proxy.config.VirtualCluster;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Identifies virtual clusters that need to be restarted because a router definition they
+ * depend on has changed.
+ * <p>
+ * A cluster is affected if any router in its router graph (starting from the cluster's
+ * {@code target.router} and following nested route targets recursively) changed between
+ * old and new configuration — i.e. the router's type, config, or routes differ.
+ * <p>
+ * This detector only produces {@code clustersToModify} entries. Added and removed clusters
+ * are the concern of {@link VirtualClusterChangeDetector}.
+ */
+final class RouterChangeDetector implements ChangeDetector {
+
+    @Override
+    public ChangeResult detect(ConfigurationChangeContext context) {
+        Configuration oldConfig = context.oldConfig();
+        Configuration newConfig = context.newConfig();
+
+        Set<String> changedRouterNames = changedRouterNames(oldConfig, newConfig);
+        if (changedRouterNames.isEmpty()) {
+            return ChangeResult.EMPTY;
+        }
+
+        Map<String, VirtualCluster> newByName = newConfig.virtualClusters().stream()
+                .collect(Collectors.toMap(VirtualCluster::name, Function.identity()));
+        Map<String, RouterDefinition> newRoutersByName = indexRouterDefinitionsByName(newConfig.routerDefinitions());
+
+        Set<String> toModify = new HashSet<>();
+        for (VirtualCluster oldCluster : oldConfig.virtualClusters()) {
+            VirtualCluster newCluster = newByName.get(oldCluster.name());
+            if (newCluster == null) {
+                // Removed — VirtualClusterChangeDetector will flag this as clustersToRemove.
+                continue;
+            }
+            if (transitivelyReferencesChangedRouter(newCluster, newRoutersByName, changedRouterNames)) {
+                toModify.add(newCluster.name());
+            }
+        }
+
+        return new ChangeResult(Set.of(), Set.of(), toModify);
+    }
+
+    /**
+     * Names of router definitions whose content changed between old and new config.
+     * Additions and removals are treated as changes because any VC referencing that
+     * name needs to be restarted to pick up the updated router state.
+     */
+    private static Set<String> changedRouterNames(Configuration oldConfig, Configuration newConfig) {
+        Map<String, RouterDefinition> oldByName = indexRouterDefinitionsByName(oldConfig.routerDefinitions());
+        Map<String, RouterDefinition> newByName = indexRouterDefinitionsByName(newConfig.routerDefinitions());
+
+        Set<String> changed = new HashSet<>();
+        Stream.concat(oldByName.keySet().stream(), newByName.keySet().stream())
+                .distinct()
+                .forEach(name -> {
+                    if (!Objects.equals(oldByName.get(name), newByName.get(name))) {
+                        changed.add(name);
+                    }
+                });
+        return changed;
+    }
+
+    private static Map<String, RouterDefinition> indexRouterDefinitionsByName(@Nullable List<RouterDefinition> defs) {
+        return defs == null ? Map.of()
+                : defs.stream().collect(Collectors.toMap(RouterDefinition::name, Function.identity()));
+    }
+
+    /**
+     * Returns {@code true} if the VC's router graph (traversed recursively from its root router)
+     * contains any router whose name is in {@code changedRouterNames}.
+     */
+    private static boolean transitivelyReferencesChangedRouter(VirtualCluster vc,
+                                                               Map<String, RouterDefinition> routersByName,
+                                                               Set<String> changedRouterNames) {
+        if (vc.router() == null) {
+            return false;
+        }
+        return routerGraphContainsChange(vc.router(), routersByName, changedRouterNames, new HashSet<>());
+    }
+
+    private static boolean routerGraphContainsChange(String routerName,
+                                                     Map<String, RouterDefinition> routersByName,
+                                                     Set<String> changedRouterNames,
+                                                     Set<String> visited) {
+        if (!visited.add(routerName)) {
+            return false;
+        }
+        if (changedRouterNames.contains(routerName)) {
+            return true;
+        }
+        RouterDefinition rd = routersByName.get(routerName);
+        if (rd == null) {
+            return false;
+        }
+        for (RouteDefinition route : rd.routes()) {
+            if (route.router() != null
+                    && routerGraphContainsChange(route.router(), routersByName, changedRouterNames, visited)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/StaticSectionDiffer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/StaticSectionDiffer.java
@@ -39,7 +39,8 @@ final class StaticSectionDiffer {
     private static final Set<String> RECONCILABLE = Set.of(
             "filterDefinitions",
             "defaultFilters",
-            "virtualClusters");
+            "virtualClusters",
+            "routerDefinitions");
 
     /**
      * Returns the names of static configuration sections that differ between {@code oldConfig}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/StaticSectionDiffer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/StaticSectionDiffer.java
@@ -40,7 +40,8 @@ final class StaticSectionDiffer {
             "filterDefinitions",
             "defaultFilters",
             "virtualClusters",
-            "routerDefinitions");
+            "routerDefinitions",
+            "clusterDefinitions");
 
     /**
      * Returns the names of static configuration sections that differ between {@code oldConfig}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/DynamicRouting.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/DynamicRouting.java
@@ -39,6 +39,11 @@ public record DynamicRouting(
         routeDescriptors = Map.copyOf(routeDescriptors);
     }
 
+    @Override
+    public void close() {
+        routerChainFactory.close();
+    }
+
     private static NodeIdMapping buildNodeIdMapping(Map<String, RouteDescriptor> routeDescriptors) {
         Objects.requireNonNull(routeDescriptors, "routeDescriptors");
         if (routeDescriptors.isEmpty()) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/DynamicRouting.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/DynamicRouting.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import io.kroxylicious.proxy.bootstrap.RouterChainFactory;
+import io.kroxylicious.proxy.router.Router;
 
 /**
  * Routing model for a virtual cluster that forwards to one or more upstream clusters via a named
@@ -37,6 +38,10 @@ public record DynamicRouting(
         Objects.requireNonNull(nodeIdMapping, "nodeIdMapping");
         Objects.requireNonNull(routerChainFactory, "routerChainFactory");
         routeDescriptors = Map.copyOf(routeDescriptors);
+    }
+
+    public Router createRouter(String clusterName) {
+        return routerChainFactory.createRouter(routerName, clusterName);
     }
 
     @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/DynamicRouting.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/DynamicRouting.java
@@ -9,28 +9,33 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import io.kroxylicious.proxy.bootstrap.RouterChainFactory;
+
 /**
  * Routing model for a virtual cluster that forwards to one or more upstream clusters via a named
  * router plugin. The {@link NodeIdMapping} is derived from the route descriptors at construction
- * time.
+ * time. The {@link RouterChainFactory} is owned by this instance and is closed when the owning
+ * {@link io.kroxylicious.proxy.model.VirtualClusterModel} is closed.
  */
 public record DynamicRouting(
                              String routerName,
                              Map<String, RouteDescriptor> routeDescriptors,
-                             NodeIdMapping nodeIdMapping)
+                             NodeIdMapping nodeIdMapping,
+                             RouterChainFactory routerChainFactory)
         implements RoutingModel {
 
     /**
      * Convenience constructor: computes the {@link NodeIdMapping} from the supplied route descriptors.
      */
-    public DynamicRouting(String routerName, Map<String, RouteDescriptor> routeDescriptors) {
-        this(routerName, routeDescriptors, buildNodeIdMapping(routeDescriptors));
+    public DynamicRouting(String routerName, Map<String, RouteDescriptor> routeDescriptors, RouterChainFactory routerChainFactory) {
+        this(routerName, routeDescriptors, buildNodeIdMapping(routeDescriptors), routerChainFactory);
     }
 
     public DynamicRouting {
         Objects.requireNonNull(routerName, "routerName");
         Objects.requireNonNull(routeDescriptors, "routeDescriptors");
         Objects.requireNonNull(nodeIdMapping, "nodeIdMapping");
+        Objects.requireNonNull(routerChainFactory, "routerChainFactory");
         routeDescriptors = Map.copyOf(routeDescriptors);
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingModel.java
@@ -12,5 +12,8 @@ package io.kroxylicious.proxy.internal.routing;
  *   <li>{@link DynamicRouting} — one or more upstream clusters reached via a named router plugin</li>
  * </ul>
  */
-public sealed interface RoutingModel permits DirectRouting, DynamicRouting {
+public sealed interface RoutingModel extends AutoCloseable permits DirectRouting, DynamicRouting {
+    @Override
+    default void close() {
+    }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -288,13 +288,11 @@ public class VirtualClusterModel implements AutoCloseable {
         // Suppress exceptions so each component still gets a chance to close; surface the
         // first failure at the end so callers see something rather than nothing.
         RuntimeException firstFailure = null;
-        if (routing instanceof DynamicRouting dr) {
-            try {
-                dr.routerChainFactory().close();
-            }
-            catch (RuntimeException e) {
-                firstFailure = e;
-            }
+        try {
+            routing.close();
+        }
+        catch (RuntimeException e) {
+            firstFailure = e;
         }
         try {
             filterChainFactory.close();

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -56,6 +56,7 @@ import io.kroxylicious.proxy.internal.tls.NettyTrustProvider;
 import io.kroxylicious.proxy.internal.tls.SslContextBuildException;
 import io.kroxylicious.proxy.internal.util.StableKroxyliciousLinkGenerator;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
+import io.kroxylicious.proxy.router.Router;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.service.NodeIdentificationStrategy;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
@@ -178,6 +179,13 @@ public class VirtualClusterModel implements AutoCloseable {
      */
     public FilterChainFactory filterChainFactory() {
         return filterChainFactory;
+    }
+
+    public Router createRouter() {
+        if (!(routing instanceof DynamicRouting dr)) {
+            throw new IllegalStateException("Virtual cluster '" + clusterName + "' does not use a router");
+        }
+        return dr.createRouter(clusterName);
     }
 
     public Duration drainTimeout() {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -32,6 +32,7 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.kroxylicious.proxy.authentication.TransportSubjectBuilder;
 import io.kroxylicious.proxy.authentication.TransportSubjectBuilderService;
 import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
+import io.kroxylicious.proxy.bootstrap.RouterChainFactory;
 import io.kroxylicious.proxy.bootstrap.TlsCredentialSupplierManager;
 import io.kroxylicious.proxy.config.CacheConfiguration;
 import io.kroxylicious.proxy.config.IllegalConfigurationException;
@@ -67,8 +68,11 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * TLS configuration, and the components whose lifecycle is bound to this VC.
  *
  * <h2>Owned resources</h2>
- * The VCM owns and is responsible for closing two per-VC components:
+ * The VCM owns and is responsible for closing three per-VC components:
  * <ul>
+ *   <li>{@link RouterChainFactory} — the router chain factory for <em>this</em> VC, or
+ *       {@code null} for VCs that use a direct {@code targetCluster}. Each VCM has its own
+ *       factory; its lifetime is tied to this VCM.</li>
  *   <li>{@link FilterChainFactory} — the filter chain factory for <em>this</em> VC. Each VCM
  *       has its own FCF.</li>
  *   <li>{@link TlsCredentialSupplierManager} — the TLS credential supplier for this VC.</li>
@@ -117,6 +121,13 @@ public class VirtualClusterModel implements AutoCloseable {
      */
     private final FilterChainFactory filterChainFactory;
 
+    /**
+     * The router chain factory for <em>this</em> virtual cluster, or {@code null} for VCs
+     * that use a direct {@code targetCluster}. Owned by the VCM — its lifetime is tied to
+     * this VCM's lifetime, closed when {@link #close()} is called.
+     */
+    private final @Nullable RouterChainFactory routerChainFactory;
+
     @VisibleForTesting
     public VirtualClusterModel(String clusterName,
                                TargetCluster targetCluster,
@@ -124,7 +135,7 @@ public class VirtualClusterModel implements AutoCloseable {
                                boolean logFrames,
                                List<NamedFilterDefinition> filters) {
         this(clusterName, new DirectRouting(targetCluster), logNetwork, logFrames, filters,
-                new CacheConfiguration(null, null, null), null, Duration.ofSeconds(10), null);
+                new CacheConfiguration(null, null, null), null, Duration.ofSeconds(10), null, null);
     }
 
     public VirtualClusterModel(String clusterName,
@@ -136,6 +147,21 @@ public class VirtualClusterModel implements AutoCloseable {
                                @Nullable TransportSubjectBuilderConfig transportSubjectBuilderConfig,
                                Duration drainTimeout,
                                @Nullable PluginFactoryRegistry pluginFactoryRegistry) {
+        this(clusterName, routing, logNetwork, logFrames, filters, topicNameCacheConfig,
+                transportSubjectBuilderConfig, drainTimeout, pluginFactoryRegistry, null);
+    }
+
+    @SuppressWarnings("java:S107")
+    public VirtualClusterModel(String clusterName,
+                               RoutingModel routing,
+                               boolean logNetwork,
+                               boolean logFrames,
+                               List<NamedFilterDefinition> filters,
+                               CacheConfiguration topicNameCacheConfig,
+                               @Nullable TransportSubjectBuilderConfig transportSubjectBuilderConfig,
+                               Duration drainTimeout,
+                               @Nullable PluginFactoryRegistry pluginFactoryRegistry,
+                               @Nullable RouterChainFactory routerChainFactory) {
         this.clusterName = Objects.requireNonNull(clusterName);
         this.routing = Objects.requireNonNull(routing);
         this.logNetwork = logNetwork;
@@ -144,6 +170,7 @@ public class VirtualClusterModel implements AutoCloseable {
         this.topicNameCacheConfig = topicNameCacheConfig;
         this.transportSubjectBuilderConfig = transportSubjectBuilderConfig;
         this.drainTimeout = Objects.requireNonNull(drainTimeout);
+        this.routerChainFactory = routerChainFactory;
 
         if (pluginFactoryRegistry != null) {
             this.filterChainFactory = new FilterChainFactory(pluginFactoryRegistry, filters);
@@ -174,6 +201,16 @@ public class VirtualClusterModel implements AutoCloseable {
      */
     public FilterChainFactory filterChainFactory() {
         return filterChainFactory;
+    }
+
+    /**
+     * Returns this VC's router chain factory, or {@code null} if this VC uses a direct
+     * {@code targetCluster}. The returned factory is alive for the lifetime of this VCM;
+     * callers should not retain the reference past the VC's lifetime.
+     */
+    @Nullable
+    public RouterChainFactory routerChainFactory() {
+        return routerChainFactory;
     }
 
     public Duration drainTimeout() {
@@ -281,14 +318,27 @@ public class VirtualClusterModel implements AutoCloseable {
      */
     @Override
     public void close() {
-        // Suppress exceptions from FCF close so the TLS close still runs; surface the first
-        // failure at the end so callers see something rather than nothing.
+        // Suppress exceptions so each component still gets a chance to close; surface the
+        // first failure at the end so callers see something rather than nothing.
         RuntimeException firstFailure = null;
+        if (routerChainFactory != null) {
+            try {
+                routerChainFactory.close();
+            }
+            catch (RuntimeException e) {
+                firstFailure = e;
+            }
+        }
         try {
             filterChainFactory.close();
         }
         catch (RuntimeException e) {
-            firstFailure = e;
+            if (firstFailure == null) {
+                firstFailure = e;
+            }
+            else {
+                firstFailure.addSuppressed(e);
+            }
         }
         try {
             tlsCredentialSupplierManager.close();

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -32,7 +32,6 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.kroxylicious.proxy.authentication.TransportSubjectBuilder;
 import io.kroxylicious.proxy.authentication.TransportSubjectBuilderService;
 import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
-import io.kroxylicious.proxy.bootstrap.RouterChainFactory;
 import io.kroxylicious.proxy.bootstrap.TlsCredentialSupplierManager;
 import io.kroxylicious.proxy.config.CacheConfiguration;
 import io.kroxylicious.proxy.config.IllegalConfigurationException;
@@ -68,15 +67,15 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * TLS configuration, and the components whose lifecycle is bound to this VC.
  *
  * <h2>Owned resources</h2>
- * The VCM owns and is responsible for closing three per-VC components:
+ * The VCM owns and is responsible for closing two per-VC components directly:
  * <ul>
- *   <li>{@link RouterChainFactory} — the router chain factory for <em>this</em> VC, or
- *       {@code null} for VCs that use a direct {@code targetCluster}. Each VCM has its own
- *       factory; its lifetime is tied to this VCM.</li>
  *   <li>{@link FilterChainFactory} — the filter chain factory for <em>this</em> VC. Each VCM
  *       has its own FCF.</li>
  *   <li>{@link TlsCredentialSupplierManager} — the TLS credential supplier for this VC.</li>
  * </ul>
+ * For VCs that use dynamic routing, the {@link io.kroxylicious.proxy.internal.routing.DynamicRouting}
+ * instance carries and owns the {@link io.kroxylicious.proxy.bootstrap.RouterChainFactory}; the VCM
+ * closes it via the routing model.
  *
  * <h2>Lifecycle</h2>
  * The VCM is created when the VC is configured (or reconfigured via hot-reload), and closed
@@ -121,13 +120,6 @@ public class VirtualClusterModel implements AutoCloseable {
      */
     private final FilterChainFactory filterChainFactory;
 
-    /**
-     * The router chain factory for <em>this</em> virtual cluster, or {@code null} for VCs
-     * that use a direct {@code targetCluster}. Owned by the VCM — its lifetime is tied to
-     * this VCM's lifetime, closed when {@link #close()} is called.
-     */
-    private final @Nullable RouterChainFactory routerChainFactory;
-
     @VisibleForTesting
     public VirtualClusterModel(String clusterName,
                                TargetCluster targetCluster,
@@ -135,20 +127,7 @@ public class VirtualClusterModel implements AutoCloseable {
                                boolean logFrames,
                                List<NamedFilterDefinition> filters) {
         this(clusterName, new DirectRouting(targetCluster), logNetwork, logFrames, filters,
-                new CacheConfiguration(null, null, null), null, Duration.ofSeconds(10), null, null);
-    }
-
-    public VirtualClusterModel(String clusterName,
-                               RoutingModel routing,
-                               boolean logNetwork,
-                               boolean logFrames,
-                               List<NamedFilterDefinition> filters,
-                               CacheConfiguration topicNameCacheConfig,
-                               @Nullable TransportSubjectBuilderConfig transportSubjectBuilderConfig,
-                               Duration drainTimeout,
-                               @Nullable PluginFactoryRegistry pluginFactoryRegistry) {
-        this(clusterName, routing, logNetwork, logFrames, filters, topicNameCacheConfig,
-                transportSubjectBuilderConfig, drainTimeout, pluginFactoryRegistry, null);
+                new CacheConfiguration(null, null, null), null, Duration.ofSeconds(10), null);
     }
 
     @SuppressWarnings("java:S107")
@@ -160,8 +139,7 @@ public class VirtualClusterModel implements AutoCloseable {
                                CacheConfiguration topicNameCacheConfig,
                                @Nullable TransportSubjectBuilderConfig transportSubjectBuilderConfig,
                                Duration drainTimeout,
-                               @Nullable PluginFactoryRegistry pluginFactoryRegistry,
-                               @Nullable RouterChainFactory routerChainFactory) {
+                               @Nullable PluginFactoryRegistry pluginFactoryRegistry) {
         this.clusterName = Objects.requireNonNull(clusterName);
         this.routing = Objects.requireNonNull(routing);
         this.logNetwork = logNetwork;
@@ -170,7 +148,6 @@ public class VirtualClusterModel implements AutoCloseable {
         this.topicNameCacheConfig = topicNameCacheConfig;
         this.transportSubjectBuilderConfig = transportSubjectBuilderConfig;
         this.drainTimeout = Objects.requireNonNull(drainTimeout);
-        this.routerChainFactory = routerChainFactory;
 
         if (pluginFactoryRegistry != null) {
             this.filterChainFactory = new FilterChainFactory(pluginFactoryRegistry, filters);
@@ -201,16 +178,6 @@ public class VirtualClusterModel implements AutoCloseable {
      */
     public FilterChainFactory filterChainFactory() {
         return filterChainFactory;
-    }
-
-    /**
-     * Returns this VC's router chain factory, or {@code null} if this VC uses a direct
-     * {@code targetCluster}. The returned factory is alive for the lifetime of this VCM;
-     * callers should not retain the reference past the VC's lifetime.
-     */
-    @Nullable
-    public RouterChainFactory routerChainFactory() {
-        return routerChainFactory;
     }
 
     public Duration drainTimeout() {
@@ -321,9 +288,9 @@ public class VirtualClusterModel implements AutoCloseable {
         // Suppress exceptions so each component still gets a chance to close; surface the
         // first failure at the end so callers see something rather than nothing.
         RuntimeException firstFailure = null;
-        if (routerChainFactory != null) {
+        if (routing instanceof DynamicRouting dr) {
             try {
-                routerChainFactory.close();
+                dr.routerChainFactory().close();
             }
             catch (RuntimeException e) {
                 firstFailure = e;

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/RouterChainFactoryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/RouterChainFactoryTest.java
@@ -6,6 +6,7 @@
 package io.kroxylicious.proxy.bootstrap;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -303,6 +304,43 @@ class RouterChainFactoryTest {
             assertThat(initCount.get()).isEqualTo(2);
             assertThat(factory.createRouter("parent", VC_NAME)).isNotNull();
             assertThat(factory.createRouter("child", VC_NAME)).isNotNull();
+        }
+    }
+
+    @Test
+    void forVirtualClusterInitialisesOnlyThatVcsRouterGraph() {
+        // Given: two router definitions but only one is reachable from the VC
+        var initCount = new AtomicInteger(0);
+        var pfr = testPfrWith(new TestRouterFactory() {
+            @Override
+            public Object initialize(RouterFactoryContext context, Object config) {
+                initCount.incrementAndGet();
+                return super.initialize(context, config);
+            }
+        });
+        var rdUsed = new RouterDefinition("used", TestRouterFactory.class.getName(), null, DUMMY_ROUTES);
+        var rdOrphan = new RouterDefinition("orphan", TestRouterFactory.class.getName(), null, DUMMY_ROUTES);
+        var vc = testVc(VC_NAME, "used");
+
+        // When
+        try (var factory = RouterChainFactory.forVirtualCluster(pfr, vc,
+                Map.of("used", rdUsed, "orphan", rdOrphan))) {
+            // Then: only the referenced router was initialised
+            assertThat(initCount.get()).isEqualTo(1);
+            assertThat(factory.createRouter("used", VC_NAME)).isNotNull();
+        }
+    }
+
+    @Test
+    void forVirtualClusterWithNullRoutersByNameProducesEmptyFactory() {
+        // Given: a VC with a router reference but null routersByName (e.g. no routerDefinitions block)
+        var vc = testVc(VC_NAME, "r1");
+
+        // When
+        try (var factory = RouterChainFactory.forVirtualCluster(testPfr(), vc, null)) {
+            // Then: no routers initialised; createRouter throws as expected
+            assertThatThrownBy(() -> factory.createRouter("r1", VC_NAME))
+                    .isInstanceOf(IllegalArgumentException.class);
         }
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
@@ -8,18 +8,25 @@ package io.kroxylicious.proxy.config;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.kroxylicious.proxy.internal.routing.DirectRouting;
 import io.kroxylicious.proxy.internal.routing.DynamicRouting;
 import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
+import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.router.RouterFactory;
+import io.kroxylicious.proxy.router.RouterFactoryContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@ExtendWith(MockitoExtension.class)
 class ConfigurationValidationTest {
 
     private static final VirtualCluster SIMPLE_VC = new VirtualCluster("demo",
@@ -36,6 +43,41 @@ class ConfigurationValidationTest {
 
     private static Configuration config(List<VirtualCluster> vcs) {
         return new Configuration(null, null, null, null, null, vcs, null, false, Optional.empty(), null, null);
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static PluginFactoryRegistry noOpRouterPfr() {
+        return new PluginFactoryRegistry() {
+            @Override
+            public <P> PluginFactory<P> pluginFactory(Class<P> pluginClass) {
+                return (PluginFactory<P>) new PluginFactory<RouterFactory<?, ?>>() {
+                    @Override
+                    public RouterFactory<?, ?> pluginInstance(String instanceName) {
+                        return new RouterFactory<Object, Object>() {
+                            @Override
+                            public Object initialize(RouterFactoryContext context, Object config) {
+                                return null;
+                            }
+
+                            @Override
+                            public Router createRouter(RouterFactoryContext context, Object initializationData) {
+                                throw new UnsupportedOperationException("no-op router factory");
+                            }
+                        };
+                    }
+
+                    @Override
+                    public Class<?> configType(String instanceName) {
+                        return Object.class;
+                    }
+
+                    @Override
+                    public Set<String> registeredInstanceNames() {
+                        return Set.of();
+                    }
+                };
+            }
+        };
     }
 
     @Test
@@ -116,7 +158,7 @@ class ConfigurationValidationTest {
                 List.of(simpleGateway("gateway")), false, false, null, null, null, null);
         var config = new Configuration(null, List.of(cluster), null, null, List.of(router),
                 List.of(virtualCluster), null, false, Optional.empty(), null, null);
-        List<VirtualClusterModel> virtualClusterModels = config.virtualClusterModel(null);
+        List<VirtualClusterModel> virtualClusterModels = config.virtualClusterModel(noOpRouterPfr());
         assertThat(virtualClusterModels).hasSize(1).singleElement().satisfies(vm -> {
             assertThat(vm.routing()).isInstanceOf(DynamicRouting.class);
             assertThat(((DynamicRouting) vm.routing()).routerName()).isEqualTo("myrouter");
@@ -134,7 +176,7 @@ class ConfigurationValidationTest {
         var config = new Configuration(null, List.of(cluster), null, null, List.of(router),
                 List.of(vc), null, false, Optional.empty(), null, null);
 
-        var model = config.virtualClusterModel(null).get(0);
+        var model = config.virtualClusterModel(noOpRouterPfr()).get(0);
 
         assertThat(((DynamicRouting) model.routing()).routeDescriptors()).containsKey("route1");
         RouteDescriptor rd = ((DynamicRouting) model.routing()).routeDescriptors().get("route1");
@@ -157,7 +199,7 @@ class ConfigurationValidationTest {
         var config = new Configuration(null, List.of(c1, c2), null, null, List.of(router),
                 List.of(vc), null, false, Optional.empty(), null, null);
 
-        var model = config.virtualClusterModel(null).get(0);
+        var model = config.virtualClusterModel(noOpRouterPfr()).get(0);
 
         assertThat(model.routing()).isInstanceOf(DynamicRouting.class);
         var dr = (DynamicRouting) model.routing();
@@ -177,7 +219,7 @@ class ConfigurationValidationTest {
         var config = new Configuration(null, List.of(c1, c2), null, null, List.of(router),
                 List.of(vc), null, false, Optional.empty(), null, null);
 
-        var model = config.virtualClusterModel(null).get(0);
+        var model = config.virtualClusterModel(noOpRouterPfr()).get(0);
 
         assertThat(((DynamicRouting) model.routing()).routeDescriptors()).hasSize(2).containsKeys("r1", "r2");
     }
@@ -194,7 +236,7 @@ class ConfigurationValidationTest {
         var config = new Configuration(null, List.of(cluster), filterDefs, null, List.of(router),
                 List.of(vc), null, false, Optional.empty(), null, null);
 
-        var model = config.virtualClusterModel(null).get(0);
+        var model = config.virtualClusterModel(noOpRouterPfr()).get(0);
 
         RouteDescriptor rd = ((DynamicRouting) model.routing()).routeDescriptors().get("r1");
         assertThat(rd.filters()).hasSize(1);
@@ -269,7 +311,7 @@ class ConfigurationValidationTest {
         var config = new Configuration(null, List.of(cluster), null, null, List.of(router),
                 List.of(vc), null, false, Optional.empty(), null, null);
 
-        var model = config.virtualClusterModel(null, "demo");
+        var model = config.virtualClusterModel(noOpRouterPfr(), "demo");
 
         assertThat(model.routing()).isInstanceOf(DynamicRouting.class);
         var dr = (DynamicRouting) model.routing();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
@@ -54,6 +54,7 @@ import io.netty.handler.codec.DecoderException;
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.concurrent.ScheduledFuture;
 
+import io.kroxylicious.proxy.bootstrap.RouterChainFactory;
 import io.kroxylicious.proxy.config.CacheConfiguration;
 import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
@@ -748,7 +749,7 @@ class ClientConnectionStateMachineTest {
         var routerVc = mock(VirtualClusterModel.class, withSettings().lenient());
         var routeDescriptors = Map.of("route",
                 new RouteDescriptor("route", 0, new TargetCluster("broker:9092", Optional.empty()), null, List.of()));
-        when(routerVc.routing()).thenReturn(new DynamicRouting("router", routeDescriptors));
+        when(routerVc.routing()).thenReturn(new DynamicRouting("router", routeDescriptors, mock(RouterChainFactory.class)));
         when(endpointGateway.virtualCluster()).thenReturn(routerVc);
     }
 
@@ -974,7 +975,7 @@ class ClientConnectionStateMachineTest {
         when(routeDescriptor.targetsCluster()).thenReturn(true);
         when(routeDescriptor.targetCluster()).thenReturn(targetCluster);
         var routerVc = mock(VirtualClusterModel.class, withSettings().lenient());
-        when(routerVc.routing()).thenReturn(new DynamicRouting("router", Map.of("my-route", routeDescriptor)));
+        when(routerVc.routing()).thenReturn(new DynamicRouting("router", Map.of("my-route", routeDescriptor), mock(RouterChainFactory.class)));
         when(endpointGateway.virtualCluster()).thenReturn(routerVc);
 
         // When: first request triggers toForwardingWithRoutes
@@ -1000,7 +1001,7 @@ class ClientConnectionStateMachineTest {
         var routerVc = mock(VirtualClusterModel.class, withSettings().lenient());
         var routeDescriptors2 = Map.of("my-route",
                 new RouteDescriptor("my-route", 0, new TargetCluster("broker:9092", Optional.empty()), null, List.of()));
-        when(routerVc.routing()).thenReturn(new DynamicRouting("router", routeDescriptors2));
+        when(routerVc.routing()).thenReturn(new DynamicRouting("router", routeDescriptors2, mock(RouterChainFactory.class)));
         when(endpointGateway.virtualCluster()).thenReturn(routerVc);
 
         // When: forwardToRoute lazily tries to create an SCSM and fails
@@ -1027,7 +1028,7 @@ class ClientConnectionStateMachineTest {
         when(routeDescriptor.targetsCluster()).thenReturn(true);
         when(routeDescriptor.targetCluster()).thenReturn(targetCluster);
         var routerVc = mock(VirtualClusterModel.class, withSettings().lenient());
-        when(routerVc.routing()).thenReturn(new DynamicRouting("router", Map.of("bad-route", routeDescriptor)));
+        when(routerVc.routing()).thenReturn(new DynamicRouting("router", Map.of("bad-route", routeDescriptor), mock(RouterChainFactory.class)));
         when(endpointGateway.virtualCluster()).thenReturn(routerVc);
 
         // When / Then

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -449,8 +449,7 @@ class KafkaProxyInitializerTest {
                                                               ProxyProtocolMode proxyProtocolMode,
                                                               EndpointBindingResolver bindingResolver,
                                                               VirtualClusterRegistry vcc) {
-        return new KafkaProxyInitializer(null,
-                pfr,
+        return new KafkaProxyInitializer(pfr,
                 tls,
                 bindingResolver,
                 (virtualCluster, upstreamNodes) -> null,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -9,7 +9,6 @@ package io.kroxylicious.proxy.internal;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -60,15 +59,12 @@ import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointBindingResolver;
 import io.kroxylicious.proxy.internal.net.EndpointResolutionException;
 import io.kroxylicious.proxy.internal.routing.DirectRouting;
-import io.kroxylicious.proxy.internal.routing.DynamicRouting;
-import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.NodeIdentificationStrategy;
 
 import static io.kroxylicious.proxy.internal.KafkaProxyInitializer.LOGGING_INBOUND_ERROR_HANDLER_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -135,17 +131,6 @@ class KafkaProxyInitializerTest {
         VirtualClusterModel testCluster = new VirtualClusterModel("testCluster",
                 new DirectRouting(new TargetCluster("localhost:9090", tls)), logNetwork,
                 logFrames, List.of(), CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
-        testCluster.addGateway("defaullt", mock(NodeIdentificationStrategy.class), tls);
-        return testCluster;
-    }
-
-    private VirtualClusterModel buildRouterVirtualCluster() {
-        final Optional<Tls> tls = Optional.empty();
-        var routeDescriptors = Map.of("myRoute",
-                new RouteDescriptor("myRoute", 0, new TargetCluster("localhost:9090", tls), null, List.of()));
-        VirtualClusterModel testCluster = new VirtualClusterModel("testCluster",
-                new DynamicRouting("myRouter", routeDescriptors), false, false,
-                List.of(), CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
         testCluster.addGateway("defaullt", mock(NodeIdentificationStrategy.class), tls);
         return testCluster;
     }
@@ -399,20 +384,6 @@ class KafkaProxyInitializerTest {
         verify(channel).close();
         verify(channelPipeline, never()).remove(anyString());
         verify(channelPipeline, never()).addLast(anyString(), any());
-    }
-
-    @Test
-    void shouldThrowWhenRouterVirtualClusterHasNullRouterChainFactory() {
-        // Given
-        var routerCluster = buildRouterVirtualCluster();
-        when(endpointBinding.endpointGateway()).thenReturn(routerCluster.gateways().values().iterator().next());
-        kafkaProxyInitializer = createKafkaProxyInitializer(false, (endpoint, sniHostname) -> bindingStage);
-
-        // When / Then
-        var session = new KafkaSession(KafkaSessionState.ESTABLISHING);
-        assertThatThrownBy(() -> kafkaProxyInitializer.initConnection(channel, endpointBinding, session))
-                .isInstanceOf(NullPointerException.class)
-                .hasMessageContaining("routerChainFactory");
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ClusterDefinitionChangeDetectorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ClusterDefinitionChangeDetectorTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.reload;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.ClusterDefinition;
+import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.PortIdentifiesNodeIdentificationStrategy;
+import io.kroxylicious.proxy.config.RouteDefinition;
+import io.kroxylicious.proxy.config.RouteTarget;
+import io.kroxylicious.proxy.config.RouterDefinition;
+import io.kroxylicious.proxy.config.TargetCluster;
+import io.kroxylicious.proxy.config.VirtualCluster;
+import io.kroxylicious.proxy.config.VirtualClusterGateway;
+import io.kroxylicious.proxy.service.HostPort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ClusterDefinitionChangeDetectorTest {
+
+    private final ClusterDefinitionChangeDetector detector = new ClusterDefinitionChangeDetector();
+
+    @Test
+    void emptyWhenNoClusterDefinitionsChanged() {
+        // Given
+        var cd = clusterDef("upstream", "kafka:9092");
+        var oldConfig = config(List.of(cd), vcWithNamedCluster("vc-a", "upstream"));
+        var newConfig = config(List.of(cd), vcWithNamedCluster("vc-a", "upstream"));
+
+        // When / Then
+        assertThat(detector.detect(new ConfigurationChangeContext(oldConfig, newConfig)).isEmpty()).isTrue();
+    }
+
+    @Test
+    void emptyWhenNoClusterDefinitionsExistInEitherConfig() {
+        // Given: VCs using deprecated inline targetCluster, no cluster definitions
+        var oldConfig = configWithNoClusterDefs(vcWithInlineTarget("vc-a"));
+        var newConfig = configWithNoClusterDefs(vcWithInlineTarget("vc-a"));
+
+        // When / Then
+        assertThat(detector.detect(new ConfigurationChangeContext(oldConfig, newConfig)).isEmpty()).isTrue();
+    }
+
+    @Test
+    void detectsVcReferencingModifiedClusterDefinition() {
+        // Given
+        var oldCd = clusterDef("upstream", "kafka:9092");
+        var newCd = clusterDef("upstream", "kafka-new:9092");
+        var oldConfig = config(List.of(oldCd), vcWithNamedCluster("vc-a", "upstream"));
+        var newConfig = config(List.of(newCd), vcWithNamedCluster("vc-a", "upstream"));
+
+        // When
+        var result = detector.detect(new ConfigurationChangeContext(oldConfig, newConfig));
+
+        // Then
+        assertThat(result.clustersToModify()).containsExactly("vc-a");
+        assertThat(result.clustersToAdd()).isEmpty();
+        assertThat(result.clustersToRemove()).isEmpty();
+    }
+
+    @Test
+    void ignoresVcNotReferencingChangedClusterDefinition() {
+        // Given: upstream-a changed, upstream-b unchanged; vc-a uses upstream-a, vc-b uses upstream-b
+        var oldA = clusterDef("upstream-a", "kafka-a-old:9092");
+        var newA = clusterDef("upstream-a", "kafka-a-new:9092");
+        var b = clusterDef("upstream-b", "kafka-b:9092");
+        var oldConfig = config(List.of(oldA, b),
+                vcWithNamedCluster("vc-a", "upstream-a"),
+                vcWithNamedCluster("vc-b", "upstream-b"));
+        var newConfig = config(List.of(newA, b),
+                vcWithNamedCluster("vc-a", "upstream-a"),
+                vcWithNamedCluster("vc-b", "upstream-b"));
+
+        // When
+        var result = detector.detect(new ConfigurationChangeContext(oldConfig, newConfig));
+
+        // Then: only the VC referencing the changed cluster definition is flagged
+        assertThat(result.clustersToModify()).containsExactly("vc-a");
+    }
+
+    @Test
+    void ignoresVcUsingRouter() {
+        // Given: a cluster definition changes but some VCs target a router, not a named cluster
+        var oldCd = clusterDef("upstream", "kafka:9092");
+        var newCd = clusterDef("upstream", "kafka-new:9092");
+        var router = routerDef("my-router", "upstream");
+        var oldConfig = configWithRouter(List.of(oldCd), List.of(router),
+                vcWithNamedCluster("direct", "upstream"),
+                vcWithRouter("routed", "my-router"));
+        var newConfig = configWithRouter(List.of(newCd), List.of(router),
+                vcWithNamedCluster("direct", "upstream"),
+                vcWithRouter("routed", "my-router"));
+
+        // When
+        var result = detector.detect(new ConfigurationChangeContext(oldConfig, newConfig));
+
+        // Then: only the directly-referencing VC is affected
+        assertThat(result.clustersToModify()).containsExactly("direct");
+    }
+
+    @Test
+    void ignoresVcUsingDeprecatedInlineTargetCluster() {
+        // Given: cluster definition changes; one VC uses inline targetCluster (namedTargetCluster() is null)
+        var oldCd = clusterDef("upstream", "kafka:9092");
+        var newCd = clusterDef("upstream", "kafka-new:9092");
+        var oldConfig = config(List.of(oldCd),
+                vcWithNamedCluster("named", "upstream"),
+                vcWithInlineTarget("inline"));
+        var newConfig = config(List.of(newCd),
+                vcWithNamedCluster("named", "upstream"),
+                vcWithInlineTarget("inline"));
+
+        // When
+        var result = detector.detect(new ConfigurationChangeContext(oldConfig, newConfig));
+
+        // Then: inline VC is not affected
+        assertThat(result.clustersToModify()).containsExactly("named");
+    }
+
+    @Test
+    void removedVcIsNotIncluded() {
+        // Given: cluster definition changes; one VC present in old but not new
+        var oldCd = clusterDef("upstream", "kafka:9092");
+        var newCd = clusterDef("upstream", "kafka-new:9092");
+        var oldConfig = config(List.of(oldCd),
+                vcWithNamedCluster("stays", "upstream"),
+                vcWithNamedCluster("goes-away", "upstream"));
+        var newConfig = config(List.of(newCd),
+                vcWithNamedCluster("stays", "upstream"));
+
+        // When
+        var result = detector.detect(new ConfigurationChangeContext(oldConfig, newConfig));
+
+        // Then: removed cluster is VirtualClusterChangeDetector's concern, not ours
+        assertThat(result.clustersToModify()).containsExactly("stays");
+        assertThat(result.clustersToRemove()).isEmpty();
+    }
+
+    @Test
+    void reorderingClusterDefinitionsDoesNotTriggerChange() {
+        // Given: clusterDefinitions reordered but content identical
+        var a = clusterDef("a", "kafka-a:9092");
+        var b = clusterDef("b", "kafka-b:9092");
+        var oldConfig = config(List.of(a, b),
+                vcWithNamedCluster("vc-a", "a"),
+                vcWithNamedCluster("vc-b", "b"));
+        var newConfig = config(List.of(b, a),
+                vcWithNamedCluster("vc-a", "a"),
+                vcWithNamedCluster("vc-b", "b"));
+
+        // When / Then
+        assertThat(detector.detect(new ConfigurationChangeContext(oldConfig, newConfig)).isEmpty()).isTrue();
+    }
+
+    @Test
+    void addedClusterDefinitionNotReferencedByAnyVcProducesNoModify() {
+        // Given: a new cluster definition appears but no VC references it
+        var existing = clusterDef("existing", "kafka:9092");
+        var added = clusterDef("new-cluster", "kafka-new:9092");
+        var oldConfig = config(List.of(existing), vcWithNamedCluster("vc-a", "existing"));
+        var newConfig = config(List.of(existing, added), vcWithNamedCluster("vc-a", "existing"));
+
+        // When / Then: new-cluster is added (changed) but no VC references it
+        assertThat(detector.detect(new ConfigurationChangeContext(oldConfig, newConfig)).isEmpty()).isTrue();
+    }
+
+    // ---- fixture helpers ----
+
+    private static ClusterDefinition clusterDef(String name, String bootstrapServers) {
+        return new ClusterDefinition(name, bootstrapServers, null);
+    }
+
+    private static VirtualCluster vcWithNamedCluster(String name, String clusterDefName) {
+        return vc(name, new RouteTarget(clusterDefName, null));
+    }
+
+    private static VirtualCluster vcWithRouter(String name, String routerName) {
+        return vc(name, new RouteTarget(null, routerName));
+    }
+
+    @SuppressWarnings("deprecation")
+    private static VirtualCluster vcWithInlineTarget(String name) {
+        return new VirtualCluster(name, new TargetCluster("kafka:9092", Optional.empty()),
+                List.of(gateway()), false, false, null);
+    }
+
+    private static VirtualCluster vc(String name, RouteTarget target) {
+        return new VirtualCluster(name, null, target, List.of(gateway()), false, false, null, null, null, null);
+    }
+
+    private static VirtualClusterGateway gateway() {
+        return new VirtualClusterGateway("default",
+                new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9192), null, null, null),
+                null, Optional.empty());
+    }
+
+    private static RouterDefinition routerDef(String name, String clusterTarget) {
+        var route = new RouteDefinition("route", 0, null, new RouteTarget(clusterTarget, null));
+        return new RouterDefinition(name, "SomeRouterType", "cfg", List.of(route));
+    }
+
+    private static Configuration config(List<ClusterDefinition> clusterDefs, VirtualCluster... clusters) {
+        return new Configuration(null, clusterDefs, null, null, null, List.of(clusters), null, false,
+                Optional.empty(), null, null);
+    }
+
+    private static Configuration configWithRouter(List<ClusterDefinition> clusterDefs,
+                                                  List<RouterDefinition> routerDefs,
+                                                  VirtualCluster... clusters) {
+        return new Configuration(null, clusterDefs, null, null, routerDefs, List.of(clusters), null, false,
+                Optional.empty(), null, null);
+    }
+
+    private static Configuration configWithNoClusterDefs(VirtualCluster... clusters) {
+        return new Configuration(null, null, null, null, null, List.of(clusters), null, false,
+                Optional.empty(), null, null);
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/RouterChangeDetectorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/RouterChangeDetectorTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.reload;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.ClusterDefinition;
+import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.PortIdentifiesNodeIdentificationStrategy;
+import io.kroxylicious.proxy.config.RouteDefinition;
+import io.kroxylicious.proxy.config.RouteTarget;
+import io.kroxylicious.proxy.config.RouterDefinition;
+import io.kroxylicious.proxy.config.TargetCluster;
+import io.kroxylicious.proxy.config.VirtualCluster;
+import io.kroxylicious.proxy.config.VirtualClusterGateway;
+import io.kroxylicious.proxy.service.HostPort;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RouterChangeDetectorTest {
+
+    private static final ClusterDefinition UPSTREAM = new ClusterDefinition("upstream", "kafka:9092", null);
+
+    private final RouterChangeDetector detector = new RouterChangeDetector();
+
+    @Test
+    void emptyWhenNoRouterDefinitionsChanged() {
+        // Given
+        var rd = routerDef("r1", "v1", "upstream");
+        var oldConfig = configWith(List.of(rd), vcWithRouter("cluster-a", "r1"));
+        var newConfig = configWith(List.of(rd), vcWithRouter("cluster-a", "r1"));
+
+        // When / Then
+        assertThat(detector.detect(new ConfigurationChangeContext(oldConfig, newConfig)).isEmpty()).isTrue();
+    }
+
+    @Test
+    void emptyWhenNoRouterDefinitionsExistInEitherConfig() {
+        // Given: VCs using targetCluster, no router definitions
+        var oldConfig = configWithNoRouters(vcWithTarget("cluster-a"));
+        var newConfig = configWithNoRouters(vcWithTarget("cluster-a"));
+
+        // When / Then
+        assertThat(detector.detect(new ConfigurationChangeContext(oldConfig, newConfig)).isEmpty()).isTrue();
+    }
+
+    @Test
+    void detectsClusterReferencingModifiedRouterDefinition() {
+        // Given
+        var oldRd = routerDef("r1", "v1", "upstream");
+        var newRd = routerDef("r1", "v2", "upstream");
+        var oldConfig = configWith(List.of(oldRd), vcWithRouter("cluster-a", "r1"));
+        var newConfig = configWith(List.of(newRd), vcWithRouter("cluster-a", "r1"));
+
+        // When
+        var result = detector.detect(new ConfigurationChangeContext(oldConfig, newConfig));
+
+        // Then
+        assertThat(result.clustersToModify()).containsExactly("cluster-a");
+        assertThat(result.clustersToAdd()).isEmpty();
+        assertThat(result.clustersToRemove()).isEmpty();
+    }
+
+    @Test
+    void ignoresClustersNotReferencingChangedRouter() {
+        // Given: r1 changed, r2 unchanged; cluster-a uses r1, cluster-b uses r2
+        var oldR1 = routerDef("r1", "v1", "upstream");
+        var newR1 = routerDef("r1", "v2", "upstream");
+        var r2 = routerDef("r2", "stable", "upstream");
+        var oldConfig = configWith(List.of(oldR1, r2),
+                vcWithRouter("cluster-a", "r1"),
+                vcWithRouter("cluster-b", "r2"));
+        var newConfig = configWith(List.of(newR1, r2),
+                vcWithRouter("cluster-a", "r1"),
+                vcWithRouter("cluster-b", "r2"));
+
+        // When
+        var result = detector.detect(new ConfigurationChangeContext(oldConfig, newConfig));
+
+        // Then: only the cluster referencing the changed router is flagged
+        assertThat(result.clustersToModify()).containsExactly("cluster-a");
+    }
+
+    @Test
+    void ignoresClustersWithNoRouter() {
+        // Given: a router definition changes but some clusters use a direct targetCluster
+        var oldRd = routerDef("r1", "v1", "upstream");
+        var newRd = routerDef("r1", "v2", "upstream");
+        var oldConfig = configWith(List.of(oldRd),
+                vcWithRouter("routed", "r1"),
+                vcWithTarget("direct"));
+        var newConfig = configWith(List.of(newRd),
+                vcWithRouter("routed", "r1"),
+                vcWithTarget("direct"));
+
+        // When
+        var result = detector.detect(new ConfigurationChangeContext(oldConfig, newConfig));
+
+        // Then: only the routed cluster is affected
+        assertThat(result.clustersToModify()).containsExactly("routed");
+    }
+
+    @Test
+    void removedClustersAreNotIncluded() {
+        // Given
+        var oldRd = routerDef("r1", "v1", "upstream");
+        var newRd = routerDef("r1", "v2", "upstream");
+        var oldConfig = configWith(List.of(oldRd),
+                vcWithRouter("stays", "r1"),
+                vcWithRouter("goes-away", "r1"));
+        var newConfig = configWith(List.of(newRd),
+                vcWithRouter("stays", "r1"));
+
+        // When
+        var result = detector.detect(new ConfigurationChangeContext(oldConfig, newConfig));
+
+        // Then: removed cluster is VirtualClusterChangeDetector's concern, not ours
+        assertThat(result.clustersToModify()).containsExactly("stays");
+        assertThat(result.clustersToRemove()).isEmpty();
+    }
+
+    @Test
+    void reorderingRouterDefinitionsAtTopLevelDoesNotTriggerChange() {
+        // Given: routerDefinitions reordered but content identical; a RouterDefinition is a
+        // record so equals() is structural — reorder is a no-op semantically.
+        var r1 = routerDef("r1", "cfg", "upstream");
+        var r2 = routerDef("r2", "cfg", "upstream");
+        var oldConfig = configWith(List.of(r1, r2),
+                vcWithRouter("a", "r1"),
+                vcWithRouter("b", "r2"));
+        var newConfig = configWith(List.of(r2, r1),
+                vcWithRouter("a", "r1"),
+                vcWithRouter("b", "r2"));
+
+        // When / Then
+        assertThat(detector.detect(new ConfigurationChangeContext(oldConfig, newConfig)).isEmpty()).isTrue();
+    }
+
+    @Test
+    void addedRouterDefinitionNotYetReferencedByAnyClusterProducesNoModify() {
+        // Given: a new router definition appears but no VC references it
+        var r1 = routerDef("r1", "cfg", "upstream");
+        var r2 = routerDef("r2", "cfg", "upstream");
+        var oldConfig = configWith(List.of(r1), vcWithRouter("cluster-a", "r1"));
+        var newConfig = configWith(List.of(r1, r2), vcWithRouter("cluster-a", "r1"));
+
+        // When / Then: r2 is new (changed) but no cluster references it
+        assertThat(detector.detect(new ConfigurationChangeContext(oldConfig, newConfig)).isEmpty()).isTrue();
+    }
+
+    // ---- fixture helpers ----
+
+    private static RouterDefinition routerDef(String name, String opaqueConfig, String clusterTarget) {
+        var route = new RouteDefinition("route", 0, null, new RouteTarget(clusterTarget, null));
+        return new RouterDefinition(name, "SomeRouterType", opaqueConfig, List.of(route));
+    }
+
+    private static VirtualCluster vcWithRouter(String name, String routerName) {
+        return vc(name, new RouteTarget(null, routerName));
+    }
+
+    @SuppressWarnings("deprecation")
+    private static VirtualCluster vcWithTarget(String name) {
+        return new VirtualCluster(name, new TargetCluster("kafka:9092", Optional.empty()),
+                List.of(gateway()), false, false, null);
+    }
+
+    private static VirtualCluster vc(String name, RouteTarget target) {
+        return new VirtualCluster(name, null, target, List.of(gateway()), false, false, null, null, null, null);
+    }
+
+    private static VirtualClusterGateway gateway() {
+        return new VirtualClusterGateway("default",
+                new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9192), null, null, null),
+                null, Optional.empty());
+    }
+
+    private static Configuration configWith(@Nullable List<RouterDefinition> routerDefs, VirtualCluster... clusters) {
+        return new Configuration(null, List.of(UPSTREAM), null, null, routerDefs, List.of(clusters), null, false,
+                Optional.empty(), null, null);
+    }
+
+    private static Configuration configWithNoRouters(VirtualCluster... clusters) {
+        return new Configuration(null, null, null, null, null, List.of(clusters), null, false,
+                Optional.empty(), null, null);
+    }
+
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/StaticSectionDifferTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/StaticSectionDifferTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import io.kroxylicious.proxy.config.ClusterDefinition;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.MicrometerDefinition;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
@@ -23,6 +24,9 @@ import io.kroxylicious.proxy.config.NetworkDefinition;
 import io.kroxylicious.proxy.config.PortIdentifiesNodeIdentificationStrategy;
 import io.kroxylicious.proxy.config.ProxyProtocolConfig;
 import io.kroxylicious.proxy.config.ProxyProtocolMode;
+import io.kroxylicious.proxy.config.RouteDefinition;
+import io.kroxylicious.proxy.config.RouteTarget;
+import io.kroxylicious.proxy.config.RouterDefinition;
 import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.config.VirtualCluster;
 import io.kroxylicious.proxy.config.VirtualClusterGateway;
@@ -169,6 +173,24 @@ class StaticSectionDifferTest {
                 oldConfig.development(),
                 oldConfig.network(),
                 oldConfig.proxyProtocol());
+        assertThat(differ.diff(oldConfig, newConfig)).isEmpty();
+    }
+
+    @Test
+    void routerDefinitionsChangesAreReconcilable() {
+        // Given: a config with one router definition pointing to a known cluster
+        var cluster = new ClusterDefinition("upstream", "kafka:9092", null);
+        var route = new RouteDefinition("route-a", 0, null, new RouteTarget("upstream", null));
+        var oldRouterDef = new RouterDefinition("my-router", "SomeRouterType", null, List.of(route));
+        var oldConfig = new Configuration(null, List.of(cluster), null, null, List.of(oldRouterDef),
+                List.of(vc("base-cluster")), null, false, Optional.empty(), null, null);
+
+        // When: the router definition config changes
+        var newRouterDef = new RouterDefinition("my-router", "SomeRouterType", "new-config", List.of(route));
+        var newConfig = new Configuration(null, List.of(cluster), null, null, List.of(newRouterDef),
+                List.of(vc("base-cluster")), null, false, Optional.empty(), null, null);
+
+        // Then: routerDefinitions is reconcilable, so the differ reports no static diff
         assertThat(differ.diff(oldConfig, newConfig)).isEmpty();
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
@@ -19,6 +19,7 @@ import javax.net.ssl.SSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.kroxylicious.proxy.bootstrap.RouterChainFactory;
 import io.kroxylicious.proxy.config.CacheConfiguration;
 import io.kroxylicious.proxy.config.IllegalConfigurationException;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
@@ -49,6 +50,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class VirtualClusterModelTest {
 
@@ -98,7 +100,6 @@ class VirtualClusterModelTest {
 
     @Test
     void usesDynamicTlsCredentialsReturnsFalseWhenDynamicRouting() {
-        // A router-targeting VC has no direct targetCluster — usesDynamicTlsCredentials must return false.
         var routeDescriptors = Map.of("r1",
                 new RouteDescriptor("r1", 0, new TargetCluster("broker:9092", Optional.empty()), null, List.of()));
         VirtualClusterModel model = new VirtualClusterModel("wibble", new DynamicRouting("some-router", routeDescriptors),
@@ -249,6 +250,41 @@ class VirtualClusterModelTest {
                 CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("Cannot apply trust options");
+    }
+
+    @Test
+    void closeClosesRouterChainFactory() {
+        // Given
+        var rcf = mock(RouterChainFactory.class);
+        DynamicRouting routing = new DynamicRouting("r1", Map.of("a", new RouteDescriptor("a", 1, null, "router", List.of())));
+        var model = new VirtualClusterModel("routed-vc", routing, false, false, EMPTY_FILTERS,
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null, rcf);
+
+        // When
+        model.close();
+
+        // Then: the RouterChainFactory is closed
+        verify(rcf).close();
+    }
+
+    @Test
+    void closeStillClosesFilterChainFactoryWhenRouterChainFactoryCloseThrows() {
+        // Given: a RouterChainFactory that throws on close
+        var rcf = mock(RouterChainFactory.class);
+        org.mockito.Mockito.doThrow(new RuntimeException("rcf close boom")).when(rcf).close();
+        var onFilterClose = new AtomicInteger();
+        var flakyConfig = new FlakyConfig(null, null, null, c -> {
+        }, c -> onFilterClose.incrementAndGet());
+        var filters = List.<NamedFilterDefinition> of(new NamedFilterDefinition("flaky", FlakyFactory.class.getName(), flakyConfig));
+        var targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
+        var model = new VirtualClusterModel("vc", new DirectRouting(targetCluster), false, false, filters,
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), combinedPluginFactoryRegistry(), rcf);
+
+        // When
+        assertThatThrownBy(model::close).hasMessage("rcf close boom");
+
+        // Then: FilterChainFactory was still closed despite the exception
+        assertThat(onFilterClose.get()).as("FilterChainFactory close should fire despite RCF failure").isEqualTo(1);
     }
 
     /**

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
@@ -103,7 +103,8 @@ class VirtualClusterModelTest {
     void usesDynamicTlsCredentialsReturnsFalseWhenDynamicRouting() {
         var routeDescriptors = Map.of("r1",
                 new RouteDescriptor("r1", 0, new TargetCluster("broker:9092", Optional.empty()), null, List.of()));
-        VirtualClusterModel model = new VirtualClusterModel("wibble", new DynamicRouting("some-router", routeDescriptors),
+        VirtualClusterModel model = new VirtualClusterModel("wibble",
+                new DynamicRouting("some-router", routeDescriptors, mock(RouterChainFactory.class)),
                 false, false, EMPTY_FILTERS, CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
 
         assertThat(model.usesDynamicTlsCredentials()).isFalse();
@@ -218,7 +219,7 @@ class VirtualClusterModelTest {
     void dynamicRoutingVcmHasNoUpstreamSslContext() {
         var routeDescriptors = Map.of("route1",
                 new RouteDescriptor("route1", 0, new TargetCluster("broker:9092", Optional.empty()), null, List.of()));
-        var dynamicRouting = new DynamicRouting("myrouter", routeDescriptors);
+        var dynamicRouting = new DynamicRouting("myrouter", routeDescriptors, mock(RouterChainFactory.class));
 
         VirtualClusterModel model = new VirtualClusterModel("routed-vc", dynamicRouting, false, false, EMPTY_FILTERS,
                 CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
@@ -233,7 +234,8 @@ class VirtualClusterModelTest {
     void logVirtualClusterSummaryWorksForDynamicRouting() {
         var routeDescriptors = Map.of("route1",
                 new RouteDescriptor("route1", 0, new TargetCluster("broker:9092", Optional.empty()), null, List.of()));
-        VirtualClusterModel model = new VirtualClusterModel("routed-vc", new DynamicRouting("myrouter", routeDescriptors),
+        VirtualClusterModel model = new VirtualClusterModel("routed-vc",
+                new DynamicRouting("myrouter", routeDescriptors, mock(RouterChainFactory.class)),
                 false, false, EMPTY_FILTERS, CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
 
         assertThatCode(model::logVirtualClusterSummary).doesNotThrowAnyException();
@@ -257,9 +259,10 @@ class VirtualClusterModelTest {
     void closeClosesRouterChainFactory() {
         // Given
         var rcf = mock(RouterChainFactory.class);
-        DynamicRouting routing = new DynamicRouting("r1", Map.of("a", new RouteDescriptor("a", 1, null, "router", List.of())));
-        var model = new VirtualClusterModel("routed-vc", routing, false, false, EMPTY_FILTERS,
-                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null, rcf);
+        var routeDescriptor = new RouteDescriptor("r1", 0, null, "nested", List.of());
+        var model = new VirtualClusterModel("routed-vc",
+                new DynamicRouting("r1", Map.of("r1", routeDescriptor), rcf),
+                false, false, EMPTY_FILTERS, CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
 
         // When
         model.close();
@@ -277,9 +280,11 @@ class VirtualClusterModelTest {
         var flakyConfig = new FlakyConfig(null, null, null, c -> {
         }, c -> onFilterClose.incrementAndGet());
         var filters = List.<NamedFilterDefinition> of(new NamedFilterDefinition("flaky", FlakyFactory.class.getName(), flakyConfig));
-        var targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
-        var model = new VirtualClusterModel("vc", new DirectRouting(targetCluster), false, false, filters,
-                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), combinedPluginFactoryRegistry(), rcf);
+        var routeDescriptor = new RouteDescriptor("r1", 0, new TargetCluster("bootstrap:9092", Optional.empty()), null, List.of());
+        var model = new VirtualClusterModel("vc",
+                new DynamicRouting("r1", Map.of("r1", routeDescriptor), rcf),
+                false, false, filters,
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), combinedPluginFactoryRegistry());
 
         // When
         assertThatThrownBy(model::close).hasMessage("rcf close boom");

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
@@ -49,6 +49,7 @@ import io.kroxylicious.proxy.tls.ServerTlsCredentialSupplierFactoryContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -271,7 +272,7 @@ class VirtualClusterModelTest {
     void closeStillClosesFilterChainFactoryWhenRouterChainFactoryCloseThrows() {
         // Given: a RouterChainFactory that throws on close
         var rcf = mock(RouterChainFactory.class);
-        org.mockito.Mockito.doThrow(new RuntimeException("rcf close boom")).when(rcf).close();
+        doThrow(new RuntimeException("rcf close boom")).when(rcf).close();
         var onFilterClose = new AtomicInteger();
         var flakyConfig = new FlakyConfig(null, null, null, c -> {
         }, c -> onFilterClose.incrementAndGet());


### PR DESCRIPTION
## Summary

Closes #4226. Three changes work together to make router definitions reloadable at runtime:

- **`StaticSectionDiffer`**: adds `routerDefinitions` to the `RECONCILABLE` set so that changes to router definitions pass the pre-flight static-section check instead of being rejected.
- **`RouterChainFactory` per-VC lifecycle**: each `VirtualClusterModel` now owns and closes its own `RouterChainFactory`, whose lifetime is tied to the VC lifecycle. This mirrors the pattern established for `FilterChainFactory`. When a VC is replaced during hot reload, the old `RouterChainFactory` is closed (firing `RouterFactory.close()` on the old init result) and a fresh one is built (firing `RouterFactory.initialize()` with the updated config). `KafkaProxyInitializer` reads the factory from the VCM rather than a global reference; `KafkaProxy` no longer holds a global instance.
- **`RouterChangeDetector`**: a new `ChangeDetector` that identifies virtual clusters affected by a router definition change. It computes which router names changed (using record structural equality), then for each VC checks whether any router in its router graph is in the changed set. Registered in `ConfigurationReloadOrchestrator.defaultDetectors()` alongside `FilterChangeDetector`.

An integration test (`RouterChangeHotReloadIT`) proves the full flow end-to-end using `InvocationCountingRouterFactory`, a test plugin that tracks `initialize()` and `close()` calls per config UUID.

## Notes

- Nested router routes are not yet supported by the config validator ("not yet supported"), so the `RouterChangeDetector`'s nested-graph traversal is implemented but not exercised by the IT. It will work without further changes when that restriction is lifted.
- No public API changes (`RouterFactory`, `RouterFactoryContext`, YAML syntax all unchanged).

## AI Disclosure

This PR was developed with significant AI assistance (Claude Sonnet 4.6). All code has been reviewed and understood by the submitter.

## Test plan

- [ ] `RouterChangeDetectorTest` — 8 unit tests covering unchanged, modified, isolated, and unreferenced router definitions
- [ ] `StaticSectionDifferTest#routerDefinitionsChangesAreReconcilable` — asserts the pre-flight check passes for router changes
- [ ] `VirtualClusterModelTest#closeClosesRouterChainFactory` and `#closeStillClosesFilterChainFactoryWhenRouterChainFactoryCloseThrows` — lifecycle close tests
- [ ] `RouterChainFactoryTest#forVirtualCluster*` — per-VC factory creation tests
- [ ] `RouterChangeHotReloadIT` — end-to-end: reconfigure replaces a router definition, asserts init/close counts and that traffic flows before and after; verifies per-VC isolation

Issue tracking the full routing runtime: https://github.com/kroxylicious/kroxylicious/issues/4158

🤖 Generated with [Claude Code](https://claude.com/claude-code)