### PR TITLE
test: add IT for active connection drain during reconfigure

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -611,8 +611,14 @@ class HotReloadIT extends BaseIT {
         }
     }
 
+    /*
+     * This test differs from shouldModifyPortAddressedVcWithSamePort in that it is the original
+     * producer client that is used to send additional messages after the virtual cluster is reconfigured.
+     * This tests the path where the virtual cluster has to drop the connection and the producer client
+     * is able to reconnect.
+     */
     @Test
-    void shouldDrainActiveConnectionsWhenVcIsReconfiguredWithFilterChange(@BrokerCluster KafkaCluster cluster) {
+    void shouldDrainActiveConnectionWhenVcIsReconfiguredWithFilterChange(@BrokerCluster KafkaCluster cluster) {
         var startingConfig = portConfig(portVc(cluster, "vc-active-conn"));
 
         var testerBuilder = KroxyliciousConfigUtils.baseConfigurationBuilder()

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -607,6 +608,48 @@ class HotReloadIT extends BaseIT {
                                         Map.of("virtual_cluster", "vc-metrics-added", "from", "initializing", "to", "serving"))
                                 .value().isEqualTo(1.0);
                     });
+        }
+    }
+
+    @Test
+    void shouldDrainActiveConnectionsWhenVcIsReconfiguredWithFilterChange(@BrokerCluster KafkaCluster cluster) {
+        var startingConfig = portConfig(portVc(cluster, "vc-active-conn"));
+
+        var testerBuilder = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToVirtualClusters(startingConfig.virtualClusters().toArray(new VirtualCluster[0]));
+        try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(testerBuilder).createDefaultKroxyliciousTester()) {
+
+            String topic = tester.createTopic("vc-active-conn");
+            int port = boundPort(tester, "vc-active-conn");
+
+            // Given
+            try (var producer = tester.producer("vc-active-conn", Map.of(ProducerConfig.LINGER_MS_CONFIG, 0))) {
+                assertThat(producer.send(new ProducerRecord<>(topic, "before-key", "before-value")))
+                        .succeedsWithin(PRODUCE_CONSUME_TIMEOUT);
+
+                // When
+                var afterConfig = portConfig(portVcWithLogNetwork(cluster, "vc-active-conn", port, true));
+                assertThat(tester.reconfigure(afterConfig))
+                        .succeedsWithin(RECONFIGURE_TIMEOUT)
+                        .satisfies(rr -> assertThat(rr.hasErrors())
+                                .as("ReconfigureResult should have no errors for logNetwork change")
+                                .isFalse());
+
+                // Then
+                assertThat(producer.send(new ProducerRecord<>(topic, "after-key", "after-value")))
+                        .succeedsWithin(PRODUCE_CONSUME_TIMEOUT);
+
+                try (var consumer = tester.consumer("vc-active-conn", Map.of(
+                        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
+                        ConsumerConfig.GROUP_ID_CONFIG, "active-conn-test"))) {
+                    consumer.subscribe(List.of(topic));
+                    var records = consumer.poll(PRODUCE_CONSUME_TIMEOUT);
+                    assertThat(records.iterator())
+                            .toIterable()
+                            .extracting(ConsumerRecord::key)
+                            .containsExactly("before-key", "after-key");
+                }
+            }
         }
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -619,7 +619,7 @@ class HotReloadIT extends BaseIT {
      * is able to reconnect. we infer that has happened by observing the producer metrics.
      */
     @Test
-    void shouldDrainActiveConnectionWhenVcIsReconfiguredWithFilterChange(@BrokerCluster KafkaCluster cluster) {
+    void shouldDrainActiveConnectionWhenVcIsReconfigured(@BrokerCluster KafkaCluster cluster) {
         var startingConfig = portConfig(portVc(cluster, "vc-active-conn"));
 
         var testerBuilder = KroxyliciousConfigUtils.baseConfigurationBuilder()

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -615,7 +616,7 @@ class HotReloadIT extends BaseIT {
      * This test differs from shouldModifyPortAddressedVcWithSamePort in that it is the original
      * producer client that is used to send additional messages after the virtual cluster is reconfigured.
      * This tests the path where the virtual cluster has to drop the connection and the producer client
-     * is able to reconnect.
+     * is able to reconnect. we infer that has happened by observing the producer metrics.
      */
     @Test
     void shouldDrainActiveConnectionWhenVcIsReconfiguredWithFilterChange(@BrokerCluster KafkaCluster cluster) {
@@ -632,6 +633,7 @@ class HotReloadIT extends BaseIT {
             try (var producer = tester.producer("vc-active-conn", Map.of(ProducerConfig.LINGER_MS_CONFIG, 0))) {
                 assertThat(producer.send(new ProducerRecord<>(topic, "before-key", "before-value")))
                         .succeedsWithin(PRODUCE_CONSUME_TIMEOUT);
+                double connectionsBefore = connectionCreationTotal(producer);
 
                 // When
                 var afterConfig = portConfig(portVcWithLogNetwork(cluster, "vc-active-conn", port, true));
@@ -645,6 +647,10 @@ class HotReloadIT extends BaseIT {
                 assertThat(producer.send(new ProducerRecord<>(topic, "after-key", "after-value")))
                         .succeedsWithin(PRODUCE_CONSUME_TIMEOUT);
 
+                assertThat(connectionCreationTotal(producer))
+                        .as("drain should have caused the producer to create at least one new connection")
+                        .isGreaterThan(connectionsBefore);
+
                 try (var consumer = tester.consumer("vc-active-conn", Map.of(
                         ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
                         ConsumerConfig.GROUP_ID_CONFIG, "active-conn-test"))) {
@@ -657,6 +663,15 @@ class HotReloadIT extends BaseIT {
                 }
             }
         }
+    }
+
+    private static double connectionCreationTotal(Producer<String, String> producer) {
+        return producer.metrics().entrySet().stream()
+                .filter(e -> e.getKey().name().equals("connection-creation-total")
+                        && e.getKey().group().equals("producer-metrics"))
+                .mapToDouble(e -> (double) e.getValue().metricValue())
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("connection-creation-total metric not found"));
     }
 
     private static ConfigurationBuilder portConfigBuilderWithMetrics(VirtualCluster... vcs) {


### PR DESCRIPTION
## Summary

Adds an integration test that validates active connections survive (via client auto-reconnect) when a virtual cluster is reconfigured.

I noticed this gap in the testing whilst reviewing #4309.  **This test does not try to reproduce the race condition described by #4309.**  

## Test Flow
1. **Phase 1**: Producer produces "before-key" record
2. **Phase 2**: Reconfigure VC (flip `logNetwork`) while producer connection is still open
3. **Phase 3**: Same producer produces "after-key" record (auto-reconnected after drain closed the socket)
4. **Phase 4**: Consumer reads both records to prove they both made it through

## What This Tests
- **Graceful reconfiguration**: Active connections survive via client auto-reconnect when a VC is modified
- **Drain doesn't hang**: The reconfigure completes successfully, proving the drain mechanism works
- **Normal drain path**: Validates that established connections (the common case) are properly drained
- **End-to-end validation**: Proves the whole `ReplaceCluster` → drain → reconnect flow works

## Notes
- This test exercises the **normal** drain path (connections that are already active/in Forwarding state)
- It does NOT expose the race condition bug where `drain()` is called before `onClientActive` fires (that's covered by the unit test `drainCompletesButChannelBecomesActiveWhenOnClientActiveFiresAfterDrain`)
- The test is still valuable as it validates the common case and would catch different failure modes (e.g., if drain deadlocked, or if the coordinator didn't properly wait for drains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)