### PR TITLE
ci(release): remove tag-push trigger and arm64 verification from staging

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -31,8 +31,6 @@ on:
     branches:
       - 'main'
       - 'release/**'
-    tags:
-      - 'v*.*.*'
   pull_request:
     types: [ opened, synchronize, reopened ]
 

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -17,8 +17,7 @@ BRANCH_FROM="main"
 WORK_BRANCH_NAME="release-work-$(openssl rand -hex 12)"
 SKIP_VALIDATION="false"
 RELEASE_NOTES_DIR=${RELEASE_NOTES_DIR:-.releaseNotes}
-PROXY_IMAGE_REPO="quay.io/kroxylicious/proxy"
-while getopts ":i:l:v:b:k:r:n:w:sh" opt; do
+while getopts ":l:v:b:k:r:n:w:sh" opt; do
   case $opt in
     v) RELEASE_VERSION="${OPTARG}"
     ;;
@@ -30,8 +29,6 @@ while getopts ":i:l:v:b:k:r:n:w:sh" opt; do
     ;;
     k) GPG_KEY="${OPTARG}"
     ;;
-    i) PROXY_IMAGE_REPO="${OPTARG}"
-    ;;
     l) RELCAND_ID_LABEL="${OPTARG}"
     ;;
     w) WORK_BRANCH_NAME="${OPTARG}"
@@ -40,14 +37,13 @@ while getopts ":i:l:v:b:k:r:n:w:sh" opt; do
     ;;
     h)
       1>&2 cat << EOF
-usage: $0 -k keyid -v version -l relcand-label [-b branch] [-r repository] [-i proxy-image-repo] [-s] [-d] [-h]
+usage: $0 -k keyid -v version -l relcand-label [-b branch] [-r repository] [-s] [-d] [-h]
  -k short key id used to sign the release
  -v version number e.g. 0.3.0
  -b branch to release from (defaults to 'main')
  -n development version e.g. 0.4.0-SNAPSHOT
  -l Release candidate label to be applied to the PR.
  -r the remote name of the kroxylicious repository (defaults to 'origin')
- -i proxy image repo override for arm64 verification (default: quay.io/kroxylicious/proxy)
  -w release work branch
  -s skips validation
  -h this help message
@@ -258,53 +254,4 @@ gh pr create --head "${PREPARE_DEVELOPMENT_BRANCH}" \
              --repo "$(gh repo set-default -v)" \
              --label "${RELCAND_ID_LABEL}"
 
-# ── Verification: arm64 proxy image contains correct native libs ──────────────
-# The docker.yaml workflow was triggered by the tag push earlier in this script.
-# By the time we reach here (after mvn deploy + release prep), the workflow has
-# had significant time to run.  We poll for the run, wait for completion, then
-# spot-check that the linux/arm64 image layer contains aarch_64 Netty native
-# libraries and NO x86_64 ones.
-#
-# Defaults to quay.io/kroxylicious/proxy; override with -i for fork testing.
-if [[ -n "${PROXY_IMAGE_REPO}" ]]; then
-  echo "Waiting for docker workflow triggered by ${RELEASE_TAG} to appear..."
-  DOCKER_RUN_ID=""
-  for _attempt in 1 2 3 4 5 6 7 8 9 10; do
-    DOCKER_RUN_ID=$(gh run list \
-      --workflow docker.yaml \
-      --branch "${RELEASE_TAG}" \
-      --json databaseId \
-      --jq '.[0].databaseId // empty' 2>/dev/null || true)
-    [[ -n "${DOCKER_RUN_ID}" ]] && break
-    echo "  Run not yet visible (attempt ${_attempt}/10); retrying in 15s..."
-    sleep 15
-  done
-
-  if [[ -z "${DOCKER_RUN_ID}" ]]; then
-    echo "ERROR: Could not find docker workflow run for tag ${RELEASE_TAG}." >&2
-    echo "       Check the Actions tab and verify the arm64 image manually." >&2
-    exit 1
-  fi
-
-  echo "Found docker workflow run ${DOCKER_RUN_ID}; waiting for completion..."
-  gh run watch "${DOCKER_RUN_ID}" --exit-status
-
-  echo "Verifying arm64 proxy image native libraries in ${PROXY_IMAGE_REPO}:${RELEASE_VERSION}..."
-  _CONTAINER_ID=$(docker create --platform linux/arm64 "${PROXY_IMAGE_REPO}:${RELEASE_VERSION}")
-  _NATIVE_DIR=$(mktemp -d)
-  docker cp "${_CONTAINER_ID}:/opt/kroxylicious/libs/native/netty/." "${_NATIVE_DIR}/"
-  docker rm "${_CONTAINER_ID}" > /dev/null
-
-  _AARCH64_COUNT=$(find "${_NATIVE_DIR}" -name '*aarch_64*' | wc -l | tr -d ' ')
-  _X86_64_COUNT=$(find "${_NATIVE_DIR}" -name '*x86_64*' | wc -l | tr -d ' ')
-  rm -rf "${_NATIVE_DIR}"
-
-  if [[ "${_AARCH64_COUNT}" -gt 0 && "${_X86_64_COUNT}" -eq 0 ]]; then
-    echo "arm64 proxy image OK: ${_AARCH64_COUNT} aarch_64 native lib(s), no x86_64 libs."
-  else
-    echo "ERROR: arm64 native lib check failed (aarch_64=${_AARCH64_COUNT}, x86_64=${_X86_64_COUNT})." >&2
-    echo "       Use drop-release to clean up, then investigate the docker workflow." >&2
-    exit 1
-  fi
-fi
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Remove the `push: tags: v*.*.*` trigger from `docker.yaml` and the arm64 image verification polling loop from `stage-release.sh`.

### Additional Context

Part of the release process redesign (#4278). Closes #4279.

`docker.yaml` triggered on `push: tags: v*.*.*`, which caused container images to be published to quay.io immediately when `stage-release.sh` pushed the release tag — before Maven artefacts had been validated or promoted.

Removing the tag trigger means docker.yaml only fires on branch pushes and PRs. The arm64 verification polling loop in `stage-release.sh` existed solely to check the image that docker.yaml would have published; with the trigger gone, the verification is moot and is also removed, along with the `-i` flag and `PROXY_IMAGE_REPO` variable that supported it.

### Checklist

- [x] New tests written (where applicable).
- [x] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).