### PR TITLE
build(deps): manage Vert.x dependencies to fix CVE vulnerabilities for v0.20.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <apicurio-schema-validation.version>0.1.3</apicurio-schema-validation.version>
         <apicurio-registry.version>3.1.6</apicurio-registry.version>
+        <vertx.version>4.5.28</vertx.version>
         <jose4j.version>0.9.6</jose4j.version>
 
         <!-- Test dependencies -->
@@ -331,6 +332,18 @@
                 <groupId>org.bitbucket.b_c</groupId>
                 <artifactId>jose4j</artifactId>
                 <version>${jose4j.version}</version>
+            </dependency>
+            <!--
+                Vert.x dependencies are transitive via apicurio-registry-schema-resolver.
+                We import the Vert.x BOM to ensure we get CVE fixes
+                (CVE-2026-1002, CVE-2026-6860) without needing to bump Apicurio itself.
+            -->
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-dependencies</artifactId>
+                <version>${vertx.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <!-- third party dependencies - test -->


### PR DESCRIPTION
## Summary

This PR imports the Vert.x BOM to address CVE vulnerabilities in transitive dependencies from Apicurio registry.

## Background

Apicurio `apicurio-registry-schema-resolver` (v3.1.6) brings in Vert.x dependencies transitively. Rather than bumping Apicurio itself, we import the Vert.x BOM to manage all Vert.x versions consistently and get security fixes while maintaining compatibility.

## Changes

Added to `<dependencyManagement>`:
- `vertx.version` property set to 4.5.28
- Import of `vertx-dependencies` BOM (type=pom, scope=import)
- Inline comment explaining why the BOM is imported

## CVEs Fixed

- **CVE-2026-1002** (Vert.x core, CVSS 6.9)
- **CVE-2026-6860** (Vert.x core, CVSS 6.9)

## Why BOM Instead of Individual Dependencies?

Using `vertx-dependencies` BOM:
- ✅ Manages all Vert.x artifacts consistently (vertx-core, vertx-auth-oauth2, vertx-web-client, etc.)
- ✅ Ensures version alignment across all Vert.x modules
- ✅ Cleaner than managing individual artifacts
- ✅ Standard Maven best practice for multi-module libraries

## Test Plan

- [ ] Verify Vert.x 4.5.28 is resolved transitively via `mvn dependency:tree`
- [ ] Full test suite to be run by CI
- [ ] No API changes, only dependency version management

## Notes

This approach:
- ✅ Fixes CVE vulnerabilities without bumping Apicurio
- ✅ Maintains compatibility with Apicurio 3.1.6
- ✅ Clearly documents why the BOM is imported
- ✅ Follows Maven dependency management best practices

Relates-to: #4179

🤖 Generated with [Claude Code](https://claude.com/claude-code)