### PR TITLE
docs: Add Thales CipherTrust Manager documentation for record encryption

### DIFF
--- a/kroxylicious-docs/README.md
+++ b/kroxylicious-docs/README.md
@@ -73,7 +73,7 @@ Start each file with an introductory paragraph. Mark it by adding a `[role="_abs
 To generate the guides in HTML, run the following Maven command from the project root directory (the parent directory of the `kroxylicious-docs` directory).
 
 ```shell
-mvn -P dist package --pl kroxylicious-docs 
+mvn -P dist package --pl kroxylicious-docs -am
 ```
 
 The HTML for each guide is output to a subdirectory of `target/docs`. 

--- a/kroxylicious-docs/docs/_assemblies/record-encryption/assembly-configuring-record-encryption-filter.adoc
+++ b/kroxylicious-docs/docs/_assemblies/record-encryption/assembly-configuring-record-encryption-filter.adoc
@@ -38,6 +38,9 @@ endif::OpenShiftOnly[]
 ifdef::include-fortanix-dsm-kms[]
 * <<con-fortanix-dsm-plugin-configuration-{context},Fortanix DSM plugin configuration>>
 endif::[]
+ifdef::include-thales-ctm-kms[]
+* <<con-thales-ctm-plugin-configuration-{context},Thales CipherTrust Manager plugin configuration>>
+endif::[]
 
 . Create a filter configuration that references the configured KMS plugins.
 +
@@ -60,6 +63,10 @@ include::../../_modules/record-encryption/azure-key-vault/con-azure-key-vault-pl
 
 ifdef::include-fortanix-dsm-kms[]
 include::../../_modules/record-encryption/fortanix-dsm/con-fortanix-dsm-plugin-configuration.adoc[leveloffset=+1]
+endif::[]
+
+ifdef::include-thales-ctm-kms[]
+include::../../_modules/record-encryption/thales-ctm/con-thales-ctm-plugin-configuration.adoc[leveloffset=+1]
 endif::[]
 
 include::../../_modules/record-encryption/con-record-encryption-filter-config.adoc[leveloffset=+1]

--- a/kroxylicious-docs/docs/_assemblies/record-encryption/assembly-kms-key-creation.adoc
+++ b/kroxylicious-docs/docs/_assemblies/record-encryption/assembly-kms-key-creation.adoc
@@ -21,4 +21,7 @@ include::azure-key-vault/assembly-key-creation-azure-key-vault.adoc[leveloffset=
 ifdef::include-fortanix-dsm-kms[]
 include::fortanix-dsm/assembly-key-creation-fortanix-dsm.adoc[leveloffset=+1]
 endif::[]
+ifdef::include-thales-ctm-kms[]
+include::thales-ctm/assembly-key-creation-thales-ctm.adoc[leveloffset=+1]
+endif::[]
 

--- a/kroxylicious-docs/docs/_assemblies/record-encryption/assembly-kms-preparing.adoc
+++ b/kroxylicious-docs/docs/_assemblies/record-encryption/assembly-kms-preparing.adoc
@@ -24,4 +24,7 @@ include::azure-key-vault/assembly-preparing-azure-key-vault.adoc[leveloffset=+1]
 ifdef::include-fortanix-dsm-kms[]
 include::fortanix-dsm/assembly-preparing-fortanix-dsm.adoc[leveloffset=+1]
 endif::[]
+ifdef::include-thales-ctm-kms[]
+include::thales-ctm/assembly-preparing-thales-ctm.adoc[leveloffset=+1]
+endif::[]
 

--- a/kroxylicious-docs/docs/_assemblies/record-encryption/thales-ctm/assembly-key-creation-thales-ctm.adoc
+++ b/kroxylicious-docs/docs/_assemblies/record-encryption/thales-ctm/assembly-key-creation-thales-ctm.adoc
@@ -1,0 +1,15 @@
+////
+  // Copyright Kroxylicious Authors.
+  //
+  // Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+////
+
+:_mod-docs-content-type: ASSEMBLY
+
+[id='assembly-key-creation-thales-ctm-{context}']
+= Creating keys in Thales CipherTrust Manager
+
+[role="_abstract"]
+To create encryption keys in Thales CipherTrust Manager for use with the Record Encryption filter, use the `ksctl` command-line tool to create AES-256 symmetric keys.
+
+include::../../../_modules/record-encryption/thales-ctm/proc-thales-ctm-key-creation.adoc[leveloffset=+1]

--- a/kroxylicious-docs/docs/_assemblies/record-encryption/thales-ctm/assembly-key-creation-thales-ctm.adoc
+++ b/kroxylicious-docs/docs/_assemblies/record-encryption/thales-ctm/assembly-key-creation-thales-ctm.adoc
@@ -10,6 +10,6 @@
 = Creating keys in Thales CipherTrust Manager
 
 [role="_abstract"]
-To create encryption keys in Thales CipherTrust Manager for use with the Record Encryption filter, use the `ksctl` command-line tool to create AES-256 symmetric keys.
+To create AES-256 symmetric encryption keys in Thales CipherTrust Manager for the Record Encryption filter, use the ksctl command-line tool.
 
 include::../../../_modules/record-encryption/thales-ctm/proc-thales-ctm-key-creation.adoc[leveloffset=+1]

--- a/kroxylicious-docs/docs/_assemblies/record-encryption/thales-ctm/assembly-preparing-thales-ctm.adoc
+++ b/kroxylicious-docs/docs/_assemblies/record-encryption/thales-ctm/assembly-preparing-thales-ctm.adoc
@@ -1,0 +1,15 @@
+////
+  // Copyright Kroxylicious Authors.
+  //
+  // Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+////
+
+:_mod-docs-content-type: ASSEMBLY
+
+[id='assembly-preparing-thales-ctm-{context}']
+= Preparing Thales CipherTrust Manager
+
+[role="_abstract"]
+To prepare Thales CipherTrust Manager for use with the Record Encryption filter, configure a group with a least-privilege policy and create an application identity using either client certificate authentication (recommended) or username and password authentication.
+
+include::../../../_modules/record-encryption/thales-ctm/con-thales-ctm-setup.adoc[leveloffset=+1]

--- a/kroxylicious-docs/docs/_assemblies/record-encryption/thales-ctm/assembly-preparing-thales-ctm.adoc
+++ b/kroxylicious-docs/docs/_assemblies/record-encryption/thales-ctm/assembly-preparing-thales-ctm.adoc
@@ -10,6 +10,6 @@
 = Preparing Thales CipherTrust Manager
 
 [role="_abstract"]
-To prepare Thales CipherTrust Manager for use with the Record Encryption filter, configure a group with a least-privilege policy and create an application identity using either client certificate authentication (recommended) or username and password authentication.
+To prepare Thales CipherTrust Manager to use with the Record Encryption filter, configure a group with a least-privilege policy and create an application identity using either client certificate authentication (recommended) or username and password authentication.
 
 include::../../../_modules/record-encryption/thales-ctm/con-thales-ctm-setup.adoc[leveloffset=+1]

--- a/kroxylicious-docs/docs/_assets/attributes.adoc
+++ b/kroxylicious-docs/docs/_assets/attributes.adoc
@@ -124,6 +124,7 @@
 // Conditional inclusion flags
 // (note: we control optional inclusion with ifdefs/ifndefs directives, so the value of the attribute is irrelevant)
 :include-fortanix-dsm-kms: 1
+:include-thales-ctm-kms: 1
 :include-aws-kms-service-config-identity-ec2-metadata: 1
 :include-aws-kms-service-config-identity-irsa: 1
 :include-aws-kms-service-config-identity-pod-identity: 1

--- a/kroxylicious-docs/docs/_assets/trademarks.adoc
+++ b/kroxylicious-docs/docs/_assets/trademarks.adoc
@@ -19,3 +19,6 @@
 ifdef::include-fortanix-dsm-kms[]
 * Fortanix and Data Security Manager are trademarks of Fortanix, Inc.
 endif::[]
+ifdef::include-thales-ctm-kms[]
+* Thales and CipherTrust Manager are trademarks of Thales Group.
+endif::[]

--- a/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/con-thales-ctm-plugin-configuration.adoc
+++ b/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/con-thales-ctm-plugin-configuration.adoc
@@ -43,7 +43,7 @@ where:
 
 == Username and password authentication
 
-For username and password authentication, use the username and password from the KMS setup:
+For username and password authentication, use the credentials from the KMS setup:
 
 [source, yaml]
 ----

--- a/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/con-thales-ctm-plugin-configuration.adoc
+++ b/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/con-thales-ctm-plugin-configuration.adoc
@@ -1,0 +1,93 @@
+////
+  // Copyright Kroxylicious Authors.
+  //
+  // Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+////
+
+:_mod-docs-content-type: CONCEPT
+
+// file included in the following:
+//
+// assembly-configuring-record-encryption-filter
+
+[id='con-thales-ctm-plugin-configuration-{context}']
+= Thales CipherTrust Manager plugin configuration
+
+[role="_abstract"]
+For Thales CipherTrust Manager, the KMS configuration depends on the authentication method you chose during setup.
+
+== Client certificate authentication
+
+For client certificate authentication (recommended for production), use the client ID, certificate, and private key from the KMS setup:
+
+[source, yaml]
+----
+kms: CipherTrustKmsService
+kmsConfig:
+  endpointUrl: https://ctm.example.com
+  clientCredentials:
+    clientId: <client-id>
+  tls:
+    key:
+      privateKeyFile: /opt/kroxylicious/ctm-client.key
+      certificateFile: /opt/kroxylicious/ctm-client.crt
+----
+
+where:
+
+* `kms` specifies the name of the KMS provider. Use `CipherTrustKmsService`.
+* `endpointUrl` provides the CipherTrust Manager endpoint URL including the protocol, such as `https://ctm.example.com`.
+* `clientId` is the client ID returned when you registered the client certificate.
+* `privateKeyFile` references the PEM-encoded private key file for the client certificate.
+* `certificateFile` references the PEM-encoded client certificate file.
+
+== Username and password authentication
+
+For username and password authentication, use the username and password from the KMS setup:
+
+[source, yaml]
+----
+kms: CipherTrustKmsService
+kmsConfig:
+  endpointUrl: https://ctm.example.com
+  userCredentials:
+    username: kroxylicious-service
+    password:
+      passwordFile: /opt/kroxylicious/ctm-password
+----
+
+where:
+
+* `kms` specifies the name of the KMS provider. Use `CipherTrustKmsService`.
+* `endpointUrl` provides the CipherTrust Manager endpoint URL including the protocol, such as `https://ctm.example.com`.
+* `username` is the CipherTrust Manager username.
+* `passwordFile` references a file containing the password.
+
+IMPORTANT: In production deployments, always use `passwordFile` to reference a password stored in a file rather than embedding the password directly in the configuration.
+
+== Optional TLS trust configuration
+
+If your CipherTrust Manager instance uses a certificate signed by an internal CA or a self-signed certificate, you can configure a custom trust store:
+
+[source, yaml]
+----
+kms: CipherTrustKmsService
+kmsConfig:
+  endpointUrl: https://ctm.example.com
+  clientCredentials:
+    clientId: <client-id>
+  tls:
+    key:
+      privateKeyFile: /opt/kroxylicious/ctm-client.key
+      certificateFile: /opt/kroxylicious/ctm-client.crt
+    trust:
+      storeFile: /opt/kroxylicious/ctm-server-ca.pem
+      storeType: PEM
+----
+
+where:
+
+* `storeFile` references a PEM-encoded CA certificate file, or a Java trust store (JKS or PKCS12 format).
+* `storeType` specifies the trust store format (`PEM`, `PKCS12`, or `JKS`).
+
+If the `tls.trust` configuration is omitted, the filter uses the Java default trust store, which includes well-known certificate authorities.

--- a/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/con-thales-ctm-setup.adoc
+++ b/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/con-thales-ctm-setup.adoc
@@ -1,0 +1,276 @@
+////
+  // Copyright Kroxylicious Authors.
+  //
+  // Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+////
+
+:_mod-docs-content-type: CONCEPT
+
+// file included in the following:
+//
+// assembly-preparing-thales-ctm.adoc
+
+[id='con-thales-ctm-setup-{context}']
+= Preparing Thales CipherTrust Manager for Kroxylicious
+
+[role="_abstract"]
+To use the Record Encryption filter with Thales CipherTrust Manager (CTM), you need to configure CTM with a group, policy, and application identity that has the minimal permissions required for envelope encryption operations.
+
+== CipherTrust Manager endpoint URL
+
+The filter requires the CTM endpoint URL to connect to your CipherTrust Manager instance.
+
+The URL format depends on your deployment:
+
+* Cloud instance: `\https://<instance-name>.ciphertrust.io`
+* On-premises instance: `\https://<hostname-or-ip>:<port>`
+
+The filter uses this URL to access the CTM REST API for cryptographic operations.
+
+== Prerequisites
+
+* Access to the CipherTrust Manager administrative interface
+* The `ksctl` command-line tool installed and configured to connect to your CTM instance
+* Administrator permissions in CTM to create groups, policies, and users (or client registrations)
+* For client certificate authentication: a Certificate Authority (CA) registered in CipherTrust Manager
+
+== Role of the administrator
+
+To use the filter, an administrator must:
+
+1. Create a group for Kroxylicious service account.
+2. Configure a policy that grants the minimal permissions Kroxylicious needs and attach the policy to the group.
+3. Create a user or client certificate registration for Kroxylicious that is a member of the group.
+
+The organization deploying the Record Encryption filter is responsible for managing this administrator or process.
+
+== Create a group for Kroxylicious service account
+
+Create a dedicated group in CipherTrust Manager to organize Kroxylicious service accounts or client certificates.
+
+Using `ksctl`:
+
+[source,shell]
+----
+ksctl groups create \
+  --name "kroxylicious-record-encryption" \
+  --description "Kroxylicious service accounts for record encryption"
+----
+
+This group will be used when configuring the access control policy.
+
+== Create a least-privilege policy
+
+Create a policy that grants only the permissions Kroxylicious needs for envelope encryption operations.
+
+The policy must grant these actions:
+
+* `ReadKey` - Required to get key metadata (used for alias resolution)
+* `EncryptWithKey` - Required to encrypt DEKs with KEKs
+* `DecryptWithKey` - Required to decrypt EDEKs
+* `UseKey` - Also required for crypto operations to work
+
+IMPORTANT: All four actions are required. The `UseKey` action might seem redundant alongside `EncryptWithKey` and `DecryptWithKey`, but CipherTrust Manager requires it for crypto operations. Without `UseKey`, encrypt and decrypt operations will fail with `403 Forbidden` even if the specific actions are granted.
+
+Create the policy JSON file named `kroxylicious-policy.json`:
+
+[source,json]
+----
+{
+  "name": "kroxylicious-least-privilege",
+  "allow": true,
+  "resources": ["kylo:kylo:vault:keys:kek-*"],
+  "actions": ["ReadKey", "EncryptWithKey", "DecryptWithKey", "UseKey"]
+}
+----
+
+IMPORTANT: The resource pattern must use lowercase `kek-*` because CTM matches against the key's URI, which lowercases the key name. A key named `KEK-production` has the URI `kylo:kylo:vault:keys:kek-production`.
+
+Create the policy using `ksctl`:
+
+[source,shell]
+----
+POLICY_RESPONSE=$(ksctl policy create --jsonfile kroxylicious-policy.json)
+POLICY_ID=$(echo "$POLICY_RESPONSE" | jq -r '.id')
+----
+
+Record the policy ID. You will need it to attach the policy to the group.
+
+This policy ensures that the Kroxylicious application identity:
+
+* CAN perform encryption and decryption operations
+* CAN read key metadata (required for alias resolution)
+* CAN only access keys matching the `kek-*` pattern
+* CANNOT create, delete, or modify keys
+* CANNOT access keys that don't match the pattern
+* CANNOt perform other admin operations
+
+== Attach the policy to the group
+
+Attach the policy to the group you created.
+
+Create a principal JSON file named `principal.json`:
+
+[source,json]
+----
+{
+  "cust": {
+    "groups": ["kroxylicious-record-encryption"]
+  }
+}
+----
+
+Attach the policy using `ksctl`:
+
+[source,shell]
+----
+ksctl polattach create \
+  --polid "$POLICY_ID" \
+  --prinjson principal.json
+----
+
+== Establish an application identity
+
+CipherTrust Manager supports two authentication methods for Kroxylicious:
+
+* **Client certificate authentication** (recommended for production)
+* **Username and password authentication** (intended for development and testing)
+
+Choose the method that best fits your organization's security requirements.
+
+=== Client certificate authentication
+
+Client certificate authentication is recommended for production deployments as it provides stronger security and doesn't require storing passwords.
+
+.Prerequisites
+
+You need a Certificate Authority (CA) registered in CipherTrust Manager that can sign client certificates. This CA should already be configured in your CTM instance.
+
+To list available CAs:
+
+[source,shell]
+----
+ksctl ca locals list | jq '.resources[] | {name: .name, id: .id}'
+----
+
+Record the CA ID of the CA you will use to sign the client certificate.
+
+[source,shell]
+----
+CA_ID=<id of CA>
+----
+
+.Generate client certificate signing request and private key
+
+Use `ksctl` to generate a Certificate Signing Request (CSR) and private key:
+
+[source,shell]
+----
+ksctl ca csr \
+  --cn "kroxylicious-production" \
+  --csr-outfile kroxylicious-client.csr \
+  --key-outfile kroxylicious-client.key
+----
+
+This creates:
+
+* `kroxylicious-client.key` - The client's private key
+* `kroxylicious-client.csr` - The certificate signing request
+
+.Issue and sign the client certificate
+
+Sign the CSR with your CA to create the client certificate:
+
+[source,shell]
+----
+ksctl ca locals certs issue \
+  --ca-id "$CA_ID" \
+  --csr-infile kroxylicious-client.csr \
+  --cert-outfile kroxylicious-client.crt \
+  --duration 365 \
+  --purpose client
+----
+
+This creates `kroxylicious-client.crt` - the signed client certificate.
+
+.Create a client management profile
+
+Create a client management profile and associate it with the group:
+
+[source,shell]
+----
+PROFILE_RESPONSE=$(ksctl clientmgmt profiles create \
+  --name 'kroxylicious-production')
+PROFILE_ID=$(echo "$PROFILE_RESPONSE" | jq -r '.id')
+
+ksctl clientmgmt profiles update \
+  --profile-id "$PROFILE_ID" \
+  --ca_id "$CA_ID" \
+  --groups 'kroxylicious-record-encryption'
+----
+
+.Create a registration token
+
+Create a registration token for the client:
+
+[source,shell]
+----
+TOKEN_RESPONSE=$(ksctl clientmgmt tokens create \
+  --ca-id "$CA_ID" \
+  --cert-duration 365 \
+  --client-mgmt-profile-id "$PROFILE_ID")
+REG_TOKEN=$(echo "$TOKEN_RESPONSE" | jq -r '.token')
+----
+
+.Register the client
+
+Register the client using the token and client certificate:
+
+[source,shell]
+----
+CLIENT_RESPONSE=$(ksctl clientmgmt clients register \
+  --reg-token "$REG_TOKEN" \
+  --cert-file kroxylicious-client.crt)
+CLIENT_ID=$(echo "$CLIENT_RESPONSE" | jq -r '.id')
+----
+
+Record the client ID, certificate file path, and private key file path. You will need these for the filter configuration:
+
+* Client ID: `$CLIENT_ID`
+* Certificate: `kroxylicious-client.crt`
+* Private key: `kroxylicious-client.key`
+
+=== Username and password authentication
+
+Alternatively, you can create a user account for Kroxylicious.
+
+.Create the user
+
+Generate a strong password and create the user:
+
+[source,shell]
+----
+# Generate a strong random password
+PASSWORD=$(openssl rand -base64 32)
+
+# Create the user
+USER_RESPONSE=$(ksctl users create \
+  --name kroxylicious-service \
+  --pword "$PASSWORD")
+USER_ID=$(echo "$USER_RESPONSE" | jq -r '.user_id')
+----
+
+.Add the user to the group
+
+Add the user to the group you created:
+
+[source,shell]
+----
+ksctl groups adduser \
+  --name kroxylicious-record-encryption \
+  --userid "$USER_ID"
+----
+
+IMPORTANT: Store the password securely. In production, use the `passwordFile` option in the filter configuration rather than embedding the password in the configuration file.
+
+Record the username and password. You will need these for the filter configuration.

--- a/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/con-thales-ctm-setup.adoc
+++ b/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/con-thales-ctm-setup.adoc
@@ -14,7 +14,7 @@
 = Preparing Thales CipherTrust Manager for Kroxylicious
 
 [role="_abstract"]
-To use the Record Encryption filter with Thales CipherTrust Manager (CTM), you need to configure CTM with a group, policy, and application identity that has the minimal permissions required for envelope encryption operations.
+To use the Record Encryption filter with Thales CipherTrust Manager (CTM), you must configure CTM with a group, policy, and application identity that has the minimal permissions required for envelope encryption operations.
 
 == CipherTrust Manager endpoint URL
 
@@ -98,12 +98,12 @@ Record the policy ID. You will need it to attach the policy to the group.
 
 This policy ensures that the Kroxylicious application identity:
 
-* CAN perform encryption and decryption operations
-* CAN read key metadata (required for alias resolution)
-* CAN only access keys matching the `kek-*` pattern
-* CANNOT create, delete, or modify keys
-* CANNOT access keys that don't match the pattern
-* CANNOt perform other admin operations
+* **Can** perform encryption and decryption operations
+* **Can** read key metadata (required for alias resolution)
+* **Can** only access keys matching the `kek-*` pattern
+* **Cannot** create, delete, or modify keys
+* **Cannot** access keys that do not match the pattern
+* **Cannot** perform other admin operations
 
 == Attach the policy to the group
 
@@ -140,7 +140,7 @@ Choose the method that best fits your organization's security requirements.
 
 === Client certificate authentication
 
-Client certificate authentication is recommended for production deployments as it provides stronger security and doesn't require storing passwords.
+Client certificate authentication is recommended for production deployments as it provides stronger security and does not require storing passwords.
 
 .Prerequisites
 

--- a/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/con-thales-ctm-setup.adoc
+++ b/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/con-thales-ctm-setup.adoc
@@ -162,11 +162,13 @@ CA_ID=<id of CA>
 
 .Generate client certificate signing request and private key
 
-Use `ksctl` to generate a Certificate Signing Request (CSR) and private key:
+Use `ksctl` to generate a Certificate Signing Request (CSR) and private key.
+Algorithm `RSA` is used so that the private key is generated in RSA format which works well in the Java ecosystem.
 
 [source,shell]
 ----
 ksctl ca csr \
+  --alg RSA \
   --cn "kroxylicious-production" \
   --csr-outfile kroxylicious-client.csr \
   --key-outfile kroxylicious-client.key

--- a/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/proc-thales-ctm-key-creation.adoc
+++ b/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/proc-thales-ctm-key-creation.adoc
@@ -1,0 +1,41 @@
+////
+  // Copyright Kroxylicious Authors.
+  //
+  // Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+////
+
+:_mod-docs-content-type: PROCEDURE
+
+// file included in the following:
+//
+// assembly-key-creation-thales-ctm.adoc
+
+[id='proc-thales-ctm-key-creation-{context}']
+= Creating keys in Thales CipherTrust Manager
+
+[role="_abstract"]
+Create AES-256 symmetric encryption keys in CipherTrust Manager for use as KEKs (Key Encryption Keys) with the Record Encryption filter.
+
+.Prerequisites
+
+* Access to the CipherTrust Manager administrative interface
+* The `ksctl` command-line tool installed and configured
+* Administrator permissions to create keys in CipherTrust Manager
+
+.Procedure
+
+. Create an AES-256 symmetric key with a name that follows your naming convention:
++
+[source,shell]
+----
+ksctl keys create \
+  --name KEK-production-topic \
+  --algorithm aes \
+  --size 256
+----
+
+. Record the key name for use in the Record Encryption filter configuration.
+
+. Repeat for each topic or encryption scope that requires a separate key.
+
+NOTE: We recommend using a naming convention such as a `KEK-` prefix to identify keys intended for Kroxylicious. This makes it clear which keys are used for envelope encryption and allows you to configure CTM policies to restrict access to these keys.

--- a/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/proc-thales-ctm-key-creation.adoc
+++ b/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/proc-thales-ctm-key-creation.adoc
@@ -34,7 +34,7 @@ ksctl keys create \
   --size 256
 ----
 
-. Record the key name for use in the Record Encryption filter configuration.
+. Record the key name to use in the Record Encryption filter configuration.
 
 . Repeat for each topic or encryption scope that requires a separate key.
 

--- a/kroxylicious-docs/docs/record-encryption-guide/index.adoc
+++ b/kroxylicious-docs/docs/record-encryption-guide/index.adoc
@@ -35,6 +35,9 @@ Kroxylicious supports the following KMS providers:
 ifdef::include-fortanix-dsm-kms[]
 * Fortanix DSM
 endif::[]
+ifdef::include-thales-ctm-kms[]
+* Thales CipherTrust Manager
+endif::[]
 
 You can provide implementations for your specific KMS systems.
 Additional KMS support may be added based on demand.

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/scripts/validate-least-privilege.sh
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/scripts/validate-least-privilege.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+#
+# Validate Least Privilege Permissions for Kroxylicious in CipherTrust Manager
+#
+# Purpose:
+#   This script validates that a CipherTrust Manager policy can be configured to grant
+#   Kroxylicious the minimal permissions it needs for record encryption operations,
+#   while blocking administrative operations like key creation and deletion.
+#
+# What it does:
+#   1. Creates a test group, policy, and user in CTM
+#   2. Configures a policy with only the actions Kroxylicious requires:
+#      - ReadKey (for alias resolution)
+#      - EncryptWithKey (to encrypt DEKs)
+#      - DecryptWithKey (to decrypt EDEKs)
+#      - UseKey (required for crypto operations)
+#   3. Restricts the policy to keys matching the pattern: kek-*
+#   4. Validates that:
+#      - Administrative operations (CreateKey) are blocked
+#      - Crypto operations on KEK-* keys are allowed
+#      - Operations on non-KEK-* keys are blocked
+#
+# This proves that CTM can enforce least privilege for Kroxylicious service accounts,
+# ensuring they cannot create, delete, or modify keys - only use existing keys for
+# envelope encryption operations.
+#
+# Environment variables:
+#   SKIP_CLEANUP - If set, resources will not be deleted after the test
+#
+
+set -euo pipefail
+
+# Configuration
+CTM_URL=$(yq '.KSCTL_URL' ~/.ksctl/config.yaml)
+USER_NAME="test-user-$$"
+USER_PASSWORD="Foobar\$2"
+GROUP_NAME="test-group-$$"
+POLICY_NAME="test-policy-$$"
+
+# Test keys
+KEK_NAME="KEK-test-$$"
+NONKEK_NAME="AES-test-$$"
+
+echo "=========================================================================="
+echo "CipherTrust Manager - Minimal Permissions Test"
+echo "=========================================================================="
+echo ""
+echo "Configuration:"
+echo "  CTM URL: $CTM_URL"
+echo "  User: $USER_NAME"
+echo "  Group: $GROUP_NAME"
+echo "  Policy: $POLICY_NAME"
+echo ""
+echo "Test Keys:"
+echo "  KEK key: $KEK_NAME"
+echo "  Non-KEK key: $NONKEK_NAME"
+echo ""
+
+# Cleanup function
+cleanup() {
+    if [ -n "${SKIP_CLEANUP:-}" ]; then
+        echo ""
+        echo "=========================================================================="
+        echo "Cleanup skipped (SKIP_CLEANUP is set)"
+        echo "=========================================================================="
+        echo ""
+        echo "Resources created:"
+        echo "  User: $USER_NAME (ID: ${USER_ID:-unknown})"
+        echo "  Group: $GROUP_NAME"
+        echo "  Policy: $POLICY_NAME (ID: ${POLICY_ID:-unknown})"
+        echo "  Policy Attachment: ${POLICY_ATTACH_ID:-unknown}"
+        echo "  KEK: $KEK_NAME"
+        echo "  Non-KEK key: $NONKEK_NAME"
+        return
+    fi
+
+    echo ""
+    echo "=========================================================================="
+    echo "Cleanup"
+    echo "=========================================================================="
+    echo ""
+
+    # Delete keys
+    if [ -n "${KEK_NAME:-}" ]; then
+        ksctl keys delete --name "$KEK_NAME" > /dev/null 2>&1 && echo "✓ Deleted key: $KEK_NAME" || true
+    fi
+    if [ -n "${NONKEK_NAME:-}" ]; then
+        ksctl keys delete --name "$NONKEK_NAME" > /dev/null 2>&1 && echo "✓ Deleted key: $NONKEK_NAME" || true
+    fi
+
+    # Delete user
+    if [ -n "${USER_ID:-}" ]; then
+        ksctl users delete -i "$USER_ID" > /dev/null 2>&1 && echo "✓ Deleted user: $USER_NAME" || true
+    fi
+
+    # Delete policy attachment
+    if [ -n "${POLICY_ATTACH_ID:-}" ]; then
+        ksctl polattach delete --id "$POLICY_ATTACH_ID" > /dev/null 2>&1 && echo "✓ Deleted policy attachment" || true
+    fi
+
+    # Delete policy
+    if [ -n "${POLICY_ID:-}" ]; then
+        ksctl policy delete --id "$POLICY_ID" > /dev/null 2>&1 && echo "✓ Deleted policy: $POLICY_NAME" || true
+    fi
+
+    # Delete group
+    if [ -n "${GROUP_NAME:-}" ]; then
+        ksctl groups delete --name "$GROUP_NAME" > /dev/null 2>&1 && echo "✓ Deleted group: $GROUP_NAME" || true
+    fi
+
+    # Delete temp files
+    rm -f /tmp/policy-$$.json /tmp/principal-$$.json /tmp/test-create-err-$$.txt /tmp/test-encrypt-kek-err-$$.txt /tmp/test-decrypt-kek-err-$$.txt /tmp/test-getkey-kek-err-$$.txt /tmp/test-encrypt-nonkek-err-$$.txt /tmp/encrypted-$$.json
+
+    echo "✓ Cleanup complete"
+}
+
+trap cleanup EXIT
+
+# Setup
+echo "=========================================================================="
+echo "Setup"
+echo "=========================================================================="
+echo ""
+
+# Create test keys
+echo "Creating test keys..."
+ksctl keys create --name "$KEK_NAME" -a AES -i 256 > /dev/null
+echo "✓ Created KEK: $KEK_NAME"
+
+ksctl keys create --name "$NONKEK_NAME" -a AES -i 256 > /dev/null
+echo "✓ Created non-KEK key: $NONKEK_NAME"
+echo ""
+
+# Create group
+echo "Creating group..."
+GROUP_RESPONSE=$(ksctl groups create \
+    --name "$GROUP_NAME" \
+    --description "Test group for Kroxylicious minimal permissions")
+
+echo "✓ Created group: $GROUP_NAME"
+echo ""
+
+# Create policy
+echo "Creating policy..."
+# Important notes about this policy:
+#
+# 1. Resource pattern must use lowercase 'kek-*':
+#    CTM matches against the key's URI, which is based on the key name but lowercased.
+#    Key "KEK-production" has URI "kylo:kylo:vault:keys:kek-production" (lowercase).
+#    The pattern must use lowercase to match.
+#
+# 2. All four actions are required:
+#    - ReadKey: Required to get key metadata (used for alias resolution)
+#    - EncryptWithKey: Required to encrypt DEKs with KEKs
+#    - DecryptWithKey: Required to decrypt EDEKs
+#    - UseKey: ALSO required for encrypt/decrypt operations to work
+#
+#    Note: UseKey might seem redundant alongside EncryptWithKey and DecryptWithKey,
+#    but CTM requires it for crypto operations. Without UseKey, encrypt/decrypt
+#    operations will fail with 403 Forbidden even if the specific actions are granted.
+cat > /tmp/policy-$$.json <<EOF
+{
+  "name": "$POLICY_NAME",
+  "allow": true,
+  "resources": ["kylo:kylo:vault:keys:kek-*"],
+  "actions": ["ReadKey", "EncryptWithKey", "DecryptWithKey", "UseKey"]
+}
+EOF
+
+POLICY_RESPONSE=$(ksctl policy create --jsonfile /tmp/policy-$$.json)
+POLICY_ID=$(echo "$POLICY_RESPONSE" | jq -r '.id')
+
+if [ -z "$POLICY_ID" ] || [ "$POLICY_ID" = "null" ]; then
+    echo "Error: Failed to create policy" >&2
+    exit 1
+fi
+
+echo "✓ Created policy: $POLICY_NAME (ID: $POLICY_ID)"
+echo "  Actions: ReadKey, EncryptWithKey, DecryptWithKey, UseKey"
+echo "  Resources: kylo:kylo:vault:keys:kek-*"
+echo ""
+
+# Attach policy to group
+echo "Attaching policy to group..."
+cat > /tmp/principal-$$.json <<EOF
+{
+  "cust": {
+    "groups": ["$GROUP_NAME"]
+  }
+}
+EOF
+
+ATTACH_RESPONSE=$(ksctl polattach create \
+    --polid "$POLICY_ID" \
+    --prinjson /tmp/principal-$$.json)
+
+POLICY_ATTACH_ID=$(echo "$ATTACH_RESPONSE" | jq -r '.id')
+
+if [ -z "$POLICY_ATTACH_ID" ] || [ "$POLICY_ATTACH_ID" = "null" ]; then
+    echo "Error: Failed to attach policy to group" >&2
+    exit 1
+fi
+
+echo "✓ Attached policy to group (Attachment ID: $POLICY_ATTACH_ID)"
+echo ""
+
+# Create test user
+echo "Creating test user..."
+USER_RESPONSE=$(ksctl users create --name "$USER_NAME" --pword "$USER_PASSWORD")
+USER_ID=$(echo "$USER_RESPONSE" | jq -r '.user_id')
+
+if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+    echo "Error: Failed to create user" >&2
+    exit 1
+fi
+
+echo "✓ Created user: $USER_NAME (ID: $USER_ID)"
+echo ""
+
+# Add user to group
+echo "Adding user to group..."
+ksctl groups adduser -n "$GROUP_NAME" -u "$USER_ID" > /dev/null
+echo "✓ Added user to group: $GROUP_NAME"
+echo ""
+
+# Tests
+echo "=========================================================================="
+echo "Test 1: CreateKey (should be DENIED)"
+echo "=========================================================================="
+echo ""
+
+echo "Attempting to create key as test user..."
+echo ""
+
+if ksctl --user ${USER_NAME} --password ${USER_PASSWORD} keys create --name "test-unauthorized-$$" -a AES -i 256 2>/tmp/test-create-err-$$.txt; then
+    echo "❌ FAIL: CreateKey succeeded"
+    echo "   Policy should block CreateKey (not in actions list)"
+    cat /tmp/test-create-err-$$.txt
+    # Cleanup unauthorized key
+    ksctl keys delete --name "test-unauthorized-$$" > /dev/null 2>&1 || true
+else
+    ERROR=$(cat /tmp/test-create-err-$$.txt | jq -r '.codeDesc // .message // "Unknown"' 2>/dev/null || echo "Permission denied")
+    echo "✅ PASS: CreateKey denied"
+    echo "   Error: $ERROR"
+    echo "   Policy correctly blocks CreateKey (not in actions list)"
+fi
+
+echo ""
+
+echo "=========================================================================="
+echo "Test 2: Encrypt with KEK-* (should be ALLOWED)"
+echo "=========================================================================="
+echo ""
+
+echo "Attempting to encrypt with KEK-* key as test user..."
+echo "  Key: $KEK_NAME (matches policy resources: kek-*)"
+echo ""
+
+if ksctl --user ${USER_NAME} --password ${USER_PASSWORD}  crypto encrypt -k "$KEK_NAME" -l "test-data" 2>/tmp/test-encrypt-kek-err-$$.txt > /dev/null; then
+    echo "✅ PASS: Encrypt with KEK-* succeeded"
+    echo "   Policy correctly allows EncryptWithKey on kek-* resources"
+else
+    cat /tmp/test-encrypt-kek-err-$$.txt
+    ERROR=$(cat /tmp/test-encrypt-kek-err-$$.txt | jq -r '.codeDesc // .message // "Unknown"' 2>/dev/null || echo "Unknown error")
+    echo "❌ FAIL: Encrypt with KEK-* denied"
+    echo "   Error: $ERROR"
+    echo "   Policy should allow EncryptWithKey on kek-* resources"
+fi
+
+echo ""
+
+echo "=========================================================================="
+echo "Test 3: Decrypt with KEK-* (should be ALLOWED)"
+echo "=========================================================================="
+echo ""
+
+echo "Attempting to decrypt with KEK-* key as test user..."
+echo "  Key: $KEK_NAME (matches policy resources: kek-*)"
+echo ""
+
+# First, encrypt some data to get ciphertext (as admin)
+ENCRYPTED=$(ksctl crypto encrypt -k "$KEK_NAME" -l "test-data-for-decrypt" -r /tmp/encrypted-$$.json 2>/dev/null)
+
+if [ -f /tmp/encrypted-$$.json ]; then
+    # Now try to decrypt as test user
+    if ksctl --user ${USER_NAME} --password ${USER_PASSWORD} crypto decrypt -r /tmp/encrypted-$$.json 2>/tmp/test-decrypt-kek-err-$$.txt > /dev/null; then
+        echo "✅ PASS: Decrypt with KEK-* succeeded"
+        echo "   Policy correctly allows DecryptWithKey on kek-* resources"
+    else
+        ERROR=$(cat /tmp/test-decrypt-kek-err-$$.txt | jq -r '.codeDesc // .message // "Unknown"' 2>/dev/null || echo "Unknown error")
+        echo "❌ FAIL: Decrypt with KEK-* denied"
+        echo "   Error: $ERROR"
+        echo "   Policy should allow DecryptWithKey on kek-* resources"
+    fi
+    rm -f /tmp/encrypted-$$.json
+else
+    echo "⚠️  Could not create encrypted data for test"
+fi
+
+echo ""
+
+echo "=========================================================================="
+echo "Test 4: List/Get KEK-* key (should be ALLOWED)"
+echo "=========================================================================="
+echo ""
+
+echo "Attempting to get KEK-* key metadata as test user..."
+echo "  Key: $KEK_NAME (matches policy resources: kek-*)"
+echo ""
+
+if ksctl --user ${USER_NAME} --password ${USER_PASSWORD} keys get --name "$KEK_NAME" 2>/tmp/test-getkey-kek-err-$$.txt > /dev/null; then
+    echo "✅ PASS: Get KEK-* key succeeded"
+    echo "   Policy correctly allows ReadKey on kek-* resources"
+else
+    ERROR=$(cat /tmp/test-getkey-kek-err-$$.txt | jq -r '.codeDesc // .message // "Unknown"' 2>/dev/null || echo "Unknown error")
+    echo "❌ FAIL: Get KEK-* key denied"
+    echo "   Error: $ERROR"
+    echo "   Policy should allow ReadKey on kek-* resources"
+fi
+
+echo ""
+
+echo "=========================================================================="
+echo "Test 5: Encrypt with non-KEK-* (should be DENIED)"
+echo "=========================================================================="
+echo ""
+
+echo "Attempting to encrypt with non-KEK-* key as test user..."
+echo "  Key: $NONKEK_NAME (does NOT match policy resources: kek-*)"
+echo ""
+
+if ksctl --user ${USER_NAME} --password ${USER_PASSWORD}  crypto encrypt -k "$NONKEK_NAME" -l "test-data" 2>/tmp/test-encrypt-nonkek-err-$$.txt > /dev/null; then
+    echo "❌ FAIL: Encrypt with non-KEK-* succeeded"
+    echo "   Policy should block EncryptWithKey on non-kek-* resources"
+else
+    ERROR_MSG=$(cat /tmp/test-encrypt-nonkek-err-$$.txt 2>/dev/null || echo "")
+    ERROR_CODE=$(echo "$ERROR_MSG" | jq -r '.codeDesc // "Unknown"' 2>/dev/null || echo "Unknown")
+
+    if echo "$ERROR_CODE" | grep -q "NotFound\|ResourceNotFound"; then
+        echo "✅ PASS: Encrypt with non-KEK-* denied"
+        echo "   Error: $ERROR_CODE"
+        echo "   Policy makes keys not matching kek-* pattern invisible"
+    else
+        echo "✅ PASS: Encrypt with non-KEK-* denied"
+        echo "   Error: $ERROR_CODE"
+        echo "   Policy correctly blocks access to keys not matching kek-* pattern"
+    fi
+fi
+
+echo ""
+
+echo "=========================================================================="
+echo "Summary"
+echo "=========================================================================="
+echo ""
+echo "This test validates that a CTM policy with:"
+echo "  - Actions: ReadKey, EncryptWithKey, DecryptWithKey, UseKey"
+echo "  - Resources: kylo:kylo:vault:keys:kek-*"
+echo ""
+echo "Correctly enforces minimal permissions for Kroxylicious:"
+echo "  1. ✓ Blocks CreateKey (not in actions list)"
+echo "  2. ✓ Allows EncryptWithKey on keys matching kek-* pattern"
+echo "  3. ✓ Allows DecryptWithKey on keys matching kek-* pattern"
+echo "  4. ✓ Allows ReadKey (get key metadata) on keys matching kek-* pattern"
+echo "  5. ✓ Blocks crypto operations on keys NOT matching kek-* pattern"
+echo ""
+echo "To skip cleanup and inspect resources, run with:"
+echo "  SKIP_CLEANUP=1 $0"
+echo ""


### PR DESCRIPTION
## Summary

Adds complete end-user documentation for the Thales CipherTrust Manager KMS provider to the Record Encryption guide.

## Changes

### Documentation
- **Setup guide** (`con-thales-ctm-setup.adoc`): Group, policy, and service account configuration
- **Plugin configuration** (`con-thales-ctm-plugin-configuration.adoc`): Configuration examples for both authentication methods
- **Key creation procedure** (`proc-thales-ctm-key-creation.adoc`): Creating KEKs using ksctl
- **Integration**: Updated assembly files to include Thales CTM content
- **Trademarks**: Added Thales trademark notice

### Discovery Script
- **validate-least-privilege.sh**: Script that validates CTM can enforce least privilege for Kroxylicious service accounts

## Key Features

The documentation covers:
- ✅ Both authentication methods: client certificate (recommended) and username/password
- ✅ Least-privilege policy configuration with all four required actions: `ReadKey`, `EncryptWithKey`, `DecryptWithKey`, `UseKey`
- ✅ Documents non-obvious requirements:
  - `UseKey` action is required for crypto operations (even though it seems redundant)
  - Resource patterns must use lowercase (`kek-*`) because CTM lowercases key names in URIs
- ✅ Uses `ksctl` commands throughout for client certificate generation
- ✅ Follows Red Hat modular documentation structure (CONCEPT, PROCEDURE, ASSEMBLY)
- ✅ Successfully builds to HTML and PDF

## Validation

- Documentation builds successfully: `mvn -P dist package --pl kroxylicious-docs -am`
- Content is visible in generated HTML output
- Validation script proves least privilege can be enforced

## Related

Resolves: #4119
Builds on: #4182 (client certificate authentication support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)