### PR TITLE
ci(release): build release images during staging, tag version at promote

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -72,6 +72,8 @@ jobs:
 
       - name: Determine Build Configuration
         id: build_configuration
+        env:
+          ADDITIONAL_TAGS: ${{ inputs.additional-tags }}
         run: |
           POMS_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "release_version=${POMS_VERSION}" >> $GITHUB_OUTPUT
@@ -108,8 +110,8 @@ jobs:
             if [[ "${{ github.event_name }}" == "push" ]]; then
               TAG_SUFFIXES+=("${POMS_VERSION}")
             fi
-            if [[ -n "${{ inputs.additional-tags }}" ]]; then
-              IFS=',' read -ra EXTRA_TAGS <<< "${{ inputs.additional-tags }}"
+            if [[ -n "${ADDITIONAL_TAGS}" ]]; then
+              IFS=',' read -ra EXTRA_TAGS <<< "${ADDITIONAL_TAGS}"
               for extra_tag in "${EXTRA_TAGS[@]}"; do
                 TAG_SUFFIXES+=("${extra_tag// /}")
               done

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -27,12 +27,15 @@ name: Docker Build
 
 on:
   workflow_dispatch:
+    inputs:
+      additional-tags:
+        description: 'Extra comma-separated image tags to apply alongside the commit SHA tag (e.g. "0.23.0-SNAPSHOT"). Leave empty for SHA-only (used by staging).'
+        required: false
+        default: ''
   push:
     branches:
       - 'main'
       - 'release/**'
-    tags:
-      - 'v*.*.*'
   pull_request:
     types: [ opened, synchronize, reopened ]
 
@@ -70,36 +73,62 @@ jobs:
       - name: Determine Build Configuration
         id: build_configuration
         run: |
-          RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "release_version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+          POMS_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "release_version=${POMS_VERSION}" >> $GITHUB_OUTPUT
+          SHA_TAG="commit-${GITHUB_SHA:0:7}"
 
           if [[ "${{ github.event_name }}" == "pull_request" || "${{ vars.REGISTRY_SERVER }}" == "" ]]; then
             # PR / no-registry builds: amd64 only for speed, no push, no manifest needed.
             echo "push_images=false" >> $GITHUB_OUTPUT
             echo "multi_arch=false" >> $GITHUB_OUTPUT
-            echo "proxy_amd64_tag=kroxylicious-proxy:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+            echo "proxy_amd64_tag=kroxylicious-proxy:${SHA_TAG}" >> $GITHUB_OUTPUT
             echo "proxy_arm64_tag=" >> $GITHUB_OUTPUT
             echo "proxy_final_tags=" >> $GITHUB_OUTPUT
             echo "operator_platforms=linux/amd64" >> $GITHUB_OUTPUT
-            echo "operator_tags=kroxylicious-operator:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+            echo "operator_tags=kroxylicious-operator:${SHA_TAG}" >> $GITHUB_OUTPUT
             echo "admission_platforms=linux/amd64" >> $GITHUB_OUTPUT
-            echo "admission_tags=kroxylicious-admission:${RELEASE_VERSION}" >> $GITHUB_OUTPUT            
+            echo "admission_tags=kroxylicious-admission:${SHA_TAG}" >> $GITHUB_OUTPUT
           else
             PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.PROXY_IMAGE_NAME }}"
             LEGACY_PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/kroxylicious"
             OPERATOR_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.OPERATOR_IMAGE_NAME }}"
             ADMISSION_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.ADMISSION_IMAGE_NAME }}"
+
             # Per-arch intermediate tags are pushed individually then merged into the
             # final manifest list (which also covers the legacy kroxylicious image name).
             echo "push_images=true" >> $GITHUB_OUTPUT
             echo "multi_arch=true" >> $GITHUB_OUTPUT
-            echo "proxy_amd64_tag=${PROXY_IMAGE}:${RELEASE_VERSION}-amd64" >> $GITHUB_OUTPUT
-            echo "proxy_arm64_tag=${PROXY_IMAGE}:${RELEASE_VERSION}-arm64" >> $GITHUB_OUTPUT
-            echo "proxy_final_tags=${PROXY_IMAGE}:${RELEASE_VERSION},${LEGACY_PROXY_IMAGE}:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+            echo "proxy_amd64_tag=${PROXY_IMAGE}:${SHA_TAG}-amd64" >> $GITHUB_OUTPUT
+            echo "proxy_arm64_tag=${PROXY_IMAGE}:${SHA_TAG}-arm64" >> $GITHUB_OUTPUT
+
+            # All builds get a commit SHA tag. Branch pushes also get the pom version
+            # (will be x.y.z-SNAPSHOT). Dispatched builds get any caller-supplied tags
+            # (empty for staging; promote_release.yaml owns the release version tag).
+            TAG_SUFFIXES=("${SHA_TAG}")
+            if [[ "${{ github.event_name }}" == "push" ]]; then
+              TAG_SUFFIXES+=("${POMS_VERSION}")
+            fi
+            if [[ -n "${{ inputs.additional-tags }}" ]]; then
+              IFS=',' read -ra EXTRA_TAGS <<< "${{ inputs.additional-tags }}"
+              for extra_tag in "${EXTRA_TAGS[@]}"; do
+                TAG_SUFFIXES+=("${extra_tag// /}")
+              done
+            fi
+
+            PROXY_FINAL_TAGS=""
+            OPERATOR_TAGS=""
+            ADMISSION_TAGS=""
+            for suffix in "${TAG_SUFFIXES[@]}"; do
+              PROXY_FINAL_TAGS="${PROXY_FINAL_TAGS:+${PROXY_FINAL_TAGS},}${PROXY_IMAGE}:${suffix},${LEGACY_PROXY_IMAGE}:${suffix}"
+              OPERATOR_TAGS="${OPERATOR_TAGS:+${OPERATOR_TAGS},}${OPERATOR_IMAGE}:${suffix}"
+              ADMISSION_TAGS="${ADMISSION_TAGS:+${ADMISSION_TAGS},}${ADMISSION_IMAGE}:${suffix}"
+            done
+
+            echo "proxy_final_tags=${PROXY_FINAL_TAGS}" >> $GITHUB_OUTPUT
             echo "operator_platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
-            echo "operator_tags=${OPERATOR_IMAGE}:${RELEASE_VERSION},${OPERATOR_IMAGE}:latest" >> $GITHUB_OUTPUT
+            echo "operator_tags=${OPERATOR_TAGS}" >> $GITHUB_OUTPUT
             echo "admission_platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
-            echo "admission_tags=${ADMISSION_IMAGE}:${RELEASE_VERSION},${ADMISSION_IMAGE}:latest" >> $GITHUB_OUTPUT
+            echo "admission_tags=${ADMISSION_TAGS}" >> $GITHUB_OUTPUT
           fi
 
       # ── Phase 1: compile and install ─────────────────────────────────────────

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -77,7 +77,7 @@ jobs:
         run: |
           POMS_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "release_version=${POMS_VERSION}" >> $GITHUB_OUTPUT
-          SHA_TAG="commit-${GITHUB_SHA:0:7}"
+          SHA_TAG="commit-$(git rev-parse --short "${GITHUB_SHA}")"
 
           if [[ "${{ github.event_name }}" == "pull_request" || "${{ vars.REGISTRY_SERVER }}" == "" ]]; then
             # PR / no-registry builds: amd64 only for speed, no push, no manifest needed.

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -246,6 +246,25 @@ jobs:
           cache-from: type=gha,scope=proxy-arm64
           cache-to: type=gha,mode=max,compression=zstd,scope=proxy-arm64
 
+      - name: Verify arm64 proxy image native libraries
+        if: steps.build_configuration.outputs.multi_arch == 'true'
+        run: |
+          ARM64_TAG="${{ steps.build_configuration.outputs.proxy_arm64_tag }}"
+          echo "Verifying arm64 native libs in ${ARM64_TAG}..."
+          _CONTAINER_ID=$(docker create --platform linux/arm64 "${ARM64_TAG}")
+          _NATIVE_DIR=$(mktemp -d)
+          docker cp "${_CONTAINER_ID}:/opt/kroxylicious/libs/native/netty/." "${_NATIVE_DIR}/"
+          docker rm "${_CONTAINER_ID}" > /dev/null
+          _AARCH64_COUNT=$(find "${_NATIVE_DIR}" -name '*aarch_64*' | wc -l | tr -d ' ')
+          _X86_64_COUNT=$(find "${_NATIVE_DIR}" -name '*x86_64*' | wc -l | tr -d ' ')
+          rm -rf "${_NATIVE_DIR}"
+          if [[ "${_AARCH64_COUNT}" -gt 0 && "${_X86_64_COUNT}" -eq 0 ]]; then
+            echo "arm64 proxy image OK: ${_AARCH64_COUNT} aarch_64 native lib(s), no x86_64 libs."
+          else
+            echo "ERROR: arm64 native lib check failed (aarch_64=${_AARCH64_COUNT}, x86_64=${_X86_64_COUNT})." >&2
+            exit 1
+          fi
+
       # ── Phase 4: multi-arch manifest ─────────────────────────────────────────
       # Assemble the canonical proxy tag and the legacy Kroxylicious alias as
       # manifest lists pointing at the per-arch images pushed above.

--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -50,6 +50,8 @@ on:
         required: true
       KROXYLICIOUS_RELEASE_TOKEN:
         required: true
+      REGISTRY_TOKEN:
+        required: true
 
 jobs:
   promote-release:
@@ -221,12 +223,64 @@ jobs:
         run: |
           gh pr merge --delete-branch --rebase ${{ inputs.release-pr-issue-number }}
 
+      - name: Login to container registry
+        if: ${{ vars.REGISTRY_SERVER != '' }}
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
+        with:
+          registry: ${{ vars.REGISTRY_SERVER }}
+          username: ${{ vars.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - name: 'Tag release container images'
+        if: ${{ inputs.command == 'promote-release' && vars.REGISTRY_SERVER != '' }}
+        run: |
+          RELEASE_SHA=$(git rev-parse "v${{ env.RELEASE_VERSION }}^{}")
+          SHA_TAG="commit-${RELEASE_SHA:0:7}"
+
+          PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.PROXY_IMAGE_NAME }}"
+          LEGACY_PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/kroxylicious"
+          OPERATOR_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.OPERATOR_IMAGE_NAME }}"
+          ADMISSION_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.ADMISSION_IMAGE_NAME }}"
+
+          # Re-tag the SHA-tagged staging images as the release version.
+          # --all copies all platform manifests (preserves multi-arch).
+          # Note: 'latest' is intentionally not published. If the project decides to
+          # resume a 'latest' tag, add additional skopeo copy lines here.
+          skopeo copy --all \
+            "docker://${PROXY_IMAGE}:${SHA_TAG}" \
+            "docker://${PROXY_IMAGE}:${{ env.RELEASE_VERSION }}"
+          skopeo copy --all \
+            "docker://${PROXY_IMAGE}:${SHA_TAG}" \
+            "docker://${LEGACY_PROXY_IMAGE}:${{ env.RELEASE_VERSION }}"
+          skopeo copy --all \
+            "docker://${OPERATOR_IMAGE}:${SHA_TAG}" \
+            "docker://${OPERATOR_IMAGE}:${{ env.RELEASE_VERSION }}"
+          skopeo copy --all \
+            "docker://${ADMISSION_IMAGE}:${SHA_TAG}" \
+            "docker://${ADMISSION_IMAGE}:${{ env.RELEASE_VERSION }}"
+
       - name: 'Drop PR'
         if: ${{ inputs.command == 'drop-release' }}
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
-          gh pr close --comment "Release dropped" --delete-branch ${{ inputs.release-pr-issue-number }} 
+          gh pr close --comment "Release dropped" --delete-branch ${{ inputs.release-pr-issue-number }}
+
+      - name: 'Delete staging container images'
+        if: ${{ inputs.command == 'drop-release' && vars.REGISTRY_SERVER != '' }}
+        run: |
+          RELEASE_SHA=$(git rev-parse "v${{ env.RELEASE_VERSION }}^{}")
+          SHA_TAG="commit-${RELEASE_SHA:0:7}"
+
+          PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.PROXY_IMAGE_NAME }}"
+          LEGACY_PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/kroxylicious"
+          OPERATOR_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.OPERATOR_IMAGE_NAME }}"
+          ADMISSION_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.ADMISSION_IMAGE_NAME }}"
+
+          skopeo delete "docker://${PROXY_IMAGE}:${SHA_TAG}"
+          skopeo delete "docker://${LEGACY_PROXY_IMAGE}:${SHA_TAG}"
+          skopeo delete "docker://${OPERATOR_IMAGE}:${SHA_TAG}"
+          skopeo delete "docker://${ADMISSION_IMAGE}:${SHA_TAG}"
 
       - name: 'Drop run label used to tag release PR'
         env:

--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -269,6 +269,20 @@ jobs:
       - name: 'Delete staging container images'
         if: ${{ inputs.command == 'drop-release' && vars.REGISTRY_SERVER != '' }}
         run: |
+          skopeo_delete_if_exists() {
+            local ref="$1"
+            skopeo inspect "docker://${ref}" > /dev/null 2>&1
+            local exit_code=$?
+            if [[ $exit_code -eq 2 ]]; then
+              echo "Image not found, skipping: docker://${ref}"
+              return 0
+            elif [[ $exit_code -ne 0 ]]; then
+              echo "Error inspecting docker://${ref}" >&2
+              return 1
+            fi
+            skopeo delete "docker://${ref}"
+          }
+
           RELEASE_SHA=$(git rev-parse "v${{ env.RELEASE_VERSION }}^{}")
           SHA_TAG="commit-${RELEASE_SHA:0:7}"
 
@@ -277,10 +291,10 @@ jobs:
           OPERATOR_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.OPERATOR_IMAGE_NAME }}"
           ADMISSION_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.ADMISSION_IMAGE_NAME }}"
 
-          skopeo delete "docker://${PROXY_IMAGE}:${SHA_TAG}"
-          skopeo delete "docker://${LEGACY_PROXY_IMAGE}:${SHA_TAG}"
-          skopeo delete "docker://${OPERATOR_IMAGE}:${SHA_TAG}"
-          skopeo delete "docker://${ADMISSION_IMAGE}:${SHA_TAG}"
+          skopeo_delete_if_exists "${PROXY_IMAGE}:${SHA_TAG}"
+          skopeo_delete_if_exists "${LEGACY_PROXY_IMAGE}:${SHA_TAG}"
+          skopeo_delete_if_exists "${OPERATOR_IMAGE}:${SHA_TAG}"
+          skopeo_delete_if_exists "${ADMISSION_IMAGE}:${SHA_TAG}"
 
       - name: 'Drop run label used to tag release PR'
         env:

--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -234,29 +234,30 @@ jobs:
       - name: 'Tag release container images'
         if: ${{ inputs.command == 'promote-release' && vars.REGISTRY_SERVER != '' }}
         run: |
-          RELEASE_SHA=$(git rev-parse "v${{ env.RELEASE_VERSION }}^{}")
-          SHA_TAG="commit-${RELEASE_SHA:0:7}"
-
+          PROXY_MANIFEST=$(jq -r '.stagedArtifacts.proxy.manifest' RELEASE_STATE.json)
+          LEGACY_PROXY_MANIFEST=$(jq -r '.stagedArtifacts.legacyProxy.manifest' RELEASE_STATE.json)
+          OPERATOR_MANIFEST=$(jq -r '.stagedArtifacts.operator.manifest' RELEASE_STATE.json)
+          ADMISSION_MANIFEST=$(jq -r '.stagedArtifacts.admission.manifest' RELEASE_STATE.json)
           PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.PROXY_IMAGE_NAME }}"
           LEGACY_PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/kroxylicious"
           OPERATOR_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.OPERATOR_IMAGE_NAME }}"
           ADMISSION_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.ADMISSION_IMAGE_NAME }}"
 
-          # Re-tag the SHA-tagged staging images as the release version.
+          # Re-tag the staged manifest lists as the release version.
           # --all copies all platform manifests (preserves multi-arch).
           # Note: 'latest' is intentionally not published. If the project decides to
           # resume a 'latest' tag, add additional skopeo copy lines here.
           skopeo copy --all \
-            "docker://${PROXY_IMAGE}:${SHA_TAG}" \
+            "docker://${PROXY_MANIFEST}" \
             "docker://${PROXY_IMAGE}:${{ env.RELEASE_VERSION }}"
           skopeo copy --all \
-            "docker://${PROXY_IMAGE}:${SHA_TAG}" \
+            "docker://${PROXY_MANIFEST}" \
             "docker://${LEGACY_PROXY_IMAGE}:${{ env.RELEASE_VERSION }}"
           skopeo copy --all \
-            "docker://${OPERATOR_IMAGE}:${SHA_TAG}" \
+            "docker://${OPERATOR_MANIFEST}" \
             "docker://${OPERATOR_IMAGE}:${{ env.RELEASE_VERSION }}"
           skopeo copy --all \
-            "docker://${ADMISSION_IMAGE}:${SHA_TAG}" \
+            "docker://${ADMISSION_MANIFEST}" \
             "docker://${ADMISSION_IMAGE}:${{ env.RELEASE_VERSION }}"
 
       - name: 'Drop PR'
@@ -285,18 +286,19 @@ jobs:
             skopeo delete "docker://${ref}"
           }
 
-          RELEASE_SHA=$(git rev-parse "v${{ env.RELEASE_VERSION }}^{}")
-          SHA_TAG="commit-${RELEASE_SHA:0:7}"
-
-          PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.PROXY_IMAGE_NAME }}"
-          LEGACY_PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/kroxylicious"
-          OPERATOR_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.OPERATOR_IMAGE_NAME }}"
-          ADMISSION_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.ADMISSION_IMAGE_NAME }}"
-
-          skopeo_delete_if_exists "${PROXY_IMAGE}:${SHA_TAG}"
-          skopeo_delete_if_exists "${LEGACY_PROXY_IMAGE}:${SHA_TAG}"
-          skopeo_delete_if_exists "${OPERATOR_IMAGE}:${SHA_TAG}"
-          skopeo_delete_if_exists "${ADMISSION_IMAGE}:${SHA_TAG}"
+          while IFS= read -r ref; do
+            skopeo_delete_if_exists "${ref}"
+          done < <(jq -r '
+            .stagedArtifacts |
+            [
+              .proxy.manifest,
+              .proxy.images.amd64.ref,
+              .proxy.images.arm64.ref,
+              .legacyProxy.manifest,
+              .operator.manifest,
+              .admission.manifest
+            ] | .[]
+          ' RELEASE_STATE.json)
 
       - name: 'Drop run label used to tag release PR'
         env:

--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -273,6 +273,8 @@ jobs:
             local ref="$1"
             skopeo inspect "docker://${ref}" > /dev/null 2>&1
             local exit_code=$?
+            # skopeo inspect exits 2 when the image is not found (distinct from other errors);
+            # exit 1 indicates a real failure worth surfacing rather than silently swallowing.
             if [[ $exit_code -eq 2 ]]; then
               echo "Image not found, skipping: docker://${ref}"
               return 0

--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -234,31 +234,22 @@ jobs:
       - name: 'Tag release container images'
         if: ${{ inputs.command == 'promote-release' && vars.REGISTRY_SERVER != '' }}
         run: |
-          PROXY_MANIFEST=$(jq -r '.stagedArtifacts.proxy.manifest' RELEASE_STATE.json)
-          LEGACY_PROXY_MANIFEST=$(jq -r '.stagedArtifacts.legacyProxy.manifest' RELEASE_STATE.json)
-          OPERATOR_MANIFEST=$(jq -r '.stagedArtifacts.operator.manifest' RELEASE_STATE.json)
-          ADMISSION_MANIFEST=$(jq -r '.stagedArtifacts.admission.manifest' RELEASE_STATE.json)
-          PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.PROXY_IMAGE_NAME }}"
-          LEGACY_PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/kroxylicious"
-          OPERATOR_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.OPERATOR_IMAGE_NAME }}"
-          ADMISSION_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.ADMISSION_IMAGE_NAME }}"
+          # Re-tag each staged manifest as the release version and latest.
+          # --all preserves the multi-arch manifest list.
+          # The staging tag is stripped from the manifest ref to derive the image name.
+          tag_release() {
+            local manifest="$1" image="$2"
+            skopeo copy --all "docker://${manifest}" "docker://${image}:${{ env.RELEASE_VERSION }}"
+            skopeo copy --all "docker://${manifest}" "docker://${image}:latest"
+          }
 
-          # Re-tag the staged manifest lists as the release version.
-          # --all copies all platform manifests (preserves multi-arch).
-          # Note: 'latest' is intentionally not published. If the project decides to
-          # resume a 'latest' tag, add additional skopeo copy lines here.
-          skopeo copy --all \
-            "docker://${PROXY_MANIFEST}" \
-            "docker://${PROXY_IMAGE}:${{ env.RELEASE_VERSION }}"
-          skopeo copy --all \
-            "docker://${PROXY_MANIFEST}" \
-            "docker://${LEGACY_PROXY_IMAGE}:${{ env.RELEASE_VERSION }}"
-          skopeo copy --all \
-            "docker://${OPERATOR_MANIFEST}" \
-            "docker://${OPERATOR_IMAGE}:${{ env.RELEASE_VERSION }}"
-          skopeo copy --all \
-            "docker://${ADMISSION_MANIFEST}" \
-            "docker://${ADMISSION_IMAGE}:${{ env.RELEASE_VERSION }}"
+          # .manifestImage.ref selects only the multi-arch manifest list for each entity.
+          # Per-arch intermediate images (proxy amd64/arm64) are staging artifacts only
+          # and are not published with a release tag.
+          MANIFEST_IMAGE_SELECTOR='.stagedArtifacts[].images.manifestImage.ref'
+          while IFS= read -r manifest; do
+            tag_release "${manifest}" "${manifest%:*}"
+          done < <(jq -r "${MANIFEST_IMAGE_SELECTOR}" RELEASE_STATE.json)
 
       - name: 'Drop PR'
         if: ${{ inputs.command == 'drop-release' }}
@@ -286,19 +277,12 @@ jobs:
             skopeo delete "docker://${ref}"
           }
 
+          # .[].ref iterates all image entries per entity (manifestImage + any per-arch
+          # intermediates), ensuring nothing is left behind on drop.
+          ALL_IMAGE_REFS_SELECTOR='.stagedArtifacts[].images[].ref'
           while IFS= read -r ref; do
             skopeo_delete_if_exists "${ref}"
-          done < <(jq -r '
-            .stagedArtifacts |
-            [
-              .proxy.manifest,
-              .proxy.images.amd64.ref,
-              .proxy.images.arm64.ref,
-              .legacyProxy.manifest,
-              .operator.manifest,
-              .admission.manifest
-            ] | .[]
-          ' RELEASE_STATE.json)
+          done < <(jq -r "${ALL_IMAGE_REFS_SELECTOR}" RELEASE_STATE.json)
 
       - name: 'Drop run label used to tag release PR'
         env:

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -151,6 +151,28 @@ jobs:
           # Deployment id is the id known to Central Publishing Portal
           echo "DEPLOYMENT_ID=$(cat DEPLOYMENT.ID)" >> $GITHUB_ENV
 
+      - name: 'Build and verify release container images'
+        env:
+          GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+        run: |
+          RELEASE_SHA=$(git rev-parse "v${{ github.event.inputs.release-version }}^{}")
+          gh workflow run docker.yaml --ref "v${{ github.event.inputs.release-version }}"
+
+          # Poll until the triggered run appears (dispatch registration can take a few seconds)
+          RUN_ID=""
+          for i in $(seq 1 12); do
+            sleep 10
+            RUN_ID=$(gh api \
+              "/repos/${{ github.repository }}/actions/workflows/docker.yaml/runs?head_sha=${RELEASE_SHA}" \
+              --jq '.workflow_runs[0].id // empty')
+            [[ -n "${RUN_ID}" ]] && break
+          done
+          if [[ -z "${RUN_ID}" ]]; then
+            echo "Timed out waiting for docker workflow run to appear for ${RELEASE_SHA}"
+            exit 1
+          fi
+          gh run watch "${RUN_ID}" --exit-status
+
       - name: 'Build release state'
         run: |
           jq -n --arg deploymentId "${{ env.DEPLOYMENT_ID }}" \

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -238,7 +238,7 @@ jobs:
         run: |
           ./scripts/stage-docs.sh -v ${{ github.event.inputs.release-version }} \
                                   -b "prepare-v${{ github.event.inputs.release-version }}-release-docs-${{ github.run_id }}" \
-                                  -u "https://user:${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}@${{ github.event.inputs.website-repository }}"
+                                  -u "https://user:${GH_TOKEN}@${{ github.event.inputs.website-repository }}"
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }} # For the gh cmd line tool used by stage-docs.sh
 

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -175,14 +175,57 @@ jobs:
             exit 1
           fi
           gh run watch "${RUN_ID}" --exit-status
+          echo "DOCKER_RUN_ID=${RUN_ID}" >> $GITHUB_ENV
 
       - name: 'Build release state'
         run: |
-          jq -n --arg deploymentId "${{ env.DEPLOYMENT_ID }}" \
-                --arg releaseVersion "${{ github.event.inputs.release-version }}" \
-                --arg developmentVersion "${{ github.event.inputs.development-version }}" \
-                --arg workBranch "${{ env.WORK_BRANCH }}" \
-              '$ARGS.named' > RELEASE_STATE.json
+          VERSION="${{ github.event.inputs.release-version }}"
+          SHA_TAG="commit-$(git rev-parse --short "v${VERSION}^{}")"
+          REGISTRY="${{ vars.REGISTRY_SERVER }}"
+          ORG="${{ vars.REGISTRY_ORGANISATION }}"
+          PROXY="${REGISTRY}/${ORG}/${{ vars.PROXY_IMAGE_NAME }}"
+          OPERATOR="${REGISTRY}/${ORG}/${{ vars.OPERATOR_IMAGE_NAME }}"
+          ADMISSION="${REGISTRY}/${ORG}/${{ vars.ADMISSION_IMAGE_NAME }}"
+
+          jq -n \
+            --arg deploymentId "${{ env.DEPLOYMENT_ID }}" \
+            --arg releaseVersion "${VERSION}" \
+            --arg developmentVersion "${{ github.event.inputs.development-version }}" \
+            --arg workBranch "${{ env.WORK_BRANCH }}" \
+            --arg imageWorkflowRunId "${{ env.DOCKER_RUN_ID }}" \
+            --arg proxyAmd64Ref "${PROXY}:${SHA_TAG}-amd64" \
+            --arg proxyArm64Ref "${PROXY}:${SHA_TAG}-arm64" \
+            --arg proxyManifest "${PROXY}:${SHA_TAG}" \
+            --arg legacyProxyManifest "${REGISTRY}/${ORG}/kroxylicious:${SHA_TAG}" \
+            --arg operatorManifest "${OPERATOR}:${SHA_TAG}" \
+            --arg admissionManifest "${ADMISSION}:${SHA_TAG}" \
+            '{
+              deploymentId: $deploymentId,
+              releaseVersion: $releaseVersion,
+              developmentVersion: $developmentVersion,
+              workBranch: $workBranch,
+              stagedArtifacts: {
+                imageWorkflowRunId: $imageWorkflowRunId,
+                proxy: {
+                  images: {
+                    amd64: { ref: $proxyAmd64Ref, builtFrom: { pom: ("io.kroxylicious:kroxylicious-app:" + $releaseVersion + ":pom"), profiles: ["dist"] } },
+                    arm64: { ref: $proxyArm64Ref, builtFrom: { pom: ("io.kroxylicious:kroxylicious-app:" + $releaseVersion + ":pom"), profiles: ["dist", "aarch64"] } }
+                  },
+                  manifest: $proxyManifest
+                },
+                legacyProxy: {
+                  manifest: $legacyProxyManifest
+                },
+                operator: {
+                  builtFrom: { pom: ("io.kroxylicious:kroxylicious-operator:" + $releaseVersion + ":pom"), profiles: ["dist"] },
+                  manifest: $operatorManifest
+                },
+                admission: {
+                  builtFrom: { pom: ("io.kroxylicious:kroxylicious-admission:" + $releaseVersion + ":pom"), profiles: ["dist"] },
+                  manifest: $admissionManifest
+                }
+              }
+            }' > RELEASE_STATE.json
 
       - name: 'Archive release state (used by the promote workflow)'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -156,15 +156,18 @@ jobs:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
           RELEASE_SHA=$(git rev-parse "v${{ github.event.inputs.release-version }}^{}")
+
+          # Capture time before dispatch so the poll can ignore runs from prior staging attempts
+          DISPATCH_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           gh workflow run docker.yaml --ref "v${{ github.event.inputs.release-version }}"
 
           # Poll until the triggered run appears (dispatch registration can take a few seconds)
           RUN_ID=""
           for i in $(seq 1 12); do
             sleep 10
-            RUN_ID=$(gh api \
-              "/repos/${{ github.repository }}/actions/workflows/docker.yaml/runs?head_sha=${RELEASE_SHA}" \
-              --jq '.workflow_runs[0].id // empty')
+            RUN_ID=$(DISPATCH_SINCE="${DISPATCH_TIME}" gh api \
+              "/repos/${{ github.repository }}/actions/workflows/docker.yaml/runs?head_sha=${RELEASE_SHA}&event=workflow_dispatch" \
+              --jq '[.workflow_runs[] | select(.created_at >= env.DISPATCH_SINCE)] | .[0].id // empty')
             [[ -n "${RUN_ID}" ]] && break
           done
           if [[ -z "${RUN_ID}" ]]; then

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -204,25 +204,31 @@ jobs:
               releaseVersion: $releaseVersion,
               developmentVersion: $developmentVersion,
               workBranch: $workBranch,
+              imageWorkflowRunId: $imageWorkflowRunId,
               stagedArtifacts: {
-                imageWorkflowRunId: $imageWorkflowRunId,
                 proxy: {
                   images: {
+                    manifestImage: { ref: $proxyManifest },
                     amd64: { ref: $proxyAmd64Ref, builtFrom: { pom: ("io.kroxylicious:kroxylicious-app:" + $releaseVersion + ":pom"), profiles: ["dist"] } },
                     arm64: { ref: $proxyArm64Ref, builtFrom: { pom: ("io.kroxylicious:kroxylicious-app:" + $releaseVersion + ":pom"), profiles: ["dist", "aarch64"] } }
-                  },
-                  manifest: $proxyManifest
+                  }
                 },
                 legacyProxy: {
-                  manifest: $legacyProxyManifest
+                  images: {
+                    manifestImage: { ref: $legacyProxyManifest }
+                  }
                 },
                 operator: {
-                  builtFrom: { pom: ("io.kroxylicious:kroxylicious-operator:" + $releaseVersion + ":pom"), profiles: ["dist"] },
-                  manifest: $operatorManifest
+                  images: {
+                    manifestImage: { ref: $operatorManifest }
+                  },
+                  builtFrom: { pom: ("io.kroxylicious:kroxylicious-operator:" + $releaseVersion + ":pom"), profiles: ["dist"] }
                 },
                 admission: {
-                  builtFrom: { pom: ("io.kroxylicious:kroxylicious-admission:" + $releaseVersion + ":pom"), profiles: ["dist"] },
-                  manifest: $admissionManifest
+                  images: {
+                    manifestImage: { ref: $admissionManifest }
+                  },
+                  builtFrom: { pom: ("io.kroxylicious:kroxylicious-admission:" + $releaseVersion + ":pom"), profiles: ["dist"] }
                 }
               }
             }' > RELEASE_STATE.json

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -17,8 +17,7 @@ BRANCH_FROM="main"
 WORK_BRANCH_NAME="release-work-$(openssl rand -hex 12)"
 SKIP_VALIDATION="false"
 RELEASE_NOTES_DIR=${RELEASE_NOTES_DIR:-.releaseNotes}
-PROXY_IMAGE_REPO="quay.io/kroxylicious/proxy"
-while getopts ":i:l:v:b:k:r:n:w:sh" opt; do
+while getopts ":l:v:b:k:r:n:w:sh" opt; do
   case $opt in
     v) RELEASE_VERSION="${OPTARG}"
     ;;
@@ -30,8 +29,6 @@ while getopts ":i:l:v:b:k:r:n:w:sh" opt; do
     ;;
     k) GPG_KEY="${OPTARG}"
     ;;
-    i) PROXY_IMAGE_REPO="${OPTARG}"
-    ;;
     l) RELCAND_ID_LABEL="${OPTARG}"
     ;;
     w) WORK_BRANCH_NAME="${OPTARG}"
@@ -40,14 +37,13 @@ while getopts ":i:l:v:b:k:r:n:w:sh" opt; do
     ;;
     h)
       1>&2 cat << EOF
-usage: $0 -k keyid -v version -l relcand-label [-b branch] [-r repository] [-i proxy-image-repo] [-s] [-d] [-h]
+usage: $0 -k keyid -v version -l relcand-label [-b branch] [-r repository] [-s] [-d] [-h]
  -k short key id used to sign the release
  -v version number e.g. 0.3.0
  -b branch to release from (defaults to 'main')
  -n development version e.g. 0.4.0-SNAPSHOT
  -l Release candidate label to be applied to the PR.
  -r the remote name of the kroxylicious repository (defaults to 'origin')
- -i proxy image repo override for arm64 verification (default: quay.io/kroxylicious/proxy)
  -w release work branch
  -s skips validation
  -h this help message
@@ -258,53 +254,4 @@ gh pr create --head "${PREPARE_DEVELOPMENT_BRANCH}" \
              --repo "$(gh repo set-default -v)" \
              --label "${RELCAND_ID_LABEL}"
 
-# ── Verification: arm64 proxy image contains correct native libs ──────────────
-# The docker.yaml workflow was triggered by the tag push earlier in this script.
-# By the time we reach here (after mvn deploy + release prep), the workflow has
-# had significant time to run.  We poll for the run, wait for completion, then
-# spot-check that the linux/arm64 image layer contains aarch_64 Netty native
-# libraries and NO x86_64 ones.
-#
-# Defaults to quay.io/kroxylicious/proxy; override with -i for fork testing.
-if [[ -n "${PROXY_IMAGE_REPO}" ]]; then
-  echo "Waiting for docker workflow triggered by ${RELEASE_TAG} to appear..."
-  DOCKER_RUN_ID=""
-  for _attempt in 1 2 3 4 5 6 7 8 9 10; do
-    DOCKER_RUN_ID=$(gh run list \
-      --workflow docker.yaml \
-      --branch "${RELEASE_TAG}" \
-      --json databaseId \
-      --jq '.[0].databaseId // empty' 2>/dev/null || true)
-    [[ -n "${DOCKER_RUN_ID}" ]] && break
-    echo "  Run not yet visible (attempt ${_attempt}/10); retrying in 15s..."
-    sleep 15
-  done
-
-  if [[ -z "${DOCKER_RUN_ID}" ]]; then
-    echo "ERROR: Could not find docker workflow run for tag ${RELEASE_TAG}." >&2
-    echo "       Check the Actions tab and verify the arm64 image manually." >&2
-    exit 1
-  fi
-
-  echo "Found docker workflow run ${DOCKER_RUN_ID}; waiting for completion..."
-  gh run watch "${DOCKER_RUN_ID}" --exit-status
-
-  echo "Verifying arm64 proxy image native libraries in ${PROXY_IMAGE_REPO}:${RELEASE_VERSION}..."
-  _CONTAINER_ID=$(docker create --platform linux/arm64 "${PROXY_IMAGE_REPO}:${RELEASE_VERSION}")
-  _NATIVE_DIR=$(mktemp -d)
-  docker cp "${_CONTAINER_ID}:/opt/kroxylicious/libs/native/netty/." "${_NATIVE_DIR}/"
-  docker rm "${_CONTAINER_ID}" > /dev/null
-
-  _AARCH64_COUNT=$(find "${_NATIVE_DIR}" -name '*aarch_64*' | wc -l | tr -d ' ')
-  _X86_64_COUNT=$(find "${_NATIVE_DIR}" -name '*x86_64*' | wc -l | tr -d ' ')
-  rm -rf "${_NATIVE_DIR}"
-
-  if [[ "${_AARCH64_COUNT}" -gt 0 && "${_X86_64_COUNT}" -eq 0 ]]; then
-    echo "arm64 proxy image OK: ${_AARCH64_COUNT} aarch_64 native lib(s), no x86_64 libs."
-  else
-    echo "ERROR: arm64 native lib check failed (aarch_64=${_AARCH64_COUNT}, x86_64=${_X86_64_COUNT})." >&2
-    echo "       Use drop-release to clean up, then investigate the docker workflow." >&2
-    exit 1
-  fi
-fi
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Replaces the tag-push trigger on `docker.yaml` with an explicit, blocking docker build during staging and a lightweight re-tag at promotion time.

**Old flow:**
- `stage-release.sh` pushes `vX.Y.Z` tag → tag trigger fires `docker.yaml` → version-tagged images pushed immediately (before Maven artefacts are validated or promoted)
- When the release PR merges to `main`, `docker.yaml` fires again with the SNAPSHOT version (wrong)

**New flow:**
- `stage-release.sh` pushes `vX.Y.Z` tag → `stage_release.yaml` dispatches `docker.yaml` on the release tag ref and **waits for it to pass** (staging fails if the build fails)
- Images are pushed tagged `commit-<sha>` only — no version tag until promotion
- `promote_release.yaml` re-tags `commit-<sha>` → `X.Y.Z` via `imagetools create` (no rebuild)

**Tagging strategy changes in `docker.yaml`:**
- All builds: `commit-<sha>` tag always
- Branch pushes (`main`, `release/**`): additionally tag with the pom version (`x.y.z-SNAPSHOT`)
- Staging dispatch: SHA only (caller passes no `additional-tags`)
- `workflow_dispatch` callers can pass `additional-tags` for any extra tags needed
- `latest` is intentionally dropped — see comment in `promote_release.yaml` for the escape hatch

### Additional Context

Part of the release process redesign (#4278). Supersedes #4397 and closes #4279.

The key insight is that building images at **promotion time** (not at tag-push time) means:
1. A failed build blocks staging rather than silently failing after the fact
2. Images are never published for releases that get dropped
3. `latest` only moves when a release is explicitly promoted

### Checklist

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).