### PR TITLE
[v0.20.x] build(deps): upgrade Jackson to 2.21.5 to fix CVE-2026-54515

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#4314](https://github.com/kroxylicious/kroxylicious/pull/4314): build(deps): Upgrade Jackson to 2.21.5 to fix CVE-2026-54515
 * [#4310](https://github.com/kroxylicious/kroxylicious/pull/4310): deps(apicurio): [0.20.x] bump Apicurio Registry from 3.1 to 3.2 to avoid CVEs in dependencies (and switch to JDK HTTP)
 * [#4111](https://github.com/kroxylicious/kroxylicious/pull/4111): build(deps): Upgrade to JOSDK 5.2.5 to avoids informer health check defect.
 * [#4304](https://github.com/kroxylicious/kroxylicious/pull/4304): build(deps): Update dependencies to fix CVE vulnerabilities
@@ -21,8 +22,7 @@ Format `<github issue/pr number>: <short description>`.
 
 #### Jackson (com.fasterxml.jackson.core)
 * [SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551](https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551) - Allocation of Resources Without Limits or Throttling in jackson-core (fixed in 2.21.4)
-
-**Note:** Jackson upgraded to 2.21.4. [CVE-2026-54515](https://nvd.nist.gov/vuln/detail/CVE-2026-54515) (Case-Insensitive Binding Reopening Ignored Fields) requires version 2.21.5 which is not yet released. See [jackson-databind#6074](https://github.com/FasterXML/jackson-databind/issues/6074)
+* [CVE-2026-54515](https://nvd.nist.gov/vuln/detail/CVE-2026-54515) - Case-Insensitive Binding Reopening Ignored Fields in jackson-databind (fixed in 2.21.5) ([Jackson Release](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.21.5))
 
 #### Log4j (org.apache.logging.log4j)
 * [CVE-2026-34477](https://nvd.nist.gov/vuln/detail/CVE-2026-34477) - TLS Hostname Verification Bypass (fixed in 2.25.4) ([Apache Advisory](https://logging.apache.org/security.html))

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <freemarker.version>2.3.34</freemarker.version>
         <guava.version>33.5.0-jre</guava.version>
         <hamcrest.version>3.0</hamcrest.version>
-        <jackson.version>2.21.4</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
         <re2j.version>1.8</re2j.version>
         <junit.version>5.14.3</junit.version>
         <kafka.version>4.2.0</kafka.version>


### PR DESCRIPTION
## Summary

This PR completes the CVE remediation work for issue #4179 by upgrading Jackson to 2.21.5 to fix the final outstanding CVE-2026-54515.

## Background

- PR #4304 previously upgraded Jackson from 2.21.1 → 2.21.4, fixing SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551
- At that time, Jackson 2.21.5 (needed for CVE-2026-54515) was not yet released
- Jackson 2.21.5 is now available on Maven Central

## Changes

**Dependency Update:**
- Jackson: 2.21.4 → 2.21.5

**CHANGELOG.md:**
- Added CVE-2026-54515 to the CVE Fixes section with authoritative source links
- Removed the note about 2.21.5 not being available

## CVE Fixed

**CVE-2026-54515** - Case-Insensitive Binding Reopening Ignored Fields in jackson-databind
- **CVSS:** 5.3 (Medium)
- **Description:** When a property uses @JsonFormat(ACCEPT_CASE_INSENSITIVE_PROPERTIES), the deserializer rebuilds its BeanPropertyMap from unfiltered properties, causing @JsonIgnoreProperties exclusions to be bypassed
- **Impact:** Fields intended to be ignored during deserialization can become writable from untrusted JSON
- **Fix:** Corrects BeanDeserializerBase.createContextual() to rebuild from the already-filtered map
- **Authoritative Sources:** 
  - [NVD CVE-2026-54515](https://nvd.nist.gov/vuln/detail/CVE-2026-54515)
  - [Jackson Release 2.21.5](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.21.5)

## Test Plan

- [ ] Maven dependency resolution confirms Jackson 2.21.5 is used
- [ ] Full test suite passes (CI)
- [ ] No API changes, only dependency version bump

Relates-to: #4179

🤖 Generated with [Claude Code](https://claude.com/claude-code)