### PR TITLE
[v0.20.x] build(deps): upgrade Log4j to 2.25.5 to fix CVE-2026-49844

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* build(deps): Upgrade Log4j to 2.25.5 to fix CVE-2026-49844
 * [#4314](https://github.com/kroxylicious/kroxylicious/pull/4314): build(deps): Upgrade Jackson to 2.21.5 to fix CVE-2026-54515
 * [#4310](https://github.com/kroxylicious/kroxylicious/pull/4310): deps(apicurio): [0.20.x] bump Apicurio Registry from 3.1 to 3.2 to avoid CVEs in dependencies (and switch to JDK HTTP)
 * [#4111](https://github.com/kroxylicious/kroxylicious/pull/4111): build(deps): Upgrade to JOSDK 5.2.5 to avoids informer health check defect.
@@ -29,6 +30,7 @@ Format `<github issue/pr number>: <short description>`.
 * [CVE-2026-34478](https://nvd.nist.gov/vuln/detail/CVE-2026-34478) - CRLF Injection Vulnerability in Rfc5424Layout (fixed in 2.25.4) ([Apache Advisory](https://logging.apache.org/security.html))
 * [CVE-2026-34479](https://nvd.nist.gov/vuln/detail/CVE-2026-34479) - Log4j 1-to-Log4j 2 Bridge XML Sanitization Issue (fixed in 2.25.4) ([Apache Advisory](https://logging.apache.org/security.html))
 * [CVE-2026-34480](https://nvd.nist.gov/vuln/detail/CVE-2026-34480) - XML Layout Sanitization Issue (fixed in 2.25.4) ([Apache Advisory](https://logging.apache.org/security.html))
+* [CVE-2026-49844](https://nvd.nist.gov/vuln/detail/CVE-2026-49844) - Fixed in 2.25.5 ([Apache Advisory](https://logging.apache.org/security.html))
 
 #### Netty (io.netty)
 * [CVE-2026-44249](https://nvd.nist.gov/vuln/detail/CVE-2026-44249) - IPv6 subnet filter bypass in netty-handler (fixed in 4.2.15.Final) ([Netty Release](https://netty.io/news/2026/06/01/4-2-15-Final.html))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
-* build(deps): Upgrade Log4j to 2.25.5 to fix CVE-2026-49844
+* [#4350](https://github.com/kroxylicious/kroxylicious/pull/4350): build(deps): Upgrade Log4j to 2.25.5 to fix CVE-2026-49844
 * [#4314](https://github.com/kroxylicious/kroxylicious/pull/4314): build(deps): Upgrade Jackson to 2.21.5 to fix CVE-2026-54515
 * [#4310](https://github.com/kroxylicious/kroxylicious/pull/4310): deps(apicurio): [0.20.x] bump Apicurio Registry from 3.1 to 3.2 to avoid CVEs in dependencies (and switch to JDK HTTP)
 * [#4111](https://github.com/kroxylicious/kroxylicious/pull/4111): build(deps): Upgrade to JOSDK 5.2.5 to avoids informer health check defect.

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <junit.version>5.14.3</junit.version>
         <kafka.version>4.2.0</kafka.version>
         <kroxy.extension.version>0.15.0</kroxy.extension.version>
-        <log4j.version>2.25.4</log4j.version>
+        <log4j.version>2.25.5</log4j.version>
         <caffeine.version>3.2.3</caffeine.version>
         <picocli.version>4.7.7</picocli.version>
         <netty.version>4.2.15.Final</netty.version>
@@ -72,7 +72,7 @@
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <apicurio-schema-validation.version>0.1.3</apicurio-schema-validation.version>
         <apicurio-registry.version>3.2.6</apicurio-registry.version>
-        <kiota.version>0.0.34</kiota.version>
+        <kiota.version>0.0.36</kiota.version>
         <jose4j.version>0.9.6</jose4j.version>
 
         <!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <apicurio-schema-validation.version>0.1.3</apicurio-schema-validation.version>
         <apicurio-registry.version>3.2.6</apicurio-registry.version>
-        <kiota.version>0.0.36</kiota.version>
+        <kiota.version>0.0.34</kiota.version>
         <jose4j.version>0.9.6</jose4j.version>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
## Summary
- Bumps Log4j from 2.25.4 to 2.25.5 to fix CVE-2026-49844
- Adds CHANGELOG entry and CVE documentation

## Test plan
- [ ] CI passes with the updated dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)