### PR TITLE
ci: don't trigger some workflows on docs changes in PRs

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -33,8 +33,14 @@ on:
       - 'release/**'
     tags:
       - 'v*.*.*'
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.adoc'
   pull_request:
     types: [ opened, synchronize, reopened ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.adoc'
 
 jobs:
   build:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -33,17 +33,30 @@ on:
       - 'release/**'
     tags:
       - 'v*.*.*'
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.adoc'
   pull_request:
     types: [ opened, synchronize, reopened ]
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.adoc'
 
 jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      only_docs_changed: ${{ steps.check.outputs.only_matching_files_changed }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 'Check out repository'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: 'Detect non-documentation changes'
+        id: check
+        run: scripts/only-matching-files-changed.sh '\.(md|adoc)$'
+
   build:
+    needs: check_changes
+    if: needs.check_changes.outputs.only_docs_changed == 'false'
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -49,6 +49,8 @@ jobs:
 
       - name: 'Check out repository'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 2
 
       - name: 'Detect non-documentation changes'
         id: check

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -19,21 +19,34 @@ name: "Run Kroxylicious Proxy Integration Tests"
 on:
   push:
     branches: [ main, 'release/**' ]
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.adoc'
   pull_request:
     types: [ opened, synchronize, reopened ]
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.adoc'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      only_docs_changed: ${{ steps.check.outputs.only_matching_files_changed }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 'Check out repository'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: 'Detect non-documentation changes'
+        id: check
+        run: scripts/only-matching-files-changed.sh '\.(md|adoc)$'
+
   discover_integration_test_chunks:
+    needs: check_changes
+    if: needs.check_changes.outputs.only_docs_changed == 'false'
     runs-on: ubuntu-latest
     outputs:
       test_chunks: ${{ steps.discover.outputs.test_chunks }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -19,8 +19,14 @@ name: "Run Kroxylicious Proxy Integration Tests"
 on:
   push:
     branches: [ main, 'release/**' ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.adoc'
   pull_request:
     types: [ opened, synchronize, reopened ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.adoc'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -39,6 +39,8 @@ jobs:
 
       - name: 'Check out repository'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 2
 
       - name: 'Detect non-documentation changes'
         id: check

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,6 +37,8 @@ jobs:
 
       - name: 'Check out repository'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 2
 
       - name: 'Detect non-documentation changes'
         id: check

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,6 +19,9 @@ name: "Lint Pull Request"
 on:
   pull_request:
     types: [ opened, synchronize, reopened ]
+    # licence:check reads .adoc files
+    paths-ignore:
+      - '**/*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,16 +19,32 @@ name: "Lint Pull Request"
 on:
   pull_request:
     types: [ opened, synchronize, reopened ]
-    # licence:check reads .adoc files
-    paths-ignore:
-      - '**/*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      only_docs_changed: ${{ steps.check.outputs.only_matching_files_changed }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 'Check out repository'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: 'Detect non-documentation changes'
+        id: check
+        run: scripts/only-matching-files-changed.sh '\.md$' # licence:check reads .adoc files
+
   lint:
+    needs: check_changes
+    if: needs.check_changes.outputs.only_docs_changed == 'false'
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -19,21 +19,34 @@ name: "Build Kroxylicious Proxy"
 on:
   push:
     branches: [ main, 'release/**' ]
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.adoc'
   pull_request:
     types: [ opened, synchronize, reopened ]
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.adoc'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      only_docs_changed: ${{ steps.check.outputs.only_matching_files_changed }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 'Check out repository'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: 'Detect non-documentation changes'
+        id: check
+        run: scripts/only-matching-files-changed.sh '\.(md|adoc)$'
+
   build_proxy:
+    needs: check_changes
+    if: needs.check_changes.outputs.only_docs_changed == 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -39,6 +39,8 @@ jobs:
 
       - name: 'Check out repository'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 2
 
       - name: 'Detect non-documentation changes'
         id: check

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -19,8 +19,14 @@ name: "Build Kroxylicious Proxy"
 on:
   push:
     branches: [ main, 'release/**' ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.adoc'
   pull_request:
     types: [ opened, synchronize, reopened ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.adoc'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -19,21 +19,34 @@ name: Build Kroxylicious Operator
 on:
   push:
     branches: [ main, 'release/**' ]
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.adoc'
   pull_request:
     types: [ opened, synchronize, reopened ]
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.adoc'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      only_docs_changed: ${{ steps.check.outputs.only_matching_files_changed }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 'Check out repository'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: 'Detect non-documentation changes'
+        id: check
+        run: scripts/only-matching-files-changed.sh '\.(md|adoc)$'
+
   build_operator:
+    needs: check_changes
+    if: needs.check_changes.outputs.only_docs_changed == 'false'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -39,6 +39,8 @@ jobs:
 
       - name: 'Check out repository'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 2
 
       - name: 'Detect non-documentation changes'
         id: check

--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -19,8 +19,14 @@ name: Build Kroxylicious Operator
 on:
   push:
     branches: [ main, 'release/**' ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.adoc'
   pull_request:
     types: [ opened, synchronize, reopened ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.adoc'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/scripts/only-matching-files-changed.sh
+++ b/scripts/only-matching-files-changed.sh
@@ -1,20 +1,10 @@
 #!/usr/bin/env bash
 #
-#  Licensed to the Apache Software Foundation (ASF) under one or more
-#  contributor license agreements. See the NOTICE file distributed with
-#  this work for additional information regarding copyright ownership.
-#  The ASF licenses this file to You under the Apache License, Version 2.0
-#  (the "License"); you may not use this file except in compliance with
-#  the License. You may obtain a copy of the License at
+# Copyright Kroxylicious Authors.
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
+
 set -euo pipefail
 
 # Checks whether all changed files in a pull_request match a given pattern,

--- a/scripts/only-matching-files-changed.sh
+++ b/scripts/only-matching-files-changed.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+set -euo pipefail
+
+# Checks whether all changed files in a pull_request match a given pattern,
+# writing only_matching_files_changed=true/false to GITHUB_OUTPUT.
+# For all other event types the output is always false (workflow always runs).
+#
+# Usage: only-matching-files-changed.sh PATTERN
+#
+#   PATTERN  ERE matched against each changed filename.
+#            only_matching_files_changed=true only when every changed file matches PATTERN.
+#
+# Required environment variables (set automatically by GitHub Actions):
+#   GITHUB_OUTPUT       Path to the step-output file
+#   GITHUB_EVENT_NAME   Event that triggered the workflow (pull_request / push / …)
+#   GITHUB_BASE_REF     Base branch name (set automatically for pull_request events)
+
+readonly PATTERN="${1:?PATTERN argument is required}"
+
+# Change detection is only performed for pull_request events. For other events
+# (push, workflow_dispatch, …) the workflow always runs. Limiting detection to
+# pull requests means we can use git diff against the already-fetched base ref
+# rather than calling the GitHub API, which avoids needing pull-requests: read
+# permission in the token for push-triggered workflows.
+if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
+  echo "only_matching_files_changed=false" >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
+changed_files=$(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD")
+
+if [[ -z "${changed_files}" ]]; then
+  # Nothing changed - no reason to run
+  echo "only_matching_files_changed=skip" >> "${GITHUB_OUTPUT}"
+elif echo "${changed_files}" | grep -qvE "${PATTERN}"; then
+  # At least one changed file does not match PATTERN - run the workflow
+  echo "only_matching_files_changed=false" >> "${GITHUB_OUTPUT}"
+else
+  # Every changed file matches PATTERN - skip the workflow
+  echo "only_matching_files_changed=true" >> "${GITHUB_OUTPUT}"
+fi

--- a/scripts/only-matching-files-changed.sh
+++ b/scripts/only-matching-files-changed.sh
@@ -29,21 +29,21 @@ set -euo pipefail
 # Required environment variables (set automatically by GitHub Actions):
 #   GITHUB_OUTPUT       Path to the step-output file
 #   GITHUB_EVENT_NAME   Event that triggered the workflow (pull_request / push / …)
-#   GITHUB_BASE_REF     Base branch name (set automatically for pull_request events)
 
 readonly PATTERN="${1:?PATTERN argument is required}"
 
 # Change detection is only performed for pull_request events. For other events
 # (push, workflow_dispatch, …) the workflow always runs. Limiting detection to
-# pull requests means we can use git diff against the already-fetched base ref
-# rather than calling the GitHub API, which avoids needing pull-requests: read
-# permission in the token for push-triggered workflows.
+# pull requests means we can use git diff against HEAD^1 (the base branch tip,
+# which is the first parent of the synthetic merge commit that actions/checkout
+# creates for PRs) rather than calling the GitHub API, which avoids needing
+# pull-requests: read permission in the token for push-triggered workflows.
 if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
   echo "only_matching_files_changed=false" >> "${GITHUB_OUTPUT}"
   exit 0
 fi
 
-changed_files=$(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD")
+changed_files=$(git diff --name-only "HEAD^1...HEAD")
 
 if [[ -z "${changed_files}" ]]; then
   # Nothing changed - no reason to run


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Don't trigger some workflows (e.g. IT tests) when only docs have changed in a pull request.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
