### PR TITLE
fix(operator): stabilise flaky KafkaServiceBootstrapReconcilerIT

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
@@ -287,12 +287,15 @@ class KafkaServiceBootstrapReconcilerIT {
         AWAIT.untilAsserted(() -> {
             final KafkaService kafkaService = clusterUser.get(KafkaService.class, ResourcesUtil.name(cr));
             Assertions.assertThat(kafkaService).isNotNull();
-            Assertions.assertThat(kafkaService.getStatus().getBootstrapServers()).isEqualTo(expectedBootstrap);
             assertThat(kafkaService.getStatus())
                     .isNotNull()
-                    .conditionList()
-                    .singleElement()
-                    .isResolvedRefsTrue();
+                    .satisfies(status -> {
+                        Assertions.assertThat(status.getBootstrapServers()).isEqualTo(expectedBootstrap);
+                        assertThat(status)
+                                .conditionList()
+                                .singleElement()
+                                .isResolvedRefsTrue();
+                    });
             String checksum = getReferentChecksum(kafkaService);
             if (hasReferents) {
                 Assertions.assertThat(checksum).isNotEqualTo(NO_CHECKSUM_SPECIFIED);


### PR DESCRIPTION
## Summary

- `KafkaServiceBootstrapReconcilerIT.shouldUpdateStatusOnceTrustAnchorConfigMapDeleted` fails intermittently with an NPE because `assertResolvedRefsTrue` dereferences `getStatus()` before checking it for null
- When the operator hasn't reconciled yet, `getStatus()` returns null and throws a `NullPointerException` — Awaitility's `untilAsserted` only retries `AssertionError`, so the NPE causes immediate failure (the CI log shows 0.212s elapsed, well short of the 60s timeout)
- An alternative fix would be to add `ignoreExceptions()` to the Awaitility chain, but the null-check-first approach using `.satisfies()` is more precise and matches the pattern already used in `KafkaServiceStrimziKafkaRefReconcilerIT`

Fixes #4417

## Test plan

- [ ] CI passes — the fix is to the test assertion ordering only, no production code changes
- [ ] Confirm the `assertResolvedRefsTrue` method now matches the pattern in `KafkaServiceStrimziKafkaRefReconcilerIT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)