### PR TITLE
fix(docs): use curl to download Strimzi manifest to avoid rate limits

### DIFF
--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -68,6 +68,16 @@ jobs:
           KROXYLICIOUS_VERSION="$(mvn --quiet org.apache.maven.plugins:maven-help-plugin:3.5.1:evaluate -Dexpression=project.version -DforceStdout)"
           minikube image ls | grep --fixed-strings ${KROXYLICIOUS_PROXY_IMAGE}
           minikube image ls | grep --fixed-strings ${KROXYLICIOUS_OPERATOR_IMAGE}
+      - name: 'Configure curl for GitHub authentication'
+        # Some quickstarts use curl to download artifacts from GitHub (e.g. Strimzi manifests).
+        # Without authentication, GitHub's unauthenticated rate limit (60 req/hour per IP) can be
+        # exceeded by CI runners. With authentication via ~/.curlrc, the limit increases to 5000 req/hour.
+        run: |
+          cat > ~/.curlrc << 'EOF'
+          --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
+          EOF
+          echo "Configured curl to use GitHub authentication"
+          curl -s -H "X-GitHub-Api-Version: 2026-03-10" https://api.github.com/rate_limit | jq -r '.resources.core | "GitHub API rate limit: \(.remaining)/\(.limit) remaining"'
       - name: 'Run documentation tests'
         run: |
           mvn -Djapicmp.skip=true -DskipUTs=true -DskipITs=true -DskipKTs=true -DskipDTs=false --batch-mode verify --activate-profiles dist --projects ':kroxylicious-docs-tests' --also-make

--- a/.github/workflows/test-curl-auth.yml
+++ b/.github/workflows/test-curl-auth.yml
@@ -1,0 +1,53 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+name: Test Curl Authentication
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test_curl_auth:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 'Configure curl for GitHub authentication'
+        run: |
+          cat > ~/.curlrc << 'EOF'
+          --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
+          EOF
+          echo "Created ~/.curlrc"
+          cat ~/.curlrc
+
+      - name: 'Test curl with authentication (verbose)'
+        run: |
+          echo "=== Testing curl with verbose output ==="
+          curl -v -o kafka-single-node.yaml https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/refs/tags/0.51.0/examples/kafka/kafka-single-node.yaml
+          echo ""
+          echo "=== Download result ==="
+          if [ -f kafka-single-node.yaml ]; then
+            echo "File downloaded successfully"
+            wc -l kafka-single-node.yaml
+            head -5 kafka-single-node.yaml
+          else
+            echo "File download failed"
+            exit 1
+          fi
+
+      - name: 'Check rate limit status'
+        run: |
+          echo "=== Checking GitHub rate limit ==="
+          curl -v -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit

--- a/.github/workflows/test-curl-auth.yml
+++ b/.github/workflows/test-curl-auth.yml
@@ -49,5 +49,5 @@ jobs:
 
       - name: 'Check rate limit status'
         run: |
-          echo "=== Checking GitHub rate limit ==="
-          curl -v -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit
+          echo "=== Checking GitHub rate limit (with authentication from ~/.curlrc) ==="
+          curl -v -H "X-GitHub-Api-Version: 2026-03-10" https://api.github.com/rate_limit

--- a/kroxylicious-docs/docs/record-encryption-quick-start/index.adoc
+++ b/kroxylicious-docs/docs/record-encryption-quick-start/index.adoc
@@ -162,7 +162,8 @@ It will create a cluster in the `kafka` namespace.
 
 [source,terminal,subs="attributes"]
 ----
-$ kubectl apply -n kafka -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/refs/tags/{strimzi-version}/examples/kafka/kafka-single-node.yaml
+$ curl -o kafka-single-node.yaml https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/refs/tags/{strimzi-version}/examples/kafka/kafka-single-node.yaml
+$ kubectl apply -n kafka -f kafka-single-node.yaml
 $ kubectl wait -n kafka kafka/my-cluster --for=condition=Ready --timeout=300s
 ----
 
@@ -304,7 +305,7 @@ To clean up, remove the proxy and the kafka cluster
 [source,terminal,subs="attributes"]
 ----
 $ kubectl delete -f examples/record-encryption/
-$ kubectl delete -n kafka -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/refs/tags/{strimzi-version}/examples/kafka/kafka-single-node.yaml
+$ kubectl delete -n kafka -f kafka-single-node.yaml
 ----
 
 Remove the Kroxylicious and Strimzi Operator.


### PR DESCRIPTION
## Summary

Fixes the non-deterministic failure in QuickStartDT by updating the record encryption quickstart to use `curl` to download the Strimzi kafka-single-node.yaml manifest before applying it with kubectl.

## Problem

The test was failing intermittently in CI with:
```
error: unable to read URL "https://raw.githubusercontent.com/...", server reported 429 Too Many Requests
```

This occurred because `kubectl apply -f <url>` downloads manifests without authentication, hitting GitHub's unauthenticated rate limit (60 requests/hour per IP). Shared CI runners frequently exceed this limit.

## Solution

1. **Quickstart documentation**: Changed from direct `kubectl apply -f <url>` to:
   ```bash
   curl -o kafka-single-node.yaml https://raw.githubusercontent.com/...
   kubectl apply -f kafka-single-node.yaml
   ```

2. **CI workflow**: Configure `~/.curlrc` to pass GitHub authentication tokens for curl commands. This increases the rate limit from 60 to 5000 requests/hour.

## Benefits

- **For users**: Keeps the quickstart simple and linear (one extra curl command)
- **For CI**: Resilient to rate limits using GitHub Actions' built-in `GITHUB_TOKEN`
- **Maintainability**: No vendored files to keep updated

## Testing

Created test workflow to verify curl authentication works correctly:
- Authorization header is sent from `~/.curlrc`
- GitHub recognizes token and grants 5000 req/hour limit
- Downloads succeed from `raw.githubusercontent.com`

Fixes #4316