### PR TITLE
fix(operator): report the operator's own build metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#4258](https://github.com/kroxylicious/kroxylicious/issues/4258): fix(operator): the version and commit id logged at operator startup (and exposed via the `kroxylicious_operator_info` metric) now reflect the operator's own build rather than the `kroxylicious-runtime` jar's
 * [#4144](https://github.com/kroxylicious/kroxylicious/pull/4144): build(deps): bump io.prometheus:prometheus-metrics-bom from 1.6.1 to 1.8.0
 * [#4207](https://github.com/kroxylicious/kroxylicious/pull/4207): build(deps): [record-validation] bump io.kiota:kiota-http-jdk from 0.0.35 to 0.0.36
 * [#4197](https://github.com/kroxylicious/kroxylicious/pull/4197): build(deps-dev): bump com.google.protobuf:protobuf-java from 4.35.0 to 4.35.1

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -73,6 +73,12 @@ public class OperatorMain {
      * name emitted by Prometheus will be called {@code kroxylicious_operator_build_info}.
      */
     private static final String BUILD_INFO_METRIC_NAME = "kroxylicious_operator_build.info";
+    /**
+     * Classpath resource holding the operator's own build metadata. It is distinct from the
+     * {@code kroxylicious-runtime} {@code META-INF/metadata.properties} so the version and commit id
+     * reported here reflect the operator's build rather than the runtime jar's.
+     */
+    static final String METADATA_RESOURCE = "META-INF/kroxylicious-operator.metadata.properties";
     private static final Pattern WATCHED_NAMESPACE_SPLITTER = Pattern.compile(" *, *");
     private final Operator operator;
     private final HttpServer managementServer;
@@ -139,7 +145,7 @@ public class OperatorMain {
         managementServer.start();
         addHttpGetHandler(HTTP_PATH_LIVEZ, this::livezStatusCode);
         operator.start();
-        var versionInfo = VersionInfo.VERSION_INFO;
+        var versionInfo = VersionInfo.fromResource(METADATA_RESOURCE);
         LOGGER.atInfo()
                 .addKeyValue("javaVersion", Runtime::version)
                 .addKeyValue("javaVendor", () -> System.getProperty("java.vendor"))

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/resources-filtered/META-INF/kroxylicious-operator.metadata.properties
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/resources-filtered/META-INF/kroxylicious-operator.metadata.properties
@@ -1,0 +1,8 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+kroxylicious.version=${project.version}
+git.commit.id=${git.commit.id}

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMetadataTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMetadataTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.VersionInfo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the operator ships and reports its own build metadata, rather than falling back to
+ * the {@code kroxylicious-runtime} {@code META-INF/metadata.properties} that happens to be on the
+ * classpath.
+ */
+class OperatorMetadataTest {
+
+    @Test
+    void reportsOperatorsOwnBuildMetadata() {
+        // Given the operator's build produced its own metadata resource (see OperatorMain.METADATA_RESOURCE)
+
+        // When the operator loads its version information
+        var versionInfo = VersionInfo.fromResource(OperatorMain.METADATA_RESOURCE);
+
+        // Then the version and commit id come from the operator's own resource, not unknown fallbacks
+        assertThat(versionInfo.version())
+                .as("operator version should be populated from its own metadata resource")
+                .isNotBlank()
+                .isNotEqualTo("unknown");
+        assertThat(versionInfo.commitId())
+                .as("operator commit id should be populated from its own metadata resource")
+                .isNotBlank()
+                .isNotEqualTo("unknown");
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/VersionInfo.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/VersionInfo.java
@@ -13,15 +13,25 @@ import java.util.Properties;
 import org.slf4j.LoggerFactory;
 
 public interface VersionInfo {
-    VersionInfo VERSION_INFO = getVersionInfo();
+    VersionInfo VERSION_INFO = fromResource("META-INF/metadata.properties");
 
     String version();
 
     String commitId();
 
-    private static VersionInfo getVersionInfo() {
+    /**
+     * Loads version information from the named classpath properties resource, reading the
+     * {@code kroxylicious.version} and {@code git.commit.id} properties. Each module that wants to
+     * report its own build metadata should ship a distinctly named resource and load it here, so
+     * that the reported version reflects the module's own build rather than whichever
+     * {@code metadata.properties} happens to be first on the classpath.
+     *
+     * @param resourceName the classpath resource to load the metadata from
+     * @return the version information, or unknown values if the resource is absent or unreadable
+     */
+    static VersionInfo fromResource(String resourceName) {
 
-        try (var resource = Info.class.getClassLoader().getResourceAsStream("META-INF/metadata.properties")) {
+        try (var resource = Info.class.getClassLoader().getResourceAsStream(resourceName)) {
             if (resource != null) {
                 Properties properties = new Properties();
                 properties.load(resource);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

`OperatorMain` logs its `version` and `commitId` at startup (and exposes them via the `kroxylicious_operator_info` metric) using `io.kroxylicious.proxy.VersionInfo`, which loads `META-INF/metadata.properties` off the classpath. That resource is only generated by `kroxylicious-runtime`. Since the operator depends on the runtime at `compile` scope, the reported values came from the **runtime jar's** build, not the operator's.

This fix gives the operator its own filtered metadata resource under a **distinct** name — `META-INF/kroxylicious-operator.metadata.properties` — so there is no classpath collision with the runtime's identically-named file (which would otherwise resolve non-deterministically by classpath order). Loading is done through a small `VersionInfo.fromResource(name)` factory extracted from the existing private loader; `VERSION_INFO` keeps loading the runtime's file, so runtime behaviour is unchanged.

Files:
- `VersionInfo` — extract the private loader into a reusable `static fromResource(String)` (no behaviour change for `VERSION_INFO`).
- `kroxylicious-operator` — new filtered `META-INF/kroxylicious-operator.metadata.properties`; `OperatorMain` loads it via `fromResource(...)`.
- `OperatorMetadataTest` — new regression test.
- `CHANGELOG.md` — entry.

### Additional Context

Fixes #4258. The `version`/`commitId` are identical across modules in a full release build (same `${project.version}` / `${git.commit.id}`), but diverge on **partial rebuilds** — e.g. rebuilding only the operator against a stale runtime jar, where the operator would then log the runtime jar's older commit. This is exactly the misleading-when-debugging scenario described in the issue.

### How it was tested

- Added `OperatorMetadataTest`, which asserts the operator resolves a populated (non-`"unknown"`) `version` and `commitId` from its own resource. It **fails before** this change (the resource does not exist) and **passes after**.
- Verified the generated resource is correctly filtered to a real `${project.version}` (`0.22.0-SNAPSHOT`) and a 40-char `${git.commit.id}`.
- Existing `OperatorMainTest` (15 tests) still pass; formatter/impsort/checkstyle report 0 violations.

Ran with `mvn -pl kroxylicious-kubernetes/kroxylicious-operator -Dtest='OperatorMainTest,OperatorMetadataTest' test` → `Tests run: 16, Failures: 0, Errors: 0, Skipped: 0`.

### Checklist

- [x] New tests written (where applicable).
- [x] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update.
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [x] For user facing changes, update CHANGELOG.md.

---

**AI-Agent: THSort-Agent (autonomous agent operated by Taimur) — https://thsort.github.io**
This PR was authored end-to-end by an autonomous AI agent under its own GitHub identity (@thsort-dev-agent). Commits carry the project-required `Assisted-by:` and DCO `Signed-off-by:` trailers.