### PR TITLE
ci: [DRAFT] enforce single squashed commit and conventional commit format on PRs

### DIFF
--- a/.claude/rules/commits.md
+++ b/.claude/rules/commits.md
@@ -55,6 +55,10 @@ Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>
 Signed-off-by: Developer Name <dev@example.com>
 ```
 
+## Squash Policy
+
+PRs must land as a single commit. **Do not squash during development** — multiple commits help reviewers follow the change. Squash only when the user says the PR is ready to merge, and only if they ask you to.
+
 ## Important Notes
 
 - **Do NOT use** `Co-Authored-By:` for AI disclosure - use `Assisted-by:`

--- a/.github/workflows/check-commit-conventions.yaml
+++ b/.github/workflows/check-commit-conventions.yaml
@@ -1,0 +1,62 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+name: Check Commit Conventions
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Check commit count
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const headRef = context.payload.pull_request.head.ref;
+            const isReleasePr = headRef.startsWith('release-work-')
+              && context.payload.pull_request.user.login === 'kroxylicious-robot';
+
+            const maxCommits = isReleasePr ? 2 : 1;
+
+            if (commits.length > maxCommits) {
+              core.setFailed(
+                `PR has ${commits.length} commits but must have exactly 1. ` +
+                `Please squash your commits into a single commit before merging.`
+              );
+            }
+
+      - name: Check conventional commit format
+        uses: webiny/action-conventional-commits@d13e2e7762992979ec06e9b5b7c7d24af1d7d7fd # v1.4.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -532,6 +532,27 @@ Signed-off-by: Jane Developer <jane@example.com>
 
 This practice maintains transparency about AI assistance in our development process while preserving the human developer's accountability for the final code.
 
+## Commit History Requirements
+
+PRs must land as a single commit with a message following [Conventional Commits](https://www.conventionalcommits.org/) format. CI enforces both rules and will block the merge if either fails.
+
+During development and review, keep as many commits as you like — granular history helps reviewers follow the change. Squash only when the PR is ready to merge.
+
+**Commit message format:**
+```
+<type>[(<scope>)]: <description>
+```
+
+Valid types: `feat`, `fix`, `docs`, `build`, `chore`, `refactor`, `perf`, `test`, `ci`
+
+**To squash before merging:**
+```shell
+git rebase -i origin/main
+# mark all but the first commit as 'squash' or 'fixup'
+git commit --amend  # set the final conventional commit message
+git push --force-with-lease
+```
+
 # Development Guide for Kroxylicious Operator
 
 This is the development guide for Kroxylicious operator for Kubernetes.


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds a GitHub Actions workflow that checks two things on every PR:

1. Commit count must be exactly 1. Release PRs (branch matching release-work-* authored by kroxylicious-robot) may have up to 2.
2. Every commit message must follow Conventional Commits format, validated using webiny/action-conventional-commits@v1.4.2.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
