### PR TITLE
fix(operator): [OpenShift] replace flaky route checksum test with AllReconcilersIT assertion

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -13,7 +13,9 @@ This document gives a detailed breakdown of the various build processes and opti
 
 > :warning: **If you are using Podman please see [these notes](#running-integration-tests-on-podman) below**
 
+If you are developing the **Kroxylicious Operator**, you'll need a Kubernetes environment. [minikube](https://minikube.sigs.k8s.io/docs/) is sufficient).
 
+A few optional operator features target OpenShift. If developing these features [Red Hat OpenShift Local](https://developers.redhat.com/products/openshift-local) is sufficient.
 
 ## Build
 

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
@@ -237,17 +237,14 @@ class AllReconcilersIT {
                     .withClusterIP(null)
                 .endSpec()
                 .build();
-        // @formatter:on
         var tlsCert = new SecretBuilder()
                 .withNewMetadata()
-                .withName("downstream-tls-certificate")
+                    .withName("downstream-tls-certificate")
                 .endMetadata()
                 .withType("kubernetes.io/tls")
                 .addToStringData("tls.crt", TestKeyMaterial.TEST_CERT_PEM)
                 .addToStringData("tls.key", TestKeyMaterial.TEST_KEY_PEM)
                 .build();
-
-        // @formatter:off
         var clusterIngress = new IngressesBuilder()
                 .withIngressRef(new IngressRefBuilder().withName(name(myIngress)).build())
                 .withNewTls()

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
@@ -41,6 +41,7 @@ import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.common.FilterRefBuilder;
+import io.kroxylicious.kubernetes.api.common.IngressRefBuilder;
 import io.kroxylicious.kubernetes.api.common.KafkaServiceRefBuilder;
 import io.kroxylicious.kubernetes.api.common.Protocol;
 import io.kroxylicious.kubernetes.api.common.ProxyRefBuilder;
@@ -77,6 +78,7 @@ import static io.kroxylicious.kubernetes.operator.ResourcesUtil.STRIMZI_CLUSTER_
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
@@ -216,6 +218,72 @@ class AllReconcilersIT {
                                 .extracting(Ingresses::getBootstrapServer, as(InstanceOfAssertFactories.STRING))
                                 .isNotEmpty()));
 
+    }
+
+    @Test
+    void downstreamOpenShiftRouteIngress() {
+        assumeThat(OpenShiftUtils.supportsRoute())
+                .withFailMessage("kubernetes server is missing support for resource kind Route").isTrue();
+
+        // Given
+        var domain = OpenShiftUtils.getDefaultIngressControllerDomain();
+        var myProxy = editableProxy(PROXY_A).build();
+        var myService = editableService(CLUSTER_FOO_SERVICE).build();
+        // @formatter:off
+        var myIngress = editableIngress(CLUSTER_FOO_CLUSTER_IP_INGRESS, myProxy)
+                .editOrNewSpec()
+                    .withNewOpenShiftRoute()
+                    .endOpenShiftRoute()
+                    .withClusterIP(null)
+                .endSpec()
+                .build();
+        // @formatter:on
+        var tlsCert = new SecretBuilder()
+                .withNewMetadata()
+                .withName("downstream-tls-certificate")
+                .endMetadata()
+                .withType("kubernetes.io/tls")
+                .addToStringData("tls.crt", TestKeyMaterial.TEST_CERT_PEM)
+                .addToStringData("tls.key", TestKeyMaterial.TEST_KEY_PEM)
+                .build();
+
+        // @formatter:off
+        var clusterIngress = new IngressesBuilder()
+                .withIngressRef(new IngressRefBuilder().withName(name(myIngress)).build())
+                .withNewTls()
+                    .withNewCertificateRef()
+                        .withName(name(tlsCert))
+                    .endCertificateRef()
+                .endTls()
+                .build();
+        var myCluster = new VirtualKafkaClusterBuilder()
+                .withNewMetadata()
+                    .withName(CLUSTER_FOO)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewProxyRef()
+                        .withName(name(myProxy))
+                    .endProxyRef()
+                    .withTargetKafkaServiceRef(new KafkaServiceRefBuilder().withName(name(myService)).build())
+                    .withIngresses(List.of(clusterIngress))
+                .endSpec()
+                .build();
+        // @formatter:on
+
+        // When
+        createAll(myProxy, myIngress, myService, tlsCert, myCluster);
+
+        // Then
+        assertResourceAttainsCondition(AllReconcilersIT::resourceAccepted, myCluster);
+        AWAIT.alias("cluster %s has route-based bootstrap server".formatted(CLUSTER_FOO))
+                .untilAsserted(() -> assertThat(clusterUser.get(VirtualKafkaCluster.class, CLUSTER_FOO))
+                        .isNotNull()
+                        .extracting(VirtualKafkaCluster::getStatus)
+                        .satisfies(vcs -> assertThat(vcs)
+                                .extracting(VirtualKafkaClusterStatus::getIngresses, as(InstanceOfAssertFactories.list(Ingresses.class)))
+                                .singleElement()
+                                .extracting(Ingresses::getBootstrapServer, as(InstanceOfAssertFactories.STRING))
+                                .endsWith("." + domain + ":443")));
     }
 
     static Stream<Arguments> upstreamTlsScenarios() {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OpenShiftUtils.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OpenShiftUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.operator.v1.IngressController;
+import io.fabric8.openshift.api.model.operator.v1.IngressControllerStatus;
+
+/**
+ * OpenShift platform utilities for operator integration tests.
+ */
+public final class OpenShiftUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenShiftUtils.class);
+    public static final String DEFAULT_INGRESS_CONTROLLER_DOMAIN = "apps.crc.testing";
+
+    private OpenShiftUtils() {
+    }
+
+    /**
+     * Returns {@code true} if the connected Kubernetes cluster supports the OpenShift {@link Route} resource kind.
+     */
+    public static boolean supportsRoute() {
+        try (var client = new KubernetesClientBuilder().build()) {
+            return client.supports(Route.class);
+        }
+    }
+
+    /**
+     * Gets the domain for the default OpenShift ingress controller.
+     * <p>
+     * Real OpenShift has the IngressController API and an instance called {@code default}
+     * in the {@code openshift-ingress-operator} namespace. MicroShift has the API but no
+     * instances or namespace. Minikube has neither. Falls back to
+     * {@link #DEFAULT_INGRESS_CONTROLLER_DOMAIN} when detection fails.
+     */
+    public static String getDefaultIngressControllerDomain() {
+        IngressController defaultIngressController;
+        try (var client = new KubernetesClientBuilder().build()) {
+            defaultIngressController = client.resources(IngressController.class)
+                    .inNamespace("openshift-ingress-operator").withName("default").get();
+        }
+
+        return Optional.ofNullable(defaultIngressController)
+                .map(IngressController::getStatus)
+                .map(IngressControllerStatus::getDomain)
+                .orElseGet(() -> {
+                    LOGGER.warn("Couldn't programmatically determine OpenShiftIngressController domain, using test default: {}", DEFAULT_INGRESS_CONTROLLER_DOMAIN);
+                    return DEFAULT_INGRESS_CONTROLLER_DOMAIN;
+                });
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OpenShiftUtils.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OpenShiftUtils.java
@@ -41,8 +41,9 @@ public final class OpenShiftUtils {
      * <p>
      * Real OpenShift has the IngressController API and an instance called {@code default}
      * in the {@code openshift-ingress-operator} namespace. MicroShift has the API but no
-     * instances or namespace. Minikube has neither. Falls back to
-     * {@link #DEFAULT_INGRESS_CONTROLLER_DOMAIN} when detection fails.
+     * instances or namespace. Minikube has neither. The Fabric8 {@code #get} API treats
+     * absence of resource/namespace/API in the same manner (all return {@code null}).
+     * Falls back to {@link #DEFAULT_INGRESS_CONTROLLER_DOMAIN} when detection fails.
      */
     public static String getDefaultIngressControllerDomain() {
         IngressController defaultIngressController;

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
@@ -57,9 +57,6 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.readiness.Readiness;
 import io.fabric8.openshift.api.model.Route;
-import io.fabric8.openshift.api.model.RouteBuilder;
-import io.fabric8.openshift.api.model.operator.v1.IngressController;
-import io.fabric8.openshift.api.model.operator.v1.IngressControllerStatus;
 
 import io.kroxylicious.kubernetes.api.common.CertificateRef;
 import io.kroxylicious.kubernetes.api.common.CertificateRefBuilder;
@@ -91,7 +88,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRanges;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRangesBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.Ingresses;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressesBuilder;
-import io.kroxylicious.kubernetes.operator.Annotations;
+import io.kroxylicious.kubernetes.operator.OpenShiftUtils;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.SecureConfigInterpolator;
 import io.kroxylicious.kubernetes.operator.TestKeyMaterial;
@@ -155,8 +152,6 @@ public class KafkaProxyReconcilerIT {
     public static final String TRUSTED_CAS_PEM = "trusted-cas.pem";
     public static final String PROTOCOL_TLS_V1_3 = "TLSv1.3";
     public static final String TLS_CIPHER_SUITE_AES256GCM_SHA384 = "TLS_AES_256_GCM_SHA384";
-    // Default ingress controller domain used if we can't detect it from the platform (CRC/MicroShift).
-    public static final String DEFAULT_INGRESS_CONTROLLER_DOMAIN = "apps.crc.testing";
 
     @RegisterExtension
     static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
@@ -905,10 +900,10 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void virtualClusterWithOpenshiftRouteIngress() {
-        assumeThat(supportsRoute()).withFailMessage("kubernetes server is missing support for resource kind Route").isTrue();
+        assumeThat(OpenShiftUtils.supportsRoute()).withFailMessage("kubernetes server is missing support for resource kind Route").isTrue();
 
         // Given
-        var domain = getDefaultOpenShiftIngressControllerDomain();
+        var domain = OpenShiftUtils.getDefaultIngressControllerDomain();
         KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
         KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
@@ -967,57 +962,6 @@ public class KafkaProxyReconcilerIT {
                 .sniHostIdentifiesNode()
                 .hasBootstrapAddress(new HostPort(routeBootstrap, proxyListenPort).toString())
                 .hasAdvertisedBrokerAddressPattern(new HostPort(routeBrokerAddressPattern, clientFacingPort).toString()));
-    }
-
-    @Test
-    void deploymentChecksumUpdatesWhenOpenshiftRouteHostAssigned() {
-        assumeThat(supportsRoute())
-                .withFailMessage("kubernetes server is missing support for resource kind Route").isTrue();
-
-        // Given
-        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
-        KafkaService kafkaService = updateStatusObservedGeneration(
-                clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
-
-        String ingressName = "openshiftroute";
-        KafkaProxyIngress openshiftRouteIngress = updateStatusObservedGeneration(
-                clusterUser.create(openshiftRouteIngress(ingressName, proxy)));
-
-        Secret tlsCert = clusterUser.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
-
-        Ingresses clusterIngress = new IngressesBuilder()
-                .withIngressRef(toIngressRef(openshiftRouteIngress))
-                .withNewTls().withCertificateRef(toCertificateRef(tlsCert)).endTls()
-                .build();
-        VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService,
-                List.of(clusterIngress), Optional.empty());
-        updateStatusObservedGeneration(clusterUser.create(cluster));
-
-        String bootstrapRouteName = name(cluster) + "-bootstrap";
-        AWAIT.alias("bootstrap route created").untilAsserted(() -> assertThat(clusterUser.get(Route.class, bootstrapRouteName)).isNotNull());
-
-        String initialChecksum = deploymentPodTemplateChecksum(proxy);
-
-        // When - OpenShift assigns a host to the bootstrap route
-        // Use updateStatus to re-fetch the latest resourceVersion, because the OpenShift
-        // ingress controller may have modified the Route since we last read it.
-        externalOperator.updateStatus(Route.class, bootstrapRouteName, route -> new RouteBuilder(route)
-                .withNewStatus()
-                .addNewIngress().withHost(bootstrapRouteName + ".apps-crc.testing").endIngress()
-                .endStatus()
-                .build());
-
-        // Then - deployment pod template checksum should change so the proxy is restarted
-        AWAIT.alias("deployment checksum updated after route host assignment")
-                .untilAsserted(() -> assertThat(deploymentPodTemplateChecksum(proxy)).isNotEqualTo(initialChecksum));
-    }
-
-    private String deploymentPodTemplateChecksum(KafkaProxy proxy) {
-        var deployment = clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
-        assertThat(deployment).isNotNull();
-        return Optional.ofNullable(deployment.getSpec().getTemplate().getMetadata().getAnnotations())
-                .map(annotations -> annotations.get(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY))
-                .orElse(null);
     }
 
     private void assertRouteManifested(String routeName, boolean isBootstrap, KafkaProxy proxy, String serviceName, int targetPort) {
@@ -1205,42 +1149,6 @@ public class KafkaProxyReconcilerIT {
                 .withIngressRef(toIngressRef(kafkaProxyIngress));
         Optional.ofNullable(serverCert).ifPresent(sc -> builder.withNewTls().withCertificateRef(toCertificateRef(sc)).endTls());
         return builder.build();
-    }
-
-    /**
-     * Gets the domain for the default openshift ingress controller.
-     * Assumes that tests are running on openshift and the cluster is running in the default state (single openshift ingress
-     * controller serving the entire cluster).
-     *
-     * @return ingress controller domain
-     */
-    private String getDefaultOpenShiftIngressControllerDomain() {
-        String ingressControllerName = "default";
-        String ingressControllerNamespace = "openshift-ingress-operator";
-
-        // Note: Real OpenShift has the IngressController API and an instance called `default` in the `openshift-ingress-operator` namespace
-        // MicroShift has the IngressController API, but no instances of the API, or a namespace of that name.
-        // Minikube has neither API nor namespace.
-        // The Fabric8 #get API treats absence of resource/namespace/api in the same manner (all return null).
-        IngressController defaultIngressController;
-        try (var client = new KubernetesClientBuilder().build()) {
-            defaultIngressController = client.resources(IngressController.class)
-                    .inNamespace(ingressControllerNamespace).withName(ingressControllerName).get();
-        }
-
-        return Optional.ofNullable(defaultIngressController)
-                .map(IngressController::getStatus)
-                .map(IngressControllerStatus::getDomain)
-                .orElseGet(() -> {
-                    LOGGER.warn("Couldn't programmatically determine OpenShiftIngressController domain, using test default: {}", DEFAULT_INGRESS_CONTROLLER_DOMAIN);
-                    return DEFAULT_INGRESS_CONTROLLER_DOMAIN;
-                });
-    }
-
-    private static boolean supportsRoute() {
-        try (var client = new KubernetesClientBuilder().build()) {
-            return client.supports(Route.class);
-        }
     }
 
     private void assertDeploymentBecomesReady(KafkaProxy proxy) {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
@@ -30,8 +30,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -126,8 +124,6 @@ import static org.awaitility.Awaitility.await;
 @EnabledIf(value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
 @SuppressWarnings("java:S8692") // ITs run against a live API server; a fixed clock would be misleading since time is not controlled
 public class KafkaProxyReconcilerIT {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyReconcilerIT.class);
 
     private static final String PROXY_A = "proxy-a";
     private static final String PROXY_B = "proxy-b";


### PR DESCRIPTION
## Summary

- Remove the flaky `KafkaProxyReconcilerIT.deploymentChecksumUpdatesWhenOpenshiftRouteHostAssigned` test (which raced with the real OpenShift ingress controller, causing intermittent 409 Conflicts)
- Add `AllReconcilersIT.downstreamOpenShiftRouteIngress` which asserts VirtualKafkaCluster status eventually expresses a route-based bootstrap address matching the ingress controller domain
- Extract `supportsRoute()` and `getDefaultIngressControllerDomain()` into shared `OpenShiftUtils` class
- Document Kubernetes/OpenShift development environment prerequisites in DEV_GUIDE.md

Fixes #4370

## Test plan

- [x] Verify `AllReconcilersIT.downstreamOpenShiftRouteIngress` passes on MicroShift/CRC CI
- [x] Verify existing `KafkaProxyReconcilerIT.virtualClusterWithOpenshiftRouteIngress` still passes
- [x] Verify compilation: `mvn compile test-compile -pl kroxylicious-kubernetes/kroxylicious-operator -Pquick`

🤖 Generated with [Claude Code](https://claude.com/claude-code)