### PR TITLE
docs(quickstart): remove unnecessary SKIP_SETCAP from Vault helm command

### DIFF
--- a/kroxylicious-docs/docs/record-encryption-quick-start/index.adoc
+++ b/kroxylicious-docs/docs/record-encryption-quick-start/index.adoc
@@ -102,8 +102,7 @@ Note that Record Encryption requires the Transit Secrets Engine, which must be e
 [source,terminal,subs="attributes",kms="vault"]
 ----
 $ helm repo add --force-update hashicorp https://helm.releases.hashicorp.com
-# Note: SKIP_SETCAP=true is a workaround for Vault 2.x in rootless containers (SETFCAP capability unavailable). Acceptable for development/testing.
-$ helm upgrade --install vault hashicorp/vault --namespace kms --create-namespace --version {vault-chart-version} --set server.dev.enabled=true,server.dev.devRootToken=myroottoken,server.extraEnvironmentVars.SKIP_SETCAP=true --wait
+$ helm upgrade --install vault hashicorp/vault --namespace kms --create-namespace --version {vault-chart-version} --set server.dev.enabled=true,server.dev.devRootToken=myroottoken --wait
 ----
 
 And enable the Transit Secrets Engine.


### PR DESCRIPTION
## Summary

- Removes the `server.extraEnvironmentVars.SKIP_SETCAP=true` override from the quickstart Vault helm command
- The Vault Helm chart already sets [`SKIP_SETCAP=true` in its StatefulSet template](https://github.com/hashicorp/vault-helm/blob/main/templates/server-statefulset.yaml#L121), so passing it again via `extraEnvironmentVars` creates a duplicate env var entry which is rejected by Kubernetes

## Test plan

- [ ] Verify `helm upgrade --install vault hashicorp/vault --namespace kms --create-namespace --version 0.32.0 --set server.dev.enabled=true,server.dev.devRootToken=myroottoken --wait` succeeds without the `SKIP_SETCAP` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)