### PR TITLE
fix(docs): cache Strimzi manifest to avoid GitHub API rate limits in doc tests

### DIFF
--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -68,7 +68,29 @@ jobs:
           KROXYLICIOUS_VERSION="$(mvn --quiet org.apache.maven.plugins:maven-help-plugin:3.5.1:evaluate -Dexpression=project.version -DforceStdout)"
           minikube image ls | grep --fixed-strings ${KROXYLICIOUS_PROXY_IMAGE}
           minikube image ls | grep --fixed-strings ${KROXYLICIOUS_OPERATOR_IMAGE}
+      - name: 'Extract Strimzi version'
+        id: strimzi
+        run: |
+          STRIMZI_VERSION=$(grep -m1 '^:strimzi-version:' kroxylicious-docs/docs/record-encryption-quick-start/index.adoc | awk '{print $2}')
+          echo "version=${STRIMZI_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Strimzi version: ${STRIMZI_VERSION}"
+      - name: 'Cache Strimzi manifest'
+        id: strimzi-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /tmp/strimzi-manifest
+          key: strimzi-manifest-${{ steps.strimzi.outputs.version }}
+      - name: 'Download Strimzi manifest'
+        if: steps.strimzi-cache.outputs.cache-hit != 'true'
+        run: |
+          curl --fail --silent --show-error \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -o /tmp/strimzi-manifest/kafka-single-node.yaml \
+            --create-dirs \
+            "https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/refs/tags/${{ steps.strimzi.outputs.version }}/examples/kafka/kafka-single-node.yaml"
       - name: 'Run documentation tests'
+        env:
+          STRIMZI_MANIFEST: /tmp/strimzi-manifest/kafka-single-node.yaml
         run: |
           mvn -Djapicmp.skip=true -DskipUTs=true -DskipITs=true -DskipKTs=true -DskipDTs=false --batch-mode verify --activate-profiles dist --projects ':kroxylicious-docs-tests' --also-make
       - name: Slack Notification on Failure

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -82,12 +82,15 @@ jobs:
           key: strimzi-manifest-${{ steps.strimzi.outputs.version }}
       - name: 'Download Strimzi manifest'
         if: steps.strimzi-cache.outputs.cache-hit != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STRIMZI_VERSION: ${{ steps.strimzi.outputs.version }}
         run: |
           curl --fail --silent --show-error \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             -o /tmp/strimzi-manifest/kafka-single-node.yaml \
             --create-dirs \
-            "https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/refs/tags/${{ steps.strimzi.outputs.version }}/examples/kafka/kafka-single-node.yaml"
+            "https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/refs/tags/${STRIMZI_VERSION}/examples/kafka/kafka-single-node.yaml"
       - name: 'Run documentation tests'
         env:
           STRIMZI_MANIFEST: /tmp/strimzi-manifest/kafka-single-node.yaml

--- a/kroxylicious-docs/docs/record-encryption-quick-start/index.adoc
+++ b/kroxylicious-docs/docs/record-encryption-quick-start/index.adoc
@@ -160,6 +160,8 @@ This is the Kafka Cluster that will be proxied.
 We'll just use one from the Strimzi Quickstart.
 It will create a cluster in the `kafka` namespace.
 
+TIP: To use a local Strimzi manifest (for example, in air-gapped environments), set `STRIMZI_MANIFEST=/path/to/kafka-single-node.yaml` before running these commands.
+
 [source,terminal,subs="attributes"]
 ----
 $ kubectl apply -n kafka -f ${STRIMZI_MANIFEST:-https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/refs/tags/{strimzi-version}/examples/kafka/kafka-single-node.yaml}

--- a/kroxylicious-docs/docs/record-encryption-quick-start/index.adoc
+++ b/kroxylicious-docs/docs/record-encryption-quick-start/index.adoc
@@ -162,7 +162,7 @@ It will create a cluster in the `kafka` namespace.
 
 [source,terminal,subs="attributes"]
 ----
-$ kubectl apply -n kafka -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/refs/tags/{strimzi-version}/examples/kafka/kafka-single-node.yaml
+$ kubectl apply -n kafka -f ${STRIMZI_MANIFEST:-https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/refs/tags/{strimzi-version}/examples/kafka/kafka-single-node.yaml}
 $ kubectl wait -n kafka kafka/my-cluster --for=condition=Ready --timeout=300s
 ----
 
@@ -304,7 +304,7 @@ To clean up, remove the proxy and the kafka cluster
 [source,terminal,subs="attributes"]
 ----
 $ kubectl delete -f examples/record-encryption/
-$ kubectl delete -n kafka -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/refs/tags/{strimzi-version}/examples/kafka/kafka-single-node.yaml
+$ kubectl delete -n kafka -f ${STRIMZI_MANIFEST:-https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/refs/tags/{strimzi-version}/examples/kafka/kafka-single-node.yaml}
 ----
 
 Remove the Kroxylicious and Strimzi Operator.


### PR DESCRIPTION
## Summary

Alternative approach to #4335 for fixing #4316 (QuickStartDT failures from GitHub's 60 req/hour unauthenticated rate limit).

Instead of writing `GITHUB_TOKEN` into `~/.curlrc` (which leaks the credential to all curl invocations) and changing the user-facing docs to a two-step curl+kubectl flow, this PR:

- Uses bash parameter expansion `${STRIMZI_MANIFEST:-<default-url>}` in the quickstart commands, so users see the default URL inline and CI can override it
- Pre-downloads the manifest in CI with a scoped `-H "Authorization: Bearer ..."` curl invocation (credential confined to one request)
- Caches the downloaded manifest via `actions/cache`, keyed on the Strimzi version extracted from the doc
- Sets `STRIMZI_MANIFEST` on the Maven test step so the quickstart uses the cached local file

The docs remain honest (no silent URL substitution — the env var override is visible in the command), and air-gapped users get a documented way to point at a local manifest.

## Test plan

- [ ] CI documentation tests pass (quickstart uses cached manifest via `STRIMZI_MANIFEST` env var)
- [ ] Verify AsciiDoc renders correctly — `${STRIMZI_MANIFEST:-...}` syntax survives attribute substitution (verified locally during development)
- [ ] On second CI run with same Strimzi version, cache hit skips the download step

Relates-to: #4316

🤖 Generated with [Claude Code](https://claude.com/claude-code)