### PR TITLE
fix(config): remove deprecated shutdownQuietPeriodSeconds field from NettySettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Format `<github issue/pr number>: <short description>`.
 * [#4196](https://github.com/kroxylicious/kroxylicious/pull/4196): build(deps): bump apicurio-schema-validation from 0.1.4 to 3.3.0, version aligning with the rest of the component.
 * [#933](https://github.com/kroxylicious/kroxylicious/issues/933): feat(pem-support): Support PEM format key material in the KMS integrations.
 * [#3970](https://github.com/kroxylicious/kroxylicious/issues/3970): feat(operator): allow `KafkaService.spec.strimziKafkaRef.namespace` to reference Strimzi `Kafka` clusters in watched namespaces other than the `KafkaService` namespace
+* [#3783](https://github.com/kroxylicious/kroxylicious/issues/3783): fix(config): remove deprecated `shutdownQuietPeriodSeconds` field from `NettySettings`. Use `shutdownQuietPeriod` with a Go-style duration string instead.
 
 ### Changes, deprecations and removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For changes that effect a public API, the [deprecation policy](./DEV_GUIDE.md#de
 Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
+
+* [#3783](https://github.com/kroxylicious/kroxylicious/issues/3783): fix(config): remove deprecated `shutdownQuietPeriodSeconds` field from `NettySettings`. Use `shutdownQuietPeriod` with a Go-style duration string instead.
+
 ## 0.23.0
 
 * [#4307](https://github.com/kroxylicious/kroxylicious/pull/4307): feat(routing): **Preview** — dynamic routing API. Implement `RouterFactory` to dispatch requests to multiple upstream clusters based on request content, with fan-out via `RouterContext.sendRequest()` and in-order response delivery. Wire routers into virtual clusters via the new top-level `routerDefinitions` configuration. Router and cluster definitions are hot-reload compatible ([#4242](https://github.com/kroxylicious/kroxylicious/pull/4242)). Enable with `KROXYLICIOUS_UNLOCK_ROUTING=true` (see Changes section below).
@@ -19,7 +22,6 @@ Format `<github issue/pr number>: <short description>`.
 * [#4196](https://github.com/kroxylicious/kroxylicious/pull/4196): build(deps): bump apicurio-schema-validation from 0.1.4 to 3.3.0, version aligning with the rest of the component.
 * [#933](https://github.com/kroxylicious/kroxylicious/issues/933): feat(pem-support): Support PEM format key material in the KMS integrations.
 * [#3970](https://github.com/kroxylicious/kroxylicious/issues/3970): feat(operator): allow `KafkaService.spec.strimziKafkaRef.namespace` to reference Strimzi `Kafka` clusters in watched namespaces other than the `KafkaService` namespace
-* [#3783](https://github.com/kroxylicious/kroxylicious/issues/3783): fix(config): remove deprecated `shutdownQuietPeriodSeconds` field from `NettySettings`. Use `shutdownQuietPeriod` with a Go-style duration string instead.
 
 ### Changes, deprecations and removals
 

--- a/kroxylicious-docs/docs/_modules/configuring/con-configuring-network-settings.adoc
+++ b/kroxylicious-docs/docs/_modules/configuring/con-configuring-network-settings.adoc
@@ -43,8 +43,4 @@ Units can be combined, for example `1m30s`.
 * The `workerThreadCount` setting allows tuning for high-concurrency deployments. Increasing this value can improve throughput when handling many simultaneous client connections.
 * The `shutdownQuietPeriod` and `shutdownTimeout` settings together control graceful shutdown behaviour. `shutdownQuietPeriod` should always be less than or equal to `shutdownTimeout`.
 
-[NOTE]
-====
-The `shutdownQuietPeriodSeconds` property (an integer number of seconds) is deprecated and will be removed in a future release.
-Use `shutdownQuietPeriod` with a Go-style duration string instead (for example, `shutdownQuietPeriod: 2s`).
-====
+

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/NettySettings.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/NettySettings.java
@@ -9,9 +9,6 @@ package io.kroxylicious.proxy.config;
 import java.time.Duration;
 import java.util.Optional;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -22,25 +19,14 @@ public record NettySettings(Optional<Integer> workerThreadCount,
                             Optional<Duration> authenticatedIdleTimeout,
                             Optional<Duration> unauthenticatedIdleTimeout) {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NettySettings.class);
-
-    /**
-     * Jackson factory that also accepts the deprecated {@code shutdownQuietPeriodSeconds}
-     * integer field, mapping it to {@code shutdownQuietPeriod} with a warning.
-     */
     @JsonCreator
     public static NettySettings fromJson(
                                          @JsonProperty("workerThreadCount") Optional<Integer> workerThreadCount,
                                          @JsonProperty("shutdownQuietPeriod") Optional<Duration> shutdownQuietPeriod,
                                          @JsonProperty("shutdownTimeout") Optional<Duration> shutdownTimeout,
                                          @JsonProperty("authenticatedIdleTimeout") Optional<Duration> authenticatedIdleTimeout,
-                                         @JsonProperty("unauthenticatedIdleTimeout") Optional<Duration> unauthenticatedIdleTimeout,
-                                         @Deprecated(since = "0.20.0", forRemoval = true) @JsonProperty("shutdownQuietPeriodSeconds") Optional<Integer> shutdownQuietPeriodSeconds) {
-        var resolvedQuietPeriod = shutdownQuietPeriod.or(() -> shutdownQuietPeriodSeconds.map(seconds -> {
-            LOGGER.atWarn().log("ShutdownQuietPeriodSeconds is deprecated, use shutdownQuietPeriod (Go-style duration e.g. \"2s\") instead");
-            return Duration.ofSeconds(seconds);
-        }));
-        return new NettySettings(workerThreadCount, resolvedQuietPeriod, shutdownTimeout, authenticatedIdleTimeout, unauthenticatedIdleTimeout);
+                                         @JsonProperty("unauthenticatedIdleTimeout") Optional<Duration> unauthenticatedIdleTimeout) {
+        return new NettySettings(workerThreadCount, shutdownQuietPeriod, shutdownTimeout, authenticatedIdleTimeout, unauthenticatedIdleTimeout);
     }
 
     public NettySettings {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTransportTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTransportTest.java
@@ -173,33 +173,6 @@ class KafkaProxyTransportTest {
     }
 
     @Test
-    void build_shouldFallBackToDeprecatedShutdownQuietPeriodSeconds_whenShutdownQuietPeriodNotSet() {
-        var config = new ConfigParser().parseConfiguration(MINIMUM_VIABLE_CONFIG_YAML + """
-                network:
-                  proxy:
-                    shutdownQuietPeriodSeconds: 7
-                """);
-        try (var mockGroupConstructor = Mockito.mockConstruction(MultiThreadIoEventLoopGroup.class)) {
-            var eventGroupConfig = KafkaProxy.EventGroupConfig.build("test", config, NetworkDefinition::proxy, false);
-            assertThat(eventGroupConfig.shutdownQuietPeriod()).isEqualTo(Duration.ofSeconds(7));
-        }
-    }
-
-    @Test
-    void build_shouldPreferShutdownQuietPeriod_overDeprecatedShutdownQuietPeriodSeconds() {
-        var config = new ConfigParser().parseConfiguration(MINIMUM_VIABLE_CONFIG_YAML + """
-                network:
-                  proxy:
-                    shutdownQuietPeriodSeconds: 7
-                    shutdownQuietPeriod: 500ms
-                """);
-        try (var mockGroupConstructor = Mockito.mockConstruction(MultiThreadIoEventLoopGroup.class)) {
-            var eventGroupConfig = KafkaProxy.EventGroupConfig.build("test", config, NetworkDefinition::proxy, false);
-            assertThat(eventGroupConfig.shutdownQuietPeriod()).isEqualTo(Duration.ofMillis(500));
-        }
-    }
-
-    @Test
     @SuppressWarnings("unchecked")
     void shutdownGracefully_shouldCallNettyWithStoredDurationsAsNanos() {
         var future = Mockito.mock(io.netty.util.concurrent.Future.class);


### PR DESCRIPTION
Remove the deprecated `shutdownQuietPeriodSeconds` field from `NettySettings`. The `shutdownQuietPeriod` field (Go-style duration) is now the sole way to configure the shutdown quiet period.

Closes #3783