### PR TITLE
refactor(runtime): remove nullables from FilterChainFactory

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -252,6 +252,9 @@ public class FilterChainFactory implements AutoCloseable {
      * @return an empty {@code FilterChainFactory}
      */
     public static FilterChainFactory empty() {
+        // A fresh instance per call rather than a shared constant: FilterChainFactory is
+        // AutoCloseable, so a shared empty instance could be closed by one caller while
+        // another still holds it.
         return new FilterChainFactory();
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -34,8 +34,6 @@ import io.kroxylicious.proxy.filter.ResponseFilter;
 import io.kroxylicious.proxy.internal.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
-
 /**
  * Builds per-connection filter instances for a single virtual cluster's filter chain.
  *
@@ -185,16 +183,16 @@ public class FilterChainFactory implements AutoCloseable {
      */
     private final Map<String, Wrapper> initialized;
 
-    public FilterChainFactory(@Nullable PluginFactoryRegistry pfr, @Nullable List<NamedFilterDefinition> filterChain) {
-        if (filterChain == null || filterChain.isEmpty()) {
-            // Empty chain — no plugin lookups needed, so a null pfr is tolerated. Empty
-            // FCFs arise from VCs that opt out of the default filter chain (filters == [])
-            // and from test-only VirtualClusterModel constructors that don't supply a pfr.
+    public FilterChainFactory(PluginFactoryRegistry pfr, List<NamedFilterDefinition> filterChain) {
+        Objects.requireNonNull(pfr, "pfr must not be null");
+        Objects.requireNonNull(filterChain, "filterChain must not be null");
+        if (filterChain.isEmpty()) {
+            // Empty chain — no plugin lookups needed. Empty FCFs arise from virtual clusters
+            // that opt out of the default filter chain (filters == []).
             this.filterChain = List.of();
             this.initialized = Map.of();
         }
         else {
-            Objects.requireNonNull(pfr, "PluginFactoryRegistry must not be null when filterChain is non-empty");
             @SuppressWarnings({ "unchecked", "rawtypes" })
             Class<FilterFactory<? super Object, ? super Object>> type = (Class) FilterFactory.class;
             PluginFactory<FilterFactory<? super Object, ? super Object>> pluginFactory = pfr.pluginFactory(type);
@@ -243,6 +241,23 @@ public class FilterChainFactory implements AutoCloseable {
                 throw e;
             }
         }
+    }
+
+    /**
+     * Returns a {@code FilterChainFactory} with an empty filter chain, for callers that have no
+     * filters to apply and therefore no {@link PluginFactoryRegistry} to supply (for example
+     * virtual clusters that opt out of the default chain, and tests that do not exercise the
+     * chain).
+     *
+     * @return an empty {@code FilterChainFactory}
+     */
+    public static FilterChainFactory empty() {
+        return new FilterChainFactory();
+    }
+
+    private FilterChainFactory() {
+        this.filterChain = List.of();
+        this.initialized = Map.of();
     }
 
     @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -148,7 +148,7 @@ public class VirtualClusterModel implements AutoCloseable {
         this.routing = Objects.requireNonNull(routing);
         this.filterChainFactory = pluginFactoryRegistry != null
                 ? new FilterChainFactory(pluginFactoryRegistry, filters)
-                : new FilterChainFactory(null, List.of());
+                : FilterChainFactory.empty();
     }
 
     /**

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -113,15 +113,20 @@ class FilterChainFactoryTest {
     }
 
     @Test
-    void testNullArgumentsAreRejected() {
+    void nullFilterChainIsRejected() {
         assertThatThrownBy(() -> new FilterChainFactory(pfr, null))
-                .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new FilterChainFactory(null, List.of()))
                 .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    void testEmptyFactoryCreatesNoFilters() {
+    void nullPluginFactoryRegistryIsRejected() {
+        List<NamedFilterDefinition> emptyFilterChain = List.of();
+        assertThatThrownBy(() -> new FilterChainFactory(null, emptyFilterChain))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void emptyFactoryCreatesNoFilters() {
         try (FilterChainFactory filterChainFactory = FilterChainFactory.empty()) {
             List<FilterAndInvoker> filters = filterChainFactory.createFilters(new NettyFilterContext(eventLoop, pfr));
             assertThat(filters)

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -113,12 +113,21 @@ class FilterChainFactoryTest {
     }
 
     @Test
-    void testNullFiltersInConfigResultsInEmptyList() {
-        FilterChainFactory filterChainFactory = new FilterChainFactory(pfr, null);
-        List<FilterAndInvoker> filters = filterChainFactory.createFilters(new NettyFilterContext(eventLoop, pfr));
-        assertThat(filters)
-                .isNotNull()
-                .isEmpty();
+    void testNullArgumentsAreRejected() {
+        assertThatThrownBy(() -> new FilterChainFactory(pfr, null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new FilterChainFactory(null, List.of()))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testEmptyFactoryCreatesNoFilters() {
+        try (FilterChainFactory filterChainFactory = FilterChainFactory.empty()) {
+            List<FilterAndInvoker> filters = filterChainFactory.createFilters(new NettyFilterContext(eventLoop, pfr));
+            assertThat(filters)
+                    .isNotNull()
+                    .isEmpty();
+        }
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientConnectionStateMachineEndToEndTest.java
@@ -501,7 +501,7 @@ class ClientConnectionStateMachineEndToEndTest {
         when(virtualClusterModel.getTopicNameCacheFilter()).thenReturn(topicNameCacheFilter);
         // FCF is now resolved per-connection from the VC (see #4055). An empty FCF here is
         // sufficient — these tests don't exercise filter behavior, just connection flow.
-        when(virtualClusterModel.filterChainFactory()).thenReturn(new io.kroxylicious.proxy.bootstrap.FilterChainFactory(null, java.util.List.of()));
+        when(virtualClusterModel.filterChainFactory()).thenReturn(io.kroxylicious.proxy.bootstrap.FilterChainFactory.empty());
         EndpointBinding endpointBinding = mock(EndpointBinding.class);
         EndpointGateway endpointGateway = mock(EndpointGateway.class);
         when(endpointGateway.virtualCluster()).thenReturn(virtualClusterModel);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerMockCollaboratorsTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerMockCollaboratorsTest.java
@@ -100,7 +100,7 @@ class KafkaProxyFrontendHandlerMockCollaboratorsTest {
     @BeforeEach
     void setUp() {
         when(virtualCluster.getClusterName()).thenReturn(CLUSTER_NAME);
-        when(virtualCluster.filterChainFactory()).thenReturn(new FilterChainFactory(null, List.of()));
+        when(virtualCluster.filterChainFactory()).thenReturn(FilterChainFactory.empty());
         when(endpointGateway.virtualCluster()).thenReturn(virtualCluster);
         when(endpointBinding.endpointGateway()).thenReturn(endpointGateway);
         when(clientConnectionStateMachine.endpointBinding()).thenReturn(endpointBinding);


### PR DESCRIPTION
### Type of change

Refactoring

### Description

`FilterChainFactory` declared its two constructor parameters as `@Nullable` only to support test-only `VirtualClusterModel` constructors, which passed a null `PluginFactoryRegistry` with an empty filter chain. The production path never passes null.

This makes both constructor parameters non-null and validates them up front, and adds a static `FilterChainFactory.empty()` for callers that have no filters (and therefore no `PluginFactoryRegistry` to supply). The test-only `VirtualClusterModel` path now uses `empty()`.

### Additional Context

Follows the approach discussed in #4073 and the suggested fix in #4086.

### Checklist

- [x] Tests updated where applicable — `FilterChainFactoryTest` now covers the non-null contract and `empty()`.
- [x] Existing unit/integration/system tests passing — ran the affected `kroxylicious-runtime` test classes locally (186 tests, 0 failures).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] AI-assisted changes carry the `Assisted-by:` trailer in the commit message.
- [ ] CHANGELOG update — not applicable, this is an internal refactoring with no user-facing change.

Closes #4086
