### PR TITLE
refactor(runtime): replace nullable routing fields with RoutingModel sealed hierarchy

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -24,7 +24,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import io.kroxylicious.proxy.config.admin.ManagementConfiguration;
+import io.kroxylicious.proxy.internal.routing.DirectRouting;
+import io.kroxylicious.proxy.internal.routing.DynamicRouting;
 import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
+import io.kroxylicious.proxy.internal.routing.RoutingModel;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -257,21 +260,24 @@ public record Configuration(
                                                       Map<String, RouterDefinition> routersByName,
                                                       Map<String, ClusterDefinition> clustersByName,
                                                       PluginFactoryRegistry pfr) {
-        TargetCluster resolvedTargetCluster = resolveTargetCluster(virtualCluster, routersByName, clustersByName);
-        Map<String, RouteDescriptor> routeDescriptors = resolveRouteDescriptors(
-                virtualCluster, filterDefinitionsByName, routersByName, clustersByName);
+        RoutingModel routing;
+        if (virtualCluster.router() != null) {
+            routing = new DynamicRouting(virtualCluster.router(),
+                    resolveRouteDescriptors(virtualCluster, filterDefinitionsByName, routersByName, clustersByName));
+        }
+        else {
+            routing = new DirectRouting(resolveDirectTargetCluster(virtualCluster, clustersByName));
+        }
 
         VirtualClusterModel virtualClusterModel = new VirtualClusterModel(virtualCluster.name(),
-                resolvedTargetCluster,
+                routing,
                 virtualCluster.logNetwork(),
                 virtualCluster.logFrames(),
                 filterDefinitions,
                 virtualCluster.topicNameCacheConfig(),
                 virtualCluster.subjectBuilder(),
                 virtualCluster.effectiveDrainTimeout(),
-                pfr,
-                virtualCluster.router(),
-                routeDescriptors);
+                pfr);
 
         addGateways(virtualCluster.gateways(), virtualClusterModel);
         virtualClusterModel.logVirtualClusterSummary();
@@ -279,10 +285,8 @@ public record Configuration(
         return virtualClusterModel;
     }
 
-    @Nullable
-    private TargetCluster resolveTargetCluster(VirtualCluster virtualCluster,
-                                               Map<String, RouterDefinition> routersByName,
-                                               Map<String, ClusterDefinition> clustersByName) {
+    private TargetCluster resolveDirectTargetCluster(VirtualCluster virtualCluster,
+                                                     Map<String, ClusterDefinition> clustersByName) {
         if (virtualCluster.targetCluster() != null) {
             return virtualCluster.targetCluster();
         }
@@ -293,27 +297,8 @@ public record Configuration(
                                     + virtualCluster.namedTargetCluster() + "'"))
                     .toTargetCluster();
         }
-        if (virtualCluster.router() != null) {
-            return resolveRouterPrimaryTargetCluster(virtualCluster, routersByName, clustersByName);
-        }
-        return null;
-    }
-
-    @Nullable
-    private TargetCluster resolveRouterPrimaryTargetCluster(VirtualCluster virtualCluster,
-                                                            Map<String, RouterDefinition> routersByName,
-                                                            Map<String, ClusterDefinition> clustersByName) {
-        RouterDefinition rd = routersByName.get(virtualCluster.router());
-        if (rd == null) {
-            throw new IllegalConfigurationException(
-                    "Virtual cluster '" + virtualCluster.name() + "' references unknown router '"
-                            + virtualCluster.router() + "'");
-        }
-        return rd.routes().stream()
-                .filter(route -> route.cluster() != null)
-                .findFirst()
-                .map(route -> resolveNamedTargetCluster(route.cluster(), clustersByName))
-                .orElse(null);
+        throw new IllegalConfigurationException(
+                "Virtual cluster '" + virtualCluster.name() + "' must specify either a targetCluster, a namedTargetCluster, or a router");
     }
 
     @Nullable
@@ -322,15 +307,11 @@ public record Configuration(
         return cd != null ? cd.toTargetCluster() : null;
     }
 
-    @Nullable
     private Map<String, RouteDescriptor> resolveRouteDescriptors(
                                                                  VirtualCluster virtualCluster,
                                                                  Map<String, NamedFilterDefinition> filterDefinitionsByName,
                                                                  Map<String, RouterDefinition> routersByName,
                                                                  Map<String, ClusterDefinition> clustersByName) {
-        if (virtualCluster.router() == null) {
-            return null;
-        }
         RouterDefinition rd = routersByName.get(virtualCluster.router());
         if (rd == null) {
             throw new IllegalConfigurationException(

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouterDefinition.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/RouterDefinition.java
@@ -5,9 +5,10 @@
  */
 package io.kroxylicious.proxy.config;
 
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -40,21 +41,19 @@ public record RouterDefinition(
         if (routes == null || routes.isEmpty()) {
             throw new IllegalConfigurationException("Router '" + name + "' must have at least one route");
         }
-        var routeNames = routes.stream()
+        Set<String> seenNames = new HashSet<>();
+        Set<String> nameDuplicates = routes.stream()
                 .map(RouteDefinition::name)
-                .toList();
-        var nameDuplicates = routeNames.stream()
-                .filter(n -> Collections.frequency(routeNames, n) > 1)
+                .filter(n -> !seenNames.add(n))
                 .collect(Collectors.toSet());
         if (!nameDuplicates.isEmpty()) {
             throw new IllegalConfigurationException(
                     "Router '" + name + "' has duplicate route names: " + nameDuplicates);
         }
-        var routeIds = routes.stream()
+        Set<Integer> seenIds = new HashSet<>();
+        Set<Integer> idDuplicates = routes.stream()
                 .map(RouteDefinition::id)
-                .toList();
-        var idDuplicates = routeIds.stream()
-                .filter(id -> Collections.frequency(routeIds, id) > 1)
+                .filter(id -> !seenIds.add(id))
                 .collect(Collectors.toSet());
         if (!idDuplicates.isEmpty()) {
             throw new IllegalConfigurationException(

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -44,6 +44,7 @@ import io.kroxylicious.proxy.internal.codec.FrameOversizedException;
 import io.kroxylicious.proxy.internal.net.BrokerEndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
+import io.kroxylicious.proxy.internal.routing.DirectRouting;
 import io.kroxylicious.proxy.internal.routing.DynamicRouting;
 import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
 import io.kroxylicious.proxy.internal.util.ActivationToken;
@@ -953,12 +954,12 @@ public class ClientConnectionStateMachine {
             this.clientSoftwareVersion = apiVersionsFrame.body().clientSoftwareVersion();
         }
         if (msg instanceof RequestFrame) {
-            if (virtualCluster().routing() instanceof DynamicRouting) {
-                toForwardingWithRoutes(forwardingFactory.get());
-            }
-            else {
-                var target = Objects.requireNonNull(endpointBinding.upstreamTarget());
-                toForwarding(forwardingFactory.get(), target);
+            switch (virtualCluster().routing()) {
+                case DynamicRouting ignored -> toForwardingWithRoutes(forwardingFactory.get());
+                case DirectRouting ignored -> {
+                    var target = Objects.requireNonNull(endpointBinding.upstreamTarget());
+                    toForwarding(forwardingFactory.get(), target);
+                }
             }
             tryUnblockClient();
             return true;

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachine.java
@@ -44,6 +44,7 @@ import io.kroxylicious.proxy.internal.codec.FrameOversizedException;
 import io.kroxylicious.proxy.internal.net.BrokerEndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
+import io.kroxylicious.proxy.internal.routing.DynamicRouting;
 import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
 import io.kroxylicious.proxy.internal.util.ActivationToken;
 import io.kroxylicious.proxy.internal.util.Metrics;
@@ -491,7 +492,7 @@ public class ClientConnectionStateMachine {
      * @param msg the RPC received from the upstream
      */
     void onDirectClientFilterChainComplete(Object msg) {
-        if (virtualCluster().usesRouter()) {
+        if (virtualCluster().routing() instanceof DynamicRouting) {
             throw new IllegalStateException(
                     "onDirectClientFilterChainComplete must not be called for a virtual cluster that uses a router");
         }
@@ -857,11 +858,11 @@ public class ClientConnectionStateMachine {
     @SuppressWarnings("java:S5738")
     private void toForwardingWithRoutes(Forwarding forwarding) {
         setState(forwarding);
-        Map<String, RouteDescriptor> descriptors = virtualCluster().routeDescriptors();
-        if (descriptors == null || descriptors.isEmpty()) {
+        if (!(virtualCluster().routing() instanceof DynamicRouting dr)) {
             throw new IllegalStateException(
-                    "toForwardingWithRoutes called but virtualCluster has no routeDescriptors — this is a bug");
+                    "toForwardingWithRoutes called but virtualCluster has no router — this is a bug");
         }
+        var descriptors = dr.routeDescriptors();
         routeTargets = new HashMap<>();
         for (var entry : descriptors.entrySet()) {
             RouteDescriptor rd = entry.getValue();
@@ -873,9 +874,8 @@ public class ClientConnectionStateMachine {
         // For per-broker connections, the EndpointReconciler has already resolved the
         // real upstream address. Override the owning route's bootstrap target with it.
         // Server connections are opened lazily in forwardToRoute().
-        var nodeIdMapping = virtualCluster().nodeIdMapping();
-        if (endpointBinding instanceof BrokerEndpointBinding beb && nodeIdMapping != null) {
-            var routeAndNode = nodeIdMapping.fromVirtual(beb.nodeId());
+        if (endpointBinding instanceof BrokerEndpointBinding beb) {
+            var routeAndNode = dr.nodeIdMapping().fromVirtual(beb.nodeId());
             RouteDescriptor owningDesc = descriptors.get(routeAndNode.route());
             if (owningDesc != null && owningDesc.targetsCluster()) {
                 routeTargets.put(routeAndNode.route(), beb.upstreamTarget());
@@ -895,7 +895,7 @@ public class ClientConnectionStateMachine {
      * for both static and dynamic routing paths.
      */
     public void forwardToRoute(String routeName, Object msg) {
-        if (!virtualCluster().usesRouter()) {
+        if (!(virtualCluster().routing() instanceof DynamicRouting)) {
             throw new IllegalStateException(
                     "forwardToRoute must not be called for a virtual cluster that does not use a router");
         }
@@ -953,7 +953,7 @@ public class ClientConnectionStateMachine {
             this.clientSoftwareVersion = apiVersionsFrame.body().clientSoftwareVersion();
         }
         if (msg instanceof RequestFrame) {
-            if (virtualCluster().usesRouter()) {
+            if (virtualCluster().routing() instanceof DynamicRouting) {
                 toForwardingWithRoutes(forwardingFactory.get());
             }
             else {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -43,6 +43,7 @@ import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointBindingResolver;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
+import io.kroxylicious.proxy.internal.routing.DynamicRouting;
 import io.kroxylicious.proxy.internal.routing.RouterDispatchHandler;
 import io.kroxylicious.proxy.internal.util.Metrics;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
@@ -261,10 +262,10 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
                 proxyNettySettings);
 
         pipeline.addLast("frontendHandler", frontendHandler);
-        if (virtualCluster.usesRouter()) {
+        if (virtualCluster.routing() instanceof DynamicRouting dr) {
             Objects.requireNonNull(routerChainFactory,
                     "routerChainFactory must not be null when virtual cluster '" + virtualCluster.getClusterName() + "' uses a router");
-            Router router = routerChainFactory.createRouter(virtualCluster.routerName(), virtualCluster.getClusterName());
+            Router router = routerChainFactory.createRouter(dr.routerName(), virtualCluster.getClusterName());
             Map<ApiKeys, String> staticRoutes = router.staticRoutes();
             Set<ApiKeys> decodedKeys = EnumSet.allOf(ApiKeys.class);
             if (!staticRoutes.isEmpty()) {
@@ -274,8 +275,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
             // can translate them, even when those keys are statically routed.
             decodedKeys.addAll(RouterDispatchHandler.NODE_ID_TRANSLATION_APIS);
             dp.setRouterDecodingRequirements(decodedKeys);
-            var nodeIdMapping = virtualCluster.nodeIdMapping();
-            var dispatchHandler = new RouterDispatchHandler(router, staticRoutes, clientConnectionStateMachine, nodeIdMapping);
+            var dispatchHandler = new RouterDispatchHandler(router, staticRoutes, clientConnectionStateMachine, dr.nodeIdMapping());
             pipeline.addLast("routerDispatchHandler", dispatchHandler);
         }
         else {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -43,6 +43,7 @@ import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointBindingResolver;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
+import io.kroxylicious.proxy.internal.routing.DirectRouting;
 import io.kroxylicious.proxy.internal.routing.DynamicRouting;
 import io.kroxylicious.proxy.internal.routing.RouterDispatchHandler;
 import io.kroxylicious.proxy.internal.util.Metrics;
@@ -262,24 +263,24 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
                 proxyNettySettings);
 
         pipeline.addLast("frontendHandler", frontendHandler);
-        if (virtualCluster.routing() instanceof DynamicRouting dr) {
-            Objects.requireNonNull(routerChainFactory,
-                    "routerChainFactory must not be null when virtual cluster '" + virtualCluster.getClusterName() + "' uses a router");
-            Router router = routerChainFactory.createRouter(dr.routerName(), virtualCluster.getClusterName());
-            Map<ApiKeys, String> staticRoutes = router.staticRoutes();
-            Set<ApiKeys> decodedKeys = EnumSet.allOf(ApiKeys.class);
-            if (!staticRoutes.isEmpty()) {
-                decodedKeys.removeAll(staticRoutes.keySet());
+        switch (virtualCluster.routing()) {
+            case DynamicRouting dr -> {
+                Objects.requireNonNull(routerChainFactory,
+                        "routerChainFactory must not be null when virtual cluster '" + virtualCluster.getClusterName() + "' uses a router");
+                Router router = routerChainFactory.createRouter(dr.routerName(), virtualCluster.getClusterName());
+                Map<ApiKeys, String> staticRoutes = router.staticRoutes();
+                Set<ApiKeys> decodedKeys = EnumSet.allOf(ApiKeys.class);
+                if (!staticRoutes.isEmpty()) {
+                    decodedKeys.removeAll(staticRoutes.keySet());
+                }
+                // Always decode API keys whose responses carry node IDs so RouterDispatchHandler
+                // can translate them, even when those keys are statically routed.
+                decodedKeys.addAll(RouterDispatchHandler.NODE_ID_TRANSLATION_APIS);
+                dp.setRouterDecodingRequirements(decodedKeys);
+                var dispatchHandler = new RouterDispatchHandler(router, staticRoutes, clientConnectionStateMachine, dr.nodeIdMapping());
+                pipeline.addLast("routerDispatchHandler", dispatchHandler);
             }
-            // Always decode API keys whose responses carry node IDs so RouterDispatchHandler
-            // can translate them, even when those keys are statically routed.
-            decodedKeys.addAll(RouterDispatchHandler.NODE_ID_TRANSLATION_APIS);
-            dp.setRouterDecodingRequirements(decodedKeys);
-            var dispatchHandler = new RouterDispatchHandler(router, staticRoutes, clientConnectionStateMachine, dr.nodeIdMapping());
-            pipeline.addLast("routerDispatchHandler", dispatchHandler);
-        }
-        else {
-            pipeline.addLast("filterChainCompletionHandler",
+            case DirectRouting ignored -> pipeline.addLast("filterChainCompletionHandler",
                     new FilterChainCompletionHandler(clientConnectionStateMachine));
         }
         addLoggingErrorHandler(pipeline);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachine.java
@@ -31,13 +31,13 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.util.ReferenceCountUtil;
 
 import io.kroxylicious.proxy.config.IllegalConfigurationException;
-import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.config.tls.TrustOptions;
 import io.kroxylicious.proxy.config.tls.TrustProvider;
 import io.kroxylicious.proxy.internal.codec.CorrelationManager;
 import io.kroxylicious.proxy.internal.codec.KafkaRequestEncoder;
 import io.kroxylicious.proxy.internal.codec.KafkaResponseDecoder;
 import io.kroxylicious.proxy.internal.metrics.MetricEmittingKafkaMessageListener;
+import io.kroxylicious.proxy.internal.routing.DirectRouting;
 import io.kroxylicious.proxy.internal.tls.ServerTlsCredentialSupplierContextImpl;
 import io.kroxylicious.proxy.internal.tls.TlsCredentialsImpl;
 import io.kroxylicious.proxy.internal.util.ActivationToken;
@@ -320,17 +320,19 @@ class ServerConnectionStateMachine {
             SslContextBuilder sslContextBuilder = SslContextBuilder.forClient()
                     .keyManager(credentialsImpl.privateKey(), credentialsImpl.certificateChain());
 
-            Optional.ofNullable(virtualCluster.targetCluster()).flatMap(TargetCluster::tls).ifPresent(tls -> {
-                VirtualClusterModel.configureCipherSuites(sslContextBuilder, tls);
-                VirtualClusterModel.configureEnabledProtocols(sslContextBuilder, tls);
-                Optional.ofNullable(tls.trust())
-                        .map(TrustProvider::trustOptions)
-                        .filter(Predicate.not(TrustOptions::forClient))
-                        .ifPresent(to -> {
-                            throw new IllegalConfigurationException("Cannot apply trust options " + to + " to upstream (client) TLS.)");
-                        });
-                VirtualClusterModel.configureTrustProvider(tls).apply(sslContextBuilder);
-            });
+            if (virtualCluster.routing() instanceof DirectRouting dr) {
+                dr.targetCluster().tls().ifPresent(tls -> {
+                    VirtualClusterModel.configureCipherSuites(sslContextBuilder, tls);
+                    VirtualClusterModel.configureEnabledProtocols(sslContextBuilder, tls);
+                    Optional.ofNullable(tls.trust())
+                            .map(TrustProvider::trustOptions)
+                            .filter(Predicate.not(TrustOptions::forClient))
+                            .ifPresent(to -> {
+                                throw new IllegalConfigurationException("Cannot apply trust options " + to + " to upstream (client) TLS.)");
+                            });
+                    VirtualClusterModel.configureTrustProvider(tls).apply(sslContextBuilder);
+                });
+            }
 
             SslContext sslContext = sslContextBuilder.build();
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/BootstrapEndpointBinding.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/BootstrapEndpointBinding.java
@@ -8,6 +8,7 @@ package io.kroxylicious.proxy.internal.net;
 
 import java.util.Objects;
 
+import io.kroxylicious.proxy.internal.routing.DirectRouting;
 import io.kroxylicious.proxy.service.HostPort;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -25,7 +26,10 @@ public record BootstrapEndpointBinding(EndpointGateway endpointGateway) implemen
 
     @Override
     public HostPort upstreamTarget() {
-        return endpointGateway().targetCluster().bootstrapServer();
+        if (!(endpointGateway().virtualCluster().routing() instanceof DirectRouting dr)) {
+            throw new IllegalStateException("BootstrapEndpointBinding only has an upstream target for direct-routing virtual clusters");
+        }
+        return dr.targetCluster().bootstrapServer();
     }
 
     @Nullable

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointGateway.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointGateway.java
@@ -12,7 +12,6 @@ import java.util.Set;
 
 import io.netty.handler.ssl.SslContext;
 
-import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 
@@ -22,12 +21,6 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * A gateway to an endpoint.
  */
 public interface EndpointGateway {
-    /**
-     * Target cluster associated with this listener.
-     * @return target cluster
-     */
-    TargetCluster targetCluster();
-
     /**
      * true if this listener uses TLS.
      *

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/MetadataDiscoveryBrokerEndpointBinding.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/MetadataDiscoveryBrokerEndpointBinding.java
@@ -8,6 +8,7 @@ package io.kroxylicious.proxy.internal.net;
 
 import java.util.Objects;
 
+import io.kroxylicious.proxy.internal.routing.DirectRouting;
 import io.kroxylicious.proxy.service.HostPort;
 
 /**
@@ -28,7 +29,10 @@ public record MetadataDiscoveryBrokerEndpointBinding(EndpointGateway endpointGat
 
     @Override
     public HostPort upstreamTarget() {
-        return endpointGateway.targetCluster().bootstrapServer();
+        if (!(endpointGateway.virtualCluster().routing() instanceof DirectRouting dr)) {
+            throw new IllegalStateException("MetadataDiscoveryBrokerEndpointBinding is only valid for direct-routing virtual clusters");
+        }
+        return dr.targetCluster().bootstrapServer();
     }
 
     @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/MetadataDiscoveryBrokerEndpointBinding.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/MetadataDiscoveryBrokerEndpointBinding.java
@@ -30,7 +30,7 @@ public record MetadataDiscoveryBrokerEndpointBinding(EndpointGateway endpointGat
     @Override
     public HostPort upstreamTarget() {
         if (!(endpointGateway.virtualCluster().routing() instanceof DirectRouting dr)) {
-            throw new IllegalStateException("MetadataDiscoveryBrokerEndpointBinding is only valid for direct-routing virtual clusters");
+            throw new IllegalStateException("upstreamTarget() requires direct routing, but virtual cluster is using dynamic routing");
         }
         return dr.targetCluster().bootstrapServer();
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/DirectRouting.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/DirectRouting.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+import java.util.Objects;
+
+import io.kroxylicious.proxy.config.TargetCluster;
+
+/**
+ * Routing model for a virtual cluster that forwards directly to a single, statically-configured
+ * upstream Kafka cluster.
+ */
+public record DirectRouting(TargetCluster targetCluster) implements RoutingModel {
+
+    public DirectRouting {
+        Objects.requireNonNull(targetCluster, "targetCluster");
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/DynamicRouting.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/DynamicRouting.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Routing model for a virtual cluster that forwards to one or more upstream clusters via a named
+ * router plugin. The {@link NodeIdMapping} is derived from the route descriptors at construction
+ * time.
+ */
+public record DynamicRouting(
+                             String routerName,
+                             Map<String, RouteDescriptor> routeDescriptors,
+                             NodeIdMapping nodeIdMapping)
+        implements RoutingModel {
+
+    /**
+     * Convenience constructor: computes the {@link NodeIdMapping} from the supplied route descriptors.
+     */
+    public DynamicRouting(String routerName, Map<String, RouteDescriptor> routeDescriptors) {
+        this(routerName, routeDescriptors, buildNodeIdMapping(routeDescriptors));
+    }
+
+    public DynamicRouting {
+        Objects.requireNonNull(routerName, "routerName");
+        Objects.requireNonNull(routeDescriptors, "routeDescriptors");
+        Objects.requireNonNull(nodeIdMapping, "nodeIdMapping");
+        routeDescriptors = Map.copyOf(routeDescriptors);
+    }
+
+    private static NodeIdMapping buildNodeIdMapping(Map<String, RouteDescriptor> routeDescriptors) {
+        Objects.requireNonNull(routeDescriptors, "routeDescriptors");
+        if (routeDescriptors.isEmpty()) {
+            throw new IllegalArgumentException("DynamicRouting requires at least one route descriptor");
+        }
+        if (routeDescriptors.size() == 1) {
+            return new IdentityNodeIdMapping(routeDescriptors.keySet().iterator().next());
+        }
+        var routeIds = new HashMap<String, Integer>(routeDescriptors.size());
+        for (var entry : routeDescriptors.entrySet()) {
+            routeIds.put(entry.getKey(), entry.getValue().id());
+        }
+        return new BijectiveNodeIdMapping(routeIds, routeIds.size());
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingModel.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+/**
+ * Sealed hierarchy representing how a virtual cluster reaches its upstream Kafka cluster(s).
+ * <ul>
+ *   <li>{@link DirectRouting} — a single, statically-configured upstream cluster</li>
+ *   <li>{@link DynamicRouting} — one or more upstream clusters reached via a named router plugin</li>
+ * </ul>
+ */
+public sealed interface RoutingModel permits DirectRouting, DynamicRouting {
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -47,10 +47,8 @@ import io.kroxylicious.proxy.config.tls.TrustOptions;
 import io.kroxylicious.proxy.config.tls.TrustProvider;
 import io.kroxylicious.proxy.internal.filter.impl.TopicNameCacheFilter;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
-import io.kroxylicious.proxy.internal.routing.BijectiveNodeIdMapping;
-import io.kroxylicious.proxy.internal.routing.IdentityNodeIdMapping;
-import io.kroxylicious.proxy.internal.routing.NodeIdMapping;
-import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
+import io.kroxylicious.proxy.internal.routing.DirectRouting;
+import io.kroxylicious.proxy.internal.routing.RoutingModel;
 import io.kroxylicious.proxy.internal.subject.DefaultTransportSubjectBuilderService;
 import io.kroxylicious.proxy.internal.tls.NettyKeyProvider;
 import io.kroxylicious.proxy.internal.tls.NettyTrustProvider;
@@ -91,7 +89,7 @@ public class VirtualClusterModel implements AutoCloseable {
 
     private final String clusterName;
 
-    private final @Nullable TargetCluster targetCluster;
+    private final RoutingModel routing;
 
     private final boolean logNetwork;
 
@@ -110,9 +108,6 @@ public class VirtualClusterModel implements AutoCloseable {
     private TopicNameCacheFilter topicNameCacheFilter = null;
 
     private final TlsCredentialSupplierManager tlsCredentialSupplierManager;
-    private final @Nullable String routerName;
-    private final @Nullable Map<String, RouteDescriptor> routeDescriptors;
-    private final @Nullable NodeIdMapping nodeIdMapping;
 
     /**
      * The filter chain factory for <em>this</em> virtual cluster. Owned by the VCM — its
@@ -127,24 +122,12 @@ public class VirtualClusterModel implements AutoCloseable {
                                boolean logNetwork,
                                boolean logFrames,
                                List<NamedFilterDefinition> filters) {
-        this(clusterName, targetCluster, logNetwork, logFrames, filters,
-                new CacheConfiguration(null, null, null), null, Duration.ofSeconds(10), null, null, null);
+        this(clusterName, new DirectRouting(targetCluster), logNetwork, logFrames, filters,
+                new CacheConfiguration(null, null, null), null, Duration.ofSeconds(10), null);
     }
 
     public VirtualClusterModel(String clusterName,
-                               TargetCluster targetCluster,
-                               boolean logNetwork,
-                               boolean logFrames,
-                               List<NamedFilterDefinition> filters,
-                               CacheConfiguration topicNameCacheConfig,
-                               @Nullable TransportSubjectBuilderConfig transportSubjectBuilderConfig,
-                               Duration drainTimeout) {
-        this(clusterName, targetCluster, logNetwork, logFrames, filters, topicNameCacheConfig,
-                transportSubjectBuilderConfig, drainTimeout, null, null, null);
-    }
-
-    public VirtualClusterModel(String clusterName,
-                               @Nullable TargetCluster targetCluster,
+                               RoutingModel routing,
                                boolean logNetwork,
                                boolean logFrames,
                                List<NamedFilterDefinition> filters,
@@ -152,53 +135,29 @@ public class VirtualClusterModel implements AutoCloseable {
                                @Nullable TransportSubjectBuilderConfig transportSubjectBuilderConfig,
                                Duration drainTimeout,
                                @Nullable PluginFactoryRegistry pluginFactoryRegistry) {
-        this(clusterName, targetCluster, logNetwork, logFrames, filters, topicNameCacheConfig,
-                transportSubjectBuilderConfig, drainTimeout, pluginFactoryRegistry, null, null);
-    }
-
-    @SuppressWarnings("java:S107")
-    public VirtualClusterModel(String clusterName,
-                               @Nullable TargetCluster targetCluster,
-                               boolean logNetwork,
-                               boolean logFrames,
-                               List<NamedFilterDefinition> filters,
-                               CacheConfiguration topicNameCacheConfig,
-                               @Nullable TransportSubjectBuilderConfig transportSubjectBuilderConfig,
-                               Duration drainTimeout,
-                               @Nullable PluginFactoryRegistry pluginFactoryRegistry,
-                               @Nullable String routerName,
-                               @Nullable Map<String, RouteDescriptor> routeDescriptors) {
         this.clusterName = Objects.requireNonNull(clusterName);
-        this.targetCluster = targetCluster;
+        this.routing = Objects.requireNonNull(routing);
         this.logNetwork = logNetwork;
         this.logFrames = logFrames;
         this.filters = filters;
         this.topicNameCacheConfig = topicNameCacheConfig;
         this.transportSubjectBuilderConfig = transportSubjectBuilderConfig;
         this.drainTimeout = Objects.requireNonNull(drainTimeout);
-        this.routerName = routerName;
-        this.routeDescriptors = routeDescriptors;
-        this.nodeIdMapping = buildNodeIdMapping(routeDescriptors);
 
-        if (targetCluster == null && routerName == null) {
-            throw new IllegalConfigurationException(
-                    "Virtual cluster '" + clusterName + "' must specify either a targetCluster or a router");
-        }
-
-        if (pluginFactoryRegistry != null && targetCluster != null) {
-            TlsCredentialSupplierConfig definition = targetCluster.tls()
-                    .flatMap(tls -> Optional.ofNullable(tls.credentialSupplier()))
-                    .orElse(null);
-            this.tlsCredentialSupplierManager = new TlsCredentialSupplierManager(pluginFactoryRegistry, definition);
+        if (pluginFactoryRegistry != null) {
             this.filterChainFactory = new FilterChainFactory(pluginFactoryRegistry, filters);
+            TlsCredentialSupplierConfig tlsSupplierConfig = routing instanceof DirectRouting dr
+                    ? dr.targetCluster().tls().flatMap(tls -> Optional.ofNullable(tls.credentialSupplier())).orElse(null)
+                    : null;
+            this.tlsCredentialSupplierManager = new TlsCredentialSupplierManager(pluginFactoryRegistry, tlsSupplierConfig);
         }
         else {
-            this.tlsCredentialSupplierManager = TlsCredentialSupplierManager.unconfigured();
             // Test-only constructors take this branch. They always pass an empty/null filter
             // list, so an empty FCF is the right shape — FilterChainFactory tolerates a null
             // pfr when the chain is empty, which spares tests from building a real
             // PluginFactoryRegistry.
             this.filterChainFactory = new FilterChainFactory(null, List.of());
+            this.tlsCredentialSupplierManager = TlsCredentialSupplierManager.unconfigured();
         }
 
         // TODO: https://github.com/kroxylicious/kroxylicious/issues/104 be prepared to reload the SslContext at runtime.
@@ -219,43 +178,8 @@ public class VirtualClusterModel implements AutoCloseable {
         return drainTimeout;
     }
 
-    @Nullable
-    public String routerName() {
-        return routerName;
-    }
-
-    public boolean usesRouter() {
-        return routerName != null;
-    }
-
-    /**
-     * @return the route descriptors for the router, or {@code null} if this VC does not use a router
-     */
-    @Nullable
-    public Map<String, RouteDescriptor> routeDescriptors() {
-        return routeDescriptors;
-    }
-
-    /**
-     * @return the node ID mapping for this VC, or {@code null} if this VC does not use a router
-     */
-    @Nullable
-    public NodeIdMapping nodeIdMapping() {
-        return nodeIdMapping;
-    }
-
-    private static @Nullable NodeIdMapping buildNodeIdMapping(@Nullable Map<String, RouteDescriptor> routeDescriptors) {
-        if (routeDescriptors == null || routeDescriptors.isEmpty()) {
-            return null;
-        }
-        if (routeDescriptors.size() == 1) {
-            return new IdentityNodeIdMapping(routeDescriptors.keySet().iterator().next());
-        }
-        var routeIds = new java.util.HashMap<String, Integer>(routeDescriptors.size());
-        for (var entry : routeDescriptors.entrySet()) {
-            routeIds.put(entry.getKey(), entry.getValue().id());
-        }
-        return new BijectiveNodeIdMapping(routeIds, routeIds.size());
+    public RoutingModel routing() {
+        return routing;
     }
 
     public void logVirtualClusterSummary() {
@@ -270,9 +194,9 @@ public class VirtualClusterModel implements AutoCloseable {
             var logBuilder = LOGGER.atInfo()
                     .addKeyValue("gateway", name)
                     .addKeyValue("downstream", downstreamBootstrap + downstreamTlsSummary);
-            if (targetCluster != null) {
+            if (routing instanceof DirectRouting dr) {
                 logBuilder = logBuilder.addKeyValue("upstream",
-                        targetCluster.bootstrapServersList() + generateTlsSummary(targetCluster.tls()));
+                        dr.targetCluster().bootstrapServersList() + generateTlsSummary(dr.targetCluster().tls()));
             }
             else {
                 logBuilder = logBuilder.addKeyValue("upstream", "(via router)");
@@ -306,13 +230,6 @@ public class VirtualClusterModel implements AutoCloseable {
         gateways.put(name, new VirtualClusterGatewayModel(this, nodeIdentificationStrategy, tls, name));
     }
 
-    /**
-     * @return the target cluster, or {@code null} if this VC uses a router
-     */
-    public @Nullable TargetCluster targetCluster() {
-        return targetCluster;
-    }
-
     public String getClusterName() {
         return clusterName;
     }
@@ -333,7 +250,7 @@ public class VirtualClusterModel implements AutoCloseable {
     public String toString() {
         return "VirtualClusterModel{" +
                 "clusterName='" + clusterName + '\'' +
-                ", targetCluster=" + targetCluster +
+                ", routing=" + routing +
                 ", gateways=" + gateways +
                 ", logNetwork=" + logNetwork +
                 ", logFrames=" + logFrames +
@@ -395,10 +312,8 @@ public class VirtualClusterModel implements AutoCloseable {
      * @return true if a credential supplier is configured
      */
     public boolean usesDynamicTlsCredentials() {
-        return Optional.ofNullable(targetCluster)
-                .flatMap(TargetCluster::tls)
-                .map(tls -> tls.credentialSupplier() != null)
-                .orElse(false);
+        return routing instanceof DirectRouting dr
+                && dr.targetCluster().tls().map(tls -> tls.credentialSupplier() != null).orElse(false);
     }
 
     public static NettyTrustProvider configureTrustProvider(Tls tlsConfiguration) {
@@ -407,10 +322,10 @@ public class VirtualClusterModel implements AutoCloseable {
     }
 
     private Optional<SslContext> buildUpstreamSslContext() {
-        if (targetCluster == null) {
+        if (!(routing instanceof DirectRouting dr)) {
             return Optional.empty();
         }
-        return targetCluster.tls().map(targetClusterTls -> {
+        return dr.targetCluster().tls().map(targetClusterTls -> {
             try {
                 var sslContextBuilder = Optional.ofNullable(targetClusterTls.key()).map(NettyKeyProvider::new).map(NettyKeyProvider::forClient)
                         .orElse(SslContextBuilder.forClient());
@@ -587,11 +502,6 @@ public class VirtualClusterModel implements AutoCloseable {
         @Override
         public HostPort getClusterBootstrapAddress() {
             return getNodeIdentificationStrategy().getClusterBootstrapAddress();
-        }
-
-        @Override
-        public TargetCluster targetCluster() {
-            return virtualCluster.targetCluster();
         }
 
         @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -48,6 +48,7 @@ import io.kroxylicious.proxy.config.tls.TrustProvider;
 import io.kroxylicious.proxy.internal.filter.impl.TopicNameCacheFilter;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
 import io.kroxylicious.proxy.internal.routing.DirectRouting;
+import io.kroxylicious.proxy.internal.routing.DynamicRouting;
 import io.kroxylicious.proxy.internal.routing.RoutingModel;
 import io.kroxylicious.proxy.internal.subject.DefaultTransportSubjectBuilderService;
 import io.kroxylicious.proxy.internal.tls.NettyKeyProvider;
@@ -146,9 +147,10 @@ public class VirtualClusterModel implements AutoCloseable {
 
         if (pluginFactoryRegistry != null) {
             this.filterChainFactory = new FilterChainFactory(pluginFactoryRegistry, filters);
-            TlsCredentialSupplierConfig tlsSupplierConfig = routing instanceof DirectRouting dr
-                    ? dr.targetCluster().tls().flatMap(tls -> Optional.ofNullable(tls.credentialSupplier())).orElse(null)
-                    : null;
+            TlsCredentialSupplierConfig tlsSupplierConfig = switch (routing) {
+                case DirectRouting dr -> dr.targetCluster().tls().flatMap(tls -> Optional.ofNullable(tls.credentialSupplier())).orElse(null);
+                case DynamicRouting ignored -> null;
+            };
             this.tlsCredentialSupplierManager = new TlsCredentialSupplierManager(pluginFactoryRegistry, tlsSupplierConfig);
         }
         else {
@@ -194,13 +196,11 @@ public class VirtualClusterModel implements AutoCloseable {
             var logBuilder = LOGGER.atInfo()
                     .addKeyValue("gateway", name)
                     .addKeyValue("downstream", downstreamBootstrap + downstreamTlsSummary);
-            if (routing instanceof DirectRouting dr) {
-                logBuilder = logBuilder.addKeyValue("upstream",
+            logBuilder = switch (routing) {
+                case DirectRouting dr -> logBuilder.addKeyValue("upstream",
                         dr.targetCluster().bootstrapServersList() + generateTlsSummary(dr.targetCluster().tls()));
-            }
-            else {
-                logBuilder = logBuilder.addKeyValue("upstream", "(via router)");
-            }
+                case DynamicRouting ignored -> logBuilder.addKeyValue("upstream", "(via router)");
+            };
             logBuilder.log("Gateway configuration");
         });
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
+import io.kroxylicious.proxy.internal.routing.DirectRouting;
+import io.kroxylicious.proxy.internal.routing.DynamicRouting;
 import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 
@@ -116,8 +118,8 @@ class ConfigurationValidationTest {
                 List.of(virtualCluster), null, false, Optional.empty(), null, null);
         List<VirtualClusterModel> virtualClusterModels = config.virtualClusterModel(null);
         assertThat(virtualClusterModels).hasSize(1).singleElement().satisfies(vm -> {
-            assertThat(vm.usesRouter()).isTrue();
-            assertThat(vm.routerName()).isEqualTo("myrouter");
+            assertThat(vm.routing()).isInstanceOf(DynamicRouting.class);
+            assertThat(((DynamicRouting) vm.routing()).routerName()).isEqualTo("myrouter");
         });
     }
 
@@ -134,8 +136,8 @@ class ConfigurationValidationTest {
 
         var model = config.virtualClusterModel(null).get(0);
 
-        assertThat(model.routeDescriptors()).containsKey("route1");
-        RouteDescriptor rd = model.routeDescriptors().get("route1");
+        assertThat(((DynamicRouting) model.routing()).routeDescriptors()).containsKey("route1");
+        RouteDescriptor rd = ((DynamicRouting) model.routing()).routeDescriptors().get("route1");
         assertThat(rd.name()).isEqualTo("route1");
         assertThat(rd.id()).isZero();
         assertThat(rd.targetsCluster()).isTrue();
@@ -143,7 +145,7 @@ class ConfigurationValidationTest {
     }
 
     @Test
-    void routerResolvesPrimaryTargetClusterFromFirstRoute() {
+    void routerResolvesRouteDescriptorsForMultipleRoutes() {
         var c1 = new ClusterDefinition("c1", "broker1:9092", null);
         var c2 = new ClusterDefinition("c2", "broker2:9092", null);
         var route1 = new RouteDefinition("r1", 0, null, new RouteTarget("c1", null));
@@ -157,9 +159,9 @@ class ConfigurationValidationTest {
 
         var model = config.virtualClusterModel(null).get(0);
 
-        assertThat(model.targetCluster()).isNotNull();
-        assertThat(model.targetCluster().bootstrapServersList()).containsExactly(
-                new io.kroxylicious.proxy.service.HostPort("broker1", 9092));
+        assertThat(model.routing()).isInstanceOf(DynamicRouting.class);
+        var dr = (DynamicRouting) model.routing();
+        assertThat(dr.routeDescriptors()).containsKeys("r1", "r2");
     }
 
     @Test
@@ -177,7 +179,7 @@ class ConfigurationValidationTest {
 
         var model = config.virtualClusterModel(null).get(0);
 
-        assertThat(model.routeDescriptors()).hasSize(2).containsKeys("r1", "r2");
+        assertThat(((DynamicRouting) model.routing()).routeDescriptors()).hasSize(2).containsKeys("r1", "r2");
     }
 
     @Test
@@ -194,19 +196,18 @@ class ConfigurationValidationTest {
 
         var model = config.virtualClusterModel(null).get(0);
 
-        RouteDescriptor rd = model.routeDescriptors().get("r1");
+        RouteDescriptor rd = ((DynamicRouting) model.routing()).routeDescriptors().get("r1");
         assertThat(rd.filters()).hasSize(1);
         assertThat(rd.filters().get(0).name()).isEqualTo("f1");
     }
 
     @Test
-    void virtualClusterWithoutRouterHasNullRouteDescriptors() {
+    void virtualClusterWithoutRouterHasDirectRouting() {
         var config = config(List.of(SIMPLE_VC));
 
         var model = config.virtualClusterModel(null).get(0);
 
-        assertThat(model.usesRouter()).isFalse();
-        assertThat(model.routeDescriptors()).isNull();
+        assertThat(model.routing()).isInstanceOf(DirectRouting.class);
     }
 
     @Test
@@ -270,9 +271,10 @@ class ConfigurationValidationTest {
 
         var model = config.virtualClusterModel(null, "demo");
 
-        assertThat(model.usesRouter()).isTrue();
-        assertThat(model.routerName()).isEqualTo("myrouter");
-        assertThat(model.routeDescriptors()).containsKey("r1");
+        assertThat(model.routing()).isInstanceOf(DynamicRouting.class);
+        var dr = (DynamicRouting) model.routing();
+        assertThat(dr.routerName()).isEqualTo("myrouter");
+        assertThat(dr.routeDescriptors()).containsKey("r1");
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
@@ -57,6 +57,7 @@ import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 
 import io.kroxylicious.proxy.config.CacheConfiguration;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
+import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.internal.codec.FrameOversizedException;
@@ -64,6 +65,7 @@ import io.kroxylicious.proxy.internal.filter.impl.TopicNameCacheFilter;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
+import io.kroxylicious.proxy.internal.routing.DirectRouting;
 import io.kroxylicious.proxy.internal.subject.DefaultSubjectBuilder;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
@@ -499,6 +501,7 @@ class ClientConnectionStateMachineEndToEndTest {
         when(endpointGateway.virtualCluster()).thenReturn(virtualClusterModel);
         when(endpointBinding.endpointGateway()).thenReturn(endpointGateway);
         when(endpointBinding.upstreamTarget()).thenReturn(new HostPort(CLUSTER_HOST, CLUSTER_PORT));
+        when(virtualClusterModel.routing()).thenReturn(new DirectRouting(new TargetCluster(CLUSTER_HOST + ":" + CLUSTER_PORT, Optional.empty())));
         final Optional<SslContext> sslContext;
         try {
             sslContext = Optional.ofNullable(tlsConfigured ? SslContextBuilder.forClient().build() : null);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineTest.java
@@ -62,6 +62,8 @@ import io.kroxylicious.proxy.internal.codec.FrameOversizedException;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
 import io.kroxylicious.proxy.internal.net.HaProxyContext;
+import io.kroxylicious.proxy.internal.routing.DirectRouting;
+import io.kroxylicious.proxy.internal.routing.DynamicRouting;
 import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
 import io.kroxylicious.proxy.internal.subject.DefaultSubjectBuilder;
 import io.kroxylicious.proxy.internal.util.VirtualClusterNode;
@@ -94,8 +96,9 @@ class ClientConnectionStateMachineTest {
     private static final Offset<Double> CLOSE_ENOUGH = Offset.offset(0.00005);
     private static final String CLUSTER_NAME = "virtualClusterA";
     private static final VirtualClusterNode VIRTUAL_CLUSTER_NODE = new VirtualClusterNode(CLUSTER_NAME, null);
-    private static final VirtualClusterModel VIRTUAL_CLUSTER_MODEL = new VirtualClusterModel(CLUSTER_NAME, new TargetCluster("", Optional.empty()), false, false,
-            List.of(), CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10));
+    private static final VirtualClusterModel VIRTUAL_CLUSTER_MODEL = new VirtualClusterModel(CLUSTER_NAME,
+            new DirectRouting(new TargetCluster("", Optional.empty())), false, false,
+            List.of(), CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
     public static final KafkaSession TEST_KAFKA_SESSION = new KafkaSession("testSession", KafkaSessionState.NOT_AUTHENTICATED);
     private final RuntimeException failure = new RuntimeException("There's Klingons on the starboard bow");
     private ClientConnectionStateMachine clientConnectionStateMachine;
@@ -743,7 +746,9 @@ class ClientConnectionStateMachineTest {
 
     private void stubAsRouterVirtualCluster() {
         var routerVc = mock(VirtualClusterModel.class, withSettings().lenient());
-        when(routerVc.usesRouter()).thenReturn(true);
+        var routeDescriptors = Map.of("route",
+                new RouteDescriptor("route", 0, new TargetCluster("broker:9092", Optional.empty()), null, List.of()));
+        when(routerVc.routing()).thenReturn(new DynamicRouting("router", routeDescriptors));
         when(endpointGateway.virtualCluster()).thenReturn(routerVc);
     }
 
@@ -969,8 +974,7 @@ class ClientConnectionStateMachineTest {
         when(routeDescriptor.targetsCluster()).thenReturn(true);
         when(routeDescriptor.targetCluster()).thenReturn(targetCluster);
         var routerVc = mock(VirtualClusterModel.class, withSettings().lenient());
-        when(routerVc.usesRouter()).thenReturn(true);
-        when(routerVc.routeDescriptors()).thenReturn(Map.of("my-route", routeDescriptor));
+        when(routerVc.routing()).thenReturn(new DynamicRouting("router", Map.of("my-route", routeDescriptor)));
         when(endpointGateway.virtualCluster()).thenReturn(routerVc);
 
         // When: first request triggers toForwardingWithRoutes
@@ -994,7 +998,9 @@ class ClientConnectionStateMachineTest {
         failingCcsm.forceState(new ClientConnectionState.Forwarding(), frontendHandler,
                 Map.of(), TEST_KAFKA_SESSION, true, Map.of("my-route", target));
         var routerVc = mock(VirtualClusterModel.class, withSettings().lenient());
-        when(routerVc.usesRouter()).thenReturn(true);
+        var routeDescriptors2 = Map.of("my-route",
+                new RouteDescriptor("my-route", 0, new TargetCluster("broker:9092", Optional.empty()), null, List.of()));
+        when(routerVc.routing()).thenReturn(new DynamicRouting("router", routeDescriptors2));
         when(endpointGateway.virtualCluster()).thenReturn(routerVc);
 
         // When: forwardToRoute lazily tries to create an SCSM and fails
@@ -1021,8 +1027,7 @@ class ClientConnectionStateMachineTest {
         when(routeDescriptor.targetsCluster()).thenReturn(true);
         when(routeDescriptor.targetCluster()).thenReturn(targetCluster);
         var routerVc = mock(VirtualClusterModel.class, withSettings().lenient());
-        when(routerVc.usesRouter()).thenReturn(true);
-        when(routerVc.routeDescriptors()).thenReturn(Map.of("bad-route", routeDescriptor));
+        when(routerVc.routing()).thenReturn(new DynamicRouting("router", Map.of("bad-route", routeDescriptor)));
         when(endpointGateway.virtualCluster()).thenReturn(routerVc);
 
         // When / Then

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -40,6 +40,7 @@ import io.kroxylicious.proxy.frame.OpaqueResponseFrame;
 import io.kroxylicious.proxy.internal.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
+import io.kroxylicious.proxy.internal.routing.DirectRouting;
 import io.kroxylicious.proxy.internal.subject.DefaultSubjectBuilder;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
@@ -85,8 +86,8 @@ public abstract class FilterHarness {
 
         final TargetCluster targetCluster = mock(TargetCluster.class);
         when(targetCluster.bootstrapServersList()).thenReturn(TARGET_CLUSTER_BOOTSTRAP);
-        var testVirtualCluster = new VirtualClusterModel("TestVirtualCluster", targetCluster, false,
-                false, List.of(), CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10));
+        var testVirtualCluster = new VirtualClusterModel("TestVirtualCluster", new DirectRouting(targetCluster), false,
+                false, List.of(), CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
         testVirtualCluster.addGateway("default", mock(NodeIdentificationStrategy.class), Optional.empty());
         var inboundChannel = new EmbeddedChannel();
         var channelProcessors = Stream.<ChannelHandler> of(new CorrelationIdIssuer(), new InternalRequestTracker());

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -42,6 +42,7 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
 import io.kroxylicious.proxy.config.CacheConfiguration;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
+import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.frame.DecodedFrame;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
@@ -53,6 +54,7 @@ import io.kroxylicious.proxy.internal.filter.impl.TopicNameCacheFilter;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
 import io.kroxylicious.proxy.internal.net.HaProxyContext;
+import io.kroxylicious.proxy.internal.routing.DirectRouting;
 import io.kroxylicious.proxy.internal.subject.DefaultSubjectBuilder;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.model.VirtualClusterModel.VirtualClusterGatewayModel;
@@ -244,6 +246,7 @@ class KafkaProxyFrontendHandlerTest {
         // FCF is now resolved per-connection from the VC (see #4055). Wire the test's fcf
         // mock through the VC so verify(fcf).createFilters(...) still works.
         when(virtualClusterModel.filterChainFactory()).thenReturn(fcf);
+        when(virtualClusterModel.routing()).thenReturn(new DirectRouting(new TargetCluster(CLUSTER_HOST + ":" + CLUSTER_PORT, Optional.empty())));
         return virtualClusterModel;
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -59,6 +59,9 @@ import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointBindingResolver;
 import io.kroxylicious.proxy.internal.net.EndpointResolutionException;
+import io.kroxylicious.proxy.internal.routing.DirectRouting;
+import io.kroxylicious.proxy.internal.routing.DynamicRouting;
+import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.NodeIdentificationStrategy;
 
@@ -129,16 +132,20 @@ class KafkaProxyInitializerTest {
 
     private VirtualClusterModel buildVirtualCluster(boolean logNetwork, boolean logFrames) {
         final Optional<Tls> tls = Optional.empty();
-        VirtualClusterModel testCluster = new VirtualClusterModel("testCluster", new TargetCluster("localhost:9090", tls), logNetwork,
-                logFrames, List.of(), CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10));
+        VirtualClusterModel testCluster = new VirtualClusterModel("testCluster",
+                new DirectRouting(new TargetCluster("localhost:9090", tls)), logNetwork,
+                logFrames, List.of(), CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
         testCluster.addGateway("defaullt", mock(NodeIdentificationStrategy.class), tls);
         return testCluster;
     }
 
     private VirtualClusterModel buildRouterVirtualCluster() {
         final Optional<Tls> tls = Optional.empty();
-        VirtualClusterModel testCluster = new VirtualClusterModel("testCluster", null, false, false,
-                List.of(), CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null, "myRouter", Map.of());
+        var routeDescriptors = Map.of("myRoute",
+                new RouteDescriptor("myRoute", 0, new TargetCluster("localhost:9090", tls), null, List.of()));
+        VirtualClusterModel testCluster = new VirtualClusterModel("testCluster",
+                new DynamicRouting("myRouter", routeDescriptors), false, false,
+                List.of(), CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
         testCluster.addGateway("defaullt", mock(NodeIdentificationStrategy.class), tls);
         return testCluster;
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ServerConnectionStateMachineTest.java
@@ -26,8 +26,10 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.ssl.SslContext;
 
+import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.internal.codec.KafkaRequestEncoder;
 import io.kroxylicious.proxy.internal.codec.KafkaResponseDecoder;
+import io.kroxylicious.proxy.internal.routing.DirectRouting;
 import io.kroxylicious.proxy.internal.tls.ServerTlsCredentialSupplierContextImpl;
 import io.kroxylicious.proxy.internal.tls.TestCertificateUtil;
 import io.kroxylicious.proxy.internal.tls.TlsCredentialsImpl;
@@ -468,8 +470,9 @@ class ServerConnectionStateMachineTest {
 
         EmbeddedChannel channel = new EmbeddedChannel();
 
-        when(virtualCluster.targetCluster()).thenReturn(mock(io.kroxylicious.proxy.config.TargetCluster.class));
-        when(virtualCluster.targetCluster().tls()).thenReturn(Optional.empty());
+        var mockTargetCluster = mock(TargetCluster.class);
+        when(mockTargetCluster.tls()).thenReturn(Optional.empty());
+        when(virtualCluster.routing()).thenReturn(new DirectRouting(mockTargetCluster));
 
         scsm.applyTlsContextToChannel(creds, REMOTE, channel, channel.pipeline());
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/net/EndpointRegistryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/net/EndpointRegistryTest.java
@@ -35,7 +35,6 @@ import io.netty.util.AttributeKey;
 import io.kroxylicious.proxy.HostPortConverter;
 import io.kroxylicious.proxy.bootstrap.BootstrapSelectionStrategy;
 import io.kroxylicious.proxy.bootstrap.FixedBootstrapSelectionStrategy;
-import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.service.HostPort;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -761,8 +760,6 @@ class EndpointRegistryTest {
         when(cluster.isUseTls()).thenReturn(tls);
         when(cluster.requiresServerNameIndication()).thenReturn(sni);
         when(cluster.discoveryAddressMap()).thenReturn(discoveryAddressMap);
-        var targetCluster = new TargetCluster(upstreamBootstrap.toString(), Optional.empty(), selectionStrategy);
-        when(cluster.targetCluster()).thenReturn(targetCluster);
         when(cluster.getBrokerIdFromBrokerAddress(any(HostPort.class))).thenReturn(null);
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
@@ -35,6 +35,8 @@ import io.kroxylicious.proxy.config.tls.TrustStore;
 import io.kroxylicious.proxy.filter.FilterFactory;
 import io.kroxylicious.proxy.internal.filter.FlakyConfig;
 import io.kroxylicious.proxy.internal.filter.FlakyFactory;
+import io.kroxylicious.proxy.internal.routing.DirectRouting;
+import io.kroxylicious.proxy.internal.routing.DynamicRouting;
 import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
 import io.kroxylicious.proxy.internal.tls.TlsTestConstants;
 import io.kroxylicious.proxy.plugin.Plugin;
@@ -95,10 +97,12 @@ class VirtualClusterModelTest {
     }
 
     @Test
-    void usesDynamicTlsCredentialsReturnsFalseWhenTargetClusterIsNull() {
-        // A router-targeting VC has a null targetCluster — usesDynamicTlsCredentials must not NPE.
-        VirtualClusterModel model = new VirtualClusterModel("wibble", null, false, false, EMPTY_FILTERS,
-                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null, "some-router", null);
+    void usesDynamicTlsCredentialsReturnsFalseWhenDynamicRouting() {
+        // A router-targeting VC has no direct targetCluster — usesDynamicTlsCredentials must return false.
+        var routeDescriptors = Map.of("r1",
+                new RouteDescriptor("r1", 0, new TargetCluster("broker:9092", Optional.empty()), null, List.of()));
+        VirtualClusterModel model = new VirtualClusterModel("wibble", new DynamicRouting("some-router", routeDescriptors),
+                false, false, EMPTY_FILTERS, CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
 
         assertThat(model.usesDynamicTlsCredentials()).isFalse();
     }
@@ -107,8 +111,8 @@ class VirtualClusterModelTest {
     void usesDynamicTlsCredentialsReturnsFalseWhenNoTlsConfigured() {
         TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
 
-        VirtualClusterModel model = new VirtualClusterModel("wibble", targetCluster, false, false, EMPTY_FILTERS,
-                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10));
+        VirtualClusterModel model = new VirtualClusterModel("wibble", new DirectRouting(targetCluster), false, false, EMPTY_FILTERS,
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
 
         assertThat(model.usesDynamicTlsCredentials()).isFalse();
         assertThat(model.getTlsCredentialSupplierManager().isConfigured()).isFalse();
@@ -118,8 +122,8 @@ class VirtualClusterModelTest {
     void usesDynamicTlsCredentialsReturnsFalseWhenTlsHasNoCredentialSupplier() {
         TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.of(new Tls(null, null, null, null, null)));
 
-        VirtualClusterModel model = new VirtualClusterModel("wibble", targetCluster, false, false, EMPTY_FILTERS,
-                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10));
+        VirtualClusterModel model = new VirtualClusterModel("wibble", new DirectRouting(targetCluster), false, false, EMPTY_FILTERS,
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
 
         assertThat(model.usesDynamicTlsCredentials()).isFalse();
     }
@@ -129,8 +133,8 @@ class VirtualClusterModelTest {
         var credentialSupplierConfig = new TlsCredentialSupplierConfig("TestSupplierFactory", new TestSupplierConfig("test"));
         TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.of(new Tls(null, null, null, null, credentialSupplierConfig)));
 
-        VirtualClusterModel model = new VirtualClusterModel("wibble", targetCluster, false, false, EMPTY_FILTERS,
-                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10));
+        VirtualClusterModel model = new VirtualClusterModel("wibble", new DirectRouting(targetCluster), false, false, EMPTY_FILTERS,
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
 
         assertThat(model.usesDynamicTlsCredentials()).isTrue();
     }
@@ -140,7 +144,7 @@ class VirtualClusterModelTest {
         var credentialSupplierConfig = new TlsCredentialSupplierConfig("TestSupplierFactory", new TestSupplierConfig("test"));
         TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.of(new Tls(null, null, null, null, credentialSupplierConfig)));
 
-        VirtualClusterModel model = new VirtualClusterModel("wibble", targetCluster, false, false, EMPTY_FILTERS,
+        VirtualClusterModel model = new VirtualClusterModel("wibble", new DirectRouting(targetCluster), false, false, EMPTY_FILTERS,
                 CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), pluginFactoryRegistry());
 
         assertThat(model.getTlsCredentialSupplierManager().isConfigured()).isTrue();
@@ -151,8 +155,8 @@ class VirtualClusterModelTest {
     @Test
     void closeIsNoOpWhenTlsCredentialSupplierManagerIsUnconfigured() {
         TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
-        VirtualClusterModel model = new VirtualClusterModel("wibble", targetCluster, false, false, EMPTY_FILTERS,
-                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10));
+        VirtualClusterModel model = new VirtualClusterModel("wibble", new DirectRouting(targetCluster), false, false, EMPTY_FILTERS,
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
 
         model.close();
     }
@@ -169,7 +173,7 @@ class VirtualClusterModelTest {
 
         var credentialSupplierConfig = new TlsCredentialSupplierConfig("TestSupplierFactory", new TestSupplierConfig("test"));
         var targetCluster = new TargetCluster("bootstrap:9092", Optional.of(new Tls(null, null, null, null, credentialSupplierConfig)));
-        var model = new VirtualClusterModel("vc1", targetCluster, false, false, filters,
+        var model = new VirtualClusterModel("vc1", new DirectRouting(targetCluster), false, false, filters,
                 CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), combinedPluginFactoryRegistry());
 
         var tlsManager = model.getTlsCredentialSupplierManager();
@@ -199,7 +203,7 @@ class VirtualClusterModelTest {
         var pfr = combinedPluginFactoryRegistry();
         var drainTimeout = Duration.ofSeconds(10);
 
-        assertThatThrownBy(() -> new VirtualClusterModel("vc1", targetCluster, false, false, filters,
+        assertThatThrownBy(() -> new VirtualClusterModel("vc1", new DirectRouting(targetCluster), false, false, filters,
                 CacheConfiguration.DEFAULT, null, drainTimeout, pfr))
                 .isExactlyInstanceOf(PluginConfigurationException.class)
                 .hasMessageContaining("Exception initializing filter factory bad-filter")
@@ -209,24 +213,26 @@ class VirtualClusterModelTest {
     }
 
     @Test
-    void routerBasedVcmHasNullTargetClusterAndEmptyUpstreamSslContext() {
+    void dynamicRoutingVcmHasNoUpstreamSslContext() {
         var routeDescriptors = Map.of("route1",
                 new RouteDescriptor("route1", 0, new TargetCluster("broker:9092", Optional.empty()), null, List.of()));
+        var dynamicRouting = new DynamicRouting("myrouter", routeDescriptors);
 
-        VirtualClusterModel model = new VirtualClusterModel("routed-vc", null, false, false, EMPTY_FILTERS,
-                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null, "myrouter", routeDescriptors);
+        VirtualClusterModel model = new VirtualClusterModel("routed-vc", dynamicRouting, false, false, EMPTY_FILTERS,
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
 
-        assertThat(model.targetCluster()).isNull();
-        assertThat(model.usesRouter()).isTrue();
-        assertThat(model.routerName()).isEqualTo("myrouter");
-        assertThat(model.routeDescriptors()).containsKey("route1");
+        assertThat(model.routing()).isInstanceOf(DynamicRouting.class);
+        assertThat(((DynamicRouting) model.routing()).routerName()).isEqualTo("myrouter");
+        assertThat(((DynamicRouting) model.routing()).routeDescriptors()).containsKey("route1");
         assertThat(model.getUpstreamSslContext()).isEmpty();
     }
 
     @Test
-    void logVirtualClusterSummaryHandlesNullTargetCluster() {
-        VirtualClusterModel model = new VirtualClusterModel("routed-vc", null, false, false, EMPTY_FILTERS,
-                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null, "myrouter", null);
+    void logVirtualClusterSummaryWorksForDynamicRouting() {
+        var routeDescriptors = Map.of("route1",
+                new RouteDescriptor("route1", 0, new TargetCluster("broker:9092", Optional.empty()), null, List.of()));
+        VirtualClusterModel model = new VirtualClusterModel("routed-vc", new DynamicRouting("myrouter", routeDescriptors),
+                false, false, EMPTY_FILTERS, CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
 
         assertThatCode(model::logVirtualClusterSummary).doesNotThrowAnyException();
     }
@@ -239,8 +245,8 @@ class VirtualClusterModelTest {
         final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", downstreamTls);
 
         // When/Then
-        assertThatThrownBy(() -> new VirtualClusterModel("wibble", targetCluster, false, false, EMPTY_FILTERS,
-                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10)))
+        assertThatThrownBy(() -> new VirtualClusterModel("wibble", new DirectRouting(targetCluster), false, false, EMPTY_FILTERS,
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("Cannot apply trust options");
     }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

`VirtualClusterModel` previously held four `@Nullable` fields encoding a discriminated union — `targetCluster`, `routerName`, `routeDescriptors`, and `nodeIdMapping` — with a runtime guard enforcing that exactly one of `targetCluster`/`routerName` was non-null. Every caller had to null-check, and the four-overload constructor chain topped out at 11 parameters (suppressed with `@SuppressWarnings("java:S107")`).

This PR introduces a sealed `RoutingModel` hierarchy:

- `DirectRouting(TargetCluster)` — single statically-configured upstream
- `DynamicRouting(routerName, routeDescriptors, nodeIdMapping)` — router-plugin routing; `nodeIdMapping` is derived from the route map at construction time

`VirtualClusterModel` now holds a single non-null `RoutingModel`, making the invariant structural rather than runtime-enforced. The four nullable getters are removed in favour of a `routing()` accessor; callers use `instanceof` pattern matching.

`Configuration` builds the appropriate subtype before constructing `VirtualClusterModel`, which also allows removing the `resolveRouterPrimaryTargetCluster` helper that existed solely to populate a nullable `targetCluster` for router-mode VCs.

`EndpointGateway.targetCluster()` is removed from the interface; `BootstrapEndpointBinding` and `MetadataDiscoveryBrokerEndpointBinding` now access `DirectRouting` directly via `virtualCluster().routing()`.

### Additional Context

Raised in #4248 — addresses the constructor arity problem by replacing the growing set of nullable parameters with a proper sealed type hierarchy.

Closes #4248

### Checklist

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).