### PR TITLE
fix: strip template name prefix at '/' instead of File.separator

### DIFF
--- a/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/main/KrpcGenerator.java
+++ b/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/main/KrpcGenerator.java
@@ -596,11 +596,22 @@ public class KrpcGenerator {
         }
 
         if (templateName != null) {
-            templateName = templateName.substring(Math.max(0, templateName.lastIndexOf(File.separator) + 1), templateName.indexOf(".ftl"));
-            pattern = pattern.replace("${templateName}", templateName);
+            pattern = pattern.replace("${templateName}", templateResourceBaseName(templateName));
         }
 
         return pattern;
+    }
+
+    /**
+     * Strips the directory prefix and the {@code .ftl} extension from a template name,
+     * e.g. {@code "Kproxy/KrpcRequestFilter.ftl"} yields {@code "KrpcRequestFilter"}.
+     * <p>
+     * Template names are FreeMarker resource names: path steps are separated by
+     * {@code '/'} on every operating system. They are not file system paths, so
+     * {@link File#separator} must not be used here (see issue #4228).
+     */
+    static String templateResourceBaseName(String templateName) {
+        return templateName.substring(Math.max(0, templateName.lastIndexOf('/') + 1), templateName.indexOf(".ftl"));
     }
 
     private Set<ApiSpec> toApiSpecs(Set<MessageSpec> messageSpecs) {

--- a/kroxylicious-krpc-plugin/src/test/java/io/kroxylicious/krpccodegen/main/KrpcGeneratorTest.java
+++ b/kroxylicious-krpc-plugin/src/test/java/io/kroxylicious/krpccodegen/main/KrpcGeneratorTest.java
@@ -148,6 +148,16 @@ class KrpcGeneratorTest {
         assertFileHasExpectedContents(file, "Kproxy/KrpcRequestFilter-expected.txt");
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "Kproxy/KrpcRequestFilter.ftl, KrpcRequestFilter",
+            "KrpcRequestFilter.ftl,        KrpcRequestFilter",
+            "deeply/nested/Template.ftl,   Template",
+    })
+    void templateResourceBaseNameStripsDirectoryPrefixAndFtlExtension(String templateName, String expected) {
+        assertThat(KrpcGenerator.templateResourceBaseName(templateName)).isEqualTo(expected);
+    }
+
     @Test
     void messageSpecsFilteredWithInputSpecFilter(@TempDir File tempDir) throws Exception {
         KrpcGenerator gen = KrpcGenerator.multi()


### PR DESCRIPTION
## Type of change
- Bug fix
## Description
KrpcGenerator.outputFile(...) derived ${templateName} using File.separator. Template names are FreeMarker resource names and use / as their path separator independently of the host operating system.

On Windows, File.separator is \, so the directory prefix of a template such as Kproxy/KrpcRequestFilter.ftl was not removed. The derived output file name retained Kproxy/, causing the generator to write to an unintended, non-existent subdirectory.

This change extracts the template resource base-name derivation into a small package-private static method and uses the FreeMarker resource-name separator. It also adds a test for nested template names and names without a directory prefix.

This follows [FreeMarker's documented template-name convention](https://freemarker.apache.org/docs/pgui_config_templateloading.html): template paths use /, rather than \, independently of the host operating system.

Fixes #4228.
## Additional context
On Linux, the previous and corrected implementations behave identically because File.separator is already /. The new test documents the template-name contract and provide a focused Windows regression check; native Windows test execution is the behavioural verification for this issue.
## Testing
- [x] mvn -pl kroxylicious-krpc-plugin "-Dtest=KrpcGeneratorTest" test on Windows
- [x] Added focused unit tests for template resource base-name derivation
- [ ] `mvn clean verify` (blocked by 7 unrelated `HeadersAssertTest` failures in `kroxylicious-filter-test-support` on Windows)
## Checklist
- [x] New tests written where applicable.
- [ ] Existing unit tests passing.
- [x] PR references the related GitHub issue.
- [x] Commit message includes the required Assisted-by: trailer.
- [x] CHANGELOG update is not needed for this build/code-generation fix.