### PR TITLE
build(deps): update dependencies to fix CVE vulnerabilities for v0.20.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,21 +49,21 @@
         <freemarker.version>2.3.34</freemarker.version>
         <guava.version>33.5.0-jre</guava.version>
         <hamcrest.version>3.0</hamcrest.version>
-        <jackson.version>2.21.1</jackson.version>
+        <jackson.version>2.21.4</jackson.version>
         <re2j.version>1.8</re2j.version>
         <junit.version>5.14.3</junit.version>
         <kafka.version>4.2.0</kafka.version>
         <kroxy.extension.version>0.15.0</kroxy.extension.version>
-        <log4j.version>2.25.3</log4j.version>
+        <log4j.version>2.25.4</log4j.version>
         <caffeine.version>3.2.3</caffeine.version>
         <picocli.version>4.7.7</picocli.version>
-        <netty.version>4.2.12.Final</netty.version>
+        <netty.version>4.2.15.Final</netty.version>
         <netty.epoll.architecture>linux-x86_64</netty.epoll.architecture>
         <netty.io_uring.architecture>linux-x86_64</netty.io_uring.architecture>
         <netty.kqueue.architecture>osx-x86_64</netty.kqueue.architecture>
         <assertj-core.version>3.27.7</assertj-core.version>
         <mockito.version>5.23.0</mockito.version>
-        <micrometer.version>1.16.4</micrometer.version>
+        <micrometer.version>1.16.6</micrometer.version>
         <slf4j.version>2.0.17</slf4j.version>
         <sundr-builder-annotations.version>0.230.2</sundr-builder-annotations.version>
         <spotbugs-annotations.version>4.9.8</spotbugs-annotations.version>
@@ -80,7 +80,7 @@
         <maven.core.version>3.9.13</maven.core.version>
         <awaitility.version>4.3.0</awaitility.version>
         <testcontainers.version>2.0.4</testcontainers.version>
-        <azure.security.keyvault.keys.version>4.10.5</azure.security.keyvault.keys.version>
+        <azure.security.keyvault.keys.version>4.10.6</azure.security.keyvault.keys.version>
         <lowkey.version>7.1.13</lowkey.version>
         <bouncycastle.version>1.83</bouncycastle.version>
         <netty-leak-detector-junit-extension.version>0.2.2</netty-leak-detector-junit-extension.version>


### PR DESCRIPTION
## Summary

This PR updates direct dependencies to address CVE vulnerabilities identified in issue #4179 for the v0.20.1 release.

## Dependencies Updated

- **Jackson**: 2.21.1 → 2.21.4 (fixes SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551)
- **Log4j**: 2.25.3 → 2.25.4 (fixes CVE-2026-34477, CVE-2026-34478, CVE-2026-34479, CVE-2026-34480)
- **Netty**: 4.2.12.Final → 4.2.15.Final (fixes 23 CVEs including critical CVE-2026-44249, CVE-2026-45416, CVE-2026-50010)
- **Micrometer**: 1.16.4 → 1.16.6 (fixes CVE-2026-40983, CVE-2026-40984)
- **Azure KeyVault Keys**: 4.10.5 → 4.10.6 (fixes CVE-2026-33117 with CVSS 9.3)

## CVEs Addressed

This PR addresses the majority of CVEs identified in the issue, including all critical vulnerabilities (CVSS ≥ 9.0).

## Known Outstanding Issues

### Jackson CVE-2026-54515
**This PR does NOT resolve CVE-2026-54515** affecting Jackson. We await Jackson 2.21.5 which will contain the fix for this CVE. Queried the Jackson project: https://github.com/FasterXML/jackson-databind/issues/6074

### Transitive Dependencies (Vert.x)
Transitive dependencies from Apicurio registry bringing in older Vert.x versions (CVE-2026-1002, CVE-2026-6860) are **not addressed** in this PR. These will be handled separately via dependency management overrides without bumping Apicurio itself.

## Test Plan

- [x] All updated dependency versions verified to exist in Maven Central
- [ ] Full test suite to be run by CI
- [ ] No API changes, only dependency version bumps

Relates-to: #4179

🤖 Generated with [Claude Code](https://claude.com/claude-code)