### PR TITLE
feat(systemtests): allow additional env vars on operator pod

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -17,49 +17,52 @@
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="edu.umd.cs.findbugs.annotations.Nullable" />
     <option name="myDefaultNotNull" value="edu.umd.cs.findbugs.annotations.NonNull" />
+    <option name="myOrdered" value="true" />
     <option name="myNullables">
       <value>
-        <list size="17">
-          <item index="0" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
-          <item index="1" class="java.lang.String" itemvalue="androidx.annotation.Nullable" />
-          <item index="2" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNullable" />
-          <item index="3" class="java.lang.String" itemvalue="com.android.annotations.Nullable" />
-          <item index="4" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
+        <list size="18">
+          <item index="0" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
+          <item index="1" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
+          <item index="2" class="java.lang.String" itemvalue="androidx.annotation.Nullable" />
+          <item index="3" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNullable" />
+          <item index="4" class="java.lang.String" itemvalue="com.android.annotations.Nullable" />
           <item index="5" class="java.lang.String" itemvalue="io.reactivex.annotations.Nullable" />
           <item index="6" class="java.lang.String" itemvalue="io.reactivex.rxjava3.annotations.Nullable" />
-          <item index="7" class="java.lang.String" itemvalue="jakarta.annotation.Nullable" />
-          <item index="8" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
-          <item index="9" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
-          <item index="10" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
-          <item index="11" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
-          <item index="12" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
+          <item index="7" class="java.lang.String" itemvalue="org.jspecify.nullness.Nullable" />
+          <item index="8" class="java.lang.String" itemvalue="org.jspecify.annotations.Nullable" />
+          <item index="9" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
+          <item index="10" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
+          <item index="11" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
+          <item index="12" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
           <item index="13" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.Nullable" />
-          <item index="14" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
-          <item index="15" class="java.lang.String" itemvalue="org.jspecify.nullness.Nullable" />
-          <item index="16" class="java.lang.String" itemvalue="org.jspecify.annotations.Nullable" />
+          <item index="14" class="java.lang.String" itemvalue="jakarta.annotation.Nullable" />
+          <item index="15" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
+          <item index="16" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
+          <item index="17" class="java.lang.String" itemvalue="org.springframework.lang.Nullable" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="17">
-          <item index="0" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
-          <item index="1" class="java.lang.String" itemvalue="androidx.annotation.NonNull" />
-          <item index="2" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNonNull" />
-          <item index="3" class="java.lang.String" itemvalue="com.android.annotations.NonNull" />
-          <item index="4" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
+        <list size="18">
+          <item index="0" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
+          <item index="1" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
+          <item index="2" class="java.lang.String" itemvalue="androidx.annotation.NonNull" />
+          <item index="3" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNonNull" />
+          <item index="4" class="java.lang.String" itemvalue="com.android.annotations.NonNull" />
           <item index="5" class="java.lang.String" itemvalue="io.reactivex.annotations.NonNull" />
           <item index="6" class="java.lang.String" itemvalue="io.reactivex.rxjava3.annotations.NonNull" />
-          <item index="7" class="java.lang.String" itemvalue="jakarta.annotation.Nonnull" />
-          <item index="8" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
-          <item index="9" class="java.lang.String" itemvalue="lombok.NonNull" />
-          <item index="10" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
-          <item index="11" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
-          <item index="12" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
+          <item index="7" class="java.lang.String" itemvalue="org.jspecify.nullness.NonNull" />
+          <item index="8" class="java.lang.String" itemvalue="org.jspecify.annotations.NonNull" />
+          <item index="9" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
+          <item index="10" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
+          <item index="11" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
+          <item index="12" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
           <item index="13" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.NonNull" />
-          <item index="14" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
-          <item index="15" class="java.lang.String" itemvalue="org.jspecify.nullness.NonNull" />
-          <item index="16" class="java.lang.String" itemvalue="org.jspecify.annotations.NonNull" />
+          <item index="14" class="java.lang.String" itemvalue="jakarta.annotation.Nonnull" />
+          <item index="15" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
+          <item index="16" class="java.lang.String" itemvalue="lombok.NonNull" />
+          <item index="17" class="java.lang.String" itemvalue="org.springframework.lang.NonNull" />
         </list>
       </value>
     </option>

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/KroxyliciousOperator.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/KroxyliciousOperator.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.systemtests.installation.kroxylicious;
 
+import java.util.Map;
+
 import io.skodjob.testframe.enums.InstallType;
 import io.skodjob.testframe.installation.InstallationMethod;
 
@@ -17,8 +19,9 @@ import io.kroxylicious.systemtests.resources.operator.KroxyliciousOperatorYamlIn
  * The type Kroxylicious operator.
  */
 public class KroxyliciousOperator {
-    private final InstallationMethod installationMethod;
+    private InstallationMethod installationMethod;
     private final String installationNamespace;
+    private Map<String, String> operatorEnvVars = Map.of();
 
     /**
      * Instantiates a new Kroxylicious operator.
@@ -27,13 +30,25 @@ public class KroxyliciousOperator {
      */
     public KroxyliciousOperator(String deploymentNamespace) {
         this.installationNamespace = deploymentNamespace;
-        this.installationMethod = getInstallationMethod();
+    }
+
+    /**
+     * Sets additional environment variables on the operator pod.
+     * Only applies to YAML-based installations.
+     *
+     * @param envVars environment variables to set
+     * @return this
+     */
+    public KroxyliciousOperator withOperatorEnvVars(Map<String, String> envVars) {
+        this.operatorEnvVars = envVars;
+        return this;
     }
 
     /**
      * Deploy.
      */
     public void deploy() {
+        this.installationMethod = createInstallationMethod();
         installationMethod.install();
     }
 
@@ -41,15 +56,17 @@ public class KroxyliciousOperator {
      * Delete.
      */
     public void delete() {
-        installationMethod.delete();
+        if (installationMethod != null) {
+            installationMethod.delete();
+        }
     }
 
-    private InstallationMethod getInstallationMethod() {
+    private InstallationMethod createInstallationMethod() {
         if (Environment.INSTALL_TYPE == InstallType.Olm) {
             return new KroxyliciousOperatorOlmBundleInstaller(installationNamespace);
         }
         else {
-            return new KroxyliciousOperatorYamlInstaller(installationNamespace);
+            return new KroxyliciousOperatorYamlInstaller(installationNamespace, operatorEnvVars);
         }
     }
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/KroxyliciousOperator.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/KroxyliciousOperator.java
@@ -34,7 +34,7 @@ public class KroxyliciousOperator {
 
     /**
      * Sets additional environment variables on the operator pod.
-     * Only applies to YAML-based installations.
+     * For bundle-image OLM installs, env vars are not supported and will throw at install time.
      *
      * @param envVars environment variables to set
      * @return this
@@ -63,7 +63,7 @@ public class KroxyliciousOperator {
 
     private InstallationMethod createInstallationMethod() {
         if (Environment.INSTALL_TYPE == InstallType.Olm) {
-            return new KroxyliciousOperatorOlmBundleInstaller(installationNamespace);
+            return new KroxyliciousOperatorOlmBundleInstaller(installationNamespace, operatorEnvVars);
         }
         else {
             return new KroxyliciousOperatorYamlInstaller(installationNamespace, operatorEnvVars);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/operator/KroxyliciousOperatorOlmBundleInstaller.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/operator/KroxyliciousOperatorOlmBundleInstaller.java
@@ -8,6 +8,7 @@
 package io.kroxylicious.systemtests.resources.operator;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -16,10 +17,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.openshift.api.model.operatorhub.v1.OperatorGroupBuilder;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.Subscription;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.SubscriptionBuilder;
+import io.fabric8.openshift.api.model.operatorhub.v1alpha1.SubscriptionConfigBuilder;
 import io.skodjob.testframe.TestFrameConstants;
 import io.skodjob.testframe.installation.InstallationMethod;
 import io.skodjob.testframe.olm.OperatorSdkRun;
@@ -51,9 +55,11 @@ public class KroxyliciousOperatorOlmBundleInstaller implements InstallationMetho
     private final String kroxyliciousOperatorName;
     private final String bundleImageRef;
     private final String operatorNamespace;
+    private final Map<String, String> additionalEnvVars;
 
-    public KroxyliciousOperatorOlmBundleInstaller(String operatorNamespace) {
+    public KroxyliciousOperatorOlmBundleInstaller(String operatorNamespace, Map<String, String> additionalEnvVars) {
         this.operatorNamespace = operatorNamespace;
+        this.additionalEnvVars = additionalEnvVars;
         this.extensionContext = KubeResourceManager.get().getTestContext();
         this.kroxyliciousOperatorName = Environment.KROXYLICIOUS_OLM_DEPLOYMENT_NAME;
         this.bundleImageRef = Environment.KROXYLICIOUS_OPERATOR_BUNDLE_IMAGE;
@@ -72,12 +78,13 @@ public class KroxyliciousOperatorOlmBundleInstaller implements InstallationMetho
         return Objects.equals(kroxyliciousOperatorName, otherInstallation.kroxyliciousOperatorName) &&
                 Objects.equals(operatorNamespace, otherInstallation.operatorNamespace) &&
                 Objects.equals(bundleImageRef, otherInstallation.bundleImageRef) &&
-                Objects.equals(extensionContext, otherInstallation.extensionContext);
+                Objects.equals(extensionContext, otherInstallation.extensionContext) &&
+                Objects.equals(additionalEnvVars, otherInstallation.additionalEnvVars);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(extensionContext, kroxyliciousOperatorName, operatorNamespace, bundleImageRef);
+        return Objects.hash(extensionContext, kroxyliciousOperatorName, operatorNamespace, bundleImageRef, additionalEnvVars);
     }
 
     @Override
@@ -87,6 +94,7 @@ public class KroxyliciousOperatorOlmBundleInstaller implements InstallationMetho
                 ", kroxyliciousOperatorName='" + kroxyliciousOperatorName + '\'' +
                 ", operatorNamespace='" + operatorNamespace + '\'' +
                 ", bundleImageRef='" + bundleImageRef + '\'' +
+                ", additionalEnvVars=" + additionalEnvVars +
                 '}';
     }
 
@@ -130,6 +138,10 @@ public class KroxyliciousOperatorOlmBundleInstaller implements InstallationMetho
             LOGGER.info("OperatorGroup already exists.");
         }
 
+        List<EnvVar> envVars = additionalEnvVars.entrySet().stream()
+                .map(e -> new EnvVarBuilder().withName(e.getKey()).withValue(e.getValue()).build())
+                .toList();
+
         // @formatter:off
         Subscription subscription = new SubscriptionBuilder()
                 .editOrNewMetadata()
@@ -142,6 +154,7 @@ public class KroxyliciousOperatorOlmBundleInstaller implements InstallationMetho
                     .withSource(source)
                     .withSourceNamespace(catalogNs)
                     .withInstallPlanApproval("Automatic")
+                    .withConfig(new SubscriptionConfigBuilder().withEnv(envVars).build())
                 .endSpec()
                 .build();
         // @formatter:on
@@ -152,6 +165,9 @@ public class KroxyliciousOperatorOlmBundleInstaller implements InstallationMetho
     }
 
     private CompletableFuture<Void> install(String operatorName, String operatorNamespace, String bundleImageRef) {
+        if (!additionalEnvVars.isEmpty()) {
+            throw new UnsupportedOperationException("Additional env vars are not supported for bundle-image OLM installs");
+        }
         OperatorSdkRun osr = new OperatorSdkRunBuilder()
                 .withBundleImage(bundleImageRef)
                 .withInstallMode("AllNamespaces")

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/operator/KroxyliciousOperatorYamlInstaller.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/operator/KroxyliciousOperatorYamlInstaller.java
@@ -75,6 +75,7 @@ public class KroxyliciousOperatorYamlInstaller implements InstallationMethod {
     private final String kroxyliciousOperatorName;
     private final String namespaceInstallTo;
     private Map<String, String> extraLabels;
+    private final Map<String, String> additionalEnvVars;
     private final int replicas;
 
     private String testClassName;
@@ -86,7 +87,12 @@ public class KroxyliciousOperatorYamlInstaller implements InstallationMethod {
             && ko.testClassName == null && ko.testMethodName == null;
 
     public KroxyliciousOperatorYamlInstaller(String namespaceInstallTo) {
+        this(namespaceInstallTo, Map.of());
+    }
+
+    public KroxyliciousOperatorYamlInstaller(String namespaceInstallTo, @NonNull Map<String, String> additionalEnvVars) {
         this.namespaceInstallTo = namespaceInstallTo;
+        this.additionalEnvVars = additionalEnvVars;
         this.replicas = 1;
         this.extensionContext = KubeResourceManager.get().getTestContext();
         this.kroxyliciousOperatorName = Constants.KROXYLICIOUS_OPERATOR_DEPLOYMENT_NAME;
@@ -188,6 +194,9 @@ public class KroxyliciousOperatorYamlInstaller implements InstallationMethod {
                                 .addToEnv(new EnvVarBuilder().withName("JAVA_OPTIONS")
                                         .withValue("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:" + DEBUG_PORT_NUMBER)
                                         .build())
+                                .addAllToEnv(additionalEnvVars.entrySet().stream()
+                                        .map(e -> new EnvVarBuilder().withName(e.getKey()).withValue(e.getValue()).build())
+                                        .toList())
                                 .addToPorts(new ContainerPortBuilder().withName(debugPortName).withContainerPort(DEBUG_PORT_NUMBER).build())
                             .endContainer()
                             .withImagePullSecrets(new LocalObjectReferenceBuilder()

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/OperatorChangeDetectionST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/OperatorChangeDetectionST.java
@@ -401,7 +401,8 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
 
     @BeforeAll
     void setupBefore() {
-        kroxyliciousOperator = new KroxyliciousOperator(Constants.KROXYLICIOUS_OPERATOR_NAMESPACE);
+        kroxyliciousOperator = new KroxyliciousOperator(Constants.KROXYLICIOUS_OPERATOR_NAMESPACE)
+                .withOperatorEnvVars(Map.of("KROXYLICIOUS_OPERATOR_RESYNC_INTERVAL_SECONDS", "30"));
         kroxyliciousOperator.deploy();
     }
 


### PR DESCRIPTION
### Type of change

Enhancement / new feature

### Description

Adds the ability to pass additional environment variables to the operator pod in system tests.
`KroxyliciousOperator` now supports a `withOperatorEnvVars()` fluent setter, which passes the
env vars through to `KroxyliciousOperatorYamlInstaller` via constructor injection.

Also enables JOSDK DEBUG logging for `OperatorChangeDetectionST` to aid diagnosis of the
reconciliation issue described in #4241.

### Additional Context

The `shouldUpdateDeploymentWhenKafkaProxyIngressChanges` test fails intermittently on CI but
not locally. Debug logging from JOSDK on the operator pod is needed to diagnose the root cause.

Relates-to: #4241

### Checklist

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).