### PR TITLE
feat(kms): add domain support for CipherTrust Manager password authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#4118](https://github.com/kroxylicious/kroxylicious/issues/4118): feat(kms): CipherTrust Manager `userCredentials` now supports an optional `domain` field. When set, the password-grant token request is scoped to that domain, enabling multi-tenant CipherTrust deployments.
 * [#4384](https://github.com/kroxylicious/kroxylicious/pull/4384): bump io.kiota:kiota-http-jdk from 0.0.36 to 0.0.37 (for CVE-2026-45292 fix in opentelemetry)
 * [#4342](https://github.com/kroxylicious/kroxylicious/pull/4342): build(deps): bump com.fasterxml.jackson:jackson-bom from 2.22.0 to 2.22.1
 * [#4345](https://github.com/kroxylicious/kroxylicious/pull/4337): build(deps): bump netty.version from 4.2.15.Final to 4.2.16.Final

--- a/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/con-thales-ctm-plugin-configuration.adoc
+++ b/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/con-thales-ctm-plugin-configuration.adoc
@@ -54,7 +54,9 @@ kmsConfig:
     username: kroxylicious-service
     password:
       passwordFile: /opt/kroxylicious/ctm-password
+    domain: my-domain # <1>
 ----
+<1> Optional. Omit if domains are not in use.
 
 where:
 
@@ -62,6 +64,7 @@ where:
 * `endpointUrl` provides the CipherTrust Manager endpoint URL including the protocol, such as `https://ctm.example.com`.
 * `username` is the CipherTrust Manager username.
 * `passwordFile` references a file containing the password.
+* `domain` (optional) is the CipherTrust Manager domain to authenticate into. CipherTrust Manager domains provide multi-tenancy by segregating keys between teams or applications. When omitted, authentication targets the root domain.
 
 IMPORTANT: In production deployments, always use `passwordFile` to reference a password stored in a file rather than embedding the password directly in the configuration.
 

--- a/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/con-thales-ctm-setup.adoc
+++ b/kroxylicious-docs/docs/_modules/record-encryption/thales-ctm/con-thales-ctm-setup.adoc
@@ -275,4 +275,6 @@ ksctl groups adduser \
 
 IMPORTANT: Store the password securely. In production, use the `passwordFile` option in the filter configuration rather than embedding the password in the configuration file.
 
-Record the username and password. You will need these for the filter configuration.
+NOTE: If the user account belongs to a specific domain in your CipherTrust Manager hierarchy, you must also specify that domain in the filter configuration using the `domain` field. When omitted, authentication targets the root domain.
+
+Record the username, password, and domain (if applicable). You will need these for the filter configuration.

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustTestKmsFacade.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustTestKmsFacade.java
@@ -284,7 +284,7 @@ public class CipherTrustTestKmsFacade implements TestKmsFacade<Config, WrappingK
         return switch (authMode) {
             case PASSWORD -> {
                 var userCredentials = new UserCredentials(Objects.requireNonNull(connectionConfig.username()),
-                        new InlinePassword(Objects.requireNonNull(connectionConfig.password())));
+                        new InlinePassword(Objects.requireNonNull(connectionConfig.password())), null);
                 yield new Config(cipherTrustUrl, userCredentials, null, connectionConfig.tls());
             }
             case CLIENT_CERT -> {

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustTestKmsFacade.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/main/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustTestKmsFacade.java
@@ -238,7 +238,7 @@ public class CipherTrustTestKmsFacade implements TestKmsFacade<Config, WrappingK
                 // Username/password authentication
                 var username = Objects.requireNonNull(connectionConfig.username());
                 var password = Objects.requireNonNull(connectionConfig.password());
-                yield AuthRequest.withPassword(username, password);
+                yield AuthRequest.withPassword(username, password, null);
             }
             case CLIENT_CERT -> {
                 // Client certificate authentication

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/test/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServerTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/src/test/java/io/kroxylicious/testing/kms/ciphertrust/CipherTrustMockServerTest.java
@@ -86,7 +86,7 @@ class CipherTrustMockServerTest {
     private String authenticate() throws Exception {
         var authRequest = AuthRequest.withPassword(
                 CipherTrustMockServer.TEST_USERNAME,
-                CipherTrustMockServer.TEST_PASSWORD);
+                CipherTrustMockServer.TEST_PASSWORD, null);
         var requestBody = OBJECT_MAPPER.writeValueAsString(authRequest);
 
         var request = HttpRequest.newBuilder()
@@ -167,7 +167,7 @@ class CipherTrustMockServerTest {
         // Already tested in setUp via authenticate(), but let's verify the structure
         var authRequest = AuthRequest.withPassword(
                 CipherTrustMockServer.TEST_USERNAME,
-                CipherTrustMockServer.TEST_PASSWORD);
+                CipherTrustMockServer.TEST_PASSWORD, null);
 
         var request = HttpRequest.newBuilder()
                 .uri(URI.create(baseUrl + "/api/v1/auth/tokens/"))
@@ -770,7 +770,7 @@ class CipherTrustMockServerTest {
                 // Authenticate
                 var authReq = AuthRequest.withPassword(
                         CipherTrustMockServer.TEST_USERNAME,
-                        CipherTrustMockServer.TEST_PASSWORD);
+                        CipherTrustMockServer.TEST_PASSWORD, null);
                 var request = HttpRequest.newBuilder()
                         .uri(URI.create(tlsBaseUrl + "/api/v1/auth/tokens/"))
                         .header("Content-Type", "application/json")
@@ -801,7 +801,7 @@ class CipherTrustMockServerTest {
                 // Authenticate
                 var authReq = AuthRequest.withPassword(
                         CipherTrustMockServer.TEST_USERNAME,
-                        CipherTrustMockServer.TEST_PASSWORD);
+                        CipherTrustMockServer.TEST_PASSWORD, null);
                 var authRequest = HttpRequest.newBuilder()
                         .uri(URI.create(tlsBaseUrl + "/api/v1/auth/tokens/"))
                         .header("Content-Type", "application/json")

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKmsService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKmsService.java
@@ -83,6 +83,7 @@ public class CipherTrustKmsService implements KmsService<Config, WrappingKey, Ci
                     config.endpointUrl(),
                     userCreds.username(),
                     userCreds.password().getProvidedPassword(),
+                    userCreds.domain(),
                     DEFAULT_TIMEOUT,
                     tlsConfigurator);
         }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/AbstractTokenService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/AbstractTokenService.java
@@ -78,6 +78,10 @@ abstract class AbstractTokenService implements BearerTokenService {
      */
     protected CompletionStage<BearerToken> authenticate(AuthRequest authRequest, String operationType) {
         try {
+            LOGGER.atDebug()
+                    .addKeyValue("operation", operationType)
+                    .addKeyValue("authRequest", authRequest)
+                    .log("sending authentication request");
             String requestBody = OBJECT_MAPPER.writeValueAsString(authRequest);
 
             HttpRequest httpRequest = HttpRequest.newBuilder()

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/UserAuthenticationTokenService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/UserAuthenticationTokenService.java
@@ -77,7 +77,7 @@ public class UserAuthenticationTokenService extends AbstractTokenService {
     }
 
     private CompletionStage<BearerToken> authenticateWithPassword() {
-        AuthRequest request = AuthRequest.withPassword(username, password);
+        AuthRequest request = AuthRequest.withPassword(username, password, null);
         return authenticate(request, "password authentication");
     }
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/UserAuthenticationTokenService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/UserAuthenticationTokenService.java
@@ -18,6 +18,8 @@ import java.util.function.UnaryOperator;
 import io.kroxylicious.kms.provider.thales.ciphertrust.model.AuthRequest;
 import io.kroxylicious.kms.provider.thales.ciphertrust.model.AuthResponse;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 /**
  * Bearer token service for CipherTrust Manager user authentication.
  * <p>
@@ -30,6 +32,8 @@ public class UserAuthenticationTokenService extends AbstractTokenService {
 
     private final String username;
     private final String password;
+    @Nullable
+    private final String domain;
     private final AtomicReference<String> refreshToken = new AtomicReference<>();
 
     /**
@@ -38,12 +42,14 @@ public class UserAuthenticationTokenService extends AbstractTokenService {
      * @param endpointUrl base URL of CipherTrust Manager instance
      * @param username username for authentication
      * @param password password for authentication
+     * @param domain optional domain to scope the token; null means the root domain
      * @param timeout HTTP request timeout
      * @param tlsConfigurator TLS configuration for HTTP client
      */
     public UserAuthenticationTokenService(URI endpointUrl,
                                           String username,
                                           String password,
+                                          @Nullable String domain,
                                           Duration timeout,
                                           UnaryOperator<HttpClient.Builder> tlsConfigurator) {
         super(endpointUrl, timeout, tlsConfigurator);
@@ -53,6 +59,7 @@ public class UserAuthenticationTokenService extends AbstractTokenService {
 
         this.username = username;
         this.password = password;
+        this.domain = domain;
     }
 
     @Override
@@ -77,7 +84,7 @@ public class UserAuthenticationTokenService extends AbstractTokenService {
     }
 
     private CompletionStage<BearerToken> authenticateWithPassword() {
-        AuthRequest request = AuthRequest.withPassword(username, password, null);
+        AuthRequest request = AuthRequest.withPassword(username, password, domain);
         return authenticate(request, "password authentication");
     }
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/config/UserCredentials.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/config/UserCredentials.java
@@ -12,15 +12,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.kroxylicious.proxy.config.secret.PasswordProvider;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 /**
  * User credentials for Thales CipherTrust Manager authentication.
  *
  * @param username the username
  * @param password the password provider
+ * @param domain   optional CipherTrust domain; when set, the token request targets that domain
  */
 public record UserCredentials(
                               @JsonProperty(required = true) String username,
-                              @JsonProperty(required = true) PasswordProvider password) {
+                              @JsonProperty(required = true) PasswordProvider password,
+                              @Nullable String domain) {
     /**
      * Constructs user credentials.
      */
@@ -35,6 +39,6 @@ public record UserCredentials(
     @Override
     @SuppressWarnings("java:S2068") // The masked password is a not a password
     public String toString() {
-        return "UserCredentials{username='" + username + "', password='***'}";
+        return "UserCredentials{username='" + username + "', password='***', domain='" + domain + "'}";
     }
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/model/AuthRequest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/model/AuthRequest.java
@@ -29,7 +29,6 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * @param refreshTokenLifetime optional refresh token lifetime
  * @param refreshTokenRevokeUnusedIn optional refresh token revoke unused duration
  * @param renewRefreshToken optional flag to renew refresh token
- * @param authDomain optional auth domain
  * @param clientId client ID for client certificate authentication
  * @param connection optional connection
  * @param cookies optional cookies flag
@@ -45,7 +44,6 @@ public record AuthRequest(
                           @JsonProperty("refresh_token_lifetime") @Nullable Integer refreshTokenLifetime,
                           @JsonProperty("refresh_token_revoke_unused_in") @Nullable Integer refreshTokenRevokeUnusedIn,
                           @JsonProperty("renew_refresh_token") @Nullable Boolean renewRefreshToken,
-                          @JsonProperty("auth_domain") @Nullable String authDomain,
                           @JsonProperty("client_id") @Nullable String clientId,
                           @JsonProperty("connection") @Nullable String connection,
                           @JsonProperty("cookies") @Nullable Boolean cookies,
@@ -61,7 +59,7 @@ public record AuthRequest(
      * @return auth request
      */
     public static AuthRequest withPassword(String username, String password, @Nullable String domain) {
-        return new AuthRequest(username, password, null, "password", null, null, null, null, null, null, null, domain, null);
+        return new AuthRequest(username, password, null, "password", null, null, null, null, null, null, domain, null);
     }
 
     /**
@@ -71,7 +69,7 @@ public record AuthRequest(
      * @return auth request
      */
     public static AuthRequest withRefreshToken(String refreshToken) {
-        return new AuthRequest(null, null, refreshToken, "refresh_token", null, null, null, null, null, null, null, null, null);
+        return new AuthRequest(null, null, refreshToken, "refresh_token", null, null, null, null, null, null, null, null);
     }
 
     /**
@@ -85,7 +83,7 @@ public record AuthRequest(
      * @return auth request
      */
     public static AuthRequest withClientCredential(String clientId) {
-        return new AuthRequest(null, null, null, "client_credential", null, null, null, null, clientId, null, null, null, null);
+        return new AuthRequest(null, null, null, "client_credential", null, null, null, clientId, null, null, null, null);
     }
 
     @Override
@@ -99,7 +97,6 @@ public record AuthRequest(
                 ", refreshTokenLifetime=" + refreshTokenLifetime +
                 ", refreshTokenRevokeUnusedIn=" + refreshTokenRevokeUnusedIn +
                 ", renewRefreshToken=" + renewRefreshToken +
-                ", authDomain='" + authDomain + '\'' +
                 ", clientId='" + clientId + '\'' +
                 ", connection='" + connection + '\'' +
                 ", cookies=" + cookies +

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/model/AuthRequest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/model/AuthRequest.java
@@ -57,10 +57,11 @@ public record AuthRequest(
      *
      * @param username the username
      * @param password the password
+     * @param domain   optional domain name; when non-null the token is scoped to that domain
      * @return auth request
      */
-    public static AuthRequest withPassword(String username, String password) {
-        return new AuthRequest(username, password, null, "password", null, null, null, null, null, null, null, null, null);
+    public static AuthRequest withPassword(String username, String password, @Nullable String domain) {
+        return new AuthRequest(username, password, null, "password", null, null, null, null, null, null, null, domain, null);
     }
 
     /**

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKmsServiceTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKmsServiceTest.java
@@ -42,7 +42,7 @@ class CipherTrustKmsServiceTest {
         service = new CipherTrustKmsService();
         var config = new Config(
                 URI.create("https://ctm.example.com"),
-                new UserCredentials("user", new InlinePassword("pass")),
+                new UserCredentials("user", new InlinePassword("pass"), null),
                 null,
                 null);
         service.initialize(config);
@@ -69,7 +69,7 @@ class CipherTrustKmsServiceTest {
         service = new CipherTrustKmsService();
         var config = new Config(
                 URI.create("https://ctm.example.com"),
-                new UserCredentials("user", new InlinePassword("pass")),
+                new UserCredentials("user", new InlinePassword("pass"), null),
                 null,
                 null);
         service.initialize(config);
@@ -87,7 +87,7 @@ class CipherTrustKmsServiceTest {
         var validButUnusualCipherSuite = "TLS_EMPTY_RENEGOTIATION_INFO_SCSV";
         var config = new Config(
                 URI.create("https://ctm.example.com"),
-                new UserCredentials("user", new InlinePassword("pass")),
+                new UserCredentials("user", new InlinePassword("pass"), null),
                 null,
                 new Tls(null, null, new AllowDeny<>(
                         List.of(validButUnusualCipherSuite), null), null, null));

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKmsTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKmsTest.java
@@ -72,7 +72,7 @@ class CipherTrustKmsTest {
 
         var config = new Config(
                 URI.create(server.baseUrl()),
-                new UserCredentials("testuser", new InlinePassword("testpass")),
+                new UserCredentials("testuser", new InlinePassword("testpass"), null),
                 null,
                 null);
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/UserAuthenticationTokenServiceTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/UserAuthenticationTokenServiceTest.java
@@ -18,8 +18,11 @@ import org.junit.jupiter.api.Test;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.not;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
@@ -55,13 +58,18 @@ class UserAuthenticationTokenServiceTest {
     @BeforeEach
     void beforeEach() {
         server.resetAll();
+        service = buildService(null);
+    }
+
+    private UserAuthenticationTokenService buildService(@Nullable String domain) {
         URI endpoint = URI.create(server.baseUrl());
-        service = new UserAuthenticationTokenService(
+        return new UserAuthenticationTokenService(
                 endpoint,
                 TEST_USERNAME,
                 TEST_PASSWORD,
+                domain,
                 Duration.ofSeconds(10),
-                builder -> builder); // No TLS configuration for test
+                builder -> builder);
     }
 
     @AfterEach
@@ -179,6 +187,60 @@ class UserAuthenticationTokenServiceTest {
     }
 
     @Test
+    void domainIsSentInPasswordAuthRequest() {
+        // Given
+        stubPasswordAuthWithDomain("my-domain", INITIAL_JWT, INITIAL_REFRESH_TOKEN);
+        service = buildService("my-domain");
+
+        // When
+        var tokenStage = service.getBearerToken();
+
+        // Then
+        assertThat(tokenStage)
+                .succeedsWithin(Duration.ofSeconds(5))
+                .satisfies(token -> assertThat(token.token()).isEqualTo(INITIAL_JWT));
+
+        server.verify(postRequestedFor(urlPathEqualTo("/api/v1/auth/tokens/"))
+                .withRequestBody(containing("\"domain\":\"my-domain\"")));
+    }
+
+    @Test
+    void domainIsAbsentFromPasswordAuthRequestWhenNotConfigured() {
+        // Given
+        stubPasswordAuth(INITIAL_JWT, INITIAL_REFRESH_TOKEN);
+
+        // When
+        var tokenStage = service.getBearerToken();
+
+        // Then
+        assertThat(tokenStage).succeedsWithin(Duration.ofSeconds(5));
+
+        server.verify(postRequestedFor(urlPathEqualTo("/api/v1/auth/tokens/"))
+                .withRequestBody(containing("\"grant_type\":\"password\""))
+                .withRequestBody(not(containing("\"domain\""))));
+    }
+
+    @Test
+    void domainIsAbsentFromRefreshTokenRequest() {
+        // Given
+        stubPasswordAuthWithDomain("my-domain", INITIAL_JWT, INITIAL_REFRESH_TOKEN);
+        stubRefreshTokenAuth(INITIAL_REFRESH_TOKEN, REFRESHED_JWT, NEW_REFRESH_TOKEN);
+        service = buildService("my-domain");
+
+        // First call: password auth with domain
+        assertThat(service.getBearerToken()).succeedsWithin(Duration.ofSeconds(5));
+        server.resetRequests();
+
+        // When: second call uses refresh token
+        assertThat(service.getBearerToken()).succeedsWithin(Duration.ofSeconds(5));
+
+        // Then: refresh request must not contain domain
+        server.verify(postRequestedFor(urlPathEqualTo("/api/v1/auth/tokens/"))
+                .withRequestBody(containing("\"grant_type\":\"refresh_token\""))
+                .withRequestBody(not(containing("\"domain\""))));
+    }
+
+    @Test
     void authenticationFailsWithInvalidCredentials() {
         // Given - stub authentication failure
         stubPasswordAuthFailure();
@@ -208,6 +270,24 @@ class UserAuthenticationTokenServiceTest {
         server.stubFor(
                 post(urlPathEqualTo("/api/v1/auth/tokens/"))
                         .withRequestBody(matchingPasswordAuth())
+                        .willReturn(aResponse()
+                                .withStatus(200)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(response)));
+    }
+
+    private void stubPasswordAuthWithDomain(String domain, String jwt, String refreshToken) {
+        String response = """
+                {
+                    "jwt": "%s",
+                    "duration": 300,
+                    "refresh_token": "%s"
+                }
+                """.formatted(jwt, refreshToken);
+
+        server.stubFor(
+                post(urlPathEqualTo("/api/v1/auth/tokens/"))
+                        .withRequestBody(matchingPasswordAuth().and(containing("\"domain\":\"" + domain + "\"")))
                         .willReturn(aResponse()
                                 .withStatus(200)
                                 .withHeader("Content-Type", "application/json")

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/config/ConfigParseTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/config/ConfigParseTest.java
@@ -49,6 +49,49 @@ class ConfigParseTest {
     }
 
     @Test
+    void endpointUrlAndUserCredentialsWithDomain() throws IOException {
+        // Given
+        String json = """
+                {
+                    "endpointUrl": "https://ctm.example.com",
+                    "userCredentials": {
+                        "username": "testuser",
+                        "password": { "password": "testpass" },
+                        "domain": "my-domain"
+                    }
+                }
+                """;
+
+        // When
+        Config config = readConfig(json);
+
+        // Then
+        assertThat(config.userCredentials()).isNotNull();
+        assertThat(config.userCredentials().domain()).isEqualTo("my-domain");
+    }
+
+    @Test
+    void userCredentialsDomainIsOptional() throws IOException {
+        // Given
+        String json = """
+                {
+                    "endpointUrl": "https://ctm.example.com",
+                    "userCredentials": {
+                        "username": "testuser",
+                        "password": { "password": "testpass" }
+                    }
+                }
+                """;
+
+        // When
+        Config config = readConfig(json);
+
+        // Then
+        assertThat(config.userCredentials()).isNotNull();
+        assertThat(config.userCredentials().domain()).isNull();
+    }
+
+    @Test
     void endpointUrlRequired() {
         // Given
         String json = """

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/config/UserCredentialsTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/config/UserCredentialsTest.java
@@ -25,7 +25,7 @@ class UserCredentialsTest {
     @MethodSource("invalidConstructorArguments")
     void constructorValidation(String username, PasswordProvider password, Class<? extends Exception> expectedExceptionType, String expectedMessage) {
         // When/Then
-        assertThatThrownBy(() -> new UserCredentials(username, password))
+        assertThatThrownBy(() -> new UserCredentials(username, password, null))
                 .isInstanceOf(expectedExceptionType)
                 .hasMessageContaining(expectedMessage);
     }
@@ -41,7 +41,7 @@ class UserCredentialsTest {
     @Test
     void toStringMasksPassword() {
         // Given
-        var credentials = new UserCredentials("testuser", new InlinePassword("secret"));
+        var credentials = new UserCredentials("testuser", new InlinePassword("secret"), null);
 
         // When
         String result = credentials.toString();
@@ -51,6 +51,24 @@ class UserCredentialsTest {
                 .contains("testuser")
                 .contains("***")
                 .doesNotContain("secret");
+    }
+
+    @Test
+    void domainIsNullByDefault() {
+        // Given
+        var credentials = new UserCredentials("testuser", new InlinePassword("secret"), null);
+
+        // When / Then
+        assertThat(credentials.domain()).isNull();
+    }
+
+    @Test
+    void domainIsStoredWhenProvided() {
+        // Given
+        var credentials = new UserCredentials("testuser", new InlinePassword("secret"), "my-domain");
+
+        // When / Then
+        assertThat(credentials.domain()).isEqualTo("my-domain");
     }
 
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds an optional `domain` field to `userCredentials` in the CipherTrust Manager KMS configuration. When set, the domain is forwarded to the `domain` field of the `POST /api/v1/auth/tokens/` password-grant request, scoping the session to that CipherTrust domain.

Config example:

```yaml
kms: CipherTrustKmsService
kmsConfig:
  endpointUrl: https://ctm.example.com
  userCredentials:
    username: kroxylicious-service
    password:
      passwordFile: /opt/kroxylicious/ctm-password
    domain: my-domain  # optional
```

The field has no effect on refresh-token or client-credential grant types, as specified in the issue.

### Additional Context

Closes #4118

### Checklist

- [x] New tests written (where applicable).
- [x] If making a user-facing change, documentation is provided — `con-thales-ctm-plugin-configuration.adoc` updated.
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed.
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [x] For user facing changes, update CHANGELOG.md.