### PR TITLE
fix(docs): remove redundant SKIP_SETCAP override from Vault helm install

### DIFF
--- a/kroxylicious-docs/docs/record-encryption-quick-start/index.adoc
+++ b/kroxylicious-docs/docs/record-encryption-quick-start/index.adoc
@@ -102,8 +102,7 @@ Note that Record Encryption requires the Transit Secrets Engine, which must be e
 [source,terminal,subs="attributes",kms="vault"]
 ----
 $ helm repo add --force-update hashicorp https://helm.releases.hashicorp.com
-# Note: SKIP_SETCAP=true is a workaround for Vault 2.x in rootless containers (SETFCAP capability unavailable). Acceptable for development/testing.
-$ helm upgrade --install vault hashicorp/vault --namespace kms --create-namespace --version {vault-chart-version} --set server.dev.enabled=true,server.dev.devRootToken=myroottoken,server.extraEnvironmentVars.SKIP_SETCAP=true --wait
+$ helm upgrade --install vault hashicorp/vault --namespace kms --create-namespace --version {vault-chart-version} --set server.dev.enabled=true,server.dev.devRootToken=myroottoken --wait
 ----
 
 And enable the Transit Secrets Engine.


### PR DESCRIPTION
## Summary

The Vault Helm chart at version 0.32.0 already sets `SKIP_SETCAP=true` in
the StatefulSet template. The `--set server.extraEnvironmentVars.SKIP_SETCAP=true`
added in #3797 creates a duplicate env var entry, which:

- Always emits a Kubernetes API warning: `hides previous definition of "SKIP_SETCAP", which may be dropped when using apply`
- Can intermittently cause server-side apply to reject the StatefulSet outright

The chart was already at 0.32.0 when the workaround was added, so this has
been redundant from the start.

## Test plan

- [ ] `helm template hashicorp/vault --version 0.32.0 --set server.dev.enabled=true,server.dev.devRootToken=myroottoken` produces exactly one `SKIP_SETCAP` entry (verified locally)
- [ ] CI documentation tests pass the Vault helm install step without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)