### PR TITLE
fix(routing): translate currentLeader.leaderId in Fetch v12-v15 responses

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslator.java
@@ -67,6 +67,7 @@ final class NodeIdResponseTranslator {
         data.setControllerId(mapping.toVirtual(route, data.controllerId()));
 
         var translatedBrokers = new MetadataResponseBrokerCollection(data.brokers().size());
+        // Must copy and duplicate: mutating nodeId in-place corrupts the ImplicitLinkedHashCollection's hash table.
         for (var broker : List.copyOf(data.brokers())) {
             var translated = broker.duplicate();
             translated.setNodeId(mapping.toVirtual(route, broker.nodeId()));
@@ -98,6 +99,7 @@ final class NodeIdResponseTranslator {
             }
         }
         var translatedEndpoints = new NodeEndpointCollection(data.nodeEndpoints().size());
+        // Must copy and duplicate: mutating nodeId in-place corrupts the ImplicitLinkedHashCollection's hash table.
         for (var ne : List.copyOf(data.nodeEndpoints())) {
             var translated = ne.duplicate();
             translated.setNodeId(mapping.toVirtual(route, ne.nodeId()));
@@ -125,6 +127,7 @@ final class NodeIdResponseTranslator {
                                                  String route) {
         data.setControllerId(mapping.toVirtual(route, data.controllerId()));
         var translatedBrokers = new DescribeClusterBrokerCollection(data.brokers().size());
+        // Must copy and duplicate: mutating brokerId in-place corrupts the ImplicitLinkedHashCollection's hash table.
         for (var broker : List.copyOf(data.brokers())) {
             var translated = broker.duplicate();
             translated.setBrokerId(mapping.toVirtual(route, broker.brokerId()));
@@ -147,6 +150,7 @@ final class NodeIdResponseTranslator {
         }
         if (apiVersion >= 16) {
             var translatedEndpoints = new FetchResponseData.NodeEndpointCollection(data.nodeEndpoints().size());
+            // Must copy and duplicate: mutating nodeId in-place corrupts the ImplicitLinkedHashCollection's hash table.
             for (var ne : List.copyOf(data.nodeEndpoints())) {
                 var translated = ne.duplicate();
                 translated.setNodeId(mapping.toVirtual(route, ne.nodeId()));
@@ -163,6 +167,7 @@ final class NodeIdResponseTranslator {
             return;
         }
         var translatedEndpoints = new ShareFetchResponseData.NodeEndpointCollection(data.nodeEndpoints().size());
+        // Must copy and duplicate: mutating nodeId in-place corrupts the ImplicitLinkedHashCollection's hash table.
         for (var ne : List.copyOf(data.nodeEndpoints())) {
             var translated = ne.duplicate();
             translated.setNodeId(mapping.toVirtual(route, ne.nodeId()));
@@ -178,6 +183,7 @@ final class NodeIdResponseTranslator {
             return;
         }
         var translatedEndpoints = new ShareAcknowledgeResponseData.NodeEndpointCollection(data.nodeEndpoints().size());
+        // Must copy and duplicate: mutating nodeId in-place corrupts the ImplicitLinkedHashCollection's hash table.
         for (var ne : List.copyOf(data.nodeEndpoints())) {
             var translated = ne.duplicate();
             translated.setNodeId(mapping.toVirtual(route, ne.nodeId()));

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslator.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslator.java
@@ -137,16 +137,23 @@ final class NodeIdResponseTranslator {
                                        short apiVersion,
                                        NodeIdMapping mapping,
                                        String route) {
-        if (apiVersion < 16) {
-            return;
+        if (apiVersion >= 12) {
+            for (var topicResponse : data.responses()) {
+                for (var partitionData : topicResponse.partitions()) {
+                    var leader = partitionData.currentLeader();
+                    leader.setLeaderId(mapping.toVirtual(route, leader.leaderId()));
+                }
+            }
         }
-        var translatedEndpoints = new FetchResponseData.NodeEndpointCollection(data.nodeEndpoints().size());
-        for (var ne : List.copyOf(data.nodeEndpoints())) {
-            var translated = ne.duplicate();
-            translated.setNodeId(mapping.toVirtual(route, ne.nodeId()));
-            translatedEndpoints.add(translated);
+        if (apiVersion >= 16) {
+            var translatedEndpoints = new FetchResponseData.NodeEndpointCollection(data.nodeEndpoints().size());
+            for (var ne : List.copyOf(data.nodeEndpoints())) {
+                var translated = ne.duplicate();
+                translated.setNodeId(mapping.toVirtual(route, ne.nodeId()));
+                translatedEndpoints.add(translated);
+            }
+            data.setNodeEndpoints(translatedEndpoints);
         }
-        data.setNodeEndpoints(translatedEndpoints);
     }
 
     private static void translateShareFetch(ShareFetchResponseData data,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslatorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslatorTest.java
@@ -259,6 +259,21 @@ class NodeIdResponseTranslatorTest {
     }
 
     @Test
+    void shouldNotTranslateFetchResponseCurrentLeaderBeforeV12() {
+        var data = new FetchResponseData();
+        var partitionData = new FetchResponseData.PartitionData()
+                .setPartitionIndex(0)
+                .setCurrentLeader(new FetchResponseData.LeaderIdAndEpoch().setLeaderId(1).setLeaderEpoch(5));
+        var topicResponse = new FetchResponseData.FetchableTopicResponse().setTopic("test");
+        topicResponse.partitions().add(partitionData);
+        data.responses().add(topicResponse);
+
+        NodeIdResponseTranslator.translate(data, (short) 11, mapping, ROUTE_A);
+
+        assertThat(partitionData.currentLeader().leaderId()).isEqualTo(1);
+    }
+
+    @Test
     void shouldNotTranslateFetchResponseNodeEndpointsBeforeV16() {
         var data = new FetchResponseData();
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslatorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/NodeIdResponseTranslatorTest.java
@@ -27,6 +27,8 @@ import org.apache.kafka.common.message.ProduceResponseData.TopicProduceResponse;
 import org.apache.kafka.common.message.ShareAcknowledgeResponseData;
 import org.apache.kafka.common.message.ShareFetchResponseData;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -221,20 +223,43 @@ class NodeIdResponseTranslatorTest {
         assertThat(data.throttleTimeMs()).isEqualTo(42);
     }
 
+    @ParameterizedTest
+    @ValueSource(shorts = { 12, 13, 14, 15 })
+    void shouldTranslateFetchResponseCurrentLeaderV12toV15(short apiVersion) {
+        var data = new FetchResponseData();
+        var partitionData = new FetchResponseData.PartitionData()
+                .setPartitionIndex(0)
+                .setCurrentLeader(new FetchResponseData.LeaderIdAndEpoch().setLeaderId(1).setLeaderEpoch(5));
+        var topicResponse = new FetchResponseData.FetchableTopicResponse().setTopic("test");
+        topicResponse.partitions().add(partitionData);
+        data.responses().add(topicResponse);
+
+        NodeIdResponseTranslator.translate(data, apiVersion, mapping, ROUTE_A);
+
+        assertThat(partitionData.currentLeader().leaderId()).isEqualTo(mapping.toVirtual(ROUTE_A, 1));
+    }
+
     @Test
-    void shouldTranslateFetchResponseV16NodeEndpoints() {
+    void shouldTranslateFetchResponseV16NodeEndpointsAndCurrentLeader() {
         var data = new FetchResponseData();
         data.nodeEndpoints().add(new FetchResponseData.NodeEndpoint().setNodeId(0).setHost("h0").setPort(9092));
         data.nodeEndpoints().add(new FetchResponseData.NodeEndpoint().setNodeId(1).setHost("h1").setPort(9093));
+        var partitionData = new FetchResponseData.PartitionData()
+                .setPartitionIndex(0)
+                .setCurrentLeader(new FetchResponseData.LeaderIdAndEpoch().setLeaderId(1).setLeaderEpoch(5));
+        var topicResponse = new FetchResponseData.FetchableTopicResponse().setTopic("test");
+        topicResponse.partitions().add(partitionData);
+        data.responses().add(topicResponse);
 
         NodeIdResponseTranslator.translate(data, (short) 16, mapping, ROUTE_A);
 
         assertThat(data.nodeEndpoints().find(mapping.toVirtual(ROUTE_A, 0))).isNotNull();
         assertThat(data.nodeEndpoints().find(mapping.toVirtual(ROUTE_A, 1))).isNotNull();
+        assertThat(partitionData.currentLeader().leaderId()).isEqualTo(mapping.toVirtual(ROUTE_A, 1));
     }
 
     @Test
-    void shouldNotTranslateFetchResponseBeforeV16() {
+    void shouldNotTranslateFetchResponseNodeEndpointsBeforeV16() {
         var data = new FetchResponseData();
 
         NodeIdResponseTranslator.translate(data, (short) 15, mapping, ROUTE_A);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

`FetchResponseData.PartitionData` carries `currentLeader.leaderId` from Fetch v12 onwards, but `translateFetch` returned early for any version below v16 (where `nodeEndpoints` was introduced), leaving `currentLeader.leaderId` untranslated for v12–v15.

The fix splits the version guard: `currentLeader.leaderId` is now translated for v12+, and `nodeEndpoints` continues to be translated for v16+ only.

### Additional Context

Raised by @SamBarker in review of #4227. The omission was not deliberate — v12–v15 clients would receive untranslated upstream node IDs in `currentLeader`.

Closes #4252
Part of #4158

### Checklist

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).