### PR TITLE
fix(testing): define tester package nullness

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/DefaultKroxyliciousTester.java
@@ -48,7 +48,6 @@ import io.kroxylicious.proxy.internal.config.Features;
 import io.kroxylicious.proxy.reload.ReconfigureResult;
 import io.kroxylicious.testing.integration.client.KafkaClient;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import info.schnatterer.mobynamesgenerator.MobyNamesGenerator;
 
@@ -112,7 +111,6 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
                 k -> clientFactory.build(key, buildDefaultClientConfiguration(virtualCluster, gateway)));
     }
 
-    @NonNull
     private Map<String, Object> buildDefaultClientConfiguration(String virtualCluster, String gateway) {
         Map<String, Object> defaultClientConfig = new HashMap<>();
         defaultClientConfig.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, getBootstrapAddress(virtualCluster, gateway));
@@ -121,13 +119,11 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     }
 
     @Override
-    @NonNull
     public String getBootstrapAddress() {
         return getBootstrapAddress(onlyVirtualCluster(), DEFAULT_GATEWAY_NAME);
     }
 
     @Override
-    @NonNull
     public String getBootstrapAddress(String virtualCluster, String gateway) {
         if (proxy instanceof KafkaProxy kp) {
             return kp.getBootstrapAddress(virtualCluster, gateway).toString();

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousConfigUtils.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousConfigUtils.java
@@ -15,8 +15,6 @@ import io.kroxylicious.proxy.config.VirtualClusterGatewayBuilder;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-
 /**
  * Class for utilities related to manipulating KroxyliciousConfig and it's builder.
  */
@@ -123,7 +121,6 @@ public class KroxyliciousConfigUtils {
         return defaultSniHostIdentifiesNodeGatewayBuilder(HostPort.parse(bootstrapAddress), advertisedBrokerAddressPattern);
     }
 
-    @NonNull
     public static VirtualClusterBuilder baseVirtualClusterBuilder(KafkaCluster cluster, String clusterName) {
         return new VirtualClusterBuilder()
                 .withNewTargetCluster()

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousTesterBuilder.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/KroxyliciousTesterBuilder.java
@@ -21,12 +21,14 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  */
 public class KroxyliciousTesterBuilder {
 
+    @Nullable
     private String trustStoreLocation = null;
     @Nullable
     private String trustStorePassword = null;
     private BiFunction<Configuration, Features, AutoCloseable> kroxyliciousFactory = DefaultKroxyliciousTester::spawnProxy;
     private Features features = Features.defaultFeatures();
     private DefaultKroxyliciousTester.ClientFactory clientFactory = (clusterName, defaultConfiguration) -> new KroxyliciousClients(defaultConfiguration);
+    @Nullable
     private ConfigurationBuilder configurationBuilder;
 
     /**

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/ManagementClient.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/ManagementClient.java
@@ -16,8 +16,6 @@ import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Objects;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-
 import static java.net.http.HttpResponse.BodyHandlers.ofString;
 
 /**
@@ -30,7 +28,7 @@ public class ManagementClient implements Closeable {
 
     private final URI uri;
 
-    ManagementClient(@NonNull URI uri) {
+    ManagementClient(URI uri) {
         Objects.requireNonNull(uri, "uri");
         this.uri = uri;
     }
@@ -54,13 +52,11 @@ public class ManagementClient implements Closeable {
      *
      * @return list of metrics.
      */
-    @NonNull
     public List<SimpleMetric> scrapeMetrics() {
         var text = getFromAdminEndpoint(METRICS).body();
         return SimpleMetric.parse(text);
     }
 
-    @NonNull
     public URI getUri() {
         return uri;
     }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/package-info.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/package-info.java
@@ -7,4 +7,12 @@
 /**
  * Test harnesses and client utilities for exercising Kroxylicious deployments.
  */
+@ReturnValuesAreNonnullByDefault
+@DefaultAnnotationForParameters(NonNull.class)
+@DefaultAnnotation(NonNull.class)
 package io.kroxylicious.testing.integration.tester;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotationForParameters;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/package-info.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/testing/integration/tester/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * Test harnesses and client utilities for exercising Kroxylicious deployments.
+ */
+package io.kroxylicious.testing.integration.tester;


### PR DESCRIPTION
### Type of change

- Code quality and nullness metadata

### Description

Adds the missing `package-info.java` for the integration tester package with the standard package-level nullness defaults:

- `@ReturnValuesAreNonnullByDefault`
- `@DefaultAnnotationForParameters(NonNull.class)`
- `@DefaultAnnotation(NonNull.class)`

The existing tester classes were reviewed to:

- remove redundant `@NonNull` annotations now provided by the package defaults
- explicitly mark nullable builder state with `@Nullable`
- retain existing nullable parameters and record components

Closes #4431.

### Testing

- `mvn -pl kroxylicious-integration-test-support -am -DskipITs=true -DskipKTs=true -DskipSTs=true -DskipDTs=true verify`
- Checkstyle passed
- SpotBugs passed with zero findings
- `git diff --cached --check`

### Checklist

- [x] Package-level nullness defaults are present
- [x] Redundant `@NonNull` annotations were removed
- [x] Nullable fields remain explicitly annotated
- [x] DCO sign-off is included
- [x] No changelog entry is required for this internal code-quality change

AI assistance was used to investigate the nullness requirements and prepare the initial update. I reviewed the changes and ran the repository verification.