### PR TITLE
fix(docs): preserve latest release ordering

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -42,6 +42,11 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
+      - name: 'Test release documentation scripts'
+        run: |
+          bash -n scripts/stage-docs.sh scripts/update-latest-docs-release.sh scripts/update-latest-docs-release-test.sh
+          shellcheck scripts/stage-docs.sh scripts/update-latest-docs-release.sh scripts/update-latest-docs-release-test.sh
+          ./scripts/update-latest-docs-release-test.sh
       - name: Setup Java
         uses: ./.github/actions/common/setup-java
       - name: 'Cache Maven packages'
@@ -75,3 +80,4 @@ jobs:
         with:
           name: PR_NUMBER
           path: PR_NUMBER.txt
+

--- a/scripts/stage-docs.sh
+++ b/scripts/stage-docs.sh
@@ -138,8 +138,7 @@ git checkout -b "${RELEASE_DOCS_BRANCH}"
 echo "Copying release docs from ${KROXYLICIOUS_DOCS_LOCATION} to ${WEBSITE_DOCS_LOCATION}"
 cp -R "${KROXYLICIOUS_DOCS_LOCATION}"/* "${WEBSITE_DOCS_LOCATION}"
 
-echo "Updating latest release to ${RELEASE_VERSION}"
-${SED} -i -e "s/^latestRelease: .*$/latestRelease: ${RELEASE_VERSION}/g" _data/kroxylicious.yml
+"${SCRIPT_DIR}/update-latest-docs-release.sh" _data/kroxylicious.yml "${RELEASE_VERSION}"
 
 echo "Committing release documentation to git"
 # Commit and push changes to branch in `kroxylicious/kroxylicious.github.io`
@@ -170,3 +169,4 @@ gh pr create --head "${RELEASE_DOCS_BRANCH}" \
              --title "Kroxylicious ${RELEASE_TAG} release documentation ${RELEASE_DATE}" \
              --body "${BODY}" \
              --repo "$(gh repo set-default -v)"
+

--- a/scripts/update-latest-docs-release-test.sh
+++ b/scripts/update-latest-docs-release-test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "${TEST_DIR}"' EXIT
+
+run_case() {
+    local name=$1
+    local current=$2
+    local release=$3
+    local expected=$4
+    local config_path="${TEST_DIR}/${name}.yml"
+    local actual
+
+    printf '# The version number of the latest release\nlatestRelease: %s\n' "${current}" > "${config_path}"
+
+    "${SCRIPT_DIR}/update-latest-docs-release.sh" "${config_path}" "${release}"
+
+    actual=$(sed -n -e 's/^latestRelease:[[:space:]]*//p' "${config_path}")
+    if [[ ${actual} != "${expected}" ]]; then
+        echo "${name}: expected ${expected}, got ${actual}" >&2
+        return 1
+    fi
+}
+
+run_case older-patch 0.22.0 0.20.1 0.22.0
+run_case newer-release 0.22.0 0.23.0 0.23.0
+
+echo "update-latest-docs-release tests passed"

--- a/scripts/update-latest-docs-release.sh
+++ b/scripts/update-latest-docs-release.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 <kroxylicious.yml> <release-version>" >&2
+    exit 1
+fi
+
+CONFIG_PATH=$1
+RELEASE_VERSION=$2
+SED_COMMAND=${SED:-sed}
+
+if [[ ! -f ${CONFIG_PATH} ]]; then
+    echo "Configuration file not found: ${CONFIG_PATH}" >&2
+    exit 1
+fi
+
+is_semver() {
+    [[ $1 =~ ^[0-9]+(\.[0-9]+){2}$ ]]
+}
+
+version_is_at_least() {
+    local candidate=$1
+    local current=$2
+    local -a candidate_parts
+    local -a current_parts
+    local index
+    local candidate_part
+    local current_part
+
+    IFS=. read -r -a candidate_parts <<< "${candidate}"
+    IFS=. read -r -a current_parts <<< "${current}"
+
+    for index in 0 1 2; do
+        candidate_part=$((10#${candidate_parts[index]}))
+        current_part=$((10#${current_parts[index]}))
+        if (( candidate_part > current_part )); then
+            return 0
+        elif (( candidate_part < current_part )); then
+            return 1
+        fi
+    done
+
+    return 0
+}
+
+CURRENT_LATEST_RELEASE=$("${SED_COMMAND}" -n -e 's/^[[:space:]]*latestRelease:[[:space:]]*\([^[:space:]]*\)[[:space:]]*$/\1/p' "${CONFIG_PATH}")
+
+if ! is_semver "${CURRENT_LATEST_RELEASE}"; then
+    echo "Invalid latestRelease in ${CONFIG_PATH}: ${CURRENT_LATEST_RELEASE}" >&2
+    exit 1
+fi
+
+if ! is_semver "${RELEASE_VERSION}"; then
+    echo "Invalid release version: ${RELEASE_VERSION}" >&2
+    exit 1
+fi
+
+if [[ ${RELEASE_VERSION} == "${CURRENT_LATEST_RELEASE}" ]]; then
+    echo "Latest release is already ${CURRENT_LATEST_RELEASE}"
+elif version_is_at_least "${RELEASE_VERSION}" "${CURRENT_LATEST_RELEASE}"; then
+    echo "Updating latest release from ${CURRENT_LATEST_RELEASE} to ${RELEASE_VERSION}"
+    "${SED_COMMAND}" -i.bak -e "s/^[[:space:]]*latestRelease:.*$/latestRelease: ${RELEASE_VERSION}/" "${CONFIG_PATH}"
+    rm -f "${CONFIG_PATH}.bak"
+else
+    echo "Keeping latest release at ${CURRENT_LATEST_RELEASE}; ${RELEASE_VERSION} is older"
+fi


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Prevents `scripts/stage-docs.sh` from moving the website's `latestRelease` value backwards when an older point release is published. The version update now goes through a focused semantic-version helper, with regression cases proving that `0.20.1` cannot replace `0.22.0` while `0.23.0` can.

The pull-request lint workflow runs Bash syntax checks, ShellCheck, and the focused regression script.

### Additional Context

An older point release should still publish its versioned documentation, but it should not become the default documentation release when a newer semantic version already exists.

Fixes #4365.

OpenAI Codex assisted with the implementation, tests, and pull-request drafting. I reviewed the change and remain responsible for the contribution.

### Validation

- `bash -n scripts/stage-docs.sh scripts/update-latest-docs-release.sh scripts/update-latest-docs-release-test.sh`
- `./scripts/update-latest-docs-release-test.sh`
- Parsed `.github/workflows/lint.yaml` locally
- Gitleaks: no findings
- TruffleHog filesystem scan: no verified or unverified secrets
- ShellCheck and the full repository checks remain pending on the exact-head GitHub workflows because the managed local shell lacks the ShellCheck binary and Git transport could not obtain a full checkout

### Checklist

- [x] New tests written (where applicable).
- [x] This is release automation, not a user-facing behavior change; user documentation is not required.
- [ ] Existing unit/integration/system tests passing — pending exact-head GitHub workflows.
- [x] No local Sonarcloud warnings are applicable to this shell-only change; exact-head analysis remains pending.
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] AI-assisted commit includes the required `Assisted-by:` trailer.
- [x] This is not user-facing, so no CHANGELOG entry is required.
