### PR TITLE
[DRAFT] feat(router): replace staticRoutes() with shouldIntercept() (proposal 118)

### DIFF
--- a/kroxylicious-api/pom.xml
+++ b/kroxylicious-api/pom.xml
@@ -184,6 +184,8 @@
                                     <exclude>io.kroxylicious.proxy.filter.ResponseFilter#onResponse(org.apache.kafka.common.protocol.ApiKeys, org.apache.kafka.common.message.ResponseHeaderData, org.apache.kafka.common.protocol.ApiMessage, io.kroxylicious.proxy.filter.FilterContext)</exclude>
                                     <!-- The following method was deprecated since 0.18 and removed at 0.21.0, see https://github.com/kroxylicious/kroxylicious/issues/3620 -->
                                     <exclude>io.kroxylicious.proxy.filter.FilterContext#clientSaslAuthenticationSuccess(java.lang.String, java.lang.String)</exclude>
+                                    <!-- The following method was removed at 0.22.0 as part of proposal 118, replaced by shouldIntercept() -->
+                                    <exclude>io.kroxylicious.proxy.router.Router#staticRoutes()</exclude>
                                 </excludes>
                                 <!-- see documentation -->
                             </parameter>

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/Router.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/Router.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.proxy.router;
 
-import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.message.RequestHeaderData;
@@ -20,6 +19,27 @@ import org.apache.kafka.common.protocol.ApiMessage;
  * down named routes and to deliver a response back to the client. A single
  * incoming request may result in multiple outgoing requests to different
  * routes (e.g. fan-out), with the router composing the final response.</p>
+ *
+ * <h2>Control plane vs data plane</h2>
+ *
+ * <p>Kafka makes no protocol distinction between a bootstrap broker and a data
+ * broker, but the router world must, because the connection's endpoint is the
+ * only signal for whether a default broker exists:</p>
+ * <ul>
+ *   <li><strong>Bootstrap endpoint</strong> → connection is <em>unbound</em>
+ *       ({@link RouterContext#virtualNode()} is empty) → the <strong>control
+ *       plane</strong>: discovery, {@code METADATA}, coordinator lookup, the
+ *       routing decisions.</li>
+ *   <li><strong>Broker endpoint</strong> → connection is <em>bound</em> to one
+ *       {@code (route, broker)} → the <strong>data plane</strong>: data-plane
+ *       traffic to a known broker.</li>
+ * </ul>
+ *
+ * <p>By default, a router intercepts only control-plane traffic (bootstrap
+ * connections where {@code virtualNode()} is empty). Data-plane traffic on
+ * bound connections passes through to the assigned broker without calling
+ * {@link #onRequest}. Routers override {@link #shouldIntercept} to declare
+ * additional API keys they need to intercept.</p>
  *
  * <h2>Observability guidelines for router implementations</h2>
  *
@@ -109,20 +129,41 @@ public interface Router {
     }
 
     /**
-     * <p>Declares API keys that are always forwarded to a fixed named route
-     * without deserialisation. For these API keys the runtime forwards
-     * frames directly (opaque or decoded) without calling
-     * {@link #onRequest}. API keys absent from this map are
-     * considered dynamically routed and will be decoded so that
-     * {@code onRequest} can inspect them.</p>
+     * Whether the router must be invoked for this request. When false the
+     * runtime forwards the frame to the connection's assigned broker
+     * ({@link RouterContext#virtualNode()}) without calling
+     * {@link #onRequest}.
      *
-     * <p>This method may only be called once in the lifetime of a Router.
-     * The runtime is free to call it once and cache the result.</p>
+     * <p>The default implementation intercepts only when there is no assigned
+     * broker (bootstrap connections where {@code virtualNode()} is empty).
+     * This allows data-plane traffic on bound connections to pass through
+     * without decoding or routing decisions.</p>
      *
-     * @return a map from API key to route name; empty means all API keys
-     *         are dynamically routed (the default)
+     * <p><strong>Common patterns:</strong></p>
+     * <ul>
+     *   <li><strong>Single-cluster router</strong>: intercept only on bootstrap
+     *       ({@code virtualNode().isEmpty()}) to assign the cluster, then pass
+     *       through on bound connections (the default behaviour).</li>
+     *   <li><strong>Client-id or subject router</strong>: intercept only on
+     *       bootstrap ({@code virtualNode().isEmpty()}) to make the routing
+     *       decision, then pass through on bound connections.</li>
+     *   <li><strong>Topic router</strong>: intercept on bootstrap plus
+     *       cluster-spanning APIs ({@code METADATA}, {@code FIND_COORDINATOR})
+     *       and coordinator-pinned APIs on bound connections.</li>
+     * </ul>
+     *
+     * <p><strong>Threading model:</strong> Called on the same Netty event loop
+     * thread as {@link #onRequest}. Router implementations do not need to
+     * synchronise access to their own state.</p>
+     *
+     * @param apiKey the API key identifying the request type
+     * @param apiVersion the API version of the request
+     * @param context the router context providing connection state
+     * @return true if the router needs to handle this request via
+     *         {@link #onRequest}, false to forward directly to the assigned
+     *         broker
      */
-    default Map<ApiKeys, String> staticRoutes() {
-        return Map.of();
+    default boolean shouldIntercept(ApiKeys apiKey, short apiVersion, RouterContext context) {
+        return context.virtualNode().isEmpty();
     }
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterContext.java
@@ -222,4 +222,5 @@ public interface RouterContext {
      * @return a stage that can optionally close the connection
      */
     CloseOrTerminalStage respondWithoutReply();
+
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/AlternatingRouterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/AlternatingRouterFactory.java
@@ -5,12 +5,8 @@
  */
 package io.kroxylicious.it.testplugins.router;
 
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
@@ -41,8 +37,6 @@ public class AlternatingRouterFactory implements RouterFactory<AlternatingRouter
     // When routing between independent clusters, the IDs differ, so cap at v12.
     private static final short MAX_PRODUCE_VERSION = 12;
 
-    private static final Set<ApiKeys> DYNAMICALLY_ROUTED = Set.of(ApiKeys.PRODUCE, ApiKeys.API_VERSIONS);
-
     public record Config(String routeA, String routeB, int batchSize) {}
 
     @Override
@@ -63,11 +57,18 @@ public class AlternatingRouterFactory implements RouterFactory<AlternatingRouter
                 .addKeyValue("batchSize", batchSize)
                 .log("AlternatingRouter created");
 
-        Map<ApiKeys, String> staticMap = Arrays.stream(ApiKeys.values())
-                .filter(k -> !DYNAMICALLY_ROUTED.contains(k))
-                .collect(Collectors.toUnmodifiableMap(k -> k, k -> routeA));
-
         return new Router() {
+            @Override
+            public boolean shouldIntercept(ApiKeys apiKey, short apiVersion, RouterContext context) {
+                // Intercept all bootstrap traffic.
+                // On bound connections, also intercept PRODUCE (for alternating routing) and
+                // API_VERSIONS (to cap the PRODUCE version and prevent topic-ID mismatches
+                // across independent clusters).
+                return context.virtualNode().isEmpty()
+                        || apiKey == ApiKeys.PRODUCE
+                        || apiKey == ApiKeys.API_VERSIONS;
+            }
+
             @Override
             public CompletionStage<RouterResponse> onRequest(ApiKeys apiKey,
                                                              short apiVersion,
@@ -87,22 +88,23 @@ public class AlternatingRouterFactory implements RouterFactory<AlternatingRouter
                             });
                 }
 
-                int index = counter.getAndIncrement();
-                String route = ((index / batchSize) % 2 == 0) ? routeA : routeB;
-                LOGGER.atDebug()
-                        .addKeyValue("sessionId", ctx.sessionId())
-                        .addKeyValue("route", route)
-                        .addKeyValue("batchIndex", index)
-                        .addKeyValue("batchSize", batchSize)
-                        .log("Alternating router chose route based on batch index");
-                var node = ctx.anyNode(route);
-                return ctx.sendRequest(node, header, request)
-                        .thenCompose(body -> ctx.respondWith(body).completed());
-            }
+                if (apiKey == ApiKeys.PRODUCE) {
+                    int index = counter.getAndIncrement();
+                    String route = ((index / batchSize) % 2 == 0) ? routeA : routeB;
+                    LOGGER.atDebug()
+                            .addKeyValue("sessionId", ctx.sessionId())
+                            .addKeyValue("route", route)
+                            .addKeyValue("batchIndex", index)
+                            .addKeyValue("batchSize", batchSize)
+                            .log("Alternating router chose route based on batch index");
+                    var node = ctx.anyNode(route);
+                    return ctx.sendRequest(node, header, request)
+                            .thenCompose(body -> ctx.respondWith(body).completed());
+                }
 
-            @Override
-            public Map<ApiKeys, String> staticRoutes() {
-                return staticMap;
+                // All other bootstrap traffic (METADATA, FIND_COORDINATOR, etc.) goes to routeA
+                return ctx.sendRequest(ctx.anyNode(routeA), header, request)
+                        .thenCompose(body -> ctx.respondWith(body).completed());
             }
         };
     }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/ContextCapturingRouterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/ContextCapturingRouterFactory.java
@@ -89,6 +89,11 @@ public class ContextCapturingRouterFactory
         String route = config.route();
         return new Router() {
             @Override
+            public boolean shouldIntercept(ApiKeys apiKey, short apiVersion, RouterContext ctx) {
+                return true;
+            }
+
+            @Override
             public CompletionStage<RouterResponse> onRequest(ApiKeys apiKey,
                                                              short apiVersion,
                                                              RequestHeaderData header,

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/DynamicProduceRouterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/DynamicProduceRouterFactory.java
@@ -5,10 +5,7 @@
  */
 package io.kroxylicious.it.testplugins.router;
 
-import java.util.Arrays;
-import java.util.Map;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
@@ -42,11 +39,13 @@ public class DynamicProduceRouterFactory
     @Override
     public Router createRouter(RouterFactoryContext context, Config config) {
         String route = config.route();
-        Map<ApiKeys, String> staticMap = Arrays.stream(ApiKeys.values())
-                .filter(k -> k != ApiKeys.PRODUCE)
-                .collect(Collectors.toUnmodifiableMap(k -> k, k -> route));
 
         return new Router() {
+            @Override
+            public boolean shouldIntercept(ApiKeys apiKey, short apiVersion, RouterContext context) {
+                return context.virtualNode().isEmpty();
+            }
+
             @Override
             public CompletionStage<RouterResponse> onRequest(ApiKeys apiKey,
                                                              short apiVersion,
@@ -54,17 +53,12 @@ public class DynamicProduceRouterFactory
                                                              ApiMessage request,
                                                              RouterContext ctx) {
                 var node = ctx.anyNode(route);
-                if (request instanceof ProduceRequestData pd && pd.acks() == 0) {
+                if (apiKey == ApiKeys.PRODUCE && request instanceof ProduceRequestData pd && pd.acks() == 0) {
                     return ctx.sendRequest(node, header, request)
                             .thenCompose(ignored -> ctx.respondWithoutReply().completed());
                 }
                 return ctx.sendRequest(node, header, request)
                         .thenCompose(body -> ctx.respondWith(body).completed());
-            }
-
-            @Override
-            public Map<ApiKeys, String> staticRoutes() {
-                return staticMap;
             }
         };
     }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/InvocationCountingRouterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/InvocationCountingRouterFactory.java
@@ -5,13 +5,11 @@
  */
 package io.kroxylicious.it.testplugins.router;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -54,19 +52,21 @@ public class InvocationCountingRouterFactory implements RouterFactory<Invocation
 
     @Override
     public Router createRouter(RouterFactoryContext context, Config initData) {
-        var allStatic = Arrays.stream(ApiKeys.values())
-                .collect(Collectors.toUnmodifiableMap(k -> k, k -> initData.route()));
         return new Router() {
+            @Override
+            public boolean shouldIntercept(ApiKeys apiKey, short apiVersion, RouterContext context) {
+                return context.virtualNode().isEmpty();
+            }
+
             @Override
             public CompletionStage<RouterResponse> onRequest(ApiKeys apiKey, short apiVersion,
                                                              RequestHeaderData header, ApiMessage request,
                                                              RouterContext routerContext) {
-                throw new IllegalStateException("Dynamic routing not supported by InvocationCountingRouterFactory");
-            }
-
-            @Override
-            public Map<ApiKeys, String> staticRoutes() {
-                return allStatic;
+                var node = routerContext.anyNode(initData.route());
+                return routerContext.sendRequest(node, header, request)
+                        .thenCompose(body -> body == null
+                                ? routerContext.respondWithoutReply().completed()
+                                : routerContext.respondWith(body).completed());
             }
         };
     }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/PassThroughRouterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/PassThroughRouterFactory.java
@@ -5,10 +5,7 @@
  */
 package io.kroxylicious.it.testplugins.router;
 
-import java.util.Arrays;
-import java.util.Map;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -20,22 +17,21 @@ import io.kroxylicious.proxy.router.RouterContext;
 import io.kroxylicious.proxy.router.RouterFactory;
 import io.kroxylicious.proxy.router.RouterFactoryContext;
 import io.kroxylicious.proxy.router.RouterResponse;
+import io.kroxylicious.proxy.topology.VirtualNode;
 
 /**
- * A test router that forwards every request to a single named route, delivering
- * the response back to the client unchanged.
+ * A test router that forwards every bootstrap request to a single named route,
+ * delivering the response back to the client. On bound connections the default
+ * {@code shouldIntercept} behaviour returns {@code false}, so frames pass through
+ * directly to the assigned broker without calling {@code onRequest}.
  */
 @Plugin(configType = PassThroughRouterFactory.Config.class)
 public class PassThroughRouterFactory implements RouterFactory<PassThroughRouterFactory.Config, PassThroughRouterFactory.Config> {
 
     public record Config(String route) {}
 
-    private Map<ApiKeys, String> allStatic;
-
     @Override
     public Config initialize(RouterFactoryContext context, Config config) {
-        allStatic = Arrays.stream(ApiKeys.values())
-                .collect(Collectors.toUnmodifiableMap(k -> k, k -> config.route()));
         return config;
     }
 
@@ -49,12 +45,13 @@ public class PassThroughRouterFactory implements RouterFactory<PassThroughRouter
                                                              RequestHeaderData header,
                                                              ApiMessage request,
                                                              RouterContext routerContext) {
-                throw new IllegalStateException("all RPCs should be statically routed, onRequest invoked unexpectedly!");
-            }
-
-            @Override
-            public Map<ApiKeys, String> staticRoutes() {
-                return allStatic;
+                // Use virtualNode() if bound, anyNode(route) if bootstrap.
+                VirtualNode target = routerContext.virtualNode()
+                        .orElseGet(() -> routerContext.anyNode(config.route()));
+                return routerContext.sendRequest(target, header, request)
+                        .thenCompose(response -> response == null
+                                ? routerContext.respondWithoutReply().completed()
+                                : routerContext.respondWith(response).completed());
             }
         };
     }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/RouterContractCapturingFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/RouterContractCapturingFactory.java
@@ -5,12 +5,9 @@
  */
 package io.kroxylicious.it.testplugins.router;
 
-import java.util.Arrays;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -73,21 +70,23 @@ public class RouterContractCapturingFactory
     @Override
     public Router createRouter(RouterFactoryContext context, InitData initData) {
         capturedCreate.set(new CreateCapture(context.virtualClusterName(), context.routerName(), initData));
-        Map<ApiKeys, String> allStatic = Arrays.stream(ApiKeys.values())
-                .collect(Collectors.toUnmodifiableMap(k -> k, k -> initData.config().route()));
         return new Router() {
+            @Override
+            public boolean shouldIntercept(ApiKeys apiKey, short apiVersion, RouterContext context) {
+                return context.virtualNode().isEmpty();
+            }
+
             @Override
             public CompletionStage<RouterResponse> onRequest(ApiKeys apiKey,
                                                              short apiVersion,
                                                              RequestHeaderData header,
                                                              ApiMessage request,
                                                              RouterContext routerContext) {
-                throw new IllegalStateException("Dynamic routing is not supported");
-            }
-
-            @Override
-            public Map<ApiKeys, String> staticRoutes() {
-                return allStatic;
+                var node = routerContext.anyNode(initData.config().route());
+                return routerContext.sendRequest(node, header, request)
+                        .thenCompose(body -> body == null
+                                ? routerContext.respondWithoutReply().completed()
+                                : routerContext.respondWith(body).completed());
             }
         };
     }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/SplitStaticRouterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/SplitStaticRouterFactory.java
@@ -5,12 +5,9 @@
  */
 package io.kroxylicious.it.testplugins.router;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -48,22 +45,23 @@ public class SplitStaticRouterFactory implements RouterFactory<SplitStaticRouter
     @Override
     public Router createRouter(RouterFactoryContext context, Config config) {
         var split = new HashSet<>(config.splitApiKeys());
-        Map<ApiKeys, String> routes = Arrays.stream(ApiKeys.values())
-                .collect(Collectors.toUnmodifiableMap(k -> k,
-                        k -> split.contains(k.name()) ? config.splitRoute() : config.defaultRoute()));
         return new Router() {
+            @Override
+            public boolean shouldIntercept(ApiKeys apiKey, short apiVersion, RouterContext context) {
+                // Intercept on bootstrap to route based on API key
+                return context.virtualNode().isEmpty();
+            }
+
             @Override
             public CompletionStage<RouterResponse> onRequest(ApiKeys apiKey,
                                                              short apiVersion,
                                                              RequestHeaderData header,
                                                              ApiMessage request,
-                                                             RouterContext routerContext) {
-                throw new IllegalStateException("Dynamic routing is not supported");
-            }
-
-            @Override
-            public Map<ApiKeys, String> staticRoutes() {
-                return routes;
+                                                             RouterContext ctx) {
+                String route = split.contains(apiKey.name()) ? config.splitRoute() : config.defaultRoute();
+                var node = ctx.anyNode(route);
+                return ctx.sendRequest(node, header, request)
+                        .thenCompose(body -> ctx.respondWith(body).completed());
             }
         };
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/DecodedFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/DecodedFrame.java
@@ -166,11 +166,12 @@ public abstract class DecodedFrame<H extends ApiMessage, B extends ApiMessage>
      * be sent to any broker on the route. Set by the router dispatch handler when
      * forwarding to a specific node via {@code sendToSpecificNode}.
      */
+    @Override
     public int targetVirtualNodeId() {
         return targetVirtualNodeId;
     }
 
-    /** Sets the target virtual node ID for this frame. See {@link #targetVirtualNodeId()}. */
+    @Override
     public void setTargetVirtualNodeId(int targetVirtualNodeId) {
         this.targetVirtualNodeId = targetVirtualNodeId;
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/Frame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/Frame.java
@@ -55,4 +55,16 @@ public interface Frame {
     /** Sets the route this frame is associated with. */
     default void setRouteName(@Nullable String routeName) {
     }
+
+    /**
+     * The target virtual node ID for this frame, or {@link #NO_TARGET_VIRTUAL_NODE_ID} if the frame
+     * should be forwarded to the route's default (bootstrap) node.
+     */
+    default int targetVirtualNodeId() {
+        return NO_TARGET_VIRTUAL_NODE_ID;
+    }
+
+    /** Sets the target virtual node ID for this frame. See {@link #targetVirtualNodeId()}. */
+    default void setTargetVirtualNodeId(int targetVirtualNodeId) {
+    }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/OpaqueFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/OpaqueFrame.java
@@ -35,6 +35,7 @@ public abstract class OpaqueFrame implements Frame {
     /** The message buffer excluding the frame size, including the header and body. */
     protected final ByteBuf buf;
     private @Nullable String routeName;
+    private int targetVirtualNodeId = Frame.NO_TARGET_VIRTUAL_NODE_ID;
 
     /**
      * @param apiKeyId api key id
@@ -118,6 +119,16 @@ public abstract class OpaqueFrame implements Frame {
     @Override
     public void setRouteName(@Nullable String routeName) {
         this.routeName = routeName;
+    }
+
+    @Override
+    public int targetVirtualNodeId() {
+        return targetVirtualNodeId;
+    }
+
+    @Override
+    public void setTargetVirtualNodeId(int targetVirtualNodeId) {
+        this.targetVirtualNodeId = targetVirtualNodeId;
     }
 
     @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/DelegatingDecodePredicate.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/DelegatingDecodePredicate.java
@@ -5,13 +5,14 @@
  */
 package io.kroxylicious.proxy.internal;
 
-import java.util.Set;
-
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.proxy.internal.codec.DecodePredicate;
+import io.kroxylicious.proxy.internal.routing.RouterDispatchHandler;
+import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.router.RouterContext;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
@@ -40,7 +41,8 @@ class DelegatingDecodePredicate implements DecodePredicate {
     private static final Logger LOGGER = LoggerFactory.getLogger(DelegatingDecodePredicate.class);
 
     private @Nullable DecodePredicate delegate = null;
-    private @Nullable Set<ApiKeys> routerRequiresDecoding = null;
+    private @Nullable Router router = null;
+    private @Nullable RouterContext routerContext = null;
 
     DelegatingDecodePredicate() {
     }
@@ -53,11 +55,16 @@ class DelegatingDecodePredicate implements DecodePredicate {
     }
 
     /**
-     * Sets the API keys for which the router requires decoded frames.
-     * These are the dynamically-routed keys that need {@code onClientRequest}.
+     * Sets the router and context for interception checks.
+     * The decode predicate will consult {@link Router#shouldIntercept} to determine
+     * if requests need decoding for router interception.
      */
-    void setRouterDecodingRequirements(@Nullable Set<ApiKeys> dynamicallyRoutedKeys) {
-        this.routerRequiresDecoding = dynamicallyRoutedKeys;
+    void setRouterInterceptionDelegate(Router router, RouterContext context) {
+        LOGGER.atDebug()
+                .addKeyValue("router", router)
+                .log("Setting router interception delegate");
+        this.router = router;
+        this.routerContext = context;
     }
 
     @Override
@@ -71,7 +78,7 @@ class DelegatingDecodePredicate implements DecodePredicate {
         if (delegate.shouldDecodeRequest(apiKey, apiVersion)) {
             return true;
         }
-        return routerRequiresDecoding != null && routerRequiresDecoding.contains(apiKey);
+        return router != null && routerContext != null && router.shouldIntercept(apiKey, apiVersion, routerContext);
     }
 
     @Override
@@ -85,14 +92,27 @@ class DelegatingDecodePredicate implements DecodePredicate {
         if (delegate.shouldDecodeResponse(apiKey, apiVersion)) {
             return true;
         }
-        return routerRequiresDecoding != null && routerRequiresDecoding.contains(apiKey);
+        if (router != null && routerContext != null) {
+            // On bootstrap (unbound) connections, always decode: static pass-through sends
+            // the response through the route filter chain, and route filters' onResponse must
+            // see a DecodedResponseFrame. Dynamic routing also needs decoded bodies for routing
+            // futures and node-ID translation.
+            if (routerContext.virtualNode().isEmpty()) {
+                return true;
+            }
+            // On bound connections: decode when the router intercepts (e.g. AlternatingRouter
+            // intercepts PRODUCE) or when the response carries node IDs that need translation.
+            return router.shouldIntercept(apiKey, apiVersion, routerContext)
+                    || RouterDispatchHandler.NODE_ID_TRANSLATION_APIS.contains(apiKey);
+        }
+        return false;
     }
 
     @Override
     public String toString() {
         return "DelegatingDecodePredicate(" +
                 "delegate=" + delegate +
-                ", routerRequiresDecoding=" + routerRequiresDecoding +
+                ", router=" + router +
                 ')';
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -6,14 +6,11 @@
 package io.kroxylicious.proxy.internal;
 
 import java.time.Duration;
-import java.util.EnumSet;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.kafka.common.protocol.ApiKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +45,7 @@ import io.kroxylicious.proxy.internal.routing.RoutingTerminalHandler;
 import io.kroxylicious.proxy.internal.util.Metrics;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.CheckReturnValue;
@@ -74,6 +72,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
     @Nullable
     private final Long unauthenticatedIdleMillis;
     private final VirtualClusterRegistry virtualClusterRegistry;
+    private final ConcurrentHashMap<DynamicRouting, ConcurrentHashMap<Integer, HostPort>> sharedNodeAddressCache = new ConcurrentHashMap<>();
 
     @SuppressWarnings({ "OptionalUsedAsFieldOrParameterType", "java:S107" })
     public KafkaProxyInitializer(PluginFactoryRegistry pfr,
@@ -260,19 +259,21 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
         switch (virtualCluster.routing()) {
             case DynamicRouting dr -> {
                 Router router = virtualCluster.createRouter();
-                Map<ApiKeys, String> staticRoutes = router.staticRoutes();
-                Set<ApiKeys> decodedKeys = EnumSet.allOf(ApiKeys.class);
-                if (!staticRoutes.isEmpty()) {
-                    decodedKeys.removeAll(staticRoutes.keySet());
-                }
-                // Always decode API keys whose responses carry node IDs so RouterDispatchHandler
-                // can translate them, even when those keys are statically routed.
-                decodedKeys.addAll(RouterDispatchHandler.NODE_ID_TRANSLATION_APIS);
-                dp.setRouterDecodingRequirements(decodedKeys);
 
+                var sharedAddresses = sharedNodeAddressCache.computeIfAbsent(dr, k -> new ConcurrentHashMap<>());
                 var dispatchHandler = new RouterDispatchHandler(
-                        router, dr.routeDescriptors(), staticRoutes, clientConnectionStateMachine, clientConnectionStateMachine.clusterName(), dr.nodeIdMapping(),
+                        router, dr.routeDescriptors(), sharedAddresses, clientConnectionStateMachine, clientConnectionStateMachine.clusterName(), dr.nodeIdMapping(),
                         binding.nodeId());
+
+                var routerContext = new io.kroxylicious.proxy.internal.routing.RouterContextImpl(
+                        null, // no frame yet
+                        dispatchHandler,
+                        clientConnectionStateMachine.sessionId(),
+                        clientConnectionStateMachine.authenticatedSubject(),
+                        binding.nodeId());
+
+                dp.setRouterInterceptionDelegate(router, routerContext);
+
                 clientConnectionStateMachine.setRouterActive();
                 clientConnectionStateMachine.setUpstreamAddressResolver(
                         virtualNodeId -> dispatchHandler.resolveRouterNodeAddress(virtualNodeId)

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterContextImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterContextImpl.java
@@ -26,7 +26,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * Per-request implementation of {@link RouterContext}. Created by
  * {@link RouterDispatchHandler} for each incoming client request.
  */
-class RouterContextImpl implements RouterContext {
+public class RouterContextImpl implements RouterContext {
 
     private final int clientCorrelationId;
     private final String sessionId;
@@ -35,12 +35,12 @@ class RouterContextImpl implements RouterContext {
     @Nullable
     private final Integer endpointVirtualNodeId;
 
-    RouterContextImpl(DecodedRequestFrame<?> clientFrame,
-                      RouterDispatchHandler handler,
-                      String sessionId,
-                      Subject subject,
-                      @Nullable Integer endpointVirtualNodeId) {
-        this.clientCorrelationId = clientFrame.correlationId();
+    public RouterContextImpl(@Nullable DecodedRequestFrame<?> clientFrame,
+                             RouterDispatchHandler handler,
+                             String sessionId,
+                             Subject subject,
+                             @Nullable Integer endpointVirtualNodeId) {
+        this.clientCorrelationId = clientFrame != null ? clientFrame.correlationId() : -1;
         this.handler = Objects.requireNonNull(handler);
         this.sessionId = Objects.requireNonNull(sessionId);
         this.subject = Objects.requireNonNull(subject);
@@ -104,12 +104,12 @@ class RouterContextImpl implements RouterContext {
 
     @Override
     public CloseOrTerminalStage respondWith(ApiMessage body) {
-        return RouterResponseImpl.builder(new RouterResponseImpl.RespondWith(null, body, false));
+        return RouterResponseImpl.builder(new RouterResponseImpl.RespondWith(null, body, false, null));
     }
 
     @Override
     public CloseOrTerminalStage respondWith(ResponseHeaderData header, ApiMessage body) {
-        return RouterResponseImpl.builder(new RouterResponseImpl.RespondWith(header, body, false));
+        return RouterResponseImpl.builder(new RouterResponseImpl.RespondWith(header, body, false, null));
     }
 
     @Override
@@ -123,4 +123,5 @@ class RouterContextImpl implements RouterContext {
     public CloseOrTerminalStage respondWithoutReply() {
         return RouterResponseImpl.builder(new RouterResponseImpl.RespondWithoutReply(false));
     }
+
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -30,11 +30,12 @@ import io.netty.channel.ChannelPromise;
 
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
-import io.kroxylicious.proxy.frame.Frame;
 import io.kroxylicious.proxy.frame.RequestFrame;
 import io.kroxylicious.proxy.internal.ClientConnectionStateMachine;
 import io.kroxylicious.proxy.internal.CorrelationIdAllocator;
 import io.kroxylicious.proxy.internal.CorrelationIdSpace;
+import io.kroxylicious.proxy.internal.InternalRequestFrame;
+import io.kroxylicious.proxy.internal.InternalResponseFrame;
 import io.kroxylicious.proxy.internal.KafkaProxyExceptionMapper;
 import io.kroxylicious.proxy.router.Router;
 import io.kroxylicious.proxy.service.HostPort;
@@ -74,17 +75,10 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
 
     private final Router router;
     final Map<String, RouteDescriptor> routes;
-    private final Map<ApiKeys, String> staticRoutes;
     private final ClientConnectionStateMachine ccsm;
     private final String virtualClusterName;
     final NodeIdMapping nodeIdMapping;
-    private final Map<Integer, HostPort> routerNodeAddresses = new HashMap<>();
-
-    /**
-     * Tracks correlation IDs of in-flight statically-routed requests that need response
-     * node ID translation. Entries are removed when the response arrives in {@link #write}.
-     */
-    private final Map<Integer, String> pendingRoutes = new HashMap<>();
+    private final Map<Integer, HostPort> routerNodeAddresses;
 
     final Map<Integer, PendingResponse> pendingResponses = new HashMap<>();
 
@@ -103,14 +97,23 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
 
     public RouterDispatchHandler(Router router,
                                  Map<String, RouteDescriptor> routes,
-                                 Map<ApiKeys, String> staticRoutes,
+                                 ClientConnectionStateMachine ccsm,
+                                 String virtualClusterName,
+                                 NodeIdMapping nodeIdMapping,
+                                 @Nullable Integer nodeId) {
+        this(router, routes, new HashMap<>(), ccsm, virtualClusterName, nodeIdMapping, nodeId);
+    }
+
+    public RouterDispatchHandler(Router router,
+                                 Map<String, RouteDescriptor> routes,
+                                 Map<Integer, HostPort> sharedNodeAddresses,
                                  ClientConnectionStateMachine ccsm,
                                  String virtualClusterName,
                                  NodeIdMapping nodeIdMapping,
                                  @Nullable Integer nodeId) {
         this.router = router;
         this.routes = routes;
-        this.staticRoutes = staticRoutes;
+        this.routerNodeAddresses = sharedNodeAddresses;
         this.ccsm = ccsm;
         this.virtualClusterName = virtualClusterName;
         this.nodeIdMapping = nodeIdMapping;
@@ -157,32 +160,52 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
         if (msg instanceof RequestFrame frame) {
             ApiKeys apiKey = ApiKeys.forId(frame.apiKeyId());
-            String staticRoute = staticRoutes.get(apiKey);
-            if (staticRoute != null) {
-                if (NODE_ID_TRANSLATION_APIS.contains(apiKey)) {
-                    pendingRoutes.put(frame.correlationId(), staticRoute);
+
+            var routingContext = new RouterContextImpl(
+                    null,
+                    this,
+                    ccsm.sessionId(),
+                    ccsm.authenticatedSubject(),
+                    nodeId);
+
+            if (!router.shouldIntercept(apiKey, frame.apiVersion(), routingContext)) {
+                if (nodeId == null) {
+                    LOGGER.atWarn()
+                            .addKeyValue("virtualCluster", virtualClusterName)
+                            .addKeyValue("sessionId", ccsm.sessionId())
+                            .addKeyValue("apiKey", apiKey)
+                            .log("Pass-through attempted on unbound connection; use passThrough(route) in onRequest instead");
+                    ctx.channel().close();
+                    return;
                 }
-                ((Frame) msg).setRouteName(staticRoute);
+
+                var routeAndNode = nodeIdMapping.fromVirtual(nodeId);
+                frame.setRouteName(routeAndNode.route());
+                frame.setTargetVirtualNodeId(nodeId);
                 ctx.fireChannelRead(msg);
+
                 LOGGER.atTrace()
                         .addKeyValue("virtualCluster", virtualClusterName)
                         .addKeyValue("sessionId", ccsm.sessionId())
                         .addKeyValue("apiKey", apiKey)
-                        .addKeyValue("route", staticRoute)
-                        .addKeyValue("routingMode", "static")
-                        .log("Request forwarded via static route");
+                        .addKeyValue("targetNodeId", nodeId)
+                        .addKeyValue("route", routeAndNode.route())
+                        .addKeyValue("routingMode", "bound-pass-through")
+                        .log("Request forwarded to bound broker");
                 return;
             }
+
             if (msg instanceof DecodedRequestFrame<?> decoded) {
                 dispatchDynamically(ctx, decoded);
                 return;
             }
+
             LOGGER.atWarn()
                     .addKeyValue("virtualCluster", virtualClusterName)
                     .addKeyValue("sessionId", ccsm.sessionId())
                     .addKeyValue("apiKey", apiKey)
-                    .log("Dynamically-routed API key arrived as opaque frame, forwarding via pipeline");
-            ctx.fireChannelRead(msg);
+                    .log("Router intercepts but frame not decoded");
+            ctx.channel().close();
             return;
         }
         ctx.fireChannelRead(msg);
@@ -218,6 +241,15 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
                 ccsm.authenticatedSubject(),
                 nodeId);
 
+        // InternalRequestFrame = filter OOB (e.g. FilterContext.sendRequest). Skip its
+        // sequence slot immediately so the sequencer never waits for it. The response is
+        // delivered via channel.writeAndFlush (bypassing the sequencer) to avoid deadlock
+        // when the OOB fires inside the onRequest/onResponse of another sequenced frame.
+        InternalRequestFrame<?> oobFrame = frame instanceof InternalRequestFrame<?> irf ? irf : null;
+        if (oobFrame != null) {
+            Objects.requireNonNull(responseSequencer).skip(sequence);
+        }
+
         router.onRequest(apiKey, apiVersion, frame.header(), frame.body(), routingContext)
                 .whenComplete((result, error) -> {
                     if (error != null) {
@@ -228,7 +260,9 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
                                 .addKeyValue("clientCorrelationId", correlationId)
                                 .setCause(error)
                                 .log("Router returned failed future");
-                        responseSequencer.skip(sequence);
+                        if (oobFrame == null) {
+                            responseSequencer.skip(sequence);
+                        }
                         ctx.channel().close();
                         return;
                     }
@@ -239,8 +273,23 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
                                 .addKeyValue("apiKey", apiKey)
                                 .addKeyValue("resultType", result == null ? "null" : result.getClass().getName())
                                 .log("Router returned unrecognised RouterResponse type; closing connection");
-                        responseSequencer.skip(sequence);
+                        if (oobFrame == null) {
+                            responseSequencer.skip(sequence);
+                        }
                         ctx.channel().close();
+                        return;
+                    }
+                    if (oobFrame != null && rri instanceof RouterResponseImpl.RespondWith rw) {
+                        // Deliver OOB response directly via writeAndFlush — bypasses the
+                        // sequencer so the OOB response arrives immediately even if a
+                        // sequenced response is still pending.
+                        var header = rw.header() != null ? rw.header() : new ResponseHeaderData();
+                        header.setCorrelationId(correlationId);
+                        var internalResponse = new InternalResponseFrame<>(
+                                oobFrame.recipient(), apiVersion, correlationId, header, rw.body(), oobFrame.promise());
+                        internalResponse.setRouteName(oobFrame.routeName());
+                        Objects.requireNonNull(ctx).channel().writeAndFlush(internalResponse);
+                        ccsm.onRoutedRequestComplete();
                         return;
                     }
                     deliverResponse(ctx, rri, apiKey, apiVersion, correlationId, sequence);
@@ -257,6 +306,9 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
             case RouterResponseImpl.RespondWith rw -> {
                 ResponseHeaderData header = rw.header() != null ? rw.header() : new ResponseHeaderData();
                 header.setCorrelationId(correlationId);
+                if (rw.routeForTranslation() != null) {
+                    NodeIdResponseTranslator.translate(rw.body(), apiVersion, nodeIdMapping, rw.routeForTranslation());
+                }
                 var responseFrame = new DecodedResponseFrame<>(apiVersion, correlationId, header, rw.body());
                 Objects.requireNonNull(responseSequencer).submit(sequence, responseFrame);
             }
@@ -311,9 +363,11 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
                 promise.setSuccess();
                 return;
             }
-            String routeName = pendingRoutes.remove(correlationId);
-            if (routeName != null) {
-                NodeIdResponseTranslator.translate(frame.body(), frame.apiVersion(), nodeIdMapping, routeName);
+            // Translate node IDs in pass-through responses on bound connections.
+            if (nodeId != null && NODE_ID_TRANSLATION_APIS.contains(frame.apiKey())) {
+                var routeAndNode = nodeIdMapping.fromVirtual(nodeId);
+                NodeIdResponseTranslator.translate(frame.body(), frame.apiVersion(), nodeIdMapping, routeAndNode.route());
+                cacheNodeAddressesIfMetadata(frame.body());
             }
         }
         ctx.write(msg, promise);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterResponseImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterResponseImpl.java
@@ -37,11 +37,18 @@ sealed interface RouterResponseImpl extends RouterResponse
     /**
      * Deliver a response body to the client. If {@code header} is null the runtime
      * supplies a default header; otherwise the provided header is used.
+     * <p>
+     * If {@code routeForTranslation} is non-null, node IDs in the response body are
+     * translated from upstream to virtual IDs using the named route's mapping before
+     * the frame is written to the client. Use this when the body contains real upstream
+     * node IDs that the client should see as virtual IDs. Leave null when the body
+     * already carries virtual IDs (e.g. the body came from {@link io.kroxylicious.proxy.router.RouterContext#sendRequest}).
      */
     record RespondWith(
                        @Nullable ResponseHeaderData header,
                        ApiMessage body,
-                       boolean closeConnection)
+                       boolean closeConnection,
+                       @Nullable String routeForTranslation)
             implements RouterResponseImpl {}
 
     /**
@@ -85,9 +92,10 @@ sealed interface RouterResponseImpl extends RouterResponse
                 return prototype;
             }
             return switch (prototype) {
-                case RespondWith rw -> new RespondWith(rw.header(), rw.body(), true);
+                case RespondWith rw -> new RespondWith(rw.header(), rw.body(), true, rw.routeForTranslation());
                 case RespondWithError rwe -> new RespondWithError(rwe.requestHeader(), rwe.request(), rwe.exception(), true);
                 case RespondWithoutReply ignored -> new RespondWithoutReply(true);
+
             };
         }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandler.java
@@ -15,11 +15,9 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 
-import io.kroxylicious.proxy.frame.DecodedFrame;
 import io.kroxylicious.proxy.frame.Frame;
 import io.kroxylicious.proxy.frame.RequestFrame;
 import io.kroxylicious.proxy.internal.ClientConnectionStateMachine;
-import io.kroxylicious.proxy.internal.CorrelationIdSpace;
 
 import static java.util.Objects.requireNonNull;
 
@@ -57,11 +55,13 @@ public class RoutingTerminalHandler extends ChannelDuplexHandler {
                 return;
             }
             boolean hasResponse = !(msg instanceof RequestFrame rf) || rf.hasResponse();
-            boolean isRouterInternal = CorrelationIdSpace.isRoutingCorrelationId(frame.correlationId());
-            if (hasResponse && !isRouterInternal) {
+            if (hasResponse) {
+                // Track all requests (including router-internal routing requests) so that
+                // RouterDispatchHandler.write() hands routing responses back through the
+                // route filter chain, enabling route-filter onResponse processing.
                 correlationIdToRoute.put(frame.correlationId(), routeName);
             }
-            int targetNodeId = (frame instanceof DecodedFrame<?, ?> df) ? df.targetVirtualNodeId() : Frame.NO_TARGET_VIRTUAL_NODE_ID;
+            int targetNodeId = frame.targetVirtualNodeId();
             if (targetNodeId >= 0) {
                 ccsm.forwardToNode(targetNodeId, routeName, msg);
                 LOGGER.atTrace()

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/DelegatingDecodePredicateTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/DelegatingDecodePredicateTest.java
@@ -6,17 +6,21 @@
 
 package io.kroxylicious.proxy.internal;
 
-import java.util.Set;
-
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import io.kroxylicious.proxy.internal.codec.DecodePredicate;
+import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.router.RouterContext;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class DelegatingDecodePredicateTest {
 
@@ -137,51 +141,63 @@ class DelegatingDecodePredicateTest {
     }
 
     @Test
-    void testRouterRequiresDecodingForcesDecodeForDynamicKeys() {
+    void testRouterInterceptForcesDecodeForInterceptedKeys() {
         givenPredicate();
         givenDelegateTargetsNothing();
-        predicate.setRouterDecodingRequirements(Set.of(ApiKeys.FETCH));
+
+        Router router = mock(Router.class);
+        RouterContext context = mock(RouterContext.class);
+        when(router.shouldIntercept(any(), anyShort(), any())).thenAnswer(inv -> {
+            ApiKeys key = inv.getArgument(0);
+            return key == ApiKeys.FETCH;
+        });
+
+        predicate.setRouterInterceptionDelegate(router, context);
         assertPredicateTargetsRequestKey(ApiKeys.FETCH);
     }
 
     @Test
-    void testRouterRequiresDecodingDoesNotForceDecodeForStaticKeys() {
+    void testRouterInterceptDoesNotForceDecodeForNonInterceptedKeys() {
         givenPredicate();
         givenDelegateTargetsNothing();
-        predicate.setRouterDecodingRequirements(Set.of(ApiKeys.FETCH));
+
+        Router router = mock(Router.class);
+        RouterContext context = mock(RouterContext.class);
+        when(router.shouldIntercept(any(), anyShort(), any())).thenAnswer(inv -> {
+            ApiKeys key = inv.getArgument(0);
+            return key == ApiKeys.FETCH;
+        });
+
+        predicate.setRouterInterceptionDelegate(router, context);
         assertPredicateDoesNotTargetRequestKey(ApiKeys.PRODUCE);
     }
 
     @Test
-    void testEmptyRouterRequirementsDoesNotForceDecoding() {
+    void testRouterNeverInterceptDoesNotForceDecoding() {
         givenPredicate();
         givenDelegateTargetsNothing();
-        predicate.setRouterDecodingRequirements(Set.of());
+
+        Router router = mock(Router.class);
+        RouterContext context = mock(RouterContext.class);
+        when(router.shouldIntercept(any(), anyShort(), any())).thenReturn(false);
+
+        predicate.setRouterInterceptionDelegate(router, context);
         assertPredicateDoesNotTargetRequestKey(ApiKeys.FETCH);
     }
 
     @Test
-    void testRouterRequiresDecodingForcesDecodeResponseForRequiredKey() {
+    void testRouterInterceptAffectsResponseDecoding() {
         givenPredicate();
         givenDelegateTargetsNothing();
-        predicate.setRouterDecodingRequirements(Set.of(ApiKeys.METADATA));
+
+        Router router = mock(Router.class);
+        RouterContext context = mock(RouterContext.class);
+        when(router.shouldIntercept(any(), anyShort(), any())).thenReturn(true);
+
+        predicate.setRouterInterceptionDelegate(router, context);
+        // Router intercept affects response decoding: router-internal requests (sendToAnyNode)
+        // need decoded response bodies for node-ID translation and to complete pending futures.
         assertPredicateTargetsResponseKey(ApiKeys.METADATA);
-    }
-
-    @Test
-    void testRouterRequiresDecodingDoesNotForceDecodeResponseForOtherKeys() {
-        givenPredicate();
-        givenDelegateTargetsNothing();
-        predicate.setRouterDecodingRequirements(Set.of(ApiKeys.METADATA));
-        assertPredicateDoesNotTargetResponseKey(ApiKeys.PRODUCE);
-    }
-
-    @Test
-    void testEmptyRouterRequirementsDoesNotForceResponseDecoding() {
-        givenPredicate();
-        givenDelegateTargetsNothing();
-        predicate.setRouterDecodingRequirements(Set.of());
-        assertPredicateDoesNotTargetResponseKey(ApiKeys.METADATA);
     }
 
     private void assertPredicateTargetsResponseKey(ApiKeys key) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/router/TestRouterFactory.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/router/TestRouterFactory.java
@@ -6,10 +6,7 @@
 
 package io.kroxylicious.proxy.internal.router;
 
-import java.util.Arrays;
-import java.util.Map;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -34,8 +31,6 @@ public class TestRouterFactory implements RouterFactory<Void, Void> {
 
     @Override
     public Router createRouter(RouterFactoryContext context, Void initializationData) {
-        Map<ApiKeys, String> allStatic = Arrays.stream(ApiKeys.values())
-                .collect(Collectors.toUnmodifiableMap(k -> k, k -> DEFAULT_ROUTE));
         return new Router() {
             @Override
             public CompletionStage<RouterResponse> onRequest(ApiKeys apiKey, short apiVersion,
@@ -45,8 +40,8 @@ public class TestRouterFactory implements RouterFactory<Void, Void> {
             }
 
             @Override
-            public Map<ApiKeys, String> staticRoutes() {
-                return allStatic;
+            public boolean shouldIntercept(ApiKeys apiKey, short apiVersion, RouterContext context) {
+                return false;
             }
         };
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterContextImplTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterContextImplTest.java
@@ -64,7 +64,7 @@ class RouterContextImplTest {
     }
 
     private RouterContextImpl createContext(Integer endpointVirtualNodeId) {
-        var handler = new RouterDispatchHandler(router, routes, Map.of(), ccsm, "test-cluster", nodeIdMapping, null);
+        var handler = new RouterDispatchHandler(router, routes, ccsm, "test-cluster", nodeIdMapping, null);
         return new RouterContextImpl(
                 clientFrame, handler, "test-session", Subject.anonymous(),
                 endpointVirtualNodeId);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
@@ -56,9 +56,9 @@ class RouterDispatchHandlerTest {
 
     private EmbeddedChannel channel;
 
-    private RouterDispatchHandler handlerWithIdentityMapping(Map<ApiKeys, String> staticRoutes) {
+    private RouterDispatchHandler handlerWithIdentityMapping() {
         return new RouterDispatchHandler(
-                router, Map.of(), staticRoutes, ccsm, "test-cluster", new IdentityNodeIdMapping(DEFAULT_ROUTE), null);
+                router, Map.of(), ccsm, "test-cluster", new IdentityNodeIdMapping(DEFAULT_ROUTE), null);
     }
 
     private EmbeddedChannel channelWithTerminal(RouterDispatchHandler handler) {
@@ -68,7 +68,7 @@ class RouterDispatchHandlerTest {
     @Test
     void shouldForwardNonFrameMessageToCcsm() {
         // Given
-        var handler = handlerWithIdentityMapping(Map.of());
+        var handler = handlerWithIdentityMapping();
         channel = channelWithTerminal(handler);
 
         // When
@@ -80,49 +80,38 @@ class RouterDispatchHandlerTest {
 
     @Test
     void shouldDispatchDynamicallyForDecodedFrame() {
-        // Given
+        // Given: router intercepts FETCH
+        when(router.shouldIntercept(eq(ApiKeys.FETCH), anyShort(), any())).thenReturn(true);
         var frame = new DecodedRequestFrame<>((short) 12, CORRELATION_ID, true,
                 new RequestHeaderData(), new FetchRequestData());
         when(router.onRequest(any(), anyShort(), any(), any(), any()))
                 .thenReturn(CompletableFuture.completedFuture(
                         new RouterResponseImpl.RespondWithoutReply(false)));
         when(ccsm.sessionId()).thenReturn("test-session");
-        when(ccsm.authenticatedSubject()).thenReturn(io.kroxylicious.proxy.authentication.Subject.anonymous());
+        when(ccsm.authenticatedSubject()).thenReturn(Subject.anonymous());
 
-        var handler = handlerWithIdentityMapping(Map.of());
+        var handler = handlerWithIdentityMapping();
         channel = new EmbeddedChannel(handler);
 
         // When
         channel.writeInbound(frame);
 
         // Then: router.onRequest was called with the frame's API key and version
-        verify(router).onRequest(any(ApiKeys.class), anyShort(), any(), any(), any());
+        verify(router).onRequest(eq(ApiKeys.FETCH), anyShort(), any(), any(), any());
     }
 
     @Test
-    void shouldForwardOpaqueFrameNotInStaticRoutesToCcsm() {
-        // Given
-        var staticRoutes = Map.of(ApiKeys.PRODUCE, DEFAULT_ROUTE);
-        var handler = handlerWithIdentityMapping(staticRoutes);
-        channel = channelWithTerminal(handler);
+    void shouldDispatchToRouterWhenInterceptReturnsTrue() {
+        // Given: router intercepts FETCH
+        when(router.shouldIntercept(eq(ApiKeys.FETCH), anyShort(), any())).thenReturn(true);
+        when(router.onRequest(any(), anyShort(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(
+                        new RouterResponseImpl.RespondWithoutReply(false)));
+        when(ccsm.sessionId()).thenReturn("test-session");
+        when(ccsm.authenticatedSubject()).thenReturn(Subject.anonymous());
 
-        var buf = Unpooled.buffer();
-        var opaqueFrame = new OpaqueRequestFrame(buf, ApiKeys.FETCH.id, (short) 12, CORRELATION_ID, false, 0, true);
-
-        // When
-        channel.writeInbound(opaqueFrame);
-
-        // Then
-        verify(ccsm).onClientFilterChainComplete(opaqueFrame);
-        buf.release();
-    }
-
-    @Test
-    void shouldForwardStaticallyRoutedDecodedFrameViaForwardToRoute() {
-        // Given
-        var staticRoutes = Map.of(ApiKeys.FETCH, DEFAULT_ROUTE);
-        var handler = handlerWithIdentityMapping(staticRoutes);
-        channel = channelWithTerminal(handler);
+        var handler = handlerWithIdentityMapping();
+        channel = new EmbeddedChannel(handler);
 
         var frame = new DecodedRequestFrame<>((short) 12, CORRELATION_ID, true,
                 new RequestHeaderData(), new FetchRequestData());
@@ -130,16 +119,19 @@ class RouterDispatchHandlerTest {
         // When
         channel.writeInbound(frame);
 
-        // Then
-        verify(ccsm).forwardToRoute(DEFAULT_ROUTE, frame);
-        assertThat(frame.routeName()).isEqualTo(DEFAULT_ROUTE);
+        // Then: router.onRequest was called
+        verify(router).onRequest(eq(ApiKeys.FETCH), anyShort(), any(), any(), any());
     }
 
     @Test
-    void shouldForwardStaticallyRoutedOpaqueFrameViaForwardToRoute() {
-        // Given
-        var staticRoutes = Map.of(ApiKeys.FETCH, DEFAULT_ROUTE);
-        var handler = handlerWithIdentityMapping(staticRoutes);
+    void shouldPassThroughToBoundBrokerWhenInterceptReturnsFalse() {
+        // Given: router does not intercept FETCH, bound to node 10
+        when(router.shouldIntercept(eq(ApiKeys.FETCH), anyShort(), any())).thenReturn(false);
+        when(ccsm.sessionId()).thenReturn("test-session");
+        when(ccsm.authenticatedSubject()).thenReturn(Subject.anonymous());
+
+        var handler = new RouterDispatchHandler(
+                router, Map.of(), ccsm, "test-cluster", new IdentityNodeIdMapping(DEFAULT_ROUTE), 10);
         channel = channelWithTerminal(handler);
 
         var buf = Unpooled.buffer();
@@ -148,34 +140,67 @@ class RouterDispatchHandlerTest {
         // When
         channel.writeInbound(opaqueFrame);
 
-        // Then
-        verify(ccsm).forwardToRoute(DEFAULT_ROUTE, opaqueFrame);
+        // Then: forwarded to the specific bound broker node
+        verify(ccsm).forwardToNode(10, DEFAULT_ROUTE, opaqueFrame);
         assertThat(opaqueFrame.routeName()).isEqualTo(DEFAULT_ROUTE);
+        assertThat(opaqueFrame.targetVirtualNodeId()).isEqualTo(10);
+        buf.release();
+    }
+
+    @Test
+    void shouldCloseConnectionWhenPassThroughAttemptedOnUnboundConnection() {
+        // Given: router does not intercept, but no bound node (nodeId=null)
+        when(router.shouldIntercept(eq(ApiKeys.FETCH), anyShort(), any())).thenReturn(false);
+        when(ccsm.sessionId()).thenReturn("test-session");
+        when(ccsm.authenticatedSubject()).thenReturn(Subject.anonymous());
+
+        var handler = handlerWithIdentityMapping();
+        channel = new EmbeddedChannel(handler);
+
+        var buf = Unpooled.buffer();
+        var opaqueFrame = new OpaqueRequestFrame(buf, ApiKeys.FETCH.id, (short) 12, CORRELATION_ID, false, 0, true);
+
+        // When
+        channel.writeInbound(opaqueFrame);
+
+        // Then: channel closed
+        assertThat(channel.isActive()).isFalse();
         buf.release();
     }
 
     @Test
     void shouldTranslateNodeIdsInMetadataResponse() {
-        // Given: bijective mapping with two routes; METADATA statically routed to route-a
-        var mapping = new BijectiveNodeIdMapping(Map.of("route-a", 0, "route-b", 1), 2);
-        var handler = new RouterDispatchHandler(
-                router, Map.of(), Map.of(ApiKeys.METADATA, "route-a"), ccsm, "test-cluster", mapping, null);
-        channel = channelWithTerminal(handler);
+        // Given: bijective mapping with two routes; router intercepts METADATA and routes to route-a
+        when(router.shouldIntercept(eq(ApiKeys.METADATA), anyShort(), any())).thenReturn(true);
+        when(ccsm.sessionId()).thenReturn("test-session");
+        when(ccsm.authenticatedSubject()).thenReturn(Subject.anonymous());
 
-        // Record the pending METADATA request
+        var mapping = new BijectiveNodeIdMapping(Map.of("route-a", 0, "route-b", 1), 2);
+        var rd = new RouteDescriptor("route-a", 0, new TargetCluster("localhost:9092", null), null, List.of());
+        var handler = new RouterDispatchHandler(
+                router, Map.of("route-a", rd), ccsm, "test-cluster", mapping, null);
+        channel = new EmbeddedChannel(handler);
+
+        // Mock router to forward METADATA to route-a
+        when(router.onRequest(eq(ApiKeys.METADATA), anyShort(), any(), any(), any()))
+                .thenAnswer(inv -> {
+                    // Simulate response with upstream node IDs
+                    var md = new MetadataResponseData();
+                    md.setControllerId(0);
+                    md.brokers().add(new MetadataResponseData.MetadataResponseBroker().setNodeId(0).setHost("h0").setPort(9092));
+                    md.brokers().add(new MetadataResponseData.MetadataResponseBroker().setNodeId(1).setHost("h1").setPort(9093));
+
+                    return CompletableFuture.completedFuture(
+                            new RouterResponseImpl.RespondWith(null, md, false, "route-a"));
+                });
+
+        // When: METADATA request arrives
         var requestFrame = new DecodedRequestFrame<>((short) 12, CORRELATION_ID, true,
                 new RequestHeaderData(), new MetadataRequestData());
         channel.writeInbound(requestFrame);
+        channel.runPendingTasks();
 
-        // When: METADATA response arrives with upstream node IDs 0 and 1
-        var md = new MetadataResponseData();
-        md.setControllerId(0);
-        md.brokers().add(new MetadataResponseData.MetadataResponseBroker().setNodeId(0).setHost("h0").setPort(9092));
-        md.brokers().add(new MetadataResponseData.MetadataResponseBroker().setNodeId(1).setHost("h1").setPort(9093));
-        var responseFrame = new DecodedResponseFrame<>((short) 12, CORRELATION_ID, new ResponseHeaderData(), md);
-        channel.writeOutbound(responseFrame);
-
-        // Then: the outbound frame has translated node IDs
+        // Then: response has translated node IDs
         DecodedResponseFrame<?> out = channel.readOutbound();
         assertThat(out).isNotNull();
         var translatedMd = (MetadataResponseData) out.body();
@@ -192,13 +217,13 @@ class RouterDispatchHandlerTest {
         when(ccsm.authenticatedSubject()).thenReturn(Subject.anonymous());
         var rd = new RouteDescriptor(routeName, 0, new TargetCluster("localhost:9092", null), null, List.of());
         return new RouterDispatchHandler(
-                router, Map.of(routeName, rd), Map.of(), ccsm, "test-cluster", new IdentityNodeIdMapping(routeName), null);
+                router, Map.of(routeName, rd), ccsm, "test-cluster", new IdentityNodeIdMapping(routeName), null);
     }
 
     private RouterDispatchHandler handlerWithRouteForSendTests(String routeName) {
         var rd = new RouteDescriptor(routeName, 0, new TargetCluster("localhost:9092", null), null, List.of());
         return new RouterDispatchHandler(
-                router, Map.of(routeName, rd), Map.of(), ccsm, "test-cluster", new IdentityNodeIdMapping(routeName), null);
+                router, Map.of(routeName, rd), ccsm, "test-cluster", new IdentityNodeIdMapping(routeName), null);
     }
 
     private DecodedRequestFrame<ProduceRequestData> produceFrame(int correlationId) {
@@ -212,12 +237,13 @@ class RouterDispatchHandlerTest {
     @Test
     void shouldSetClientCorrelationIdOnRespondWithResponse() {
         // Given
+        when(router.shouldIntercept(eq(ApiKeys.PRODUCE), anyShort(), any())).thenReturn(true);
         var handler = handlerWithRoute(DEFAULT_ROUTE);
         channel = new EmbeddedChannel(handler);
         var body = new MetadataRequestData();
         when(router.onRequest(any(), anyShort(), any(), any(), any()))
                 .thenReturn(CompletableFuture.completedFuture(
-                        new RouterResponseImpl.RespondWith(null, body, false)));
+                        new RouterResponseImpl.RespondWith(null, body, false, null)));
 
         // When
         channel.writeInbound(produceFrame(CORRELATION_ID));
@@ -234,13 +260,14 @@ class RouterDispatchHandlerTest {
     @Test
     void shouldSetClientCorrelationIdOnRespondWithExplicitHeader() {
         // Given: router provides its own header (which has a different correlationId)
+        when(router.shouldIntercept(eq(ApiKeys.PRODUCE), anyShort(), any())).thenReturn(true);
         var handler = handlerWithRoute(DEFAULT_ROUTE);
         channel = new EmbeddedChannel(handler);
         var routerHeader = new ResponseHeaderData().setCorrelationId(999);
         var body = new MetadataRequestData();
         when(router.onRequest(any(), anyShort(), any(), any(), any()))
                 .thenReturn(CompletableFuture.completedFuture(
-                        new RouterResponseImpl.RespondWith(routerHeader, body, false)));
+                        new RouterResponseImpl.RespondWith(routerHeader, body, false, null)));
 
         // When
         channel.writeInbound(produceFrame(CORRELATION_ID));
@@ -255,6 +282,7 @@ class RouterDispatchHandlerTest {
     @Test
     void shouldSetClientCorrelationIdOnRespondWithErrorResponse() {
         // Given
+        when(router.shouldIntercept(eq(ApiKeys.PRODUCE), anyShort(), any())).thenReturn(true);
         var handler = handlerWithRoute(DEFAULT_ROUTE);
         channel = new EmbeddedChannel(handler);
         var requestHeader = new RequestHeaderData()
@@ -280,7 +308,7 @@ class RouterDispatchHandlerTest {
     @Test
     void shouldPassThroughUnknownCorrelationIdInResponse() {
         // Given: a handler with no pending requests
-        var handler = handlerWithIdentityMapping(Map.of(ApiKeys.METADATA, DEFAULT_ROUTE));
+        var handler = handlerWithIdentityMapping();
         channel = new EmbeddedChannel(handler);
 
         // When: a response arrives for an unknown correlation ID
@@ -297,6 +325,7 @@ class RouterDispatchHandlerTest {
     @Test
     void shouldCloseChannelWhenRouterReturnedFutureFails() {
         // Given
+        when(router.shouldIntercept(eq(ApiKeys.PRODUCE), anyShort(), any())).thenReturn(true);
         when(router.onRequest(any(), anyShort(), any(), any(), any()))
                 .thenReturn(CompletableFuture.failedFuture(new RuntimeException("boom")));
         var handler = handlerWithRoute(DEFAULT_ROUTE);
@@ -313,6 +342,7 @@ class RouterDispatchHandlerTest {
     @Test
     void shouldCloseChannelWhenRouterReturnsNullResult() {
         // Given
+        when(router.shouldIntercept(eq(ApiKeys.PRODUCE), anyShort(), any())).thenReturn(true);
         when(router.onRequest(any(), anyShort(), any(), any(), any()))
                 .thenReturn(CompletableFuture.completedFuture(null));
         var handler = handlerWithRoute(DEFAULT_ROUTE);
@@ -329,9 +359,10 @@ class RouterDispatchHandlerTest {
     @Test
     void shouldCloseChannelAfterRespondWithWhenCloseConnectionIsTrue() {
         // Given
+        when(router.shouldIntercept(eq(ApiKeys.PRODUCE), anyShort(), any())).thenReturn(true);
         when(router.onRequest(any(), anyShort(), any(), any(), any()))
                 .thenReturn(CompletableFuture.completedFuture(
-                        new RouterResponseImpl.RespondWith(null, new MetadataRequestData(), true)));
+                        new RouterResponseImpl.RespondWith(null, new MetadataRequestData(), true, null)));
         var handler = handlerWithRoute(DEFAULT_ROUTE);
         channel = new EmbeddedChannel(handler);
 
@@ -346,6 +377,7 @@ class RouterDispatchHandlerTest {
     @Test
     void shouldCallOnRoutedRequestCompleteAfterDynamicDispatch() {
         // Given
+        when(router.shouldIntercept(eq(ApiKeys.PRODUCE), anyShort(), any())).thenReturn(true);
         when(router.onRequest(any(), anyShort(), any(), any(), any()))
                 .thenReturn(CompletableFuture.completedFuture(
                         new RouterResponseImpl.RespondWithoutReply(false)));
@@ -363,6 +395,7 @@ class RouterDispatchHandlerTest {
     @Test
     void shouldNotWriteOutboundFrameForRespondWithoutReply() {
         // Given
+        when(router.shouldIntercept(eq(ApiKeys.PRODUCE), anyShort(), any())).thenReturn(true);
         when(router.onRequest(any(), anyShort(), any(), any(), any()))
                 .thenReturn(CompletableFuture.completedFuture(
                         new RouterResponseImpl.RespondWithoutReply(false)));
@@ -380,10 +413,11 @@ class RouterDispatchHandlerTest {
     @Test
     void respondWithoutReplyShouldNotBlockSubsequentResponse() {
         // Given: first request gets no reply, second gets a response
+        when(router.shouldIntercept(eq(ApiKeys.PRODUCE), anyShort(), any())).thenReturn(true);
         when(router.onRequest(any(), anyShort(), any(), any(), any()))
                 .thenReturn(CompletableFuture.completedFuture(new RouterResponseImpl.RespondWithoutReply(false)))
                 .thenReturn(CompletableFuture.completedFuture(
-                        new RouterResponseImpl.RespondWith(null, new MetadataResponseData(), false)));
+                        new RouterResponseImpl.RespondWith(null, new MetadataResponseData(), false, null)));
         var handler = handlerWithRoute(DEFAULT_ROUTE);
         channel = new EmbeddedChannel(handler);
 
@@ -402,7 +436,7 @@ class RouterDispatchHandlerTest {
     @Test
     void shouldCloseRouterWhenHandlerRemoved() {
         // Given
-        var handler = handlerWithIdentityMapping(Map.of());
+        var handler = handlerWithIdentityMapping();
         channel = new EmbeddedChannel(handler);
 
         // When
@@ -415,7 +449,7 @@ class RouterDispatchHandlerTest {
     @Test
     void writeShouldPassThroughNonFrame() {
         // Given
-        var handler = handlerWithIdentityMapping(Map.of());
+        var handler = handlerWithIdentityMapping();
         channel = new EmbeddedChannel(handler);
 
         // When / Then
@@ -426,7 +460,7 @@ class RouterDispatchHandlerTest {
     @Test
     void writeShouldPassThroughFrameWithNonRoutingCorrelationId() {
         // Given
-        var handler = handlerWithIdentityMapping(Map.of());
+        var handler = handlerWithIdentityMapping();
         channel = new EmbeddedChannel(handler);
         var frame = new DecodedResponseFrame<>((short) 9, 99, new ResponseHeaderData(), new ProduceResponseData());
 
@@ -443,7 +477,7 @@ class RouterDispatchHandlerTest {
         when(ccsm.sessionId()).thenReturn("test-session");
         var handler = new RouterDispatchHandler(
                 router, Map.of(DEFAULT_ROUTE, new RouteDescriptor(DEFAULT_ROUTE, 0, new TargetCluster("localhost:9092", null), null, List.of())),
-                Map.of(), ccsm, "test-cluster", new IdentityNodeIdMapping(DEFAULT_ROUTE), null);
+                ccsm, "test-cluster", new IdentityNodeIdMapping(DEFAULT_ROUTE), null);
         channel = channelWithTerminal(handler);
 
         var header = new RequestHeaderData()
@@ -470,7 +504,7 @@ class RouterDispatchHandlerTest {
         when(ccsm.sessionId()).thenReturn("test-session");
         var handler = new RouterDispatchHandler(
                 router, Map.of(DEFAULT_ROUTE, new RouteDescriptor(DEFAULT_ROUTE, 0, new TargetCluster("localhost:9092", null), null, List.of())),
-                Map.of(), ccsm, "test-cluster", new IdentityNodeIdMapping(DEFAULT_ROUTE), null);
+                ccsm, "test-cluster", new IdentityNodeIdMapping(DEFAULT_ROUTE), null);
         channel = channelWithTerminal(handler);
 
         int routingCorrelationId = Integer.MIN_VALUE / 2;
@@ -528,7 +562,7 @@ class RouterDispatchHandlerTest {
         var routerRd = new RouteDescriptor("router-route", 1, null, "some-router-name", List.of());
         var handler = new RouterDispatchHandler(
                 router, Map.of(DEFAULT_ROUTE, rd, "router-route", routerRd),
-                Map.of(), ccsm, "test-cluster", new IdentityNodeIdMapping(DEFAULT_ROUTE), null);
+                ccsm, "test-cluster", new IdentityNodeIdMapping(DEFAULT_ROUTE), null);
         channel = new EmbeddedChannel(handler);
         var header = new RequestHeaderData()
                 .setRequestApiKey(ApiKeys.FETCH.id)

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandlerTest.java
@@ -173,7 +173,7 @@ class RoutingTerminalHandlerTest {
     }
 
     @Test
-    void shouldNotRecordCorrelationIdForRouterInternalRequest() {
+    void shouldRecordCorrelationIdForRouterInternalRequest() {
         // Given
         when(ccsm.sessionId()).thenReturn("test-session");
         var handler = new RoutingTerminalHandler(ccsm);
@@ -197,7 +197,7 @@ class RoutingTerminalHandlerTest {
         // Then
         DecodedResponseFrame<?> out = channel.readOutbound();
         assertThat(out).isNotNull();
-        assertThat(out.routeName()).as("router-internal correlation IDs must not be recorded, so no route name is set on the response").isNull();
+        assertThat(out.routeName()).as("router-internal requests are tracked so route-filter onResponse can fire").isEqualTo(ROUTE_A);
     }
 
     private DecodedRequestFrame<FetchRequestData> fetchRequest() {


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Implements proposal 118: replaces `Router.staticRoutes()` with `Router.shouldIntercept()`. The old API required routers to declare a static map of API keys to fixed routes before the connection was established. The new API lets routers inspect the request and the connection state (bootstrap vs bound, authenticated subject, etc.) at dispatch time and declare whether they need to intercept each request.

The default implementation of `shouldIntercept()` returns true only for bootstrap (unbound) connections, matching the most common pattern: make a routing decision on the control plane, then let data-plane traffic pass through to the assigned broker without decoding.

== Runtime changes ==

`RouterDispatchHandler` no longer holds a static-routes map. When `shouldIntercept()` returns false on a bound connection, the frame is forwarded directly to the assigned broker (forwardToNode) without calling `onRequest`. When it returns true, the frame is decoded and dispatched to the router.

Three bugs that existed in main are also fixed:

1. Route filter onResponse not called for dynamically-dispatched requests. RouterDispatchHandler.write() previously consumed routing responses internally, so they never reached RouteFilterHandler. RoutingTerminalHandler only tracked non-routing correlation IDs in correlationIdToRoute, so routing responses arrived without a route name and RouteFilterHandler skipped them. Fixed by removing the isRouterInternal exclusion so all requests are tracked, letting RoutingTerminalHandler stamp the route name on routing responses and RouteFilterHandler invoke onResponse.

2. FilterContext.sendRequest() hung when the API key was dynamically routed. The router returned RespondWith(body), creating a DecodedResponseFrame that FilterHandler dispatched to onResponse instead of completing the filterPromise. Fixed: InternalRequestFrame (filter OOB) is now detected in dispatchDynamically, its sequence slot is immediately skipped, and the router's response is delivered via channel.writeAndFlush(InternalResponseFrame) rather than the response sequencer. This delivers the OOB response immediately regardless of outstanding sequenced client responses, and the InternalResponseFrame carries the route name from the original OOB frame so RouteFilterHandler matches and completes the filter promise.

3. Deadlock when a route filter sent OOBs from onResponse of a dynamically-dispatched request: the OOB sequence could not be delivered until the enclosing sequenced response completed, which waited for the OOB. Fixed by the immediate-skip approach above.

DelegatingDecodePredicate.shouldDecodeResponse is updated to always decode responses on bootstrap connections (where route filter onResponse must receive a DecodedResponseFrame), and to decode node-ID-carrying responses on bound connections for translation.

A shared node-address cache (ConcurrentHashMap keyed by DynamicRouting per KafkaProxyInitializer) ensures that upstream broker addresses discovered by any connection are available to all subsequent connections for the same virtual cluster, preventing "upstream address not yet known" errors for non-bootstrap nodes in multi-node clusters.

`Frame.targetVirtualNodeId()` is promoted from `DecodedFrame` to the Frame interface (with a default no-op on `OpaqueFrame`), so the pass-through path can set the target virtual node ID on any frame type and `RoutingTerminalHandler` can call `forwardToNode` correctly.

== API changes ==

`Router.staticRoutes()` removed; `Router.shouldIntercept()` added with a default implementation that intercepts only bootstrap connections.

== Integration-test router updates ==

All six test router factories are migrated to shouldIntercept():

- PassThroughRouterFactory: shouldIntercept uses default (bootstrap only); onRequest uses virtualNode().orElseGet(() -> anyNode(route)) so the configured route is always used on bootstrap.
- AlternatingRouterFactory: intercepts all bootstrap traffic plus PRODUCE and API_VERSIONS on bound connections (PRODUCE for the alternating counter, API_VERSIONS to cap the version and prevent topic-ID mismatches across independent clusters).
- DynamicProduceRouterFactory: intercepts all bootstrap traffic.
- SplitStaticRouterFactory: intercepts all bootstrap traffic.
- InvocationCountingRouterFactory: intercepts bootstrap, forwards via sendRequest.
- RouterContractCapturingFactory: intercepts bootstrap, forwards via sendRequest.
- ContextCapturingRouterFactory: intercepts all traffic unconditionally so virtualNode() is captured on bound connections as well.

Relates-to: #4154

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
