### PR TITLE
ci(docker): add OCI image annotations to all built images

### DIFF
--- a/.github/workflows/build-omb-image.yml
+++ b/.github/workflows/build-omb-image.yml
@@ -66,6 +66,7 @@ jobs:
           KROX_SHORT=$(git rev-parse --short=7 HEAD)
           IMAGE_TAG="omb-${{ steps.omb.outputs.short }}-krox-${KROX_SHORT}-${{ github.run_number }}"
           echo "image_tag=${IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "image_created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${GITHUB_OUTPUT}"
           echo "Image tag: ${IMAGE_TAG}" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Set up Docker Buildx
@@ -101,7 +102,10 @@ jobs:
           build-args: |
             OMB_COMMIT=${{ steps.omb.outputs.sha }}
           labels: |
+            org.opencontainers.image.created=${{ steps.tag.outputs.image_created }}
             org.opencontainers.image.revision=${{ steps.omb.outputs.sha }}
+            org.opencontainers.image.source=https://github.com/openmessaging/benchmark
+            org.opencontainers.image.version=${{ steps.tag.outputs.image_tag }}
           tags: ${{ steps.build_configuration.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max,compression=zstd

--- a/.github/workflows/build-omb-image.yml
+++ b/.github/workflows/build-omb-image.yml
@@ -100,6 +100,8 @@ jobs:
           push: ${{ steps.build_configuration.outputs.push_images == 'true' }}
           build-args: |
             OMB_COMMIT=${{ steps.omb.outputs.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ steps.omb.outputs.sha }}
           tags: ${{ steps.build_configuration.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max,compression=zstd

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -134,7 +134,6 @@ jobs:
             echo "admission_tags=${ADMISSION_TAGS}" >> $GITHUB_OUTPUT
           fi
 
-      # ── Phase 1: compile and install ─────────────────────────────────────────
       # Install (not just package) so the per-arch dist steps can resolve local
       # module JARs from ~/.m2 without needing --also-make.
 
@@ -159,8 +158,6 @@ jobs:
           registry: ${{ vars.REGISTRY_SERVER }}
           username: ${{ vars.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-
-      # ── Phase 2: amd64 dist + images ─────────────────────────────────────────
 
       - name: Build amd64 distribution artifacts
         run: |
@@ -229,7 +226,6 @@ jobs:
           cache-from: type=gha,scope=admission
           cache-to: type=gha,mode=max,compression=zstd,scope=admission
 
-      # ── Phase 3: arm64 dist + image ──────────────────────────────────────────
       # `clean package` on kroxylicious-app alone wipes its target/ directory so
       # the aarch64 assembly contains only linux-aarch_64 Netty native binaries
       # (no leftovers from the amd64 run above).
@@ -285,10 +281,6 @@ jobs:
             echo "ERROR: arm64 native lib check failed (aarch_64=${_AARCH64_COUNT}, x86_64=${_X86_64_COUNT})." >&2
             exit 1
           fi
-
-      # ── Phase 4: multi-arch manifest ─────────────────────────────────────────
-      # Assemble the canonical proxy tag and the legacy Kroxylicious alias as
-      # annotated manifest lists pointing at the per-arch images pushed above.
 
       - name: Create and push proxy multi-arch manifest
         if: steps.build_configuration.outputs.multi_arch == 'true'

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -275,7 +275,7 @@ jobs:
 
       # ── Phase 4: multi-arch manifest ─────────────────────────────────────────
       # Assemble the canonical proxy tag and the legacy Kroxylicious alias as
-      # manifest lists pointing at the per-arch images pushed above.
+      # annotated manifest lists pointing at the per-arch images pushed above.
 
       - name: Create and push proxy multi-arch manifest
         if: steps.build_configuration.outputs.multi_arch == 'true'

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -77,6 +77,7 @@ jobs:
         run: |
           POMS_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "release_version=${POMS_VERSION}" >> $GITHUB_OUTPUT
+          echo "image_created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
           SHA_TAG="commit-$(git rev-parse --short "${GITHUB_SHA}")"
 
           if [[ "${{ github.event_name }}" == "pull_request" || "${{ vars.REGISTRY_SERVER }}" == "" ]]; then
@@ -184,7 +185,10 @@ jobs:
           build-args: |
             KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
           labels: |
+            org.opencontainers.image.created=${{ steps.build_configuration.outputs.image_created }}
             org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/kroxylicious/kroxylicious
+            org.opencontainers.image.version=${{ steps.build_configuration.outputs.release_version }}
           tags: ${{ steps.build_configuration.outputs.proxy_amd64_tag }}
           cache-from: type=gha,scope=proxy-amd64
           cache-to: type=gha,mode=max,compression=zstd,scope=proxy-amd64
@@ -199,7 +203,10 @@ jobs:
           build-args: |
             KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
           labels: |
+            org.opencontainers.image.created=${{ steps.build_configuration.outputs.image_created }}
             org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/kroxylicious/kroxylicious
+            org.opencontainers.image.version=${{ steps.build_configuration.outputs.release_version }}
           tags: ${{ steps.build_configuration.outputs.operator_tags }}
           cache-from: type=gha,scope=operator
           cache-to: type=gha,mode=max,compression=zstd,scope=operator
@@ -214,7 +221,10 @@ jobs:
           build-args: |
             KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
           labels: |
+            org.opencontainers.image.created=${{ steps.build_configuration.outputs.image_created }}
             org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/kroxylicious/kroxylicious
+            org.opencontainers.image.version=${{ steps.build_configuration.outputs.release_version }}
           tags: ${{ steps.build_configuration.outputs.admission_tags }}
           cache-from: type=gha,scope=admission
           cache-to: type=gha,mode=max,compression=zstd,scope=admission
@@ -249,7 +259,10 @@ jobs:
           build-args: |
             KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
           labels: |
+            org.opencontainers.image.created=${{ steps.build_configuration.outputs.image_created }}
             org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/kroxylicious/kroxylicious
+            org.opencontainers.image.version=${{ steps.build_configuration.outputs.release_version }}
           tags: ${{ steps.build_configuration.outputs.proxy_arm64_tag }}
           cache-from: type=gha,scope=proxy-arm64
           cache-to: type=gha,mode=max,compression=zstd,scope=proxy-arm64
@@ -282,7 +295,10 @@ jobs:
         run: |
           for TAG in $(echo "${{ steps.build_configuration.outputs.proxy_final_tags }}" | tr ',' ' '); do
             docker buildx imagetools create \
+              --annotation "index:org.opencontainers.image.created=${{ steps.build_configuration.outputs.image_created }}" \
               --annotation "index:org.opencontainers.image.revision=${{ github.sha }}" \
+              --annotation "index:org.opencontainers.image.source=https://github.com/kroxylicious/kroxylicious" \
+              --annotation "index:org.opencontainers.image.version=${{ steps.build_configuration.outputs.release_version }}" \
               -t "${TAG}" \
               "${{ steps.build_configuration.outputs.proxy_amd64_tag }}" \
               "${{ steps.build_configuration.outputs.proxy_arm64_tag }}"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -183,6 +183,8 @@ jobs:
           push: ${{ steps.build_configuration.outputs.push_images == 'true' }}
           build-args: |
             KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
           tags: ${{ steps.build_configuration.outputs.proxy_amd64_tag }}
           cache-from: type=gha,scope=proxy-amd64
           cache-to: type=gha,mode=max,compression=zstd,scope=proxy-amd64
@@ -196,6 +198,8 @@ jobs:
           push: ${{ steps.build_configuration.outputs.push_images == 'true' }}
           build-args: |
             KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
           tags: ${{ steps.build_configuration.outputs.operator_tags }}
           cache-from: type=gha,scope=operator
           cache-to: type=gha,mode=max,compression=zstd,scope=operator
@@ -209,6 +213,8 @@ jobs:
           push: ${{ steps.build_configuration.outputs.push_images == 'true' }}
           build-args: |
             KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
           tags: ${{ steps.build_configuration.outputs.admission_tags }}
           cache-from: type=gha,scope=admission
           cache-to: type=gha,mode=max,compression=zstd,scope=admission
@@ -242,6 +248,8 @@ jobs:
           push: true
           build-args: |
             KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
           tags: ${{ steps.build_configuration.outputs.proxy_arm64_tag }}
           cache-from: type=gha,scope=proxy-arm64
           cache-to: type=gha,mode=max,compression=zstd,scope=proxy-arm64
@@ -273,7 +281,9 @@ jobs:
         if: steps.build_configuration.outputs.multi_arch == 'true'
         run: |
           for TAG in $(echo "${{ steps.build_configuration.outputs.proxy_final_tags }}" | tr ',' ' '); do
-            docker buildx imagetools create -t "${TAG}" \
+            docker buildx imagetools create \
+              --annotation "index:org.opencontainers.image.revision=${{ github.sha }}" \
+              -t "${TAG}" \
               "${{ steps.build_configuration.outputs.proxy_amd64_tag }}" \
               "${{ steps.build_configuration.outputs.proxy_arm64_tag }}"
           done

--- a/changelog/unreleased/4465-add-oci-annotations.yml
+++ b/changelog/unreleased/4465-add-oci-annotations.yml
@@ -1,0 +1,10 @@
+# This file is used by logchange tool to generate CHANGELOG.md 🌳 🪓 => 🪵 
+# Visit https://github.com/logchange/logchange and leave a star 🌟 
+# More info about configuration you can find https://github.com/logchange/logchange#yaml-format ⬅️⬅ ️
+title: Adding OCI annotations to the published images
+merge_requests:
+  - 4465
+issues:
+  - 4281
+type: added
+


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Adds the standard OCI image annotations to all images built by the Docker and OMB image workflows:

- `org.opencontainers.image.revision` — full commit SHA of the source used to build the image
- `org.opencontainers.image.created` — RFC 3339 build timestamp
- `org.opencontainers.image.source` — URL to the source repository
- `org.opencontainers.image.version` — release version from the project POM (or composite image tag for OMB)

For the proxy multi-arch manifest list (assembled via `imagetools create`), the same set of annotations is applied at the OCI index level.

For the OMB image, `revision` is set to the OMB commit SHA being packaged and `source` points to the upstream OMB repository, since that is the primary software being packaged.

### Additional Context

\#4281 was mostly addressed by #4406 but the `org.opencontainers.image.revision` annotation (and the other standard OCI annotations) were not added to the built images. This PR completes that work.

### Checklist

- [ ] New tests written (where applicable).
- [x] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

Fixes #4281