### PR TITLE
fix(test): bind ImmediateCloseSocketServer to the wildcard address

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ImmediateCloseSocketServer.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ImmediateCloseSocketServer.java
@@ -7,7 +7,6 @@ package io.kroxylicious.it;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
@@ -25,7 +24,7 @@ public class ImmediateCloseSocketServer implements AutoCloseable {
 
     public ImmediateCloseSocketServer() {
         try {
-            this.serverSocket = new ServerSocket(0, 50, InetAddress.getLocalHost());
+            this.serverSocket = new ServerSocket(0, 50);
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);


### PR DESCRIPTION
## Summary

Changes `ImmediateCloseSocketServer` to use the `ServerSocket(int, int)` constructor, letting Java select the local bind address itself instead of specifying `InetAddress.getLocalHost()`.

I found this while debugging `ResilienceIT` failures on my machine.

## The Problem

1. The server bound to the address returned by `InetAddress.getLocalHost()`
2. `getHostPort()` advertised the *hostname*, not the bound address
3. On some machines (e.g. on a corporate VPN with split-horizon DNS), that hostname resolves to a different address — one with no listener
4. Connections to it hang until the OS connect timeout (~75s observed on macOS) instead of being closed immediately

## What This Fixes

- Fast failure restored: connection attempts to the server fail/close promptly regardless of how the local hostname resolves
- `ResilienceIT` bootstrap tests no longer exceed their time budgets on affected machines (previously `shouldBeAbleToBootstrapIfMultipleBootstrapUnavailable` took ~15s against a 10s assertion; now passes — Tests run: 8, Failures: 0)

## Notes

- The tests only require that connections to these fake brokers terminate quickly; they never depended on a specific bind address
- Port 0 (ephemeral allocation) and the backlog of 50 are unchanged
- Constructor choice follows review discussion — Java selecting the local address is preferable to us specifying one

🤖 Generated with [Claude Code](https://claude.com/claude-code)