### PR TITLE
Increase default JOSDK logging level

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/resources/log4j2.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/resources/log4j2.yaml
@@ -43,7 +43,7 @@ Configuration:
         AppenderRef:
           - ref: STDOUT
       - name: io.javaoperatorsdk
-        level: "${env:KROXYLICIOUS_JOSDK_LOG_LEVEL:-DEBUG}"
+        level: "${env:KROXYLICIOUS_JOSDK_LOG_LEVEL:-INFO}"
         additivity: false
         AppenderRef:
           - ref: STDOUT


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Bump the default Java Operator SDK log level to info.

### Additional Context

DEBUG level is very handy for chasing issues in the test suite but far to verbose for normal usage.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
