### PR TITLE
fix(authorization): use client-negotiated version for internal metadata request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#3759](https://github.com/kroxylicious/kroxylicious/issues/3759): fix(authorization): use client-negotiated version for internal metadata request
 * [#3783](https://github.com/kroxylicious/kroxylicious/issues/3783): fix(config): remove deprecated `shutdownQuietPeriodSeconds` field from `NettySettings`.
 
 ### Changes, deprecations and removals

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/MetadataEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/MetadataEnforcement.java
@@ -130,7 +130,8 @@ class MetadataEnforcement extends ApiEnforcement<MetadataRequestData, MetadataRe
 
         var initialRequestHeader = new RequestHeaderData()
                 .setRequestApiKey(ApiKeys.METADATA.id)
-                .setRequestApiVersion(authorizationFilter.useMetadataVersion() != -1 ? authorizationFilter.useMetadataVersion() : ApiKeys.METADATA.latestVersion()) // Should support topic ids
+                .setRequestApiVersion(authorizationFilter.useMetadataVersion() != -1 ? authorizationFilter.useMetadataVersion()
+                        : (short) Math.max(4, header.requestApiVersion()))
                 .setClientId(header.clientId());
         var initialRequest = new MetadataRequestData()
                 .setTopics(request.topics())

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/0/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/0/baseline.yaml
@@ -12,18 +12,16 @@ metadata:
 given:
   mockedUpstreamResponses:
     - expectedRequestKey: "METADATA"
-      expectedRequestVersion: 13
+      expectedRequestVersion: 4
       expectedRequestHeader:
         requestApiKey: 3
-        requestApiVersion: 13
+        requestApiVersion: 4
         correlationId: 0
         clientId: "clientId"
       expectedRequest:
         topics:
-          - topicId: "AAAAAAAAAAAAAAAAAAAAAA"
-            name: "my-topic"
+          - name: "my-topic"
         allowAutoTopicCreation: false
-        includeTopicAuthorizedOperations: false
       upstreamResponseHeader:
         correlationId: 1
       upstreamResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/1/baseline.yaml
@@ -12,18 +12,16 @@ metadata:
 given:
   mockedUpstreamResponses:
     - expectedRequestKey: "METADATA"
-      expectedRequestVersion: 13
+      expectedRequestVersion: 4
       expectedRequestHeader:
         requestApiKey: 3
-        requestApiVersion: 13
+        requestApiVersion: 4
         correlationId: 0
         clientId: "clientId"
       expectedRequest:
         topics:
-          - topicId: "AAAAAAAAAAAAAAAAAAAAAA"
-            name: "my-topic"
+          - name: "my-topic"
         allowAutoTopicCreation: false
-        includeTopicAuthorizedOperations: false
       upstreamResponseHeader:
         correlationId: 1
       upstreamResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/10/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/10/baseline.yaml
@@ -12,10 +12,10 @@ metadata:
 given:
   mockedUpstreamResponses:
     - expectedRequestKey: "METADATA"
-      expectedRequestVersion: 13
+      expectedRequestVersion: 10
       expectedRequestHeader:
         requestApiKey: 3
-        requestApiVersion: 13
+        requestApiVersion: 10
         correlationId: 0
         clientId: "clientId"
       expectedRequest:
@@ -23,6 +23,7 @@ given:
           - topicId: "cwd1urkUQkmOMDQ5k5jKug"
             name: "my-topic"
         allowAutoTopicCreation: false
+        includeClusterAuthorizedOperations: false
         includeTopicAuthorizedOperations: false
       upstreamResponseHeader:
         correlationId: 1
@@ -52,6 +53,7 @@ given:
                 offlineReplicas:
                   - 421
             topicAuthorizedOperations: 769
+        clusterAuthorizedOperations: 760
         errorCode: 0
     - expectedRequestKey: "METADATA"
       expectedRequestVersion: 10

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/12/non-idempotent.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/12/non-idempotent.yaml
@@ -1,0 +1,152 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# Regression test for https://github.com/kroxylicious/kroxylicious/issues/3759
+# When a client sends allowAutoTopicCreation=true before the ApiVersions exchange has completed
+# (useMetadataVersion == -1), the internal probe must use the client's negotiated version (v12),
+# not latestVersion() (v13). A broker capped at v12 (e.g. Kafka 3.5) would reject a v13 probe.
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 12
+  scenario: "non-idempotent before ApiVersions exchange"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 12
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 12
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "Xn83BxP-S4C8MqoMjIf6uw"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 0
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 12
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 12
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics: [ ]
+        allowAutoTopicCreation: true
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            topicAuthorizedOperations: 760
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 0
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 12
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - topicId: "Xn83BxP-S4C8MqoMjIf6uw"
+        name: "my-topic"
+    allowAutoTopicCreation: true
+    includeTopicAuthorizedOperations: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        topicAuthorizedOperations: 760

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/2/baseline.yaml
@@ -12,18 +12,16 @@ metadata:
 given:
   mockedUpstreamResponses:
     - expectedRequestKey: "METADATA"
-      expectedRequestVersion: 13
+      expectedRequestVersion: 4
       expectedRequestHeader:
         requestApiKey: 3
-        requestApiVersion: 13
+        requestApiVersion: 4
         correlationId: 0
         clientId: "clientId"
       expectedRequest:
         topics:
-          - topicId: "AAAAAAAAAAAAAAAAAAAAAA"
-            name: "my-topic"
+          - name: "my-topic"
         allowAutoTopicCreation: false
-        includeTopicAuthorizedOperations: false
       upstreamResponseHeader:
         correlationId: 1
       upstreamResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/3/baseline.yaml
@@ -12,18 +12,16 @@ metadata:
 given:
   mockedUpstreamResponses:
     - expectedRequestKey: "METADATA"
-      expectedRequestVersion: 13
+      expectedRequestVersion: 4
       expectedRequestHeader:
         requestApiKey: 3
-        requestApiVersion: 13
+        requestApiVersion: 4
         correlationId: 0
         clientId: "clientId"
       expectedRequest:
         topics:
-          - topicId: "AAAAAAAAAAAAAAAAAAAAAA"
-            name: "my-topic"
+          - name: "my-topic"
         allowAutoTopicCreation: false
-        includeTopicAuthorizedOperations: false
       upstreamResponseHeader:
         correlationId: 1
       upstreamResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/5/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/5/baseline.yaml
@@ -12,18 +12,16 @@ metadata:
 given:
   mockedUpstreamResponses:
     - expectedRequestKey: "METADATA"
-      expectedRequestVersion: 13
+      expectedRequestVersion: 5
       expectedRequestHeader:
         requestApiKey: 3
-        requestApiVersion: 13
+        requestApiVersion: 5
         correlationId: 0
         clientId: "clientId"
       expectedRequest:
         topics:
-          - topicId: "AAAAAAAAAAAAAAAAAAAAAA"
-            name: "my-topic"
+          - name: "my-topic"
         allowAutoTopicCreation: false
-        includeTopicAuthorizedOperations: false
       upstreamResponseHeader:
         correlationId: 1
       upstreamResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/7/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/7/baseline.yaml
@@ -12,18 +12,16 @@ metadata:
 given:
   mockedUpstreamResponses:
     - expectedRequestKey: "METADATA"
-      expectedRequestVersion: 13
+      expectedRequestVersion: 7
       expectedRequestHeader:
         requestApiKey: 3
-        requestApiVersion: 13
+        requestApiVersion: 7
         correlationId: 0
         clientId: "clientId"
       expectedRequest:
         topics:
-          - topicId: "AAAAAAAAAAAAAAAAAAAAAA"
-            name: "my-topic"
+          - name: "my-topic"
         allowAutoTopicCreation: false
-        includeTopicAuthorizedOperations: false
       upstreamResponseHeader:
         correlationId: 1
       upstreamResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/8/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/8/baseline.yaml
@@ -12,17 +12,17 @@ metadata:
 given:
   mockedUpstreamResponses:
     - expectedRequestKey: "METADATA"
-      expectedRequestVersion: 13
+      expectedRequestVersion: 8
       expectedRequestHeader:
         requestApiKey: 3
-        requestApiVersion: 13
+        requestApiVersion: 8
         correlationId: 0
         clientId: "clientId"
       expectedRequest:
         topics:
-          - topicId: "AAAAAAAAAAAAAAAAAAAAAA"
-            name: "my-topic"
+          - name: "my-topic"
         allowAutoTopicCreation: false
+        includeClusterAuthorizedOperations: false
         includeTopicAuthorizedOperations: false
       upstreamResponseHeader:
         correlationId: 1
@@ -52,6 +52,7 @@ given:
                 offlineReplicas:
                   - 421
             topicAuthorizedOperations: 769
+        clusterAuthorizedOperations: 760
         errorCode: 0
     - expectedRequestKey: "METADATA"
       expectedRequestVersion: 8

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/9/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/9/baseline.yaml
@@ -12,17 +12,17 @@ metadata:
 given:
   mockedUpstreamResponses:
     - expectedRequestKey: "METADATA"
-      expectedRequestVersion: 13
+      expectedRequestVersion: 9
       expectedRequestHeader:
         requestApiKey: 3
-        requestApiVersion: 13
+        requestApiVersion: 9
         correlationId: 0
         clientId: "clientId"
       expectedRequest:
         topics:
-          - topicId: "AAAAAAAAAAAAAAAAAAAAAA"
-            name: "my-topic"
+          - name: "my-topic"
         allowAutoTopicCreation: false
+        includeClusterAuthorizedOperations: false
         includeTopicAuthorizedOperations: false
       upstreamResponseHeader:
         correlationId: 1
@@ -52,6 +52,7 @@ given:
                 offlineReplicas:
                   - 421
             topicAuthorizedOperations: 769
+        clusterAuthorizedOperations: 760
         errorCode: 0
     - expectedRequestKey: "METADATA"
       expectedRequestVersion: 9


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When `MetadataEnforcement.onNonIdempotentMetadataRequest()` sends an internal metadata request to the broker (to probe topic existence before allowing auto-creation), it falls back to `ApiKeys.METADATA.latestVersion()` (v13) when `useMetadataVersion` has not been set via `checkCompat()`. If the broker only supports up to v12 (e.g. Kafka 3.5), the broker rejects the unsupported version, causing a ~20 second timeout visible to the client as "Broker connection closed."

The fix uses `Math.max(4, header.requestApiVersion())` as the fallback instead. The client's version is already broker-compatible (intersected by `ApiVersionsIntersectFilter`), and the floor at v4 ensures the `allowAutoTopicCreation` field (introduced in Metadata v4) is available for the internal request.

#### Test YAML changes

The test scenarios assert the internal request serialized at the exact API version (`MockUpstream.respond()`). Changing the version from 13 to the client's version means the expected fields change per Kafka's schema evolution:

- **v4–v7**: `topicId` (added v10) and `includeTopicAuthorizedOperations` (added v8) are absent from `expectedRequest`
- **v8–v9**: `includeClusterAuthorizedOperations` and `includeTopicAuthorizedOperations` appear in `expectedRequest`; `clusterAuthorizedOperations` is mandatory in `upstreamResponse` (added v8, removed v12)
- **v10**: `topicId` appears in `expectedRequest`; `clusterAuthorizedOperations` remains mandatory in `upstreamResponse`
- **v13**: no change

### Additional Context

Fixes #3759

`useMetadataVersion` is set in `checkCompat()` when an ApiVersions response flows through the filter. If a Metadata request arrives before that has happened (e.g. client pipelining, reconnection skipping ApiVersions), the field is still -1 and the fallback to `latestVersion()` sends a version the broker may not support. `sendRequest()` only validates the version against the proxy's supported range, not the broker's, so there is no safety net.

### Checklist

- [x] New tests written (where applicable).
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).