### PR TITLE
use min int for internal correlation id of out-of-band sendRequest

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/CorrelationIdSpace.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/CorrelationIdSpace.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+// A class that divides the correlation id space into ranges reserved for different internal purposes
+public class CorrelationIdSpace {
+
+    private CorrelationIdSpace() {
+
+    }
+
+    // use a correlation id outside the Routing range (Integer.MIN_VALUE/2, 0] to avoid collisions
+    public static final int RESERVED_OUT_OF_BAND_CORRELATION_ID = Integer.MIN_VALUE;
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -707,7 +707,7 @@ public class FilterHandler extends ChannelDuplexHandler {
 
             var apiKey = ApiKeys.forId(request.apiKey());
             header.setRequestApiKey(apiKey.id);
-            header.setCorrelationId(-1);
+            header.setCorrelationId(CorrelationIdSpace.RESERVED_OUT_OF_BAND_CORRELATION_ID);
 
             if (!apiKey.isVersionSupported(header.requestApiVersion())) {
                 throw new IllegalArgumentException(


### PR DESCRIPTION

### Type of change

- Refactoring

### Description

Our upcoming routing implementation uses the range (Int.MIN/2, 0] as a way to detect which messages have been dynamically dispatched, so messages arriving in the Router with a -1 correlationId causes ambiguity. We can awkwardly sidestep this by using a distinct negative correlation id for FilterContext sendRequest originated requests.

This will cover users of the FilterContext topicNames APIs as well as the EagerMetadataLearner, which sends Metadata requests to bootstrap endpoint bindings.

Relates to #4154
Tracked by #4158 

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
