### PR TITLE
ci(microshift): allow unsafe PR checkout in workflow_run context

### DIFF
--- a/.github/workflows/operator-tests-microshift.yaml
+++ b/.github/workflows/operator-tests-microshift.yaml
@@ -93,6 +93,10 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          # workflow_run triggers run with the base repo's token and secrets, so checking out
+          # fork code carries risk. The mitigation here is requiring maintainer approval before
+          # this workflow runs for contributions from new contributors.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Java
         uses: ./.github/actions/common/setup-java


### PR DESCRIPTION
## Summary

- The `operator-tests-microshift` workflow triggers via `workflow_run`, which runs with the base repo's token and secrets.
- A recent `actions/checkout` update started refusing to check out fork PR code in that trusted context without explicit opt-in.
- Adds `allow-unsafe-pr-checkout: true` with a comment noting the existing mitigation: maintainer approval is required before this workflow runs for new contributors.

Fixes: #4423

## Test plan

- [ ] Observe the next fork PR run of the microshift workflow succeeds past the checkout step.

---

> [!NOTE]
> AI tools played a significant role in this contribution (see `Assisted-by:` commit trailer).