### PR TITLE
fix(ci): correct file paths in Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -75,7 +75,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultTestKmsFacade.java/",
+        "/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/VaultTestKmsFacade.java/",
         "/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/TestVault.java/",
         "/kroxylicious-systemtests/src/main/resources/helm_vault_overrides.yaml/",
         "/performance-tests/perf-tests.sh/",
@@ -91,7 +91,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/src/main/java/io/kroxylicious/kms/provider/azure/kms/AzureKeyVaultKmsTestKmsFacade.java/",
+        "/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/src/main/java/io/kroxylicious/testing/kms/azure/AzureKeyVaultKmsTestKmsFacade.java/",
         "/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/keyvault/KeyVaultClientIT.java/",
         "/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/azure/LowkeyVault.java/"
       ],
@@ -114,9 +114,9 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms-test-support/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTestKmsFacade.java/",
+        "/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms-test-support/src/main/java/io/kroxylicious/testing/kms/aws/AwsKmsTestKmsFacade.java/",
         "/kroxylicious-systemtests/src/main/resources/helm_localstack_overrides.yaml/",
-        "/kroxylicious-docs/docs/record-encryption-quickstart/index.adoc/"
+        "/kroxylicious-docs/docs/record-encryption-quick-start/index.adoc/"
       ],
       "matchStrings": [
         "(?<depName>localstack/localstack):(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>sha256:[a-f0-9]{64})",
@@ -130,7 +130,7 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/BaseOauthBearerIT.java/",
-        "/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/src/main/java/io/kroxylicious/kms/provider/azure/kms/OauthServerContainer.java/",
+        "/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/src/main/java/io/kroxylicious/testing/kms/azure/OauthServerContainer.java/",
         "/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/azure/MockOauthServer.java/"
       ],
       "matchStrings": [


### PR DESCRIPTION
## Impact

A couple of package/file renames made recently weren't reflected in the renovate config.  The impact is that some test containers haven't been upgraded.  

This showed itself in #4303 (**Azure SDK upgrade from 4.10.6 to 4.11.1**) where the PR updating the Azure SDK  failed because the Low Key Vault test container had slipped behind, and was incompatible with the newer SDK. 

## Summary

Fixes incorrect file paths in Renovate's custom regex managers that were preventing automatic Docker image updates for KMS test facade files.

## Root Cause

The KMS test facade files were refactored from:
- `io/kroxylicious/kms/provider/{provider}/kms/`

To:
- `io/kroxylicious/testing/kms/{provider}/`

But the Renovate configuration in `.github/renovate.json` was never updated to reflect this change.

## Files Affected by Path Errors

Renovate has been silently skipping these files when checking for Docker image updates:
- **HashiCorp Vault** - `VaultTestKmsFacade.java`
- **Azure Key Vault** - `AzureKeyVaultKmsTestKmsFacade.java` ⬅️ **Causing test failure in #4303**
- **AWS KMS** - `AwsKmsTestKmsFacade.java`
- **Mock OAuth2** - `OauthServerContainer.java`
- **LocalStack docs** - `index.adoc` (also had typo: `quickstart` vs `quick-start`)

## Changes

Updated 5 file path patterns in `.github/renovate.json`:
1. Line 78 - HashiCorp Vault test facade
2. Line 94 - Azure Key Vault test facade 
3. Line 117 - AWS KMS test facade
4. Line 119 - LocalStack quickstart doc (typo fix)
5. Line 133 - Mock OAuth2 container

## Testing

- [x] Verified all corrected paths exist on disk
- [x] Confirmed Renovate will now track these files for Docker image updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)