### PR TITLE
feat(routing): hot-reload clusterDefinition changes

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/ConfigurationReloadOrchestrator.java
@@ -96,7 +96,7 @@ public class ConfigurationReloadOrchestrator {
 
     /**
      * The production-default set of change detectors:
-     * {@link VirtualClusterChangeDetector} and {@link FilterChangeDetector}.
+     * {@link VirtualClusterChangeDetector}, {@link FilterChangeDetector}, and {@link ClusterDefinitionChangeDetector}.
      */
     public static List<ChangeDetector> defaultDetectors() {
         return List.of(new VirtualClusterChangeDetector(), new FilterChangeDetector(), new RouterChangeDetector(), new ClusterDefinitionChangeDetector());


### PR DESCRIPTION
## Summary

Closes #4249.

- Adds `"clusterDefinitions"` to `StaticSectionDiffer.RECONCILABLE` so changes to cluster definitions pass the pre-flight static-section check.
- Introduces `ClusterDefinitionChangeDetector`, which computes the set of changed cluster definition names (by record structural equality) and flags any virtual cluster whose `namedTargetCluster()` is in that set as needing replacement. VCs targeting a router or using an inline `targetCluster` are unaffected. Transitively-referenced cluster definitions (reached via the router DAG) are deferred — see #4249.
- Registers `ClusterDefinitionChangeDetector` in `ConfigurationReloadOrchestrator.defaultDetectors()`.

## Test plan

- [ ] `ClusterDefinitionChangeDetectorTest` — 9 unit tests covering unchanged, modified, isolated, router-targeting, inline-target, removed, reordered, and unreferenced cluster definitions.
- [ ] `StaticSectionDifferTest` — existing tests, which now also exercise `clusterDefinitions` as a reconcilable section.
- [ ] `ClusterDefinitionChangeHotReloadIT` — end-to-end: changing a cluster definition's `bootstrapServers` restarts the referencing VC (verified via `InvocationCountingFilterFactory` lifecycle counts) and traffic continues before and after; cross-VC isolation test verifies only the affected VC is restarted.

## AI Disclosure

This PR was developed with significant AI assistance (Claude Sonnet 4.6). All code has been reviewed and understood by the submitter.