### PR TITLE
Remove inadventent BouncyCastle from production dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For changes that effect a public API, the [deprecation policy](./DEV_GUIDE.md#de
 Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
+
+* [#933](https://github.com/kroxylicious/kroxylicious/issues/933): feat(pem-support): Support PEM format key material in the KMS integrations.
+
 ## 0.22.0
 
 * [#4152](https://github.com/kroxylicious/kroxylicious/pull/4152): feat(config): add `clusterDefinitions` top-level configuration property. Named cluster definitions can be defined once and referenced from virtual clusters via `target: { cluster: "<name>" }`, replacing the inline `targetCluster` field.

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/scripts/register-client-cert.sh
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/scripts/register-client-cert.sh
@@ -86,8 +86,12 @@ ksctl ca locals self-sign --duration 3650 --id "${CA_ID}" > /dev/null
 echo "    CA self-signed with 3650 day duration"
 
 echo "==> Step 2: Generating CSR and Private Key for the Client..."
+# Use RSA algorithm to generate PKCS#1 RSA keys which PemUtils converts
+# to PKCS#8. The default EC algorithm generates PKCS#1 EC keys which
+# PemUtils does not support.
 ksctl ca csr \
   --cn "my-auth-client" \
+  --alg RSA \
   --csr-outfile "$OUTPUT_DIR/kroxylicious-client.csr" \
   --key-outfile "$OUTPUT_DIR/kroxylicious-client.key" > /dev/null
 echo "    Private key: $OUTPUT_DIR/kroxylicious-client.key"

--- a/kroxylicious-kms-tls-support/pom.xml
+++ b/kroxylicious-kms-tls-support/pom.xml
@@ -25,9 +25,19 @@
     </properties>
 
     <dependencies>
+        <!-- project dependencies - runtime and compile -->
+
         <dependency>
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-api</artifactId>
+        </dependency>
+
+        <!-- project dependencies - test -->
+
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-certificate-test-support</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- third party dependencies - build and compile -->
@@ -39,10 +49,6 @@
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.kroxylicious</groupId>
-            <artifactId>kroxylicious-certificate-test-support</artifactId>
         </dependency>
 
         <!-- third party dependencies - test -->

--- a/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/testing/kms/tls/PemUtils.java
+++ b/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/testing/kms/tls/PemUtils.java
@@ -65,6 +65,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * <li>Encrypted keys are NOT supported - use JKS/PKCS12 keystore format for encrypted keys</li>
  * </ul>
  */
+@SuppressWarnings({ "java:S6035", "java:S5855", "java:S8786", "java:S5998" }) // These concern the formation of the REs As code is forked from Netty, I'm opting to keep the code as is.
 final class PemUtils {
 
     private static final Pattern CERT_HEADER = Pattern.compile(
@@ -244,6 +245,7 @@ final class PemUtils {
         return certificates.toArray(new X509Certificate[0]);
     }
 
+    @SuppressWarnings("java:S135") // S135 concerns the number of breaks in the loop. As code is forked from Netty, I'm opting to keep the code as is.
     private static byte[][] readCertificates(InputStream in) throws IOException {
         String content = readContent(in);
 

--- a/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/testing/kms/tls/PemUtils.java
+++ b/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/testing/kms/tls/PemUtils.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Adapted from Netty's io.netty.handler.ssl.PemReader for use without Netty dependencies.
+ * Modifications:
+ * - Replaced Netty ByteBuf with byte arrays
+ * - Replaced Netty Base64 decoder with JDK Base64
+ * - Added JCA integration to return PrivateKey and X509Certificate objects
+ * - Added encrypted key detection and rejection
+ */
+
+package io.kroxylicious.testing.kms.tls;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Parses PEM-encoded private keys and certificates using only JDK APIs.
+ * <p>
+ * Forked from Netty's {@code io.netty.handler.ssl.PemReader} and adapted to work without Netty dependencies.
+ * <p>
+ * <strong>Limitations:</strong>
+ * <ul>
+ * <li>Only supports unencrypted PKCS#8 private keys ({@code -----BEGIN PRIVATE KEY-----})</li>
+ * <li>Also supports unencrypted PKCS#1 RSA keys ({@code -----BEGIN RSA PRIVATE KEY-----})</li>
+ * <li>Encrypted keys are NOT supported - use JKS/PKCS12 keystore format for encrypted keys</li>
+ * </ul>
+ */
+final class PemUtils {
+
+    private static final Pattern CERT_HEADER = Pattern.compile(
+            "-+BEGIN\\s[^-\\r\\n]*CERTIFICATE[^-\\r\\n]*-+(?:\\s|\\r|\\n)+");
+    private static final Pattern CERT_FOOTER = Pattern.compile(
+            "-+END\\s[^-\\r\\n]*CERTIFICATE[^-\\r\\n]*-+(?:\\s|\\r|\\n)*");
+    private static final Pattern KEY_HEADER = Pattern.compile(
+            "-+BEGIN\\s[^-\\r\\n]*PRIVATE\\s+KEY[^-\\r\\n]*-+(?:\\s|\\r|\\n)+");
+    private static final Pattern KEY_FOOTER = Pattern.compile(
+            "-+END\\s[^-\\r\\n]*PRIVATE\\s+KEY[^-\\r\\n]*-+(?:\\s|\\r|\\n)*");
+    private static final Pattern BODY = Pattern.compile("[a-z0-9+/=][a-z0-9+/=\\r\\n]*", Pattern.CASE_INSENSITIVE);
+
+    private PemUtils() {
+    }
+
+    /**
+     * Parses a PEM-encoded private key from a byte array.
+     * <p>
+     * <strong>Note:</strong> Only unencrypted PKCS#8 and PKCS#1 formats are supported.
+     *
+     * @param pemKeyBytes PEM-encoded private key bytes
+     * @param password password for decrypting the private key (must be {@code null} as encryption is not supported)
+     * @return the parsed PrivateKey
+     * @throws IOException if the key cannot be parsed or is encrypted
+     */
+    @NonNull
+    static PrivateKey parsePrivateKey(@NonNull byte[] pemKeyBytes, @Nullable char[] password) throws IOException {
+        if (password != null) {
+            throw new IOException(
+                    "Encrypted private keys are not supported by this PEM parser. " +
+                            "Use a keystore format (JKS/PKCS12) for encrypted keys, " +
+                            "or convert to unencrypted PKCS#8: " +
+                            "openssl pkcs8 -topk8 -nocrypt -in encrypted.pem -out unencrypted.pem");
+        }
+
+        byte[] keyBytes = readPrivateKey(new ByteArrayInputStream(pemKeyBytes));
+
+        // First try as PKCS#8 (most common, works for all algorithms)
+        PrivateKey key = tryParsePKCS8(keyBytes);
+        if (key != null) {
+            return key;
+        }
+
+        // Fall back to PKCS#1 RSA (legacy format from BouncyCastle JcaPEMWriter)
+        key = tryParsePKCS1Rsa(keyBytes);
+        if (key != null) {
+            return key;
+        }
+
+        throw new IOException(
+                "Failed to parse private key. Supported formats: PKCS#8 (all algorithms) and PKCS#1 (RSA only). " +
+                        "PKCS#1 EC keys (BEGIN EC PRIVATE KEY) are not supported - convert to PKCS#8 using: " +
+                        "openssl pkcs8 -topk8 -nocrypt -in ec_key.pem -out ec_key_pkcs8.pem");
+    }
+
+    private static PrivateKey tryParsePKCS8(byte[] keyBytes) {
+        // Try common algorithms in order of likelihood
+        String[] algorithms = { "RSA", "EC", "EdDSA", "DSA" };
+
+        for (String algorithm : algorithms) {
+            try {
+                PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
+                KeyFactory keyFactory = KeyFactory.getInstance(algorithm);
+                return keyFactory.generatePrivate(keySpec);
+            }
+            catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+                // Try next algorithm
+            }
+        }
+        return null;
+    }
+
+    private static PrivateKey tryParsePKCS1Rsa(byte[] keyBytes) {
+        try {
+            // PKCS#1 RSA keys need to be wrapped in PKCS#8 structure
+            // This is a simple conversion that works for RSA keys
+            byte[] pkcs8Bytes = convertPKCS1ToPKCS8(keyBytes);
+            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(pkcs8Bytes);
+            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+            return keyFactory.generatePrivate(keySpec);
+        }
+        catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Converts PKCS#1 RSA private key to PKCS#8 format by wrapping it in the PKCS#8 structure.
+     * PKCS#8 format is: SEQUENCE { version, algorithm, privateKey }
+     * where privateKey is the PKCS#1 RSAPrivateKey wrapped as an OCTET STRING.
+     */
+    private static byte[] convertPKCS1ToPKCS8(byte[] pkcs1Bytes) throws IOException {
+        // PKCS#8 wrapper for RSA:
+        // SEQUENCE {
+        // INTEGER 0 (version)
+        // SEQUENCE { rsaEncryption OID, NULL }
+        // OCTET STRING (containing the PKCS#1 key)
+        // }
+
+        int pkcs1Length = pkcs1Bytes.length;
+        int totalLength = pkcs1Length + 22; // Fixed overhead for RSA wrapper
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream(totalLength + 4);
+
+        // Outer SEQUENCE tag and length
+        out.write(0x30); // SEQUENCE tag
+        if (totalLength < 128) {
+            out.write(totalLength);
+        }
+        else {
+            out.write(0x82); // Long form: 2 length bytes
+            out.write((totalLength >> 8) & 0xff);
+            out.write(totalLength & 0xff);
+        }
+
+        // Version: INTEGER 0
+        out.write(new byte[]{ 0x02, 0x01, 0x00 });
+
+        // Algorithm: SEQUENCE { rsaEncryption OID, NULL }
+        out.write(new byte[]{
+                0x30, 0x0D, // SEQUENCE, length 13
+                0x06, 0x09, // OID, length 9
+                0x2A, (byte) 0x86, 0x48, (byte) 0x86, (byte) 0xF7, 0x0D, 0x01, 0x01, 0x01, // rsaEncryption OID: 1.2.840.113549.1.1.1
+                0x05, 0x00 // NULL
+        });
+
+        // Private key: OCTET STRING containing PKCS#1 key
+        out.write(0x04); // OCTET STRING tag
+        if (pkcs1Length < 128) {
+            out.write(pkcs1Length);
+        }
+        else if (pkcs1Length < 256) {
+            out.write(0x81); // Long form: 1 length byte
+            out.write(pkcs1Length);
+        }
+        else {
+            out.write(0x82); // Long form: 2 length bytes
+            out.write((pkcs1Length >> 8) & 0xff);
+            out.write(pkcs1Length & 0xff);
+        }
+        out.write(pkcs1Bytes);
+
+        return out.toByteArray();
+    }
+
+    /**
+     * Parses a PEM-encoded X.509 certificate chain from a byte array.
+     *
+     * @param pemBytes PEM-encoded certificate bytes
+     * @return array of parsed X509Certificates
+     * @throws IOException if the certificates cannot be parsed
+     */
+    @NonNull
+    static X509Certificate[] parseCertificateChain(@NonNull byte[] pemBytes) throws IOException {
+        byte[][] certBytes = readCertificates(new ByteArrayInputStream(pemBytes));
+
+        CertificateFactory cf;
+        try {
+            cf = CertificateFactory.getInstance("X.509");
+        }
+        catch (CertificateException e) {
+            throw new IOException("Failed to get X.509 certificate factory", e);
+        }
+
+        List<X509Certificate> certificates = new ArrayList<>();
+        for (byte[] certByte : certBytes) {
+            try {
+                X509Certificate cert = (X509Certificate) cf.generateCertificate(
+                        new ByteArrayInputStream(certByte));
+                certificates.add(cert);
+            }
+            catch (CertificateException e) {
+                throw new IOException("Failed to parse certificate: " + e.getMessage(), e);
+            }
+        }
+
+        return certificates.toArray(new X509Certificate[0]);
+    }
+
+    private static byte[][] readCertificates(InputStream in) throws IOException {
+        String content = readContent(in);
+
+        List<byte[]> certs = new ArrayList<>();
+        Matcher m = CERT_HEADER.matcher(content);
+        int start = 0;
+        for (;;) {
+            if (!m.find(start)) {
+                break;
+            }
+
+            start = m.end();
+            m.usePattern(BODY);
+            if (!m.find(start)) {
+                break;
+            }
+
+            String base64 = m.group(0).replaceAll("\\s", "");
+            start = m.end();
+            m.usePattern(CERT_FOOTER);
+            if (!m.find(start)) {
+                // Certificate is incomplete
+                break;
+            }
+
+            byte[] der = Base64.getDecoder().decode(base64);
+            certs.add(der);
+
+            start = m.end();
+            m.usePattern(CERT_HEADER);
+        }
+
+        if (certs.isEmpty()) {
+            throw new IOException("found no certificates in input stream");
+        }
+
+        return certs.toArray(new byte[0][]);
+    }
+
+    private static byte[] readPrivateKey(InputStream in) throws IOException {
+        String content = readContent(in);
+
+        Matcher m = KEY_HEADER.matcher(content);
+        if (!m.find()) {
+            throw new IOException(
+                    "could not find a PKCS #8 private key in input stream " +
+                            "(see https://netty.io/wiki/sslcontextbuilder-and-private-key.html for more information)");
+        }
+
+        m.usePattern(BODY);
+        if (!m.find()) {
+            throw new IOException("could not find private key body");
+        }
+
+        String base64 = m.group(0).replaceAll("\\s", "");
+        m.usePattern(KEY_FOOTER);
+        if (!m.find()) {
+            // Key is incomplete
+            throw new IOException("could not find private key footer");
+        }
+
+        return Base64.getDecoder().decode(base64);
+    }
+
+    private static String readContent(InputStream in) throws IOException {
+        return new String(in.readAllBytes(), StandardCharsets.US_ASCII);
+    }
+
+}

--- a/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/testing/kms/tls/TlsHttpClientConfigurator.java
+++ b/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/testing/kms/tls/TlsHttpClientConfigurator.java
@@ -47,7 +47,6 @@ import io.kroxylicious.proxy.config.tls.TrustProvider;
 import io.kroxylicious.proxy.config.tls.TrustProviderVisitor;
 import io.kroxylicious.proxy.config.tls.TrustStore;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
-import io.kroxylicious.testing.certificate.PemParser;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -216,8 +215,8 @@ public class TlsHttpClientConfigurator implements UnaryOperator<HttpClient.Build
                     char[] keypassword = keyPair.keyPasswordProvider() != null
                             ? keyPair.keyPasswordProvider().getProvidedPassword().toCharArray()
                             : null;
-                    PrivateKey privateKey = PemParser.parsePrivateKey(keyBytes, keypassword);
-                    X509Certificate[] certs = PemParser.parseCertificateChain(certBytes);
+                    PrivateKey privateKey = PemUtils.parsePrivateKey(keyBytes, keypassword);
+                    X509Certificate[] certs = PemUtils.parseCertificateChain(certBytes);
 
                     // Create in-memory KeyStore
                     KeyStore ks = KeyStore.getInstance("JKS");
@@ -294,7 +293,7 @@ public class TlsHttpClientConfigurator implements UnaryOperator<HttpClient.Build
     private static TrustManager[] loadPemTrustStore(TrustStore trustStore) {
         try {
             byte[] pemBytes = Files.readAllBytes(Paths.get(trustStore.storeFile()));
-            X509Certificate[] certs = PemParser.parseCertificateChain(pemBytes);
+            X509Certificate[] certs = PemUtils.parseCertificateChain(pemBytes);
 
             // Create in-memory KeyStore from PEM certificates
             KeyStore ks = KeyStore.getInstance("JKS");

--- a/kroxylicious-kms-tls-support/src/test/java/io/kroxylicious/testing/kms/tls/PemUtilsTest.java
+++ b/kroxylicious-kms-tls-support/src/test/java/io/kroxylicious/testing/kms/tls/PemUtilsTest.java
@@ -187,7 +187,7 @@ class PemUtilsTest {
     }
 
     @Test
-    void mustRejectEncryptedPrivateKeyWithPassword() throws Exception {
+    void mustRejectEncryptedPrivateKeyWithPassword() {
         // Given: encrypted PKCS#8 key with password - from Netty test data
         byte[] encryptedKey = ("""
                 -----BEGIN ENCRYPTED PRIVATE KEY-----
@@ -214,7 +214,7 @@ class PemUtilsTest {
     }
 
     @Test
-    void mustRejectEncryptedPrivateKeyWithoutPassword() throws Exception {
+    void mustRejectEncryptedPrivateKeyWithoutPassword() {
         // Given: encrypted key without password - should fail during parsing
         byte[] encryptedKey = ("""
                 -----BEGIN ENCRYPTED PRIVATE KEY-----

--- a/kroxylicious-kms-tls-support/src/test/java/io/kroxylicious/testing/kms/tls/PemUtilsTest.java
+++ b/kroxylicious-kms-tls-support/src/test/java/io/kroxylicious/testing/kms/tls/PemUtilsTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Adapted from Netty's PemReaderTest for testing PemUtils.
+ * Uses inline PEM test data from Netty's test suite.
+ */
+
+package io.kroxylicious.testing.kms.tls;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SuppressWarnings("UnnecessaryParentheses") // Parentheses required for text blocks with .getBytes()
+class PemUtilsTest {
+
+    @Test
+    void mustBeAbleToReadSingleCertificate() throws Exception {
+        // Given
+        byte[] cert = """
+                -----BEGIN CERTIFICATE-----
+                MIICqjCCAZKgAwIBAgIIEaz8uuDHTcIwDQYJKoZIhvcNAQELBQAwFDESMBAGA1UEAwwJbG9jYWxo
+                b3N0MCAXDTIxMDYxNjE3MjYyOFoYDzk5OTkxMjMxMjM1OTU5WjAUMRIwEAYDVQQDDAlsb2NhbGhv
+                c3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCVjENomtpMqHkg1yJ/uYZgSWmf/0Gb
+                U4yMDf30muPvMYb3gO6peEnoXa2b0WDOjLbLrcltp1YdjTlLhRRTYgDo9TAvHoUdoMGlTnfQtQne
+                2o+/92bnlZTroRIjUT0lqSxQ6UNXcOi9tNqVD4tML3vk20fudwBur8Plx+3hOhM/v64GbV46k06+
+                AblrFwBt9u6V0uIVtvgraOd+NgL4yNf594uND30mbB7Q7xe/Y6DiPhI6cVI/CbLlXVwKLvC5OziS
+                JKZ7svP0K3DBRxk+dOD9pg4SdaAEQVtR734ZlDh1XJ+mZssuDDda3NGZAjpCU4rkeV/J3Tr5KKMD
+                g3NEOmifAgMBAAEwDQYJKoZIhvcNAQELBQADggEBABejZGeRNCyPdIqac6cyAf99JPp5OySEMWHU
+                QXVCHEbQ8Eh6hsmrXSEaZS2zy/5dixPb5Rin0xaX5fqZdfLIUc0Mw/zXV/RiOIjrtUKez15Ko/4K
+                ONyxELjUq+SaJx2C1UcKEMfQBeq7O6XO60CLQ2AtVozmvJU9pt4KYQv0Kr+br3iNFpRuR43IYHyx
+                HP7QsD3L3LEqIqW/QtYEnAAngZofUiq0XELh4GB0L8DbcSJIxfZmYagFl7c2go9OZPD14mlaTnMV
+                Pjd+OkwMif5T7v+r+KVSmDSMQwa+NfW+V6Xngg5/bN3kWHdw9qFQGANojl9wsRVN/B3pu3Cc2XFD
+                MmQ=
+                -----END CERTIFICATE-----
+                """.getBytes(StandardCharsets.US_ASCII);
+
+        // When
+        X509Certificate[] certificates = PemUtils.parseCertificateChain(cert);
+
+        // Then
+        assertThat(certificates).hasSize(1);
+        X509Certificate x509 = certificates[0];
+        assertThat(x509.getSubjectX500Principal().getName()).contains("CN=localhost");
+        assertThat(x509.getIssuerX500Principal().getName()).contains("CN=localhost"); // self-signed
+        assertThat(x509.getSigAlgName()).isEqualTo("SHA256withRSA");
+        assertThat(x509.getVersion()).isEqualTo(3); // X.509 v3
+    }
+
+    @Test
+    void mustBeAbleToReadMultipleCertificates() throws Exception {
+        // Given
+        byte[] certs = """
+                -----BEGIN CERTIFICATE-----
+                MIICqjCCAZKgAwIBAgIIEaz8uuDHTcIwDQYJKoZIhvcNAQELBQAwFDESMBAGA1UEAwwJbG9jYWxo
+                b3N0MCAXDTIxMDYxNjE3MjYyOFoYDzk5OTkxMjMxMjM1OTU5WjAUMRIwEAYDVQQDDAlsb2NhbGhv
+                c3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCVjENomtpMqHkg1yJ/uYZgSWmf/0Gb
+                U4yMDf30muPvMYb3gO6peEnoXa2b0WDOjLbLrcltp1YdjTlLhRRTYgDo9TAvHoUdoMGlTnfQtQne
+                2o+/92bnlZTroRIjUT0lqSxQ6UNXcOi9tNqVD4tML3vk20fudwBur8Plx+3hOhM/v64GbV46k06+
+                AblrFwBt9u6V0uIVtvgraOd+NgL4yNf594uND30mbB7Q7xe/Y6DiPhI6cVI/CbLlXVwKLvC5OziS
+                JKZ7svP0K3DBRxk+dOD9pg4SdaAEQVtR734ZlDh1XJ+mZssuDDda3NGZAjpCU4rkeV/J3Tr5KKMD
+                g3NEOmifAgMBAAEwDQYJKoZIhvcNAQELBQADggEBABejZGeRNCyPdIqac6cyAf99JPp5OySEMWHU
+                QXVCHEbQ8Eh6hsmrXSEaZS2zy/5dixPb5Rin0xaX5fqZdfLIUc0Mw/zXV/RiOIjrtUKez15Ko/4K
+                ONyxELjUq+SaJx2C1UcKEMfQBeq7O6XO60CLQ2AtVozmvJU9pt4KYQv0Kr+br3iNFpRuR43IYHyx
+                HP7QsD3L3LEqIqW/QtYEnAAngZofUiq0XELh4GB0L8DbcSJIxfZmYagFl7c2go9OZPD14mlaTnMV
+                Pjd+OkwMif5T7v+r+KVSmDSMQwa+NfW+V6Xngg5/bN3kWHdw9qFQGANojl9wsRVN/B3pu3Cc2XFD
+                MmQ=
+                -----END CERTIFICATE-----
+                -----BEGIN CERTIFICATE-----
+                MIICqjCCAZKgAwIBAgIIIsUS6UkDau4wDQYJKoZIhvcNAQELBQAwFDESMBAGA1UEAwwJbG9jYWxo
+                b3N0MCAXDTIxMDYxNjE3MjYyOFoYDzk5OTkxMjMxMjM1OTU5WjAUMRIwEAYDVQQDDAlsb2NhbGhv
+                c3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCTZmahFZXB0Dv3N8t6gfXTeqhTxRng
+                mIBBPmrbZBODrZm06vrR5KNhxB2FhWIq1Yu8xXXv8sO+PaO2Sw/h6TeslRJ4EkrNd9zmYhT2cJvP
+                d1CtkX5EHyMZRUKj7Eg4eUO1k/+JnhMmaY+nUAG7fCtvs8pS9SEXbEqYW7S4AQ1oopbCAMqQekly
+                KCdnjGlVhXwL2Lj2rr/uw1Fc2+WvY/leQGo0rbIqoc7OSAktsP+MXI6iQ1RWJOec15V6iFRzcdE3
+                Q4ODSMZ/R8wm9DH+4hkeQNPMbcc1wlvVZpDZ/FZegr1XimcYcJr2AoAQf3Xe1yFKAtBMXCjCIGm8
+                veCQ+xeHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGyV+dib2MdpenbntKk7PdZEx+/vNl9cEpwL
+                BfWmQN/j2RmHUxrUM+PVkLTgyCq8okdCKqCvraKwBkF6vlzp4u5CL4L323z+/uxAi6pzbcWnG1EH
+                JpSkf1OhTUFu6UhLfpg3XqeiIujYdVZTpHr7KHVLRYUSQPprt4HjLZeCIg4P2pZ0yQ3SEBhVed89
+                GMj/+O4jjvuZv5NQc57NpMIrE9fNINczLG1CPTgnhvqMP42W6ahBuexQUe4gP+jmB/BZmBYKoauU
+                mPBKruq3mNuoXtbHufv5I7CFVXNgJ0/aT+lvEkQ4IlCIcJyvTgyUTOQVbqDp+SswymAIRowaRdxa
+                7Ss=
+                -----END CERTIFICATE-----
+                """.getBytes(StandardCharsets.US_ASCII);
+
+        // When
+        X509Certificate[] certificates = PemUtils.parseCertificateChain(certs);
+
+        // Then
+        assertThat(certificates).hasSize(2);
+    }
+
+    @Test
+    void mustBeAbleToReadPKCS8RsaPrivateKey() throws Exception {
+        // Given: PKCS#8 format RSA key (BEGIN PRIVATE KEY) - from Netty test data
+        byte[] pkcs8Key = ("""
+                -----BEGIN PRIVATE KEY-----
+                MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDb+HBO3C0URBKvDUgJHbhIlBye
+                8X/cbNH3lDq3XOOFBz7L4XZKLDIXS+FeQqSAUMo2otmU+Vkj0KorshMjbUXfE1KkTijTMJlaga2M
+                2xVVt21fRIkJNWbIL0dWFLWyRq7OXdygyFkIiW9b2/LYaePBgET22kbtHSCAEj+BlSf265+1rNxy
+                AXBGGGccCKzEbcqASBKHOgVp6pLqlQAfuSy6g/OzGzces3zXRrGu1N3pBIzAIwCW429n52ZlYfYR
+                0nr+REKDnRrPIIDsWASmEHhBezTD+v0qCJRyLz2usFgWY+7agUJE2yHHI2mTu2RAFngBilJXlMCt
+                VwT0xGuQxkbHAgMBAAECggEBAJJdKaVfXWNptCDkLnVaYB9y5eRgfppVkhQxfiw5023Vl1QjrgjG
+                hYH4zHli0IBMwXA/RZWZoFVzZ3dxoshk0iQPgGKxWvrDEJcnSCo8MGL7jPvh52jILp6uzsGZQBji
+                bTgFPmOBS7ShdgZiQKD9PD2psrmqHZ1yTwjIm5cGfzQM8Y6tjm0xLBn676ecJNdS1TL10y9vmSUM
+                Ofdkmeg9Z9TEK95lP2fF/NIcxCo0LF9JcHUvTuYBDnBH0XMZi0w0ZcRReMSdAZ2lLiXgBeCO53el
+                2NIrtkRx+qOvLua9UfwO2h/0rs66ZeV0YuFCjv067nytyZf2zhU/QbCHRypzfrkCgYEA/facuAJs
+                6MQKsNvhozoBeDRMkrZPMh8Sb0w50EqzIGz3pdms6UvCiggoMbhxKOwuYWZ689fBPGwm7x0RdwDO
+                jyUuEbFnQFe+CpdHy6VK7vIQed1SwAcdTMDwCYbkJNglqHEB7qUYYTFLr8okGyWVdthUoh4IAubU
+                TR3TFbGraDUCgYEA3bwJ/UNA5pHtb/nh4/dNL7/bRMwXyPZPpC5z+gjjgUMgsSRBz8+iPNTB4iSQ
+                1j9zm+pnXGi35zWZcI4jvIcFusb08eS7xcZDb+7X2r2wenLNmyuTOa1812y233FicU+ah91fa9aD
+                yUfTjj3GFawbgNNhMyWa3aEMV+c73t6sKosCgYEA35oQZhsMlOx2lT0jrzlVLeauPMZzeCfPbVrp
+                1DDRAg2vBcFf8pCXmjyQVyaTy3oXY/585tDh/DclGIa5Z9O4CmSr6TwPMqGOW3jS58SC81sBkqqB
+                Pz2EWJ3POjQgDyiYD3RgRSPrETf78azCmXw/2sGh0pMqbpOZ/MPzpDgoOLkCgYEAsdv4g09kCs75
+                Dz34hRzErE2P+8JePdPdlEuyudhRbUlEOvNjWucpMvRSRSyhhUnGWUWP/V7+TRcAanmJjtsbrHOU
+                3Udlm0HqrCmAubQ4kC/wXsx4Pua7Yi2RDvBrT4rT4LGgreaXNWhI+Srx7kZslUx5Bkbez3I0bXpM
+                2vvwS/sCgYAducNt1KC4W7jzMWUivvuy5hQQmX/G0JHtu1pfv9cmA8agnc1I/r7xoirftuSG25Pm
+                r+eP5SKbKb8ZQlp10JeBkNnk8eAG8OkQyBaECYDBadEr1/LK2LmIEjYKzKAjYQ4cX2KMtY271jjX
+                WrzzXNqBdThFfMHiJE8k9xYmaLDKhQ==
+                -----END PRIVATE KEY-----
+                """).getBytes(StandardCharsets.US_ASCII);
+
+        // When
+        PrivateKey privateKey = PemUtils.parsePrivateKey(pkcs8Key, null);
+
+        // Then
+        assertThat(privateKey).isNotNull();
+        assertThat(privateKey.getAlgorithm()).isEqualTo("RSA");
+        assertThat(privateKey.getFormat()).isEqualTo("PKCS#8");
+    }
+
+    @Test
+    void mustBeAbleToReadPKCS1RsaPrivateKey() throws Exception {
+        // Given: PKCS#1 format RSA key (BEGIN RSA PRIVATE KEY) - traditional format
+        byte[] pkcs1Key = ("""
+                -----BEGIN RSA PRIVATE KEY-----
+                MIICXgIBAAKBgQC7Ic1+osUw/w29o607wPWtCE4lPinuYG+l7HfxDiLabg/laxVU
+                Tcev7HwLltUBx8r45lzB6LhGKy5xdeCEvZ3nKm5ZnCM408lX/R1jeFy2h+lzhIOU
+                vrRfsRe/krbm0jwrY/mPPWKWqU+PVAd0fvhjG3GRrgYlu2/pzZjA+RB18wIDAQAB
+                AoGBAKisym7oRvhoHjmezGp8/rWuM8osI12j/V9BK8fTpyTeamOvxzULOwBfGFzV
+                40BMl68M7fU3UMqm56EL0Im15RpLq4aludygMvuISsAQUR7okdDFL+gWGmovrrRl
+                bcmicJpbxJKIdVySEUJYJimXXB0/5cW41+3/8OpBsUArZRFxAkEA3lAcH+Usi9np
+                5/daZGOW00CQW+R700NjE1F8IHTA/91wCJLEuyyqvQV9ytPYKBIYA+DoK/FCHj3D
+                kcbZYYbcqwJBANd896kyeKojBvrxI0LvkBqVVj8j70Trd3ci6V8V7VzDYY73s6K5
+                61GbFXFvD3kLo0kYDOoV7yewrELiyOKsO9kCQQCwUKbNoQvAava5M5MsNVPkfbtA
+                NikCt9o28xRYBWEgTHZTRlvi+xz6xwUqPPOdbCRBxzk7yJ8grumRjzzOvY/7AkEA
+                hVwKrcTVln3NARqhNvip1znawYLMvnt3WNzbTwRz/LfSNbeojanAL6Xp1GTmT4Rb
+                To4619gxRP/66/4MUvRCqQJAX7YC1BsTLoQK0Ez6bxFYjNgaiVOOnDxLC9l95Vyy
+                LMqrHn3z/S078tNouyAtWsX5NcH2Bqs3//OZQfoevpJglQ==
+                -----END RSA PRIVATE KEY-----
+                """).getBytes(StandardCharsets.US_ASCII);
+
+        // When
+        PrivateKey privateKey = PemUtils.parsePrivateKey(pkcs1Key, null);
+
+        // Then
+        assertThat(privateKey).isNotNull();
+        assertThat(privateKey.getAlgorithm()).isEqualTo("RSA");
+        // PKCS#1 is converted to PKCS#8 internally
+        assertThat(privateKey.getFormat()).isEqualTo("PKCS#8");
+    }
+
+    @Test
+    void mustRejectEncryptedPrivateKeyWithPassword() throws Exception {
+        // Given: encrypted PKCS#8 key with password - from Netty test data
+        byte[] encryptedKey = ("""
+                -----BEGIN ENCRYPTED PRIVATE KEY-----
+                MIIE9jAoBgoqhkiG9w0BDAEDMBoEFDBlaUwB8TQ9ImbApCmAyVRTTX+kAgIIAASC
+                BMhC8QFNyn0VbVp7I+R9Yvmr+Ksl0xZshGg3zaUN8/HRblNSS3gPiP673rmnhcU3
+                PfSNFR9hOrTqdtd5i6Qq4HznECs81KBlqRNB9ihgy++ByFkf6GTzdfBA6zJInhNx
+                qSWjUwpFtV4or1w/N23bTcpdGmjfdCSFBMQdbkIDgT7GaWxd3mCLxSbfVzF64tev
+                x+V22nA/TR0VWnG+aj7aVbReK6VpepiCX7ZmQ5KehXAeB0SDrgT89kcz2VIfDxvE
+                hkCymNTcJY/ETdPfTSiR+DSZvVJMgVmfk7j1toZZSnoMwl4IhlXmIPmDOUE465l3
+                sNWLygkNKymTmMI5FTT1hChAIdsmeVTfDmVzNPK4HQi5gfEnTCy0uxj9U3HCZWr1
+                Zlzmw7/430TRqNYSEJ/XkhFaV5V+6LfeZOyuwf2VJAs+CwNo+UYzEQqkW11JMqhA
+                i9fz8bCNoy4/dyWbE/wEK8UPGif1rzCpoodBYeWTt0QtHcIokE3ylXWyTTarz7jV
+                u9Rnbq4HAXYYEwPjLmWFQ6NeD/rx/t44oEAyekxS+ZPIHNTVXRLBH5Tl/LDkpK15
+                -----END ENCRYPTED PRIVATE KEY-----
+                """).getBytes(StandardCharsets.US_ASCII);
+        char[] password = "password".toCharArray();
+
+        // When/Then
+        assertThatThrownBy(() -> PemUtils.parsePrivateKey(encryptedKey, password))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Encrypted private keys are not supported")
+                .hasMessageContaining("JKS/PKCS12")
+                .hasMessageContaining("openssl pkcs8 -topk8 -nocrypt");
+    }
+
+    @Test
+    void mustRejectEncryptedPrivateKeyWithoutPassword() throws Exception {
+        // Given: encrypted key without password - should fail during parsing
+        byte[] encryptedKey = ("""
+                -----BEGIN ENCRYPTED PRIVATE KEY-----
+                MIIE9jAoBgoqhkiG9w0BDAEDMBoEFDBlaUwB8TQ9ImbApCmAyVRTTX+kAgIIAASC
+                BMhC8QFNyn0VbVp7I+R9Yvmr+Ksl0xZshGg3zaUN8/HRblNSS3gPiP673rmnhcU3
+                -----END ENCRYPTED PRIVATE KEY-----
+                """).getBytes(StandardCharsets.US_ASCII);
+
+        // When/Then - fails because the encrypted key can't be parsed as unencrypted
+        assertThatThrownBy(() -> PemUtils.parsePrivateKey(encryptedKey, null))
+                .isInstanceOf(IOException.class);
+    }
+
+    @Test
+    void mustRejectMalformedCertificate() {
+        // Given
+        byte[] malformed = "not a valid PEM file".getBytes(StandardCharsets.UTF_8);
+
+        // When/Then
+        assertThatThrownBy(() -> PemUtils.parseCertificateChain(malformed))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("found no certificates");
+    }
+
+    @Test
+    void mustRejectMalformedPrivateKeyNullPassword() {
+        // Given
+        byte[] malformed = "not a valid PEM file".getBytes(StandardCharsets.UTF_8);
+
+        // When/Then
+        assertThatThrownBy(() -> PemUtils.parsePrivateKey(malformed, null))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("could not find a PKCS #8 private key");
+    }
+
+    @Test
+    void mustRejectPrivateKeyWithMissingFooter() {
+        // Given
+        byte[] missingFooter = """
+                -----BEGIN PRIVATE KEY-----
+                MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDb+HBO3C0URBKv
+                """.getBytes(StandardCharsets.US_ASCII);
+
+        // When/Then
+        assertThatThrownBy(() -> PemUtils.parsePrivateKey(missingFooter, null))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("could not find private key footer");
+    }
+
+    @Test
+    void mustRejectPKCS1EcPrivateKey() {
+        // Given
+        byte[] pkcs1EcKey = ("""
+                -----BEGIN EC PRIVATE KEY-----
+                MHcCAQEEIHerzPcVTKQmBL/eBzVEo6AIVg2rXTy6YhjMBxkntDzFoAoGCCqGSM49
+                AwEHoUQDQgAEbU4kz0QpW7MQvkqbijjDt/fu9T/FrjZuMd+8F9wSxwXrTfJhcHAA
+                7ibbeqf4y9m9QTPuRKzOQXS8A0qlOYEhzA==
+                -----END EC PRIVATE KEY-----
+                """).getBytes(StandardCharsets.US_ASCII);
+
+        // When/Then
+        assertThatThrownBy(() -> PemUtils.parsePrivateKey(pkcs1EcKey, null))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Failed to parse private key")
+                .hasMessageContaining("PKCS#1 (RSA only)");
+    }
+}

--- a/kroxylicious-kms-tls-support/src/test/java/io/kroxylicious/testing/kms/tls/TlsHttpClientConfiguratorTest.java
+++ b/kroxylicious-kms-tls-support/src/test/java/io/kroxylicious/testing/kms/tls/TlsHttpClientConfiguratorTest.java
@@ -257,21 +257,19 @@ class TlsHttpClientConfiguratorTest {
     }
 
     @Test
-    void shouldAcceptEncryptedPemKeyPairWithPassword() {
-        // Given: an encrypted PEM private key with the correct password
+    void shouldRejectEncryptedPemKeyPairWithPassword() {
+        // Given: an encrypted PEM private key with password
         var keys = CertificateGenerator.generate();
         KeyPair keyPair = new KeyPair(keys.encryptedPrivateKeyPem().toString(), keys.selfSignedCertificatePem().toString(),
                 new InlinePassword(keys.encryptedPrivateKeyPassword()));
 
-        // When: attempting to get key managers with the password
-        var keyManagers = TlsHttpClientConfigurator.getKeyManagers(keyPair);
-
-        // Then: should succeed and return the correct private key
-        assertThat(keyManagers)
-                .singleElement()
-                .asInstanceOf(InstanceOfAssertFactories.type(X509KeyManager.class))
-                .extracting(x -> x.getPrivateKey("key"))
-                .isEqualTo(keys.serverKey().getPrivate());
+        // When: attempting to get key managers
+        // Then: should throw SslConfigurationException because encrypted keys are not supported
+        assertThatThrownBy(() -> TlsHttpClientConfigurator.getKeyManagers(keyPair))
+                .isInstanceOf(SslConfigurationException.class)
+                .cause()
+                .hasMessageContaining("Encrypted private keys are not supported")
+                .hasMessageContaining("JKS/PKCS12");
     }
 
     @Test
@@ -281,11 +279,11 @@ class TlsHttpClientConfiguratorTest {
         KeyPair keyPair = new KeyPair(keys.encryptedPrivateKeyPem().toString(), keys.selfSignedCertificatePem().toString(), null);
 
         // When: attempting to get key managers without a password
-        // Then: should throw SslConfigurationException with clear message
+        // Then: should throw SslConfigurationException because the key is encrypted (even though no password was provided)
         assertThatThrownBy(() -> TlsHttpClientConfigurator.getKeyManagers(keyPair))
                 .isInstanceOf(SslConfigurationException.class)
                 .cause()
-                .hasMessageContaining("Encrypted private key requires a password");
+                .isInstanceOf(IOException.class);
     }
 
     @Test


### PR DESCRIPTION
## Summary

The Thales work inadvertently used a test dependency `kroxylicious-kms-tls-support` (which depends on Bouncy Castle) on the production path for parsing PEM files.  This went unnoticed during the integration tests as Bouncy Castle is made available as a test dependency.  However, if you run Proxy standalone for Record Encryption and try to load key material from a PEM, it fails with a NoClassDefFoundError as Bouncy Castle is not present.

As Thales uses PEMs natively, my intention was to allow PEMs created by Thales to be used, to minimise friction.  However, I didn't intend for Bouncy Castle to be a dependency.

This PR removes BouncyCastle from production dependencies in `kroxylicious-kms-tls-support` by replacing `PemParser` with a new `PemUtils` class forked from Netty's `PemReader`.

Also fixes the Thales CipherTrust Manager DEV_GUIDE script (`register-client-cert.sh`) to generate RSA keys for Java compatibility reasons. 

## Motivation

The `kroxylicious-kms-tls-support` module had an unintended production dependency on `kroxylicious-certificate-test-support`, which transitively brought in BouncyCastle. While BouncyCastle is MIT-licensed (compatible with Apache 2.0), avoiding unnecessary dependencies is preferred.

## Changes

### Commit 1: Remove BouncyCastle Dependency

**Created `PemUtils.java`** - Forked from Netty's `io.netty.handler.ssl.PemReader` (Apache 2.0)
- Replaced Netty ByteBuf with `byte[]`
- Replaced Netty Base64 with `java.util.Base64`
- Added JCA integration to return `PrivateKey` and `X509Certificate[]` objects
- Added PKCS#1 RSA to PKCS#8 conversion for RSA keys
- Added encrypted key detection with clear error messages

**Updated `TlsHttpClientConfigurator`** to use `PemUtils` instead of `PemParser`
- Changed 3 call sites (lines 219, 220, 297)
- Removed import of `io.kroxylicious.testing.certificate.PemParser`

**Updated `pom.xml`** to restore `<scope>test</scope>` on certificate-test-support dependency
- BouncyCastle now only appears in test scope
- Verified with `mvn dependency:tree`

**Created `PemUtilsTest`** with 10 comprehensive tests using inline PEM data from Netty's test suite

**Updated `TlsHttpClientConfiguratorTest`** to expect encrypted key rejection

### Commit 2: Use RSA Keys for Java Compatibility  

**Updated `register-client-cert.sh`** to generate RSA keys by adding `--alg RSA`

## Supported Key Formats

✅ **PKCS#8** - All algorithms (RSA, EC, EdDSA, DSA)  
✅ **PKCS#1 RSA** - Automatically converted to PKCS#8  
❌ **PKCS#1 EC** - Not supported (error message guides to conversion)  
❌ **Encrypted keys** - Not supported (error message directs to JKS/PKCS12)  

## Testing

All 44 tests pass (34 existing + 10 new)

## Checklist

- [x] Commits are signed-off (DCO)
- [x] AI disclosure included (Assisted-by trailer)
- [x] Tests added
- [x] All tests pass
- [x] No new quality violations