### PR TITLE
fix(ci): use branch variable instead of hardcoded 'main' in stage script

### DIFF
--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -205,13 +205,14 @@ jobs:
       - name: 'Comment on PR to prompt next phase of the release'
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }} # For the gh cmd line tool used by stage-release.sh
+          RELEASE_BRANCH: ${{ inputs.branch }}
         run: |
           export REPO="https://central.sonatype.com/api/v1/publisher/deployment/${{ env.DEPLOYMENT_ID }}/download"
           envsubst << "EOF" | gh pr comment ${{ env.WORK_BRANCH }} --body-file -
-          Hey, that's the ${{ github.event.inputs.release-version }} release prepared and its artefacts successfully staged to Sonatype. This PR contains a commit for ${{ github.event.inputs.release-version }} and a commit for ${{ github.event.inputs.development-version }} which will reopen ${{ inputs.branch }} for new work.
-          
+          Hey, that's the ${{ github.event.inputs.release-version }} release prepared and its artefacts successfully staged to Sonatype. This PR contains a commit for ${{ github.event.inputs.release-version }} and a commit for ${{ github.event.inputs.development-version }} which will reopen ${RELEASE_BRANCH} for new work.
+
           There are a couple of steps to do before the release is completed.
-          
+
           * [ ] Let the CI workflow on this PR complete
           * [ ] [Kick the tyres](https://github.com/kroxylicious/kroxylicious/blob/main/RELEASING.md#verify-the-release) using the staged Maven artefacts (available at `${REPO}`).
                 You can use this Maven snippet in your test project's pom.xml to configure Maven to download from the Portal. You also need to configure Maven to [authenticate](https://central.sonatype.org/publish/publish-portal-api/#maven) using
@@ -225,8 +226,8 @@ jobs:
             </repositories>
             ```
           * [ ] Approve this PR.
-          
-          Once the above is done, comment <code>&commat;kroxylicious-robot promote-release</code> on this PR. This will release the artefacts to Maven Central and merge this PR to ${{ inputs.branch }}.
+
+          Once the above is done, comment <code>&commat;kroxylicious-robot promote-release</code> on this PR. This will release the artefacts to Maven Central and merge this PR to ${RELEASE_BRANCH}.
           If things don't look good, abort the release by saying <code>&commat;kroxylicious-robot drop-release</code>.
           
           Thank you,

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -18,7 +18,7 @@ name: Stage Release
 
 # This workflow will stage a kroxylicious release.  The release artefacts will be
 # built, signed, and staged on Nexus.  The staging repository will be closed.  A PR will be opened
-# containing commits that versions the release and reopen main for development at the next snapshot version.
+# containing commits that versions the release and reopen the base branch for development at the next snapshot version.
 #
 # Once the staged artefacts have been verified, run the workflow deploy_release with the argument `release` to
 # release the artefacts to Maven Central and merge the release PR.
@@ -208,7 +208,7 @@ jobs:
         run: |
           export REPO="https://central.sonatype.com/api/v1/publisher/deployment/${{ env.DEPLOYMENT_ID }}/download"
           envsubst << "EOF" | gh pr comment ${{ env.WORK_BRANCH }} --body-file -
-          Hey, that's the ${{ github.event.inputs.release-version }} release prepared and its artefacts successfully staged to Sonatype. This PR contains a commit for ${{ github.event.inputs.release-version }} and a commit for ${{ github.event.inputs.development-version }} which will reopen main for new work.
+          Hey, that's the ${{ github.event.inputs.release-version }} release prepared and its artefacts successfully staged to Sonatype. This PR contains a commit for ${{ github.event.inputs.release-version }} and a commit for ${{ github.event.inputs.development-version }} which will reopen ${{ inputs.branch }} for new work.
           
           There are a couple of steps to do before the release is completed.
           
@@ -226,7 +226,7 @@ jobs:
             ```
           * [ ] Approve this PR.
           
-          Once the above is done, comment <code>&commat;kroxylicious-robot promote-release</code> on this PR. This will release the artefacts to Maven Central and merge this PR to main.
+          Once the above is done, comment <code>&commat;kroxylicious-robot promote-release</code> on this PR. This will release the artefacts to Maven Central and merge this PR to ${{ inputs.branch }}.
           If things don't look good, abort the release by saying <code>&commat;kroxylicious-robot drop-release</code>.
           
           Thank you,

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -199,7 +199,7 @@ replaceInFile "s_##\s${RELEASE_VERSION//./\\.}_## SNAPSHOT\n## ${RELEASE_VERSION
 
 # bump the docs for the development version
 replaceInFile "s_:KroxyliciousVersion:.*_:KroxyliciousVersion: ${NEXT_VERSION}_g" kroxylicious-docs/docs/_assets/attributes.adoc
-replaceInFile "s_:KroxyliciousGitRef:.*_:KroxyliciousGitRef: main_g" kroxylicious-docs/docs/_assets/attributes.adoc # this doesn't make a lot sense...
+replaceInFile "s_:KroxyliciousGitRef:.*_:KroxyliciousGitRef: ${BRANCH_FROM}_g" kroxylicious-docs/docs/_assets/attributes.adoc
 
 replaceInFile "s_image: 'quay.io/kroxylicious/proxy:.*'_image: 'quay.io/kroxylicious/proxy:${NEXT_VERSION}'_g" compose/kafka-compose.yaml
 


### PR DESCRIPTION
## Summary

Fixes #4282 - replaces hardcoded `main` references with dynamic branch variables to support staging releases from release branches (e.g., `release/1.x`).

## Changes

### `scripts/stage-release.sh` (line 202)
- **Before:** `KroxyliciousGitRef: main`
- **After:** `KroxyliciousGitRef: ${BRANCH_FROM}`
- **Why:** Ensures documentation links (via `github-blob-root`, `github-source-tree-root`, `github-raw-root`) point to the correct branch

### `.github/workflows/stage_release.yaml` (lines 21, 211, 229)
- **Before:** Hardcoded "main" in comments and PR text
- **After:** Dynamic `${{ inputs.branch }}`
- **Why:** PR comments accurately reflect the actual target branch

## Impact

When staging from `release/1.x`:
- ✅ Documentation attributes will reference `release/1.x` (not `main`)
- ✅ PR comment text will say "merge to release/1.x" (not "main")

When staging from `main` (default):
- ✅ No change in behavior - still references `main`

## Test plan

- [x] Verified `BRANCH_FROM` variable is available and used throughout `stage-release.sh`
- [x] Verified `inputs.branch` defaults to `main` in workflow
- [x] Confirmed backward compatibility: default behavior unchanged
- [x] Validated that `KroxyliciousGitRef` is actively used in 5 locations across documentation

## Backport required

This fix should be backported to active release branches to ensure the stage-release process works correctly when run from those branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)