### PR TITLE
fix(docs): Replaced invalid @link block tags with @see and promoted invalid block tag warning to Error

### DIFF
--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm-test-support/src/main/java/io/kroxylicious/testing/kms/fortanix/FortanixDsmKmsTestKmsFacade.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm-test-support/src/main/java/io/kroxylicious/testing/kms/fortanix/FortanixDsmKmsTestKmsFacade.java
@@ -181,10 +181,9 @@ public class FortanixDsmKmsTestKmsFacade implements TestKmsFacade<Config, String
 
         /**
          * {@inheritDoc}
-         * <br>
-         * @link <a href="https://support.fortanix.com/apidocs/generate-a-new-security-object">https://support.fortanix.com/apidocs/generate-a-new-security-object</a>
          *
          * @param alias kek alias
+         * @see <a href="https://support.fortanix.com/apidocs/generate-a-new-security-object">Fortanix DSM API</a>
          */
         @Override
         public void generateKek(String alias) {
@@ -196,10 +195,9 @@ public class FortanixDsmKmsTestKmsFacade implements TestKmsFacade<Config, String
 
         /**
          * {@inheritDoc}
-         * <br>
-         * @link <a href="https://support.fortanix.com/apidocs/lookup-a-security-object">https://support.fortanix.com/apidocs/lookup-a-security-object</a>
          *
          * @param alias kek alias
+         * @see <a href="https://support.fortanix.com/apidocs/lookup-a-security-object">Fortanix DSM API</a>
          */
         @Override
         public SecurityObjectResponse read(String alias) {
@@ -214,10 +212,9 @@ public class FortanixDsmKmsTestKmsFacade implements TestKmsFacade<Config, String
 
         /**
          * {@inheritDoc}
-         * <br>
-         * @link <a href="https://support.fortanix.com/apidocs/delete-the-specified-security-object">https://support.fortanix.com/apidocs/delete-the-specified-security-object</a>
          *
          * @param alias kek alias
+         * @see <a href="https://support.fortanix.com/apidocs/delete-the-specified-security-object">Fortanix DSM API</a>
          */
         @Override
         public void deleteKek(String alias) {
@@ -240,9 +237,9 @@ public class FortanixDsmKmsTestKmsFacade implements TestKmsFacade<Config, String
 
         /**
          * {@inheritDoc}
-         * <br>
+         *
          * @param alias kek alias
-         * @link <a href="https://support.fortanix.com/apidocs/rotate-a-security-object-to-an-existing-security-object">https://support.fortanix.com/apidocs/rotate-a-security-object-to-an-existing-security-object</a>
+         * @see <a href="https://support.fortanix.com/apidocs/rotate-a-security-object-to-an-existing-security-object">Fortanix DSM API</a>
          */
         @Override
         public void rotateKek(String alias) {

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm-test-support/src/main/java/io/kroxylicious/testing/kms/fortanix/FortanixDsmKmsTestKmsFacade.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm-test-support/src/main/java/io/kroxylicious/testing/kms/fortanix/FortanixDsmKmsTestKmsFacade.java
@@ -183,7 +183,7 @@ public class FortanixDsmKmsTestKmsFacade implements TestKmsFacade<Config, String
          * {@inheritDoc}
          *
          * @param alias kek alias
-         * @see <a href="https://support.fortanix.com/apidocs/generate-a-new-security-object">Fortanix DSM API</a>
+         * @see <a href="https://support.fortanix.com/apidocs/generate-a-new-security-object">"Generate a new security object" in the Fortanix DSM API</a>
          */
         @Override
         public void generateKek(String alias) {
@@ -197,7 +197,7 @@ public class FortanixDsmKmsTestKmsFacade implements TestKmsFacade<Config, String
          * {@inheritDoc}
          *
          * @param alias kek alias
-         * @see <a href="https://support.fortanix.com/apidocs/lookup-a-security-object">Fortanix DSM API</a>
+         * @see <a href="https://support.fortanix.com/apidocs/lookup-a-security-object">"Lookup a security object" in the Fortanix DSM API</a>
          */
         @Override
         public SecurityObjectResponse read(String alias) {
@@ -214,7 +214,7 @@ public class FortanixDsmKmsTestKmsFacade implements TestKmsFacade<Config, String
          * {@inheritDoc}
          *
          * @param alias kek alias
-         * @see <a href="https://support.fortanix.com/apidocs/delete-the-specified-security-object">Fortanix DSM API</a>
+         * @see <a href="https://support.fortanix.com/apidocs/delete-the-specified-security-object">"Delete the specified security object" in the Fortanix DSM API</a>
          */
         @Override
         public void deleteKek(String alias) {
@@ -239,7 +239,7 @@ public class FortanixDsmKmsTestKmsFacade implements TestKmsFacade<Config, String
          * {@inheritDoc}
          *
          * @param alias kek alias
-         * @see <a href="https://support.fortanix.com/apidocs/rotate-a-security-object-to-an-existing-security-object">Fortanix DSM API</a>
+         * @see <a href="https://support.fortanix.com/apidocs/rotate-a-security-object-to-an-existing-security-object">"Rotate a security object to an existing security object" in the Fortanix DSM API</a>
          */
         @Override
         public void rotateKek(String alias) {

--- a/pom.xml
+++ b/pom.xml
@@ -1400,7 +1400,7 @@
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <arg>--should-stop=ifError=FLOW</arg>
                                 <!-- The following <arg> cannot be split over multiple lines :-( -->
-                                <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/target/generated-sources/.* -Xep:MissingOverride:ERROR -Xep:MutablePublicArray:ERROR -Xep:MathAbsoluteNegative:ERROR -Xep:EffectivelyPrivate:ERROR -Xep:ByteBufferBackingArray:ERROR -Xep:UnnecessaryMethodReference:ERROR -Xep:OperatorPrecedence:ERROR -Xep:ImmutableEnumChecker:ERROR -Xep:StatementSwitchToExpressionSwitch:ERROR -Xep:StaticAssignmentOfThrowable:ERROR -Xep:BadImport:ERROR -Xep:EmptyBlockTag:ERROR -Xep:UnnecessaryParentheses:ERROR</arg>
+                                <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/target/generated-sources/.* -Xep:MissingOverride:ERROR -Xep:MutablePublicArray:ERROR -Xep:MathAbsoluteNegative:ERROR -Xep:EffectivelyPrivate:ERROR -Xep:ByteBufferBackingArray:ERROR -Xep:UnnecessaryMethodReference:ERROR -Xep:OperatorPrecedence:ERROR -Xep:ImmutableEnumChecker:ERROR -Xep:StatementSwitchToExpressionSwitch:ERROR -Xep:StaticAssignmentOfThrowable:ERROR -Xep:BadImport:ERROR -Xep:EmptyBlockTag:ERROR -Xep:UnnecessaryParentheses:ERROR -Xep:InvalidBlockTag:ERROR</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>


### PR DESCRIPTION
## Summary
  
  Contributes towards: [#3609](https://github.com/kroxylicious/kroxylicious/issues/3609)

  Resolves 4 ErrorProne `InvalidBlockTag` warnings by replacing invalid `@link` block tags with proper `@see` block tags, and promotes the check to ERROR to prevent regressions.

  ## Changes

  ### Source Files (4 warnings)

  | File | Warnings | Description |
  |------|----------|-------------|
  | `FortanixDsmKmsTestKmsFacade.java` | 4 | Replaced invalid `@link <a href=...>` block tags with `@see <a href=...>` across `generateKek`, `read`, `deleteKek`, and `rotateKek` methods. Removed unnecessary
  `<br>` tags and normalized block tag ordering (`@param` before `@see`). |

  ### Build (regression prevention)
  
  - **`pom.xml`**: Appended `-Xep:InvalidBlockTag:ERROR` to the ErrorProne compiler args, per the process agreed in #3609 (step 3), following the precedent of earlier promotions (e.g. `EmptyBlockTag`,
  `UnnecessaryParentheses`).

  ## Verification
  
  ```bash
  # After — 0 InvalidBlockTag warnings
  mvn -B clean install -DskipTests 2>/dev/null | grep '\[InvalidBlockTag\]'
  # Result: no output (zero matches)

  - ✅  Full build succeeds with the check promoted to ERROR (any missed site would now fail compilation)
  - ✅  git diff shows only Javadoc corrections plus the single pom.xml line
```
  **Testing**

  No new tests added — changes are Javadoc-only with no functional impact.

  - The touched methods are covered by existing tests in FortanixDsmKmsTestKmsFacadeTest
  - @link → @see is a Javadoc tag correction; no runtime behaviour changes

  **Key Properties**

  - ✅  All changes are Javadoc-only — no functional or behavioural changes
  - ✅  Block tag ordering normalized to @param before @see (conventional Javadoc order)
  - ✅  @link was misused as a block tag; @see is the correct block tag for external URL references
  - ✅  Check promoted to ERROR so any reintroduction fails the build

**Related Issue:** https://github.com/kroxylicious/kroxylicious/issues/4354

  🤖 Generated with Claude Code
  