### PR TITLE
fix(record-validation): remove deprecated WireFormatVersion.V2

### DIFF
--- a/kroxylicious-docs/docs/_modules/record-validation/proc-configuring-record-validation-filter.adoc
+++ b/kroxylicious-docs/docs/_modules/record-validation/proc-configuring-record-validation-filter.adoc
@@ -84,10 +84,8 @@ allowEmpty: true
 ** `storeFile` path to the truststore file that contains the trust anchors used to validate the server connection.
 ** `storePassword` (Optional) password used to protect the truststore.
 ** `storeType` truststore type. Supported values include `PKCS12`, `JKS`, and `PEM`.
-* `wireFormatVersion` controls whether the Apicurio client operates in `V3` (default) or `V2` (deprecated).
+* `wireFormatVersion` controls whether the Apicurio client operates in `V3` (default).
    In `V3` mode, the `apicurioId` property identifies schema by content ID, and the filter expects the Kafka producer to use content IDs to identify schema.
-   In `V2` mode, the `apicurioId` property identifies schema by global ID, and the filter expects the Kafka producer to use global IDs to identify schema.
-   `V2` mode exists only for compatibility with older Apicurio configurations and is deprecated. For new applications, use `V3`.
 * `allowNulls` specifies whether the validator allows record keys or values to be `null`. The default is `false`.
 * `allowEmpty` specifies whether the validator allows record keys or values to be empty. The default is `false`.
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/config/SchemaValidationConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/config/SchemaValidationConfig.java
@@ -50,20 +50,10 @@ public record SchemaValidationConfig(URL apicurioRegistryUrl,
     }
 
     /**
-     * Wire format versions for Apicurio Registry schema identifiers.
-     * <p>
+     * Wire format version for Apicurio Registry schema identifiers.
      * V3 uses 4-byte content IDs (Confluent-compatible format) and is the default.
-     * V2 uses 8-byte global IDs and is deprecated.
-     * </p>
      */
     public enum WireFormatVersion {
-        /**
-         * Apicurio Registry v2 wire format using 8-byte global IDs.
-         * @deprecated Use {@link #V3} instead for Confluent compatibility. This option will be removed in a future release.
-         */
-        @Deprecated(since = "0.19.0", forRemoval = true)
-        V2,
-
         /**
          * Apicurio Registry v3 wire format using 4-byte content IDs (Confluent-compatible).
          * This is the recommended and default format.

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AbstractSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AbstractSchemaBytebufValidator.java
@@ -18,7 +18,6 @@ import org.apache.kafka.common.record.Record;
 import io.apicurio.registry.serde.BaseSerde;
 import io.apicurio.registry.serde.Default4ByteIdHandler;
 import io.apicurio.registry.serde.IdHandler;
-import io.apicurio.registry.serde.Legacy8ByteIdHandler;
 import io.apicurio.registry.serde.kafka.headers.DefaultHeadersHandler;
 import io.apicurio.registry.serde.kafka.headers.HeadersHandler;
 
@@ -98,7 +97,6 @@ abstract class AbstractSchemaBytebufValidator implements BytebufValidator {
         // default: no extra bytes to skip
     }
 
-    @SuppressWarnings("removal")
     private Optional<Long> extractSchemaIdFromRecord(ByteBuffer buffer, Record kafkaRecord, boolean isKey) {
         // Try headers first
         var headerId = extractSchemaIdFromHeaders(kafkaRecord, isKey);
@@ -112,26 +110,17 @@ abstract class AbstractSchemaBytebufValidator implements BytebufValidator {
         if (buffer.remaining() > minBytes && buffer.get(buffer.position()) == BaseSerde.MAGIC_BYTE) {
             buffer.get(); // ignore magic
             var ref = idHandler.readId(buffer);
-            Long id = switch (wireFormatVersion) {
-                case V2 -> ref.getGlobalId();
-                case V3 -> ref.getContentId();
-            };
-            return Optional.ofNullable(id);
+            return Optional.ofNullable(ref.getContentId());
         }
         return Optional.empty();
     }
 
-    @SuppressWarnings("removal")
     private Optional<Long> extractSchemaIdFromHeaders(Record kafkaRecord, boolean isKey) {
         if (kafkaRecord.headers().length > 0) {
             var recordHeaders = new RecordHeaders(kafkaRecord.headers());
             var headerHandler = isKey ? keyHeaderHandler : valueHeaderHandler;
             var ref = headerHandler.readHeaders(recordHeaders);
-
-            Long id = switch (wireFormatVersion) {
-                case V2 -> ref.getGlobalId();
-                case V3 -> ref.getContentId();
-            };
+            Long id = ref.getContentId();
             if (id != null) {
                 return Optional.of(id);
             }
@@ -145,12 +134,8 @@ abstract class AbstractSchemaBytebufValidator implements BytebufValidator {
         return handler;
     }
 
-    @SuppressWarnings("removal")
     private static IdHandler buildIdHandler(boolean isKey, WireFormatVersion wireFormatVersion) {
-        IdHandler handler = switch (wireFormatVersion) {
-            case V2 -> new Legacy8ByteIdHandler();
-            case V3 -> new Default4ByteIdHandler();
-        };
+        var handler = new Default4ByteIdHandler();
         handler.configure(Map.of(), isKey);
         return handler;
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/BytebufValidators.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/BytebufValidators.java
@@ -59,7 +59,7 @@ public class BytebufValidators {
      * get validator that validates if a non-null/non-empty buffer contains data that matches a JSONSchema registered in the Schema Registry
      * @param schemaResolverConfig schema resolver configuration
      * @param contentId content ID to validate against
-     * @param wireFormatVersion wire format version (V2 or V3)
+     * @param wireFormatVersion wire format version (V3)
      * @return validator
      */
     public static BytebufValidator jsonSchemaValidator(Map<String, Object> schemaResolverConfig, Long contentId, WireFormatVersion wireFormatVersion) {
@@ -70,7 +70,7 @@ public class BytebufValidators {
      * get validator that validates if a non-null/non-empty buffer contains data that matches an Avro schema registered in the Schema Registry
      * @param schemaResolverConfig schema resolver configuration
      * @param contentId content ID to validate against
-     * @param wireFormatVersion wire format version (V2 or V3)
+     * @param wireFormatVersion wire format version (V3)
      * @return validator
      */
     public static BytebufValidator avroSchemaValidator(Map<String, Object> schemaResolverConfig, Long contentId, WireFormatVersion wireFormatVersion) {
@@ -81,7 +81,7 @@ public class BytebufValidators {
      * get validator that validates if a non-null/non-empty buffer contains data that matches a Protobuf schema registered in the Schema Registry
      * @param schemaResolverConfig schema resolver configuration
      * @param contentId content ID to validate against
-     * @param wireFormatVersion wire format version (V2 or V3)
+     * @param wireFormatVersion wire format version (V3)
      * @return validator
      */
     public static BytebufValidator protobufSchemaValidator(Map<String, Object> schemaResolverConfig, Long contentId, WireFormatVersion wireFormatVersion) {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/bytebuf/JsonSchemaBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/bytebuf/JsonSchemaBytebufValidatorTest.java
@@ -252,60 +252,6 @@ class JsonSchemaBytebufValidatorTest {
     }
 
     @Test
-    @SuppressWarnings("removal")
-    void v2WireFormatUsesLegacy8ByteIdHandler() {
-        // V2 wire format uses 8-byte global IDs
-        var value = asV2SchemaIdPrefixBuf(CONTENT_ID, VALID_JSON);
-        Record record = record(RECORD_KEY, value);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V2);
-        var future = validator.validate(record.value(), record, false);
-        assertThat(future)
-                .succeedsWithin(Duration.ofSeconds(1))
-                .returns(true, Result::valid);
-    }
-
-    @Test
-    @SuppressWarnings("removal")
-    void v2ValueWithCorrectGlobalIdInHeaderPassesValidation() {
-        // V2 mode should read globalId from headers (not contentId)
-        Header[] headers = new Header[]{ new RecordHeader(KafkaSerdeHeaders.HEADER_VALUE_GLOBAL_ID, toByteArray(CONTENT_ID)) };
-        Record record = record(RECORD_KEY, VALID_JSON, headers);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V2);
-        var future = validator.validate(record.value(), record, false);
-        assertThat(future)
-                .succeedsWithin(Duration.ofSeconds(1))
-                .returns(true, Result::valid);
-    }
-
-    @Test
-    @SuppressWarnings("removal")
-    void v2ValueWithWrongGlobalIdInHeaderRejected() {
-        // V2 mode should reject wrong globalId in headers
-        Header[] headers = new Header[]{ new RecordHeader(KafkaSerdeHeaders.HEADER_VALUE_GLOBAL_ID, toByteArray(CONTENT_ID + 1)) };
-        Record record = record(RECORD_KEY, VALID_JSON, headers);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V2);
-        var future = validator.validate(record.value(), record, false);
-        assertThat(future)
-                .succeedsWithin(Duration.ofSeconds(1))
-                .isEqualTo(new Result(false, "Unexpected schema id in record (2), expecting 1"));
-    }
-
-    @Test
-    @SuppressWarnings("removal")
-    void v2ValueWithContentIdInHeaderFallsBackToMagicByte() {
-        // V2 mode should ignore contentId header (only reads globalId)
-        // If contentId header is present but no globalId, it should fall back to magic byte detection
-        Header[] headers = new Header[]{ new RecordHeader(KafkaSerdeHeaders.HEADER_VALUE_CONTENT_ID, toByteArray(CONTENT_ID)) };
-        var value = asV2SchemaIdPrefixBuf(CONTENT_ID, VALID_JSON);
-        Record record = record(RECORD_KEY, value, headers);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V2);
-        var future = validator.validate(record.value(), record, false);
-        assertThat(future)
-                .succeedsWithin(Duration.ofSeconds(1))
-                .returns(true, Result::valid);
-    }
-
-    @Test
     void v3WireFormatUsesDefault4ByteIdHandler() {
         // V3 wire format uses 4-byte content IDs (Confluent-compatible)
         var value = asV3SchemaIdPrefixBuf(CONTENT_ID, VALID_JSON);
@@ -315,32 +261,6 @@ class JsonSchemaBytebufValidatorTest {
         assertThat(future)
                 .succeedsWithin(Duration.ofSeconds(1))
                 .returns(true, Result::valid);
-    }
-
-    @Test
-    @SuppressWarnings("removal")
-    void v2ValidatorRejectsV3WireFormat() {
-        // V2 validator should reject V3 format (4-byte content ID)
-        var value = asV3SchemaIdPrefixBuf(CONTENT_ID, VALID_JSON);
-        Record record = record(RECORD_KEY, value);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V2);
-        var future = validator.validate(record.value(), record, false);
-        assertThat(future)
-                .succeedsWithin(Duration.ofSeconds(1))
-                .returns(false, Result::valid);
-    }
-
-    @Test
-    @SuppressWarnings("removal")
-    void v3ValidatorRejectsV2WireFormat() {
-        // V3 validator should reject V2 format (8-byte global ID)
-        var value = asV2SchemaIdPrefixBuf(CONTENT_ID, VALID_JSON);
-        Record record = record(RECORD_KEY, value);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
-        var future = validator.validate(record.value(), record, false);
-        assertThat(future)
-                .succeedsWithin(Duration.ofSeconds(1))
-                .returns(false, Result::valid);
     }
 
     private byte[] toByteArray(long contentId) {
@@ -364,12 +284,4 @@ class JsonSchemaBytebufValidatorTest {
         return buf.array();
     }
 
-    private byte[] asV2SchemaIdPrefixBuf(long contentId, byte[] content) {
-        // V2 wire format: 1 byte magic + 8 bytes global ID
-        ByteBuffer buf = ByteBuffer.allocate(1 /* magic */ + Long.BYTES /* global id */ + content.length);
-        buf.put(BaseSerde.MAGIC_BYTE);
-        buf.putLong(contentId);
-        buf.put(content);
-        return buf.array();
-    }
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/JsonSchemaRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/JsonSchemaRecordValidationIT.java
@@ -342,47 +342,6 @@ class JsonSchemaRecordValidationIT extends RecordSchemaValidationBaseIT {
     }
 
     @Test
-    void v2WireFormatValidationWorks(KafkaCluster cluster, Topic topic) {
-        // Configure V2 wire format (8-byte global IDs) - deprecated but should still work
-        var config = createContentIdRecordValidationConfigWithWireFormat(cluster, topic, "valueRule", firstContentId, "V2");
-
-        var keySerde = new Serdes.StringSerde();
-        // Create a V2-compatible producer (8-byte IDs)
-        var producerValueSerde = createJsonSchemaProducerSerdeV2(false);
-        var consumerValueSerde = createJsonSchemaConsumerSerdeV2(false);
-
-        try (var tester = kroxyliciousTester(config);
-                var producer = tester.producer(keySerde, producerValueSerde, Map.of());
-                var consumer = consumeFromEarliestOffsets(tester, keySerde, consumerValueSerde)) {
-            // Should accept valid data with V2 wire format
-            assertThat(producer.send(new ProducerRecord<>(topic.name(), "my-key", PERSON_BEAN)))
-                    .succeedsWithin(Duration.ofSeconds(10));
-            consumer.subscribe(Set.of(topic.name()));
-
-            var records = consumer.poll(Duration.ofSeconds(10));
-            assertSingleRecordInTopicHasProperty(records, topic, ConsumerRecord::value, OBJECT_MAPPER.valueToTree(PERSON_BEAN));
-        }
-    }
-
-    @Test
-    void v3ValidatorRejectsV2WireFormatData(KafkaCluster cluster, Topic topic) {
-        // Configure V3 wire format validator
-        var config = createContentIdRecordValidationConfigWithWireFormat(cluster, topic, "valueRule", firstContentId, "V3");
-
-        var keySerde = new Serdes.StringSerde();
-        // Produce data with V2 wire format (8-byte IDs)
-        var producerValueSerde = createJsonSchemaProducerSerdeV2(false);
-
-        try (var tester = kroxyliciousTester(config);
-                var producer = tester.producer(keySerde, producerValueSerde, Map.of())) {
-            // V3 validator should reject V2 format data
-            var future = producer.send(new ProducerRecord<>(topic.name(), "my-key", PERSON_BEAN));
-            // The validator should fail the produce request - wire format mismatch
-            assertThatFutureFails(future, InvalidRecordException.class, "");
-        }
-    }
-
-    @Test
     void defaultWireFormatIsV3(KafkaCluster cluster, Topic topic) {
         // When wireFormatVersion is not specified, it should default to V3
         var config = createContentIdRecordValidationConfig(cluster, topic, "valueRule", firstContentId);
@@ -426,30 +385,6 @@ class JsonSchemaRecordValidationIT extends RecordSchemaValidationBaseIT {
         return proxy(cluster)
                 .addToFilterDefinitions(namedFilterDefinition)
                 .addToDefaultFilters(namedFilterDefinition.name());
-    }
-
-    private static @NonNull JsonSchemaSerde<PersonBean> createJsonSchemaProducerSerdeV2(boolean schemaIdInHeader) {
-        // V2 wire format uses Legacy8ByteIdHandler
-        var producerSerde = new JsonSchemaSerde<PersonBean>();
-        producerSerde.configure(Map.of(
-                SerdeConfig.REGISTRY_URL, apicurioRegistryUrl,
-                SerdeConfig.EXPLICIT_ARTIFACT_ID, firstArtifactId,
-                SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
-                KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader,
-                SerdeConfig.ID_HANDLER, "io.apicurio.registry.serde.Legacy8ByteIdHandler"), false);
-        return producerSerde;
-    }
-
-    private static @NonNull JsonSchemaSerde<Object> createJsonSchemaConsumerSerdeV2(boolean schemaIdInHeader) {
-        // V2 wire format uses Legacy8ByteIdHandler
-        var consumerSerde = new JsonSchemaSerde<>();
-        consumerSerde.configure(Map.of(
-                SerdeConfig.EXPLICIT_ARTIFACT_ID, firstArtifactId,
-                SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
-                KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader,
-                SerdeConfig.REGISTRY_URL, apicurioRegistryUrl,
-                SerdeConfig.ID_HANDLER, "io.apicurio.registry.serde.Legacy8ByteIdHandler"), false);
-        return consumerSerde;
     }
 
     private static <T, S> org.apache.kafka.clients.consumer.Consumer<T, S> consumeFromEarliestOffsets(KroxyliciousTester tester, Serde<T> keySerde,


### PR DESCRIPTION
Remove the deprecated V2 wire format option from the record validation filter. The V3 wire format (4-byte content IDs, Confluent-compatible) is now the only supported format.

Closes #3785