### PR TITLE
test(systemtests): re-test OperatorChangeDetectionST against JOSDK 5.4.1-SNAPSHOT

### DIFF
--- a/kroxylicious-kubernetes/pom.xml
+++ b/kroxylicious-kubernetes/pom.xml
@@ -22,8 +22,18 @@
     <packaging>pom</packaging>
 
     <properties>
-        <josdk.version>5.4.0</josdk.version>
+        <josdk.version>5.4.1-SNAPSHOT</josdk.version>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>central-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <modules>
         <module>kroxylicious-kubernetes-api</module>

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/OperatorChangeDetectionST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/OperatorChangeDetectionST.java
@@ -18,6 +18,8 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -103,7 +105,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         kroxylicious.createOrUpdateResources();
     }
 
-    @Test
+    @RepeatedTest(20)
     void shouldUpdateDeploymentWhenKafkaProxyIngressChanges(String namespace) {
         // Given
         deployPortIdentifiesNodeWithNoFilters(namespace, kafkaClusterName);
@@ -121,6 +123,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUpdated(namespace, originalChecksum);
     }
 
+    @Disabled
     @Test
     void shouldUpdateDeploymentWhenVirtualKafkaClusterChanges(String namespace) {
         // Given
@@ -156,6 +159,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUpdated(namespace, originalChecksum);
     }
 
+    @Disabled
     @Test
     void shouldUpdateDeploymentWhenDownstreamTlsCertUpdated(String namespace) {
         // Given
@@ -182,6 +186,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUpdated(namespace, originalChecksum);
     }
 
+    @Disabled
     @Test
     void shouldUpdateDeploymentWhenDownstreamTrustUpdated(String namespace) {
         // Given
@@ -206,6 +211,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUpdated(namespace, originalChecksum);
     }
 
+    @Disabled
     @Test
     void shouldUpdateWhenFilterConfigurationChanges(String namespace) {
         // Given
@@ -233,6 +239,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUpdated(namespace, originalChecksum);
     }
 
+    @Disabled
     @Test
     void shouldUpdateDeploymentWhenResourceRequirementsChange(String namespace) {
         // Given
@@ -281,6 +288,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         });
     }
 
+    @Disabled
     @Test
     void shouldNotUpdateDeploymentChecksumWhenKafkaProxyScaled(String namespace) {
         // Given
@@ -302,6 +310,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertDeploymentUnchanged(namespace, originalChecksum, 2);
     }
 
+    @Disabled
     @Test
     void shouldPreserveExternalSsaPatchOnProxyDeploymentAfterReconcile(String namespace) {
         // Given
@@ -321,6 +330,7 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
         assertEnvVarsStillPresent(namespace, kubeClient);
     }
 
+    @Disabled
     @Test
     void shouldUpdateDeploymentWhenSecretChanges(String namespace) {
         // Given

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/OperatorChangeDetectionST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/OperatorChangeDetectionST.java
@@ -402,7 +402,9 @@ class OperatorChangeDetectionST extends AbstractSystemTests {
     @BeforeAll
     void setupBefore() {
         kroxyliciousOperator = new KroxyliciousOperator(Constants.KROXYLICIOUS_OPERATOR_NAMESPACE)
-                .withOperatorEnvVars(Map.of("KROXYLICIOUS_OPERATOR_RESYNC_INTERVAL_SECONDS", "30"));
+                .withOperatorEnvVars(Map.of(
+                        "KROXYLICIOUS_JOSDK_LOG_LEVEL", "DEBUG",
+                        "KROXYLICIOUS_OPERATOR_RESYNC_INTERVAL_SECONDS", "300"));
         kroxyliciousOperator.deploy();
     }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Re-test the flaky `OperatorChangeDetectionST` against JOSDK 5.4.1-SNAPSHOT at the
request of the JOSDK team.

Sets `KROXYLICIOUS_JOSDK_LOG_LEVEL=DEBUG` and
`KROXYLICIOUS_OPERATOR_RESYNC_INTERVAL_SECONDS=300` (5 minutes) so the original
unmasked flaky window is preserved — the 30s workaround on main was specifically
there to paper over the race, so 5 minutes deliberately exceeds the test timeout.

Relates-to: #4241

### Additional Context

The JOSDK team believe 5.4.1-SNAPSHOT contains a fix for the race. This branch
lets us run CI against it before the release is cut.

### Checklist

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).