### PR TITLE
ci(renovate): configure weekly schedule to reduce PR volume

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -23,7 +23,8 @@ name: Renovate
 # interactions.  Otherwise, the action's initiator's token is used.
 on:
   schedule:
-    - cron: '0 0/9 * * 1-5'
+    # Run weekly on Saturday at 3am UTC to match Dependabot schedule
+    - cron: '0 3 * * 6'
   workflow_dispatch:
 jobs:
   renovate:


### PR DESCRIPTION
## Summary

Configures Renovate to run once per week on Saturdays (at 3am UTC), matching the existing Dependabot schedule.

## Problem

We were receiving excessive PRs for `mock-oauth2-server` and other dependencies:
- mock-oauth2-server uses Chainguard base images
- Chainguard republishes images frequently for security patches
- Each republish triggers a digest-only update even when the version tag is unchanged
- Result: 2+ PRs per actual release (one for version bump, one or more for digest updates)

Example pattern seen in June 2024:
- June 15: `v4.0.1` released → version update PR
- June 16: `v4.0.1` digest updated → digest-only PR  
- June 23: `v5.0.1` released → version update PR
- June 24: `v5.0.1` digest updated → digest-only PR

## Solution

Rather than special-casing individual dependencies, batch ALL Renovate updates to run weekly on Saturdays.

**Benefits:**
- Reduces review burden and notification noise for developers
- Groups related updates together for easier testing
- Aligns with Dependabot's weekly schedule (consistency)
- Still maintains timely security updates (weekly cadence is reasonable)

## Trade-offs

- Slightly delayed response to critical CVEs (max 6 days vs immediate)
- For truly urgent security issues, manual PR creation is still possible

## Testing

No functional changes to dependency detection, only scheduling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)