### PR TITLE
fix(operator): use operator build metadata

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -73,9 +73,18 @@ public class OperatorMain {
      * name emitted by Prometheus will be called {@code kroxylicious_operator_build_info}.
      */
     private static final String BUILD_INFO_METRIC_NAME = "kroxylicious_operator_build.info";
+    /**
+     * Operator build metadata resource. This intentionally does
+     * not use {@code META-INF/metadata.properties}, because that resource
+     * is provided by the runtime artifact and may be resolved first from
+     * the classpath.
+     */
+    private static final String OPERATOR_METADATA_RESOURCE = "META-INF/kroxylicious/operator/metadata.properties";
+
     private final Operator operator;
     private final HttpServer managementServer;
     private final ControllerConfigurer controllerConfigurer;
+
     @Nullable
     private SharedInformerManager sharedInformerManager;
 
@@ -100,6 +109,11 @@ public class OperatorMain {
         });
         this.managementServer = managementServer;
         this.controllerConfigurer = controllerConfigurer;
+    }
+
+    @VisibleForTesting
+    static VersionInfo versionInfo() {
+        return VersionInfo.fromResource(OPERATOR_METADATA_RESOURCE);
     }
 
     public static void main(String[] args) {
@@ -139,7 +153,7 @@ public class OperatorMain {
         managementServer.start();
         addHttpGetHandler(HTTP_PATH_LIVEZ, this::livezStatusCode);
         operator.start();
-        var versionInfo = VersionInfo.VERSION_INFO;
+        var versionInfo = versionInfo();
         LOGGER.atInfo()
                 .addKeyValue("javaVersion", Runtime::version)
                 .addKeyValue("javaVendor", () -> System.getProperty("java.vendor"))

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/resources-filtered/META-INF/kroxylicious/operator/metadata.properties
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/resources-filtered/META-INF/kroxylicious/operator/metadata.properties
@@ -1,0 +1,8 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+kroxylicious.version=0.23.0-SNAPSHOT
+git.commit.id=938cbde378a4d35e49abbe04bb32a5aba8ad4b2f

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/resources-filtered/META-INF/kroxylicious/operator/metadata.properties
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/resources-filtered/META-INF/kroxylicious/operator/metadata.properties
@@ -4,5 +4,5 @@
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
-kroxylicious.version=0.23.0-SNAPSHOT
-git.commit.id=938cbde378a4d35e49abbe04bb32a5aba8ad4b2f
+kroxylicious.version=${project.version}
+git.commit.id=${git.commit.id}

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMetadataResourceTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMetadataResourceTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OperatorMetadataResourceTest {
+
+    @Test
+    void shouldReturnOperatorVersionInfo() {
+        var versionInfo = OperatorMain.versionInfo();
+
+        assertThat(versionInfo.version()).isEqualTo("operator-metadata-version-test");
+        assertThat(versionInfo.commitId()).isEqualTo("operator-metadata-commit-test");
+    }
+
+    @Test
+    void operatorMetadataResourceShouldBePackagedInMainClasses() throws IOException {
+        // Keep this path in sync with OperatorMain.OPERATOR_METADATA_RESOURCE
+        Path metadata = Path.of("target/classes/META-INF/kroxylicious/operator/metadata.properties");
+
+        assertThat(metadata).isRegularFile();
+
+        var properties = new Properties();
+        try (var reader = Files.newBufferedReader(metadata)) {
+            properties.load(reader);
+        }
+
+        assertThat(properties.getProperty("kroxylicious.version")).isNotBlank();
+        assertThat(properties.getProperty("git.commit.id")).isNotBlank();
+
+        String content = Files.readString(metadata);
+        assertThat(content)
+                .as("metadata should not contain unresolved maven properties")
+                .doesNotContain("${project.version}")
+                .doesNotContain("${git.commit.id}");
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMetadataResourceTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMetadataResourceTest.java
@@ -6,11 +6,6 @@
 
 package io.kroxylicious.kubernetes.operator;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Properties;
-
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,27 +18,5 @@ class OperatorMetadataResourceTest {
 
         assertThat(versionInfo.version()).isEqualTo("operator-metadata-version-test");
         assertThat(versionInfo.commitId()).isEqualTo("operator-metadata-commit-test");
-    }
-
-    @Test
-    void operatorMetadataResourceShouldBePackagedInMainClasses() throws IOException {
-        // Keep this path in sync with OperatorMain.OPERATOR_METADATA_RESOURCE
-        Path metadata = Path.of("target/classes/META-INF/kroxylicious/operator/metadata.properties");
-
-        assertThat(metadata).isRegularFile();
-
-        var properties = new Properties();
-        try (var reader = Files.newBufferedReader(metadata)) {
-            properties.load(reader);
-        }
-
-        assertThat(properties.getProperty("kroxylicious.version")).isNotBlank();
-        assertThat(properties.getProperty("git.commit.id")).isNotBlank();
-
-        String content = Files.readString(metadata);
-        assertThat(content)
-                .as("metadata should not contain unresolved maven properties")
-                .doesNotContain("${project.version}")
-                .doesNotContain("${git.commit.id}");
     }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/META-INF/kroxylicious/operator/metadata.properties
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/META-INF/kroxylicious/operator/metadata.properties
@@ -1,0 +1,8 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+kroxylicious.version=operator-metadata-version-test
+git.commit.id=operator-metadata-commit-test

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/META-INF/metadata.properties
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/META-INF/metadata.properties
@@ -1,0 +1,8 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+kroxylicious.version=proxy-metadata-version-test
+git.commit.id=proxy-metadata-commit-test

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/VersionInfo.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/VersionInfo.java
@@ -13,15 +13,39 @@ import java.util.Properties;
 import org.slf4j.LoggerFactory;
 
 public interface VersionInfo {
+
+    /**
+     * Version information loaded from the default Kroxylicious runtime metadata
+     * resource, {@code META-INF/metadata.properties}.
+     *
+     * <p>
+     * Other Kroxylicious artifacts should use {@link #fromResource(String)}
+     * when their version metadata is stored in an artifact-specific resource.
+     */
     VersionInfo VERSION_INFO = getVersionInfo();
 
     String version();
 
     String commitId();
 
-    private static VersionInfo getVersionInfo() {
+    /**
+     * Loads version information from the supplied classpath resource.
+     *
+     * @param resourceName the classpath resource containing version metadata
+     * @return the version information, or unknown values if the resource cannot be
+     *         loaded
+     */
+    static VersionInfo fromResource(String resourceName) {
+        return getVersionInfo(resourceName);
+    }
 
-        try (var resource = Info.class.getClassLoader().getResourceAsStream("META-INF/metadata.properties")) {
+    private static VersionInfo getVersionInfo() {
+        return fromResource("META-INF/metadata.properties");
+    }
+
+    private static VersionInfo getVersionInfo(String resourceName) {
+
+        try (var resource = Info.class.getClassLoader().getResourceAsStream(resourceName)) {
             if (resource != null) {
                 Properties properties = new Properties();
                 properties.load(resource);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes the operator build metadata reported at startup and in the `kroxylicious_operator_build_info` metric.

Previously the operator used the default `VersionInfo.VERSION_INFO`, which loads `META-INF/metadata.properties`. That resource can come from the runtime/proxy artifact when both artifacts are present on the classpath, so the operator could report the runtime artifact's version and commit instead of its own.

The operator now loads build metadata from an operator-specific resource:

`META-INF/kroxylicious/operator/metadata.properties`

This avoids relying on the generic runtime metadata resource and makes the source of the operator build information explicit.

The PR also updates `VersionInfo` so callers can load version information from a specific classpath resource via `VersionInfo.fromResource(String)`. The existing default behaviour is preserved for the runtime metadata resource.

**Tests added**:
- Verify that `OperatorMain.versionInfo()` returns the operator metadata even when generic runtime metadata is also present on the test classpath.
- Verify that the operator metadata resource is packaged into target/classes and that Maven placeholders such as `${project.version}` and `${git.commit.id}` have been resolved.

Fixes #4258 


### Additional Context

I chose `META-INF/kroxylicious/operator/metadata.properties` rather than another generic` META-INF/metadata.properties` location because the latter is already used by the runtime artifact. I did not find an existing project convention for artifact-specific metadata under `META-INF`, so I used a namespaced path that should leave room for other modules to add their own metadata resources later without colliding.

One of the regression tests checks the generated file under target/classes. This is slightly more coupled to the Maven output layout than a pure unit test, but I included it intentionally because the bug depends not only on the Java lookup code but also on the metadata resource actually being packaged and filtered correctly.

### Follow-up note
While looking at this, I also noticed that VersionInfo is used by `KafkaProxy.java` and the `Kroxylicious.java` entrypoint. `KafkaProxy.java` appears to live with the runtime/proxy code, so the default runtime metadata seems appropriate there. `Kroxylicious.java` is in `kroxylicious-app`, so it may be worth checking separately whether it should report app artifact metadata or proxy/runtime metadata. I left that unchanged because this PR is scoped to the operator metadata bug.


### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

### AI assistance disclosure

AI tools were used to help understand the existing metadata-loading flow, discuss possible refactoring options, and review the wording and structure of this PR. The final code changes and tests were implemented, reviewed, and validated by me.