### PR TITLE
Refactor lifecycle state dispatch to exhaustive switches

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterLifecycle.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterLifecycle.java
@@ -9,7 +9,6 @@ package io.kroxylicious.proxy.internal;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -158,16 +157,13 @@ public class VirtualClusterLifecycle {
      */
     public void stop() {
         transition(current -> {
-            if (current instanceof Stopped) {
-                return current;
-            }
-            if (current instanceof Failed s) {
-                return s.toStopped();
-            }
-            if (current instanceof Initializing s) {
-                return s.toStopped();
-            }
-            throw unexpectedState(current, "stop");
+            return switch (current) {
+                case Stopped ignored -> current;
+                case Failed failed -> failed.toStopped();
+                case Initializing initializing -> initializing.toStopped();
+                case Serving ignored -> throw unexpectedState(current, "stop");
+                case Draining ignored -> throw unexpectedState(current, "stop");
+            };
         });
     }
 
@@ -204,7 +200,13 @@ public class VirtualClusterLifecycle {
             return;
         }
         recordTransitionMetrics(previous, state);
-        var logBuilder = (state instanceof Serving || state instanceof Failed || state instanceof Stopped) ? LOGGER.atInfo() : LOGGER.atDebug();
+        var logBuilder = switch (state) {
+            case Serving ignored -> LOGGER.atInfo();
+            case Failed ignored -> LOGGER.atInfo();
+            case Stopped ignored -> LOGGER.atInfo();
+            case Initializing ignored -> LOGGER.atDebug();
+            case Draining ignored -> LOGGER.atDebug();
+        };
         logBuilder
                 .addKeyValue("virtualCluster", clusterName)
                 .addKeyValue("from", () -> previous.getClass().getSimpleName())
@@ -222,7 +224,13 @@ public class VirtualClusterLifecycle {
     }
 
     private static String stateLabel(VirtualClusterLifecycleState state) {
-        return state.getClass().getSimpleName().toLowerCase(Locale.ROOT);
+        return switch (state) {
+            case Initializing ignored -> "initializing";
+            case Serving ignored -> "serving";
+            case Draining ignored -> "draining";
+            case Failed ignored -> "failed";
+            case Stopped ignored -> "stopped";
+        };
     }
 
     private IllegalStateException unexpectedState(VirtualClusterLifecycleState current, String operation) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterRegistry.java
@@ -291,13 +291,13 @@ public class VirtualClusterRegistry implements AutoCloseable {
      */
     private CompletableFuture<Void> initiateDrain(VirtualClusterLifecycle lifecycle) {
         var state = lifecycle.state();
-        if (state instanceof VirtualClusterLifecycleState.Serving) {
-            return lifecycle.startDraining();
-        }
-        if (state instanceof VirtualClusterLifecycleState.Draining) {
-            return lifecycle.drainFuture();
-        }
-        return CompletableFuture.completedFuture(null);
+        return switch (state) {
+            case VirtualClusterLifecycleState.Serving ignored -> lifecycle.startDraining();
+            case VirtualClusterLifecycleState.Draining ignored -> lifecycle.drainFuture();
+            case VirtualClusterLifecycleState.Failed ignored -> CompletableFuture.completedFuture(null);
+            case VirtualClusterLifecycleState.Initializing ignored -> CompletableFuture.completedFuture(null);
+            case VirtualClusterLifecycleState.Stopped ignored -> CompletableFuture.completedFuture(null);
+        };
     }
 
     /**
@@ -310,30 +310,31 @@ public class VirtualClusterRegistry implements AutoCloseable {
     @VisibleForTesting
     void transitionToStoppedAndClose(String clusterName, VirtualClusterLifecycle lifecycle) {
         var current = lifecycle.state();
-        if (current instanceof VirtualClusterLifecycleState.Draining) {
-            lifecycle.drainComplete();
-            closeAndFireStopped(clusterName, Optional.empty());
+        switch (current) {
+            case VirtualClusterLifecycleState.Draining ignored -> {
+                lifecycle.drainComplete();
+                closeAndFireStopped(clusterName, Optional.empty());
+            }
+            case VirtualClusterLifecycleState.Failed(var cause) -> {
+                lifecycle.stop();
+                closeAndFireStopped(clusterName, Optional.of(cause));
+            }
+            case VirtualClusterLifecycleState.Initializing ignored -> {
+                lifecycle.stop();
+                closeAndFireStopped(clusterName, Optional.empty());
+            }
+            case VirtualClusterLifecycleState.Stopped ignored -> {
+                // Expected — a concurrent dispatch already drove this cluster to Stopped.
+            }
+            case VirtualClusterLifecycleState.Serving ignored -> {
+                throw unexpectedState(clusterName, current, "transitionToStoppedAndClose");
+            }
         }
-        else if (current instanceof VirtualClusterLifecycleState.Failed failed) {
-            lifecycle.stop();
-            closeAndFireStopped(clusterName, Optional.of(failed.cause()));
-        }
-        else if (current instanceof VirtualClusterLifecycleState.Initializing) {
-            lifecycle.stop();
-            closeAndFireStopped(clusterName, Optional.empty());
-        }
-        else if (current instanceof VirtualClusterLifecycleState.Stopped) {
-            // Expected — a concurrent dispatch already drove this cluster to Stopped.
-        }
-        else {
-            // Unexpected: by the time this task runs, no other code path should put a cluster
-            // back into a non-terminal state. Most likely initializationSucceeded raced with
-            // our dispatch — log so the race shows up in operator diagnostics.
-            LOGGER.atWarn()
-                    .addKeyValue("virtualCluster", clusterName)
-                    .addKeyValue("state", current.getClass().getSimpleName())
-                    .log("transitionToStoppedAndClose observed unexpected state; no-op");
-        }
+    }
+
+    private static IllegalStateException unexpectedState(String clusterName, VirtualClusterLifecycleState current, String operation) {
+        return new IllegalStateException(
+                "Cannot " + operation + " for virtual cluster '" + clusterName + "' in state " + current.getClass().getSimpleName());
     }
 
     /**

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterLifecycleTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterLifecycleTest.java
@@ -191,6 +191,12 @@ class VirtualClusterLifecycleTest {
                     m.initializationSucceeded();
                     m.stop();
                 }),
+                argumentSet("stop from DRAINING", (Runnable) () -> {
+                    var m = new VirtualClusterLifecycle("c", DRAIN_TIMEOUT);
+                    m.initializationSucceeded();
+                    m.startDraining();
+                    m.stop();
+                }),
                 argumentSet("initializationSucceeded from STOPPED", (Runnable) () -> {
                     var m = new VirtualClusterLifecycle("c", DRAIN_TIMEOUT);
                     m.initializationFailed(new RuntimeException("x"));

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterRegistryTest.java
@@ -1088,7 +1088,7 @@ class VirtualClusterRegistryTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void transitionToStoppedAndCloseLogsWhenObservingUnexpectedState() {
+    void transitionToStoppedAndCloseThrowsWhenObservingServingState() {
         // given — a cluster in Serving (the unexpected state for this method, which only ever
         // expects Draining / Failed / Initializing / Stopped on entry)
         var model = mockModel(CLUSTER_A);
@@ -1100,10 +1100,13 @@ class VirtualClusterRegistryTest {
 
         // when — direct invocation simulates the race where initializationSucceeded() raced
         // with our dispatch (left the cluster in Serving when transitionToStoppedAndClose ran)
-        registry.transitionToStoppedAndClose(CLUSTER_A, lifecycle);
+        assertThatThrownBy(() -> registry.transitionToStoppedAndClose(CLUSTER_A, lifecycle))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("transitionToStoppedAndClose")
+                .hasMessageContaining(CLUSTER_A)
+                .hasMessageContaining("Serving");
 
-        // then — silent no-op on the work, but the unexpected state was logged (logging
-        // verified implicitly: the method must not throw and must not fire close/callback)
+        // then — fail fast without closing the model or firing the stopped callback.
         verify(model, never()).close();
         verifyNoInteractions(callback);
     }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Converts the `VirtualClusterLifecycleState` dispatch sites called out in #4216 to exhaustive switch expressions.

This covers both `VirtualClusterLifecycle` and `VirtualClusterRegistry`, while preserving the normal shutdown, drain, close, idempotent stopped and transition logging behavior. It also fails fast if `transitionToStoppedAndClose` observes `Serving` after drain initiation should already have moved the cluster to `Draining`.

### Additional Context

Closes #4216.

This supersedes #4239, which was closed after the fork branch history became detached. This branch has been rebuilt and rebased on top of the current `main` so the PR diff is limited to the intended lifecycle state dispatch changes.

Verification:

```
mvn -pl kroxylicious-runtime -am -Dtest=VirtualClusterRegistryTest,VirtualClusterLifecycleTest,VirtualClusterLifecycleMetricsTest -Dsurefire.failIfNoSpecifiedTests=false test
```

Result: 97 tests passed.

### Checklist

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).