### PR TITLE
fix(routing): four correctness fixes for dynamic routing

### DIFF
--- a/changelog/unreleased/04524-fix-dynamic-routing-correctness.yaml
+++ b/changelog/unreleased/04524-fix-dynamic-routing-correctness.yaml
@@ -1,0 +1,4 @@
+title: "fix(routing): route-filter onResponse and OOB sendRequest now work correctly with dynamic routing"
+type: fixed
+merge_requests:
+  - 4524

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/FilterRouteFilterApiIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/FilterRouteFilterApiIT.java
@@ -293,21 +293,15 @@ class FilterRouteFilterApiIT {
     }
 
     /**
-     * A route filter sends an OOB request ({@code FilterContext.sendRequest()}) inside
-     * {@code onResponse} for a dynamically-dispatched PRODUCE. The OOB response must arrive
-     * immediately without deadlocking the response pipeline.
-     *
-     * <p>With dynamic routing ({@code ContextCapturingRouterFactory}) the OOB response was
-     * delivered as a {@code DecodedResponseFrame} and chained in {@code FilterHandler.writeFuture}
-     * behind the enclosing routing response. The enclosing response could not complete until
-     * {@code onResponse} returned; {@code onResponse} waited for the OOB promise; the OOB was
-     * queued after the routing response. Circular wait, response never arrived.
+     * A route filter sends an OOB request from {@code onResponse} during a dynamically-dispatched
+     * PRODUCE. The OOB response must arrive without deadlocking the response pipeline.
+     * Exposed a bug where the OOB and the routing response formed a circular wait.
      */
     @Test
     void routeFilterOobFromOnResponseDoesNotDeadlock(KafkaCluster cluster, Topic topic) {
         var filterName = "oob-onresponse-filter";
 
-        // Given: route-level filter that sends an OOB from onResponse for PRODUCE
+        // Given
         var filterDef = new NamedFilterDefinitionBuilder(filterName, RequestResponseMarkingFilterFactory.class.getName())
                 .withConfig("keysToMark", Set.of(ApiKeys.PRODUCE),
                         "direction", Set.of(RequestResponseMarkingFilterFactory.Direction.RESPONSE),
@@ -319,13 +313,13 @@ class FilterRouteFilterApiIT {
         try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
                 var client = tester.simpleTestClient()) {
 
-            // Given: establish the upstream connection
+            // Given
             client.getSync(new Request(ApiKeys.METADATA, (short) 12, "metadata-client", new MetadataRequestData()));
 
-            // When: async so the test fails fast if the response deadlocks
+            // When
             var futureResponse = client.get(produceRequest(topic.name(), (short) 1));
 
-            // Then: response must arrive without deadlock and carry the filter's tag
+            // Then
             assertThat(futureResponse)
                     .as("PRODUCE response must arrive: OOB from route filter onResponse must not deadlock")
                     .succeedsWithin(Duration.ofSeconds(5));

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/FilterRouteFilterApiIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/FilterRouteFilterApiIT.java
@@ -22,8 +22,11 @@ import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.common.message.ListTransactionsRequestData;
 import org.apache.kafka.common.message.ListTransactionsResponseData;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.serialization.Serdes;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -38,6 +41,7 @@ import io.kroxylicious.it.testplugins.RequestCountingFilter;
 import io.kroxylicious.it.testplugins.RequestCountingFilterFactory;
 import io.kroxylicious.it.testplugins.RequestResponseMarkingFilter;
 import io.kroxylicious.it.testplugins.RequestResponseMarkingFilterFactory;
+import io.kroxylicious.it.testplugins.router.ContextCapturingRouterFactory;
 import io.kroxylicious.it.testplugins.router.PassThroughRouterFactory;
 import io.kroxylicious.proxy.config.ClusterDefinition;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
@@ -48,6 +52,7 @@ import io.kroxylicious.proxy.config.RouterDefinition;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.internal.config.Feature;
 import io.kroxylicious.proxy.internal.config.Features;
+import io.kroxylicious.testing.filter.record.RecordTestUtils;
 import io.kroxylicious.testing.integration.Request;
 import io.kroxylicious.testing.integration.Response;
 import io.kroxylicious.testing.integration.ResponsePayload;
@@ -87,6 +92,45 @@ class FilterRouteFilterApiIT {
     private static final String ROUTER_NAME = "pass-through";
     private static final String CLUSTER_NAME = "backing";
     private static final String PLAINTEXT = "Hello, world!";
+
+    @BeforeEach
+    void resetRouterState() {
+        ContextCapturingRouterFactory.reset();
+    }
+
+    private ConfigurationBuilder contextCapturingConfigWithRouteFilter(String bootstrapServers, NamedFilterDefinition filterDef) {
+        var clusterDef = new ClusterDefinition(CLUSTER_NAME, bootstrapServers, null);
+        var route = new RouteDefinition(ROUTE_NAME, 0, List.of(filterDef.name()), new RouteTarget(CLUSTER_NAME, null));
+        var routerDef = new RouterDefinition(ROUTER_NAME, ContextCapturingRouterFactory.class.getName(),
+                new ContextCapturingRouterFactory.Config(ROUTE_NAME), List.of(route));
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, ROUTER_NAME))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder("localhost:9192").build())
+                .build();
+        return baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDef)
+                .addToFilterDefinitions(filterDef)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
+    }
+
+    private static Request produceRequest(String topicName, short acks) {
+        var records = RecordTestUtils.singleElementMemoryRecords("key", "value");
+        var partitionData = new ProduceRequestData.PartitionProduceData()
+                .setIndex(0)
+                .setRecords(records);
+        var topicData = new ProduceRequestData.TopicProduceData()
+                .setName(topicName)
+                .setPartitionData(List.of(partitionData));
+        var topicCollection = new ProduceRequestData.TopicProduceDataCollection(
+                List.of(topicData).iterator());
+        var produceData = new ProduceRequestData()
+                .setAcks(acks)
+                .setTimeoutMs(5000)
+                .setTopicData(topicCollection);
+        return new Request(ApiKeys.PRODUCE, (short) 9, "test-client", produceData);
+    }
 
     private ConfigurationBuilder routedConfigWithRouteFilter(String bootstrapServers, NamedFilterDefinition... filterDefs) {
         var clusterDef = new ClusterDefinition(CLUSTER_NAME, bootstrapServers, null);
@@ -245,6 +289,50 @@ class FilterRouteFilterApiIT {
             producer.send(new ProducerRecord<>(topic.name(), "key", "value")).get();
 
             // Then: no exception means both request and response paths completed correctly through the route filter
+        }
+    }
+
+    /**
+     * A route filter sends an OOB request ({@code FilterContext.sendRequest()}) inside
+     * {@code onResponse} for a dynamically-dispatched PRODUCE. The OOB response must arrive
+     * immediately without deadlocking the response pipeline.
+     *
+     * <p>With dynamic routing ({@code ContextCapturingRouterFactory}) the OOB response was
+     * delivered as a {@code DecodedResponseFrame} and chained in {@code FilterHandler.writeFuture}
+     * behind the enclosing routing response. The enclosing response could not complete until
+     * {@code onResponse} returned; {@code onResponse} waited for the OOB promise; the OOB was
+     * queued after the routing response. Circular wait, response never arrived.
+     */
+    @Test
+    void routeFilterOobFromOnResponseDoesNotDeadlock(KafkaCluster cluster, Topic topic) {
+        var filterName = "oob-onresponse-filter";
+
+        // Given: route-level filter that sends an OOB from onResponse for PRODUCE
+        var filterDef = new NamedFilterDefinitionBuilder(filterName, RequestResponseMarkingFilterFactory.class.getName())
+                .withConfig("keysToMark", Set.of(ApiKeys.PRODUCE),
+                        "direction", Set.of(RequestResponseMarkingFilterFactory.Direction.RESPONSE),
+                        "name", filterName,
+                        "forwardingStyle", ForwardingStyle.ASYNCHRONOUS_REQUEST_TO_BROKER)
+                .build();
+        var config = contextCapturingConfigWithRouteFilter(cluster.getBootstrapServers(), filterDef);
+
+        try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
+                var client = tester.simpleTestClient()) {
+
+            // Given: establish the upstream connection
+            client.getSync(new Request(ApiKeys.METADATA, (short) 12, "metadata-client", new MetadataRequestData()));
+
+            // When: async so the test fails fast if the response deadlocks
+            var futureResponse = client.get(produceRequest(topic.name(), (short) 1));
+
+            // Then: response must arrive without deadlock and carry the filter's tag
+            assertThat(futureResponse)
+                    .as("PRODUCE response must arrive: OOB from route filter onResponse must not deadlock")
+                    .succeedsWithin(Duration.ofSeconds(5));
+            var response = futureResponse.toCompletableFuture().join();
+            assertThat(unknownTaggedFieldsToStrings(response.payload().message(), FILTER_NAME_TAG))
+                    .as("route filter onResponse must be called and its OOB must complete before the response is forwarded")
+                    .containsExactly(RequestResponseMarkingFilter.class.getSimpleName() + "-" + filterName + "-response");
         }
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouteFilterCorrectnessIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouteFilterCorrectnessIT.java
@@ -15,7 +15,10 @@ import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.common.message.ListTransactionsRequestData;
 import org.apache.kafka.common.message.ListTransactionsResponseData;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -26,6 +29,7 @@ import io.kroxylicious.it.testplugins.RequestCountingFilter;
 import io.kroxylicious.it.testplugins.RequestCountingFilterFactory;
 import io.kroxylicious.it.testplugins.RequestResponseMarkingFilter;
 import io.kroxylicious.it.testplugins.RequestResponseMarkingFilterFactory;
+import io.kroxylicious.it.testplugins.router.ContextCapturingRouterFactory;
 import io.kroxylicious.it.testplugins.router.DynamicProduceRouterFactory;
 import io.kroxylicious.it.testplugins.router.PassThroughRouterFactory;
 import io.kroxylicious.proxy.config.ClusterDefinition;
@@ -37,6 +41,7 @@ import io.kroxylicious.proxy.config.RouterDefinition;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.internal.config.Feature;
 import io.kroxylicious.proxy.internal.config.Features;
+import io.kroxylicious.testing.filter.record.RecordTestUtils;
 import io.kroxylicious.testing.integration.Request;
 import io.kroxylicious.testing.integration.ResponsePayload;
 import io.kroxylicious.testing.integration.config.NamedFilterDefinitionBuilder;
@@ -86,6 +91,11 @@ class RouteFilterCorrectnessIT {
     private static final String CLUSTER_NAME = "backing";
     private static final String ROUTE_A = "route-a";
     private static final String ROUTE_B = "route-b";
+
+    @BeforeEach
+    void resetRouterState() {
+        ContextCapturingRouterFactory.reset();
+    }
 
     // ---------------------------------------------------------------------------
     // C1: Route filters see all traffic on a route, including router-originated
@@ -346,8 +356,86 @@ class RouteFilterCorrectnessIT {
     }
 
     // ---------------------------------------------------------------------------
+    // C7: Route filter onResponse called for dynamically-dispatched responses
+    // ---------------------------------------------------------------------------
+
+    /**
+     * When a router uses dynamic dispatch ({@code RouterContext.sendRequest()} +
+     * {@code respondWith()}), the upstream response flows back through the route filter
+     * chain. {@code RouteFilterHandler.write()} must stamp the route name on the response
+     * so that route filters can invoke {@code onResponse}.
+     *
+     * <p>Previously, {@code RoutingTerminalHandler.channelRead()} excluded routing-range
+     * correlation IDs from {@code correlationIdToRoute}, so routing responses arrived at
+     * {@code RouteFilterHandler} without a route name and {@code matchesRoute()} returned
+     * false, silently skipping {@code onResponse}.
+     */
+    @Test
+    void routeFilterOnResponseCalledForDynamicallyDispatchedResponse(KafkaCluster cluster, Topic topic) {
+        var filterName = "c7-filter";
+
+        // Given: route-level filter that marks the PRODUCE response body
+        var filterDef = new NamedFilterDefinitionBuilder(filterName, RequestResponseMarkingFilterFactory.class.getName())
+                .withConfig("keysToMark", Set.of(ApiKeys.PRODUCE),
+                        "direction", Set.of(RequestResponseMarkingFilterFactory.Direction.RESPONSE),
+                        "name", filterName,
+                        "forwardingStyle", ForwardingStyle.SYNCHRONOUS)
+                .build();
+        var config = contextCapturingConfigWithRouteFilter(cluster.getBootstrapServers(), filterDef);
+
+        try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
+                var client = tester.simpleTestClient()) {
+
+            // Given: establish the upstream connection
+            client.getSync(new Request(ApiKeys.METADATA, (short) 12, "metadata-client", new MetadataRequestData()));
+
+            // When
+            var response = client.getSync(produceRequest(topic.name(), (short) 1));
+
+            // Then: the filter's tag must be on the response body, proving onResponse was called
+            assertThat(unknownTaggedFieldsToStrings(response.payload().message(), FILTER_NAME_TAG))
+                    .as("route filter onResponse must be invoked for dynamically-dispatched PRODUCE responses")
+                    .containsExactly(RequestResponseMarkingFilter.class.getSimpleName() + "-" + filterName + "-response");
+        }
+    }
+
+    // ---------------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------------
+
+    private ConfigurationBuilder contextCapturingConfigWithRouteFilter(String bootstrapServers, NamedFilterDefinition filterDef) {
+        var clusterDef = new ClusterDefinition(CLUSTER_NAME, bootstrapServers, null);
+        var route = new RouteDefinition(ROUTE_A, 0, List.of(filterDef.name()), new RouteTarget(CLUSTER_NAME, null));
+        var routerDef = new RouterDefinition(ROUTER_NAME, ContextCapturingRouterFactory.class.getName(),
+                new ContextCapturingRouterFactory.Config(ROUTE_A), List.of(route));
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, ROUTER_NAME))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder("localhost:9192").build())
+                .build();
+        return baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDef)
+                .addToFilterDefinitions(filterDef)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
+    }
+
+    private static Request produceRequest(String topicName, short acks) {
+        var records = RecordTestUtils.singleElementMemoryRecords("key", "value");
+        var partitionData = new ProduceRequestData.PartitionProduceData()
+                .setIndex(0)
+                .setRecords(records);
+        var topicData = new ProduceRequestData.TopicProduceData()
+                .setName(topicName)
+                .setPartitionData(List.of(partitionData));
+        var topicCollection = new ProduceRequestData.TopicProduceDataCollection(
+                List.of(topicData).iterator());
+        var produceData = new ProduceRequestData()
+                .setAcks(acks)
+                .setTimeoutMs(5000)
+                .setTopicData(topicCollection);
+        return new Request(ApiKeys.PRODUCE, (short) 9, "test-client", produceData);
+    }
 
     private ConfigurationBuilder twoRouteConfig(String bootstrapServers,
                                                 List<String> routeAFilterNames,

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouteFilterCorrectnessIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouteFilterCorrectnessIT.java
@@ -64,23 +64,14 @@ import static org.apache.kafka.common.protocol.ApiKeys.LIST_TRANSACTIONS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Integration tests that demonstrate correctness issues identified in the per-route filter
- * chain implementation.  Each test targets a specific bug and is expected to fail until
- * the corresponding issue is fixed.
+ * Verifies per-route filter correctness across a range of user-facing gestures.
  *
- * <p>C1: Router-internal frames pass through route filter handlers.
- * <p>C2: {@code correlationIdToRoute} entries are never removed for router-internal requests.
- * <p>C3: {@code sendRequest()} in a route filter sends to an arbitrary backend when multiple
- *         routes are active.
- * <p>C4: Test name / behaviour mismatch in RouterDispatchHandlerTest masks a regression where
- *         forwarding failures leave the pending future stuck rather than completing exceptionally.
- * <p>C5: {@code InternalRequestFrame} objects created by a filter on route-a are processed by
- *         route-b's filter handlers. {@code RouteFilterHandler.channelRead} passes all
- *         {@code InternalRequestFrame} instances to {@code super.channelRead()} without checking
- *         whether they belong to that handler's route, so a filter on route-b can mutate
- *         internal requests it should never see.
- * <p>C6: Same filter factory type on both routes — internal requests must stay within the
- *         originating route even when both routes have filters created from the same factory.
+ * <p>C1: Route filters see all traffic on a route, including router-originated frames.
+ * <p>C2: Routing stays stable across many dynamic-produce operations.
+ * <p>C3: {@code sendRequest()} from a route filter reaches the correct backend.
+ * <p>C5: Route filters process only their own route's {@code InternalRequestFrame}s.
+ * <p>C6: Same filter factory type on multiple routes does not cause cross-contamination.
+ * <p>C7: Route filter {@code onResponse} is called for dynamically-dispatched responses.
  */
 @ExtendWith(KafkaClusterExtension.class)
 @ExtendWith(NettyLeakDetectorExtension.class)
@@ -98,19 +89,14 @@ class RouteFilterCorrectnessIT {
     }
 
     // ---------------------------------------------------------------------------
-    // C1: Route filters see all traffic on a route, including router-originated
+    // C1: Route filters see all traffic on a route, including router-originated frames
     // ---------------------------------------------------------------------------
 
     /**
-     * When a router uses dynamic routing (e.g. {@link DynamicProduceRouterFactory}), it
-     * forwards the request to the backend by calling {@code RouterContext.sendRequest()},
-     * which fires a {@code DecodedRequestFrame} through the pipeline.  Route filter handlers
-     * sit after {@code RouterDispatchHandler} in the pipeline, so they see this frame.
-     *
-     * <p>This is the intended behaviour: per-route filters apply to <em>all</em> traffic on
-     * a route, regardless of whether it was originated by the client or by the router.
-     * A name-mapping filter on a route must transform topic names in all requests reaching
-     * the backend through that route.
+     * When a router uses dynamic routing, it forwards client requests to the backend via
+     * {@code RouterContext.sendRequest()}. Route filters apply to all traffic on a route,
+     * including these router-originated frames. A name-mapping filter on a route must
+     * transform topic names in all requests reaching the backend through that route.
      */
     @Test
     void routeFilterSeesRouterOriginatedTraffic(KafkaCluster cluster, Topic topic) throws Exception {
@@ -150,22 +136,13 @@ class RouteFilterCorrectnessIT {
     }
 
     // ---------------------------------------------------------------------------
-    // C2: correlationIdToRoute entries never removed for router-internal requests
+    // C2: Routing stability across many dynamic-produce operations
     // ---------------------------------------------------------------------------
 
     /**
-     * {@code RoutingTerminalHandler} records a {@code correlationId → routeName} mapping for
-     * every inbound frame that expects a response.  When a router-internal frame goes through
-     * the terminal handler (as a consequence of C1), its router-range correlation ID is
-     * recorded.  The response is then consumed by {@code RouterDispatchHandler.write()} without
-     * calling {@code ctx.write()}, so {@code RoutingTerminalHandler.write()} is never triggered
-     * and the entry is never removed.
-     *
-     * <p>This leak is bounded (router correlation IDs cycle through a fixed range) and does
-     * not currently cause observable routing failures with a single route.  A targeted unit test
-     * against {@code RoutingTerminalHandler} is the appropriate level at which to assert the
-     * map invariant directly.  This test exercises the same code path at the integration level
-     * and verifies that routing remains correct after many dynamic-produce operations.
+     * When a router uses dynamic routing across many operations, routing must remain stable
+     * and deliver all records. Exposed a bug where correlation ID map entries leaked for
+     * router-internal requests.
      */
     @Test
     void routingRemainsStableAfterManyDynamicOperations(KafkaCluster cluster, Topic topic) throws Exception {
@@ -188,7 +165,7 @@ class RouteFilterCorrectnessIT {
                 var producer = tester.producer(Map.of(DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
                 var consumer = tester.consumer(Map.of(GROUP_ID_CONFIG, "c2-stability", AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
 
-            // When: many dynamic produce cycles (each triggers a router-internal re-forward that leaks a map entry)
+            // When
             for (int i = 0; i < 50; i++) {
                 producer.send(new ProducerRecord<>(topic.name(), "key", "value-" + i)).get();
             }
@@ -196,28 +173,19 @@ class RouteFilterCorrectnessIT {
             consumer.subscribe(Set.of(topic.name()));
             var records = consumer.poll(Duration.ofSeconds(30));
 
-            // Then: routing continues to deliver all records correctly despite the growing correlationIdToRoute map
+            // Then
             assertThat(records).hasSize(50);
         }
     }
 
     // ---------------------------------------------------------------------------
-    // C3: sendRequest() from a route filter goes to an arbitrary backend
+    // C3: Route filter sendRequest() reaches the correct backend
     // ---------------------------------------------------------------------------
 
     /**
-     * When a route filter calls {@code FilterContext.sendRequest()}, the resulting
-     * {@code InternalRequestFrame} reaches {@code RoutingTerminalHandler} with a null route
-     * name.  The terminal handler delegates to
-     * {@code ClientConnectionStateMachine.onClientFilterChainComplete()}, which picks a backend
-     * connection via {@code serverConnections.values().iterator().next()}.  With a single active
-     * route this always returns the correct connection.  With two or more routes whose backends
-     * differ, the choice is non-deterministic.
-     *
-     * <p>This test uses a single cluster and a single route, so {@code sendRequest()} works
-     * correctly by accident.  Demonstrating the actual bug requires two distinct Kafka clusters
-     * (one per route) so that sending to the wrong connection produces a different — observable
-     * — response.
+     * When a route filter calls {@code FilterContext.sendRequest()}, the OOB request must reach
+     * the correct backend and the filter must observe the response. Exposed a bug where the
+     * backend was chosen non-deterministically with multiple active routes.
      */
     @Test
     void routeFilterSendRequestWorksWithSingleRoute() {
@@ -245,7 +213,7 @@ class RouteFilterCorrectnessIT {
             // When
             client.getSync(new Request(LIST_TRANSACTIONS, LIST_TRANSACTIONS.latestVersion(), "client", new ListTransactionsRequestData()));
 
-            // Then: sendRequest() reached the correct (only) backend and the filter marked the request
+            // Then
             var requestAtBroker = tester.getOnlyRequestForApiKey(LIST_TRANSACTIONS).message();
             assertThat(unknownTaggedFieldsToStrings(requestAtBroker, FILTER_NAME_TAG))
                     .as("filter must have marked the request, proving sendRequest() reached the mock backend")
@@ -254,16 +222,9 @@ class RouteFilterCorrectnessIT {
     }
 
     /**
-     * {@code RouteFilterHandler.channelRead} passes every {@code InternalRequestFrame} to
-     * {@code super.channelRead()} without checking whether the frame originated from that
-     * handler's own filter.  As a result, a filter on route-b processes internal requests
-     * created by a filter on route-a.
-     *
-     * <p>{@code ASYNCHRONOUS_REQUEST_TO_BROKER} fires an {@code InternalRequestFrame} carrying
-     * a {@code ListGroupsRequestData} payload when it sees a matching client request.  With the
-     * bug, route-b's counting filter sees this LIST_GROUPS internal frame even though all client
-     * traffic is routed exclusively to route-a, incrementing the LIST_GROUPS counter.  After the
-     * fix the counter remains zero.
+     * When a filter on route-a sends an internal request, filters on route-b must not process it.
+     * Exposed a bug where {@code RouteFilterHandler} passed all {@code InternalRequestFrame}s
+     * to downstream handlers without checking route ownership.
      */
     @Test
     void routeFilterDoesNotSeeInternalRequestsOriginatedByOtherRouteFilter(KafkaCluster cluster, Topic topic) throws Exception {
@@ -288,31 +249,24 @@ class RouteFilterCorrectnessIT {
         try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
                 var producer = tester.producer(Map.of(DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000))) {
 
-            // When: client sends PRODUCE through route-a; route-a's marking filter fires an
-            // internal LIST_GROUPS via sendRequest()
+            // When
             producer.send(new ProducerRecord<>(topic.name(), "key", "value")).get();
         }
 
-        // Then: route-b's counting filter must not have seen the internal LIST_GROUPS frame
+        // Then
         assertThat(RequestCountingFilter.countFor(counterId, ApiKeys.LIST_GROUPS))
                 .as("route-b filter must not process InternalRequestFrame from route-a's filter")
                 .isZero();
     }
 
     // ---------------------------------------------------------------------------
-    // C6: Same filter definition on both routes — internal request must stay
-    // within the originating route even when both routes share the same
-    // filter factory type.
+    // C6: Same filter factory type on multiple routes does not cause cross-contamination
     // ---------------------------------------------------------------------------
 
     /**
-     * When the same filter factory type (here {@code RequestCountingFilterFactory}) appears
-     * on multiple routes, each route gets its own filter instance.  An {@code InternalRequestFrame}
-     * created by a filter on route-a must only be processed by route-a's filter chain, not
-     * route-b's — even though route-b has a filter of the same type.
-     *
-     * <p>This is the critical scenario for nested routers where a filter definition may appear
-     * on routes belonging to different routers.
+     * When the same filter factory type appears on multiple routes, each route gets its own
+     * filter instance. Internal requests from one route must not reach the other route's filters,
+     * even when both routes share the same factory type.
      */
     @Test
     void sameFilterDefinitionOnBothRoutesDoesNotCrossContaminate(KafkaCluster cluster, Topic topic) throws Exception {
@@ -360,21 +314,16 @@ class RouteFilterCorrectnessIT {
     // ---------------------------------------------------------------------------
 
     /**
-     * When a router uses dynamic dispatch ({@code RouterContext.sendRequest()} +
-     * {@code respondWith()}), the upstream response flows back through the route filter
-     * chain. {@code RouteFilterHandler.write()} must stamp the route name on the response
-     * so that route filters can invoke {@code onResponse}.
-     *
-     * <p>Previously, {@code RoutingTerminalHandler.channelRead()} excluded routing-range
-     * correlation IDs from {@code correlationIdToRoute}, so routing responses arrived at
-     * {@code RouteFilterHandler} without a route name and {@code matchesRoute()} returned
-     * false, silently skipping {@code onResponse}.
+     * When a router uses dynamic dispatch, the upstream response flows back through the route
+     * filter chain and the filter's {@code onResponse} must be called. Exposed a bug where
+     * routing-range correlation IDs were excluded from {@code correlationIdToRoute}, causing
+     * responses to skip {@code onResponse} silently.
      */
     @Test
     void routeFilterOnResponseCalledForDynamicallyDispatchedResponse(KafkaCluster cluster, Topic topic) {
         var filterName = "c7-filter";
 
-        // Given: route-level filter that marks the PRODUCE response body
+        // Given
         var filterDef = new NamedFilterDefinitionBuilder(filterName, RequestResponseMarkingFilterFactory.class.getName())
                 .withConfig("keysToMark", Set.of(ApiKeys.PRODUCE),
                         "direction", Set.of(RequestResponseMarkingFilterFactory.Direction.RESPONSE),
@@ -386,13 +335,13 @@ class RouteFilterCorrectnessIT {
         try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
                 var client = tester.simpleTestClient()) {
 
-            // Given: establish the upstream connection
+            // Given
             client.getSync(new Request(ApiKeys.METADATA, (short) 12, "metadata-client", new MetadataRequestData()));
 
             // When
             var response = client.getSync(produceRequest(topic.name(), (short) 1));
 
-            // Then: the filter's tag must be on the response body, proving onResponse was called
+            // Then
             assertThat(unknownTaggedFieldsToStrings(response.payload().message(), FILTER_NAME_TAG))
                     .as("route filter onResponse must be invoked for dynamically-dispatched PRODUCE responses")
                     .containsExactly(RequestResponseMarkingFilter.class.getSimpleName() + "-" + filterName + "-response");

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingDynamicIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingDynamicIT.java
@@ -14,32 +14,42 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
 
+import io.kroxylicious.it.testplugins.ForwardingStyle;
+import io.kroxylicious.it.testplugins.RequestResponseMarkingFilterFactory;
+import io.kroxylicious.it.testplugins.router.ContextCapturingRouterFactory;
 import io.kroxylicious.it.testplugins.router.DynamicProduceRouterFactory;
 import io.kroxylicious.proxy.config.ClusterDefinition;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
+import io.kroxylicious.proxy.config.NamedRange;
 import io.kroxylicious.proxy.config.RouteDefinition;
 import io.kroxylicious.proxy.config.RouteTarget;
 import io.kroxylicious.proxy.config.RouterDefinition;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.internal.config.Feature;
 import io.kroxylicious.proxy.internal.config.Features;
+import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.filter.record.RecordTestUtils;
 import io.kroxylicious.testing.integration.Request;
+import io.kroxylicious.testing.integration.config.NamedFilterDefinitionBuilder;
 import io.kroxylicious.testing.integration.tester.KroxyliciousTesters;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 import io.kroxylicious.testing.kafka.junit5ext.Topic;
 
 import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.baseConfigurationBuilder;
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.defaultGatewayBuilder;
 import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -58,6 +68,11 @@ class RoutingDynamicIT {
     private static final String ROUTE_NAME = "default-route";
     private static final String ROUTER_NAME = "dynamic-produce";
     private static final String TARGET_CLUSTER_NAME = "backing";
+
+    @BeforeEach
+    void resetRouterState() {
+        ContextCapturingRouterFactory.reset();
+    }
 
     private ConfigurationBuilder dynamicRoutingConfig(KafkaCluster cluster) {
         var targetCluster = new ClusterDefinition(TARGET_CLUSTER_NAME, cluster.getBootstrapServers(), null);
@@ -127,6 +142,116 @@ class RoutingDynamicIT {
                     .satisfies(r -> assertThat(r.partitionResponses()).singleElement()
                             .satisfies(p -> assertThat(p.errorCode()).isEqualTo(Errors.NONE.code())));
         }
+    }
+
+    /**
+     * A VC-level filter calls {@code FilterContext.sendRequest()} inside {@code onRequest}
+     * for PRODUCE. The OOB {@code InternalRequestFrame} reaches {@code RouterDispatchHandler}
+     * and enters {@code dispatchDynamically}. The router's response must complete the filter
+     * promise rather than being dispatched to {@code onResponse}, so that PRODUCE can proceed.
+     */
+    @Test
+    void vcFilterOobCompletesWhenApiKeyDynamicallyRouted(KafkaCluster cluster, Topic topic) {
+        var filterName = "oob-filter";
+
+        // Given: VC-level filter that sends an OOB from onRequest for PRODUCE
+        var filterDef = new NamedFilterDefinitionBuilder(filterName, RequestResponseMarkingFilterFactory.class.getName())
+                .withConfig("keysToMark", Set.of(ApiKeys.PRODUCE),
+                        "direction", Set.of(RequestResponseMarkingFilterFactory.Direction.REQUEST),
+                        "name", filterName,
+                        "forwardingStyle", ForwardingStyle.ASYNCHRONOUS_REQUEST_TO_BROKER)
+                .build();
+        var config = contextCapturingConfigWithVcFilter(cluster, filterDef);
+
+        try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
+                var producer = tester.producer()) {
+
+            // When
+            var send = producer.send(new ProducerRecord<>(topic.name(), "key", "value"));
+
+            // Then: the OOB must complete so PRODUCE can reach the broker
+            assertThat(send)
+                    .as("PRODUCE must succeed: VC filter OOB must complete when API key is dynamically routed")
+                    .succeedsWithin(Duration.ofSeconds(10));
+        }
+    }
+
+    /**
+     * When a client connects to a per-node port before the proxy has learned the upstream
+     * topology, {@code EagerMetadataLearner} fires an OOB METADATA request. The OOB
+     * response must complete the filter promise so the connection closes and the client can
+     * reconnect to the correct broker.
+     */
+    @Test
+    void eagerMetadataLearnerOobCompletesWhenApiKeyDynamicallyRouted(KafkaCluster cluster, Topic topic) {
+        // Given
+        var config = contextCapturingConfigWithNodePort(cluster);
+
+        try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester()) {
+
+            // When: first connection to per-node port triggers EagerMetadataLearner OOB
+            var firstFuture = tester.simpleTestClient("localhost:9193", false)
+                    .get(new Request(ApiKeys.METADATA, (short) 12, "init", new MetadataRequestData()));
+
+            // Then: EagerMetadataLearner must receive the METADATA response and close
+            assertThat(firstFuture)
+                    .as("EagerMetadataLearner OOB METADATA must complete so the first connection returns and closes")
+                    .succeedsWithin(Duration.ofSeconds(5));
+            assertThat(firstFuture.toCompletableFuture().join().payload().message())
+                    .isInstanceOf(MetadataResponseData.class);
+
+            // When: second connection to the same port, upstream topology now known
+            try (var secondClient = tester.simpleTestClient("localhost:9193", false)) {
+                var response = secondClient.getSync(produceRequest(topic.name(), (short) 1));
+
+                // Then: PRODUCE succeeds normally on the second connection
+                assertThat(response.payload().message()).isInstanceOf(ProduceResponseData.class);
+                var produceResponse = (ProduceResponseData) response.payload().message();
+                assertThat(produceResponse.responses())
+                        .singleElement()
+                        .satisfies(r -> assertThat(r.partitionResponses()).singleElement()
+                                .satisfies(p -> assertThat(p.errorCode()).isEqualTo(Errors.NONE.code())));
+            }
+        }
+    }
+
+    private ConfigurationBuilder contextCapturingConfigWithVcFilter(KafkaCluster cluster, NamedFilterDefinition filterDef) {
+        var clusterDef = new ClusterDefinition(TARGET_CLUSTER_NAME, cluster.getBootstrapServers(), null);
+        var route = new RouteDefinition(ROUTE_NAME, 0, List.of(), new RouteTarget(TARGET_CLUSTER_NAME, null));
+        var routerDef = new RouterDefinition(ROUTER_NAME, ContextCapturingRouterFactory.class.getName(),
+                new ContextCapturingRouterFactory.Config(ROUTE_NAME), List.of(route));
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, ROUTER_NAME))
+                .withFilters(List.of(filterDef.name()))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder("localhost:9192").build())
+                .build();
+        return baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDef)
+                .addToFilterDefinitions(filterDef)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
+    }
+
+    private ConfigurationBuilder contextCapturingConfigWithNodePort(KafkaCluster cluster) {
+        var clusterDef = new ClusterDefinition(TARGET_CLUSTER_NAME, cluster.getBootstrapServers(), null);
+        var route = new RouteDefinition(ROUTE_NAME, 0, List.of(), new RouteTarget(TARGET_CLUSTER_NAME, null));
+        var routerDef = new RouterDefinition(ROUTER_NAME, ContextCapturingRouterFactory.class.getName(),
+                new ContextCapturingRouterFactory.Config(ROUTE_NAME), List.of(route));
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, ROUTER_NAME))
+                .addToGateways(defaultGatewayBuilder()
+                        .withNewPortIdentifiesNode()
+                        .withBootstrapAddress(HostPort.parse("localhost:9192"))
+                        .withNodeIdRanges(new NamedRange("nodes", 0, 0))
+                        .endPortIdentifiesNode()
+                        .build())
+                .build();
+        return baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDef)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
     }
 
     private static Request produceRequest(String topicName, short acks) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -48,6 +49,7 @@ import io.kroxylicious.proxy.internal.routing.RoutingTerminalHandler;
 import io.kroxylicious.proxy.internal.util.Metrics;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.CheckReturnValue;
@@ -74,6 +76,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
     @Nullable
     private final Long unauthenticatedIdleMillis;
     private final VirtualClusterRegistry virtualClusterRegistry;
+    private final ConcurrentHashMap<DynamicRouting, ConcurrentHashMap<Integer, HostPort>> sharedNodeAddressCache = new ConcurrentHashMap<>();
 
     @SuppressWarnings({ "OptionalUsedAsFieldOrParameterType", "java:S107" })
     public KafkaProxyInitializer(PluginFactoryRegistry pfr,
@@ -270,9 +273,10 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
                 decodedKeys.addAll(RouterDispatchHandler.NODE_ID_TRANSLATION_APIS);
                 dp.setRouterDecodingRequirements(decodedKeys);
 
+                var sharedAddresses = sharedNodeAddressCache.computeIfAbsent(dr, k -> new ConcurrentHashMap<>());
                 var dispatchHandler = new RouterDispatchHandler(
-                        router, dr.routeDescriptors(), staticRoutes, clientConnectionStateMachine, clientConnectionStateMachine.clusterName(), dr.nodeIdMapping(),
-                        binding.nodeId());
+                        router, dr.routeDescriptors(), staticRoutes, sharedAddresses, clientConnectionStateMachine, clientConnectionStateMachine.clusterName(),
+                        dr.nodeIdMapping(), binding.nodeId());
                 clientConnectionStateMachine.setRouterActive();
                 clientConnectionStateMachine.setUpstreamAddressResolver(
                         virtualNodeId -> dispatchHandler.resolveRouterNodeAddress(virtualNodeId)

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -270,13 +270,26 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
                         ctx.channel().close();
                         return;
                     }
-                    if (oobFrame != null && rri instanceof RouterResponseImpl.RespondWith rw) {
-                        var header = rw.header() != null ? rw.header() : new ResponseHeaderData();
-                        header.setCorrelationId(correlationId);
-                        var internalResponse = new InternalResponseFrame<>(
-                                oobFrame.recipient(), apiVersion, correlationId, header, rw.body(), oobFrame.promise());
-                        internalResponse.setRouteName(oobFrame.routeName());
-                        Objects.requireNonNull(ctx).channel().writeAndFlush(internalResponse);
+                    if (oobFrame != null) {
+                        if (rri instanceof RouterResponseImpl.RespondWith rw) {
+                            var header = rw.header() != null ? rw.header() : new ResponseHeaderData();
+                            header.setCorrelationId(correlationId);
+                            var internalResponse = new InternalResponseFrame<>(
+                                    oobFrame.recipient(), apiVersion, correlationId, header, rw.body(), oobFrame.promise());
+                            internalResponse.setRouteName(oobFrame.routeName());
+                            Objects.requireNonNull(ctx).channel().writeAndFlush(internalResponse);
+                        }
+                        else {
+                            // RespondWithError or RespondWithoutReply for an OOB: complete the promise
+                            // exceptionally so the filter's sendRequest() future resolves rather than hanging.
+                            Throwable cause = rri instanceof RouterResponseImpl.RespondWithError rwe
+                                    ? rwe.exception()
+                                    : new IllegalStateException("Router returned no-reply response for OOB request (apiKey=" + apiKey + ")");
+                            oobFrame.promise().completeExceptionally(cause);
+                            if (rri.closeConnection()) {
+                                Objects.requireNonNull(ctx).channel().close();
+                            }
+                        }
                         ccsm.onRoutedRequestComplete();
                         return;
                     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -80,7 +80,7 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
     private final ClientConnectionStateMachine ccsm;
     private final String virtualClusterName;
     final NodeIdMapping nodeIdMapping;
-    private final Map<Integer, HostPort> routerNodeAddresses = new HashMap<>();
+    private final Map<Integer, HostPort> routerNodeAddresses;
 
     /**
      * Tracks correlation IDs of in-flight statically-routed requests that need response
@@ -110,9 +110,21 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
                                  String virtualClusterName,
                                  NodeIdMapping nodeIdMapping,
                                  @Nullable Integer nodeId) {
+        this(router, routes, staticRoutes, new HashMap<>(), ccsm, virtualClusterName, nodeIdMapping, nodeId);
+    }
+
+    public RouterDispatchHandler(Router router,
+                                 Map<String, RouteDescriptor> routes,
+                                 Map<ApiKeys, String> staticRoutes,
+                                 Map<Integer, HostPort> sharedNodeAddresses,
+                                 ClientConnectionStateMachine ccsm,
+                                 String virtualClusterName,
+                                 NodeIdMapping nodeIdMapping,
+                                 @Nullable Integer nodeId) {
         this.router = router;
         this.routes = routes;
         this.staticRoutes = staticRoutes;
+        this.routerNodeAddresses = sharedNodeAddresses;
         this.ccsm = ccsm;
         this.virtualClusterName = virtualClusterName;
         this.nodeIdMapping = nodeIdMapping;

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -35,6 +35,8 @@ import io.kroxylicious.proxy.frame.RequestFrame;
 import io.kroxylicious.proxy.internal.ClientConnectionStateMachine;
 import io.kroxylicious.proxy.internal.CorrelationIdAllocator;
 import io.kroxylicious.proxy.internal.CorrelationIdSpace;
+import io.kroxylicious.proxy.internal.InternalRequestFrame;
+import io.kroxylicious.proxy.internal.InternalResponseFrame;
 import io.kroxylicious.proxy.internal.KafkaProxyExceptionMapper;
 import io.kroxylicious.proxy.router.Router;
 import io.kroxylicious.proxy.service.HostPort;
@@ -218,6 +220,15 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
                 ccsm.authenticatedSubject(),
                 nodeId);
 
+        // InternalRequestFrame = filter OOB (e.g. FilterContext.sendRequest). Skip its
+        // sequence slot immediately so the sequencer never waits for it. The response is
+        // delivered via channel.writeAndFlush (bypassing the sequencer) to avoid deadlock
+        // when the OOB fires inside the onRequest/onResponse of another sequenced frame.
+        InternalRequestFrame<?> oobFrame = frame instanceof InternalRequestFrame<?> irf ? irf : null;
+        if (oobFrame != null) {
+            Objects.requireNonNull(responseSequencer).skip(sequence);
+        }
+
         router.onRequest(apiKey, apiVersion, frame.header(), frame.body(), routingContext)
                 .whenComplete((result, error) -> {
                     if (error != null) {
@@ -228,7 +239,9 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
                                 .addKeyValue("clientCorrelationId", correlationId)
                                 .setCause(error)
                                 .log("Router returned failed future");
-                        responseSequencer.skip(sequence);
+                        if (oobFrame == null) {
+                            responseSequencer.skip(sequence);
+                        }
                         ctx.channel().close();
                         return;
                     }
@@ -239,8 +252,23 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
                                 .addKeyValue("apiKey", apiKey)
                                 .addKeyValue("resultType", result == null ? "null" : result.getClass().getName())
                                 .log("Router returned unrecognised RouterResponse type; closing connection");
-                        responseSequencer.skip(sequence);
+                        if (oobFrame == null) {
+                            responseSequencer.skip(sequence);
+                        }
                         ctx.channel().close();
+                        return;
+                    }
+                    if (oobFrame != null && rri instanceof RouterResponseImpl.RespondWith rw) {
+                        // Deliver OOB response directly via writeAndFlush — bypasses the
+                        // sequencer so the OOB response arrives immediately even if a
+                        // sequenced response is still pending.
+                        var header = rw.header() != null ? rw.header() : new ResponseHeaderData();
+                        header.setCorrelationId(correlationId);
+                        var internalResponse = new InternalResponseFrame<>(
+                                oobFrame.recipient(), apiVersion, correlationId, header, rw.body(), oobFrame.promise());
+                        internalResponse.setRouteName(oobFrame.routeName());
+                        Objects.requireNonNull(ctx).channel().writeAndFlush(internalResponse);
+                        ccsm.onRoutedRequestComplete();
                         return;
                     }
                     deliverResponse(ctx, rri, apiKey, apiVersion, correlationId, sequence);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -39,6 +39,7 @@ import io.kroxylicious.proxy.internal.InternalRequestFrame;
 import io.kroxylicious.proxy.internal.InternalResponseFrame;
 import io.kroxylicious.proxy.internal.KafkaProxyExceptionMapper;
 import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.router.RouterResponse;
 import io.kroxylicious.proxy.service.HostPort;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -232,69 +233,89 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
                 ccsm.authenticatedSubject(),
                 nodeId);
 
-        // InternalRequestFrame = filter OOB (e.g. FilterContext.sendRequest). Skip its
-        // sequence slot immediately so the sequencer never waits for it. The response is
-        // delivered via channel.writeAndFlush (bypassing the sequencer) to avoid deadlock
-        // when the OOB fires inside the onRequest/onResponse of another sequenced frame.
-        InternalRequestFrame<?> oobFrame = frame instanceof InternalRequestFrame<?> irf ? irf : null;
-        if (oobFrame != null) {
-            Objects.requireNonNull(responseSequencer).skip(sequence);
+        if (frame instanceof InternalRequestFrame<?> oobFrame) {
+            // Skip the slot immediately: OOB response bypasses the sequencer to avoid
+            // deadlock when the OOB fires inside the onRequest/onResponse of a sequenced frame.
+            responseSequencer.skip(sequence);
+            router.onRequest(apiKey, apiVersion, frame.header(), frame.body(), routingContext)
+                    .whenComplete((result, error) -> handleOobCompletion(ctx, oobFrame, result, error, apiKey, apiVersion, correlationId));
         }
+        else {
+            router.onRequest(apiKey, apiVersion, frame.header(), frame.body(), routingContext)
+                    .whenComplete((result, error) -> handleRegularCompletion(ctx, result, error, apiKey, apiVersion, correlationId, sequence));
+        }
+    }
 
-        router.onRequest(apiKey, apiVersion, frame.header(), frame.body(), routingContext)
-                .whenComplete((result, error) -> {
-                    if (error != null) {
-                        LOGGER.atError()
-                                .addKeyValue("virtualCluster", virtualClusterName)
-                                .addKeyValue("sessionId", ccsm.sessionId())
-                                .addKeyValue("apiKey", apiKey)
-                                .addKeyValue("clientCorrelationId", correlationId)
-                                .setCause(error)
-                                .log("Router returned failed future");
-                        if (oobFrame == null) {
-                            responseSequencer.skip(sequence);
-                        }
-                        ctx.channel().close();
-                        return;
-                    }
-                    if (!(result instanceof RouterResponseImpl rri)) {
-                        LOGGER.atError()
-                                .addKeyValue("virtualCluster", virtualClusterName)
-                                .addKeyValue("sessionId", ccsm.sessionId())
-                                .addKeyValue("apiKey", apiKey)
-                                .addKeyValue("resultType", result == null ? "null" : result.getClass().getName())
-                                .log("Router returned unrecognised RouterResponse type; closing connection");
-                        if (oobFrame == null) {
-                            responseSequencer.skip(sequence);
-                        }
-                        ctx.channel().close();
-                        return;
-                    }
-                    if (oobFrame != null) {
-                        if (rri instanceof RouterResponseImpl.RespondWith rw) {
-                            var header = rw.header() != null ? rw.header() : new ResponseHeaderData();
-                            header.setCorrelationId(correlationId);
-                            var internalResponse = new InternalResponseFrame<>(
-                                    oobFrame.recipient(), apiVersion, correlationId, header, rw.body(), oobFrame.promise());
-                            internalResponse.setRouteName(oobFrame.routeName());
-                            Objects.requireNonNull(ctx).channel().writeAndFlush(internalResponse);
-                        }
-                        else {
-                            // RespondWithError or RespondWithoutReply for an OOB: complete the promise
-                            // exceptionally so the filter's sendRequest() future resolves rather than hanging.
-                            Throwable cause = rri instanceof RouterResponseImpl.RespondWithError rwe
-                                    ? rwe.exception()
-                                    : new IllegalStateException("Router returned no-reply response for OOB request (apiKey=" + apiKey + ")");
-                            oobFrame.promise().completeExceptionally(cause);
-                            if (rri.closeConnection()) {
-                                Objects.requireNonNull(ctx).channel().close();
-                            }
-                        }
-                        ccsm.onRoutedRequestComplete();
-                        return;
-                    }
-                    deliverResponse(ctx, rri, apiKey, apiVersion, correlationId, sequence);
-                });
+    private void handleOobCompletion(ChannelHandlerContext ctx, InternalRequestFrame<?> oobFrame,
+                                     RouterResponse result, Throwable error,
+                                     ApiKeys apiKey, short apiVersion, int correlationId) {
+        if (error != null) {
+            LOGGER.atError()
+                    .addKeyValue("virtualCluster", virtualClusterName)
+                    .addKeyValue("sessionId", ccsm.sessionId())
+                    .addKeyValue("apiKey", apiKey)
+                    .addKeyValue("clientCorrelationId", correlationId)
+                    .setCause(error)
+                    .log("Router returned failed future");
+            ctx.channel().close();
+            return;
+        }
+        if (!(result instanceof RouterResponseImpl rri)) {
+            LOGGER.atError()
+                    .addKeyValue("virtualCluster", virtualClusterName)
+                    .addKeyValue("sessionId", ccsm.sessionId())
+                    .addKeyValue("apiKey", apiKey)
+                    .addKeyValue("resultType", result == null ? "null" : result.getClass().getName())
+                    .log("Router returned unrecognised RouterResponse type; closing connection");
+            ctx.channel().close();
+            return;
+        }
+        if (rri instanceof RouterResponseImpl.RespondWith rw) {
+            var header = rw.header() != null ? rw.header() : new ResponseHeaderData();
+            header.setCorrelationId(correlationId);
+            var internalResponse = new InternalResponseFrame<>(
+                    oobFrame.recipient(), apiVersion, correlationId, header, rw.body(), oobFrame.promise());
+            internalResponse.setRouteName(oobFrame.routeName());
+            ctx.channel().writeAndFlush(internalResponse);
+        }
+        else {
+            Throwable cause = rri instanceof RouterResponseImpl.RespondWithError rwe
+                    ? rwe.exception()
+                    : new IllegalStateException("Router returned no-reply response for OOB request (apiKey=" + apiKey + ")");
+            oobFrame.promise().completeExceptionally(cause);
+            if (rri.closeConnection()) {
+                ctx.channel().close();
+            }
+        }
+        ccsm.onRoutedRequestComplete();
+    }
+
+    private void handleRegularCompletion(ChannelHandlerContext ctx, RouterResponse result, Throwable error,
+                                         ApiKeys apiKey, short apiVersion, int correlationId, long sequence) {
+        if (error != null) {
+            LOGGER.atError()
+                    .addKeyValue("virtualCluster", virtualClusterName)
+                    .addKeyValue("sessionId", ccsm.sessionId())
+                    .addKeyValue("apiKey", apiKey)
+                    .addKeyValue("clientCorrelationId", correlationId)
+                    .setCause(error)
+                    .log("Router returned failed future");
+            Objects.requireNonNull(responseSequencer).skip(sequence);
+            ctx.channel().close();
+            return;
+        }
+        if (!(result instanceof RouterResponseImpl rri)) {
+            LOGGER.atError()
+                    .addKeyValue("virtualCluster", virtualClusterName)
+                    .addKeyValue("sessionId", ccsm.sessionId())
+                    .addKeyValue("apiKey", apiKey)
+                    .addKeyValue("resultType", result == null ? "null" : result.getClass().getName())
+                    .log("Router returned unrecognised RouterResponse type; closing connection");
+            Objects.requireNonNull(responseSequencer).skip(sequence);
+            ctx.channel().close();
+            return;
+        }
+        deliverResponse(ctx, rri, apiKey, apiVersion, correlationId, sequence);
     }
 
     private void deliverResponse(ChannelHandlerContext ctx,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -249,45 +249,53 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
     private void handleOobCompletion(ChannelHandlerContext ctx, InternalRequestFrame<?> oobFrame,
                                      RouterResponse result, Throwable error,
                                      ApiKeys apiKey, short apiVersion, int correlationId) {
-        if (error != null) {
-            LOGGER.atError()
-                    .addKeyValue("virtualCluster", virtualClusterName)
-                    .addKeyValue("sessionId", ccsm.sessionId())
-                    .addKeyValue("apiKey", apiKey)
-                    .addKeyValue("clientCorrelationId", correlationId)
-                    .setCause(error)
-                    .log("Router returned failed future");
-            ctx.channel().close();
-            return;
-        }
-        if (!(result instanceof RouterResponseImpl rri)) {
-            LOGGER.atError()
-                    .addKeyValue("virtualCluster", virtualClusterName)
-                    .addKeyValue("sessionId", ccsm.sessionId())
-                    .addKeyValue("apiKey", apiKey)
-                    .addKeyValue("resultType", result == null ? "null" : result.getClass().getName())
-                    .log("Router returned unrecognised RouterResponse type; closing connection");
-            ctx.channel().close();
-            return;
-        }
-        if (rri instanceof RouterResponseImpl.RespondWith rw) {
-            var header = rw.header() != null ? rw.header() : new ResponseHeaderData();
-            header.setCorrelationId(correlationId);
-            var internalResponse = new InternalResponseFrame<>(
-                    oobFrame.recipient(), apiVersion, correlationId, header, rw.body(), oobFrame.promise());
-            internalResponse.setRouteName(oobFrame.routeName());
-            ctx.channel().writeAndFlush(internalResponse);
-        }
-        else {
-            Throwable cause = rri instanceof RouterResponseImpl.RespondWithError rwe
-                    ? rwe.exception()
-                    : new IllegalStateException("Router returned no-reply response for OOB request (apiKey=" + apiKey + ")");
-            oobFrame.promise().completeExceptionally(cause);
-            if (rri.closeConnection()) {
+        try {
+            if (error != null) {
+                LOGGER.atError()
+                        .addKeyValue("virtualCluster", virtualClusterName)
+                        .addKeyValue("sessionId", ccsm.sessionId())
+                        .addKeyValue("apiKey", apiKey)
+                        .addKeyValue("clientCorrelationId", correlationId)
+                        .setCause(error)
+                        .log("Router returned failed future");
+                oobFrame.promise().completeExceptionally(error);
                 ctx.channel().close();
+                return;
+            }
+            if (!(result instanceof RouterResponseImpl rri)) {
+                var cause = new IllegalStateException(
+                        "Router returned unrecognised RouterResponse type (apiKey=" + apiKey + ", type=" + (result == null ? "null" : result.getClass().getName()) + ")");
+                LOGGER.atError()
+                        .addKeyValue("virtualCluster", virtualClusterName)
+                        .addKeyValue("sessionId", ccsm.sessionId())
+                        .addKeyValue("apiKey", apiKey)
+                        .addKeyValue("resultType", result == null ? "null" : result.getClass().getName())
+                        .log("Router returned unrecognised RouterResponse type; closing connection");
+                oobFrame.promise().completeExceptionally(cause);
+                ctx.channel().close();
+                return;
+            }
+            if (rri instanceof RouterResponseImpl.RespondWith rw) {
+                var header = rw.header() != null ? rw.header() : new ResponseHeaderData();
+                header.setCorrelationId(correlationId);
+                var internalResponse = new InternalResponseFrame<>(
+                        oobFrame.recipient(), apiVersion, correlationId, header, rw.body(), oobFrame.promise());
+                internalResponse.setRouteName(oobFrame.routeName());
+                ctx.channel().writeAndFlush(internalResponse);
+            }
+            else {
+                Throwable cause = rri instanceof RouterResponseImpl.RespondWithError rwe
+                        ? rwe.exception()
+                        : new IllegalStateException("Router returned no-reply response for OOB request (apiKey=" + apiKey + ")");
+                oobFrame.promise().completeExceptionally(cause);
+                if (rri.closeConnection()) {
+                    ctx.channel().close();
+                }
             }
         }
-        ccsm.onRoutedRequestComplete();
+        finally {
+            ccsm.onRoutedRequestComplete();
+        }
     }
 
     private void handleRegularCompletion(ChannelHandlerContext ctx, RouterResponse result, Throwable error,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -271,9 +271,6 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
                         return;
                     }
                     if (oobFrame != null && rri instanceof RouterResponseImpl.RespondWith rw) {
-                        // Deliver OOB response directly via writeAndFlush — bypasses the
-                        // sequencer so the OOB response arrives immediately even if a
-                        // sequenced response is still pending.
                         var header = rw.header() != null ? rw.header() : new ResponseHeaderData();
                         header.setCorrelationId(correlationId);
                         var internalResponse = new InternalResponseFrame<>(
@@ -487,7 +484,6 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
                 .addKeyValue("route", route);
     }
 
-    // post transformation of ids into virtual ids
     private void cacheNodeAddressesIfMetadata(Object body) {
         if (body instanceof MetadataResponseData md) {
             for (var broker : md.brokers()) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandler.java
@@ -19,7 +19,6 @@ import io.kroxylicious.proxy.frame.DecodedFrame;
 import io.kroxylicious.proxy.frame.Frame;
 import io.kroxylicious.proxy.frame.RequestFrame;
 import io.kroxylicious.proxy.internal.ClientConnectionStateMachine;
-import io.kroxylicious.proxy.internal.CorrelationIdSpace;
 
 import static java.util.Objects.requireNonNull;
 
@@ -57,8 +56,10 @@ public class RoutingTerminalHandler extends ChannelDuplexHandler {
                 return;
             }
             boolean hasResponse = !(msg instanceof RequestFrame rf) || rf.hasResponse();
-            boolean isRouterInternal = CorrelationIdSpace.isRoutingCorrelationId(frame.correlationId());
-            if (hasResponse && !isRouterInternal) {
+            if (hasResponse) {
+                // Track all requests (including router-internal routing requests) so that
+                // routing responses are stamped with the route name as they flow back through
+                // the route filter chain, enabling route-filter onResponse processing.
                 correlationIdToRoute.put(frame.correlationId(), routeName);
             }
             int targetNodeId = (frame instanceof DecodedFrame<?, ?> df) ? df.targetVirtualNodeId() : Frame.NO_TARGET_VIRTUAL_NODE_ID;

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandler.java
@@ -57,9 +57,7 @@ public class RoutingTerminalHandler extends ChannelDuplexHandler {
             }
             boolean hasResponse = !(msg instanceof RequestFrame rf) || rf.hasResponse();
             if (hasResponse) {
-                // Track all requests (including router-internal routing requests) so that
-                // routing responses are stamped with the route name as they flow back through
-                // the route filter chain, enabling route-filter onResponse processing.
+                // Include router-internal requests so their responses are stamped with the route name, enabling route-filter onResponse.
                 correlationIdToRoute.put(frame.correlationId(), routeName);
             }
             int targetNodeId = (frame instanceof DecodedFrame<?, ?> df) ? df.targetVirtualNodeId() : Frame.NO_TARGET_VIRTUAL_NODE_ID;

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -9,6 +9,7 @@ package io.kroxylicious.proxy.internal;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -48,6 +49,7 @@ import io.netty.handler.ssl.SniHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.internal.StringUtil;
 
+import io.kroxylicious.proxy.bootstrap.RouterChainFactory;
 import io.kroxylicious.proxy.config.CacheConfiguration;
 import io.kroxylicious.proxy.config.NettySettings;
 import io.kroxylicious.proxy.config.ProxyProtocolMode;
@@ -59,7 +61,12 @@ import io.kroxylicious.proxy.internal.net.EndpointBindingResolver;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
 import io.kroxylicious.proxy.internal.net.EndpointResolutionException;
 import io.kroxylicious.proxy.internal.routing.DirectRouting;
+import io.kroxylicious.proxy.internal.routing.DynamicRouting;
+import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
+import io.kroxylicious.proxy.internal.routing.RouterDispatchHandler;
+import io.kroxylicious.proxy.internal.routing.RoutingTerminalHandler;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
+import io.kroxylicious.proxy.router.Router;
 import io.kroxylicious.proxy.service.NodeIdentificationStrategy;
 
 import static io.kroxylicious.proxy.internal.KafkaProxyInitializer.LOGGING_INBOUND_ERROR_HANDLER_NAME;
@@ -406,6 +413,35 @@ class KafkaProxyInitializerTest {
     private KafkaProxyInitializer createKafkaProxyInitializer(boolean tls,
                                                               EndpointBindingResolver bindingResolver) {
         return createKafkaProxyInitializer(tls, ProxyProtocolMode.DISABLED, bindingResolver);
+    }
+
+    @Test
+    void shouldAddRouterDispatchHandlerForDynamicRoutingOnBindingComplete() {
+        // Given
+        var routerChainFactory = mock(RouterChainFactory.class);
+        var router = mock(Router.class);
+        when(routerChainFactory.createRouter(any(), any())).thenReturn(router);
+        when(router.staticRoutes()).thenReturn(Map.of());
+
+        virtualClusterModel = buildDynamicRoutingVirtualCluster(routerChainFactory);
+        when(endpointBinding.endpointGateway()).thenReturn(virtualClusterModel.gateways().values().iterator().next());
+        kafkaProxyInitializer = createKafkaProxyInitializer(false, (endpoint, sniHostname) -> bindingStage);
+
+        // When
+        kafkaProxyInitializer.initConnection(channel, endpointBinding, new KafkaSession(KafkaSessionState.ESTABLISHING));
+
+        // Then
+        verify(channelPipeline).addLast(eq("routerDispatchHandler"), isA(RouterDispatchHandler.class));
+        verify(channelPipeline).addLast(eq("routingTerminalHandler"), isA(RoutingTerminalHandler.class));
+    }
+
+    private VirtualClusterModel buildDynamicRoutingVirtualCluster(RouterChainFactory routerChainFactory) {
+        var route = new RouteDescriptor("default", 0, new TargetCluster("localhost:9090", Optional.empty()), null, List.of());
+        var routing = new DynamicRouting("test-router", Map.of("default", route), routerChainFactory);
+        VirtualClusterModel testCluster = new VirtualClusterModel("testCluster", routing, false, false, List.of(),
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
+        testCluster.addGateway("default", mock(NodeIdentificationStrategy.class), Optional.empty());
+        return testCluster;
     }
 
     @SuppressWarnings("DataFlowIssue")

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
@@ -801,6 +801,54 @@ class RouterDispatchHandlerTest {
         assertThat(channel.isOpen()).isFalse();
     }
 
+    @Test
+    void oobFrameNullResultShouldCloseChannelAndCompletePromiseExceptionally() {
+        // Given
+        var promise = new CompletableFuture<ProduceResponseData>();
+        var oob = oobProduceFrame(CORRELATION_ID, promise);
+        oob.setRouteName(DEFAULT_ROUTE);
+        when(router.onRequest(any(), anyShort(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        when(ccsm.sessionId()).thenReturn("test-session");
+        when(ccsm.authenticatedSubject()).thenReturn(Subject.anonymous());
+
+        var handler = handlerWithRoute(DEFAULT_ROUTE);
+        channel = new EmbeddedChannel(handler);
+
+        // When
+        channel.writeInbound(oob);
+        channel.runPendingTasks();
+
+        // Then
+        assertThat(channel.isOpen()).isFalse();
+        assertThat(promise).isCompletedExceptionally();
+    }
+
+    @Test
+    void oobFrameUnrecognisedResultTypeShouldCloseChannelAndCompletePromiseExceptionally() {
+        // Given
+        var promise = new CompletableFuture<ProduceResponseData>();
+        var oob = oobProduceFrame(CORRELATION_ID, promise);
+        oob.setRouteName(DEFAULT_ROUTE);
+        RouterResponse unknown = new RouterResponse() {
+        };
+        when(router.onRequest(any(), anyShort(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(unknown));
+        when(ccsm.sessionId()).thenReturn("test-session");
+        when(ccsm.authenticatedSubject()).thenReturn(Subject.anonymous());
+
+        var handler = handlerWithRoute(DEFAULT_ROUTE);
+        channel = new EmbeddedChannel(handler);
+
+        // When
+        channel.writeInbound(oob);
+        channel.runPendingTasks();
+
+        // Then
+        assertThat(channel.isOpen()).isFalse();
+        assertThat(promise).isCompletedExceptionally();
+    }
+
     private InternalRequestFrame<ProduceRequestData> oobProduceFrame(int correlationId, CompletableFuture<?> promise) {
         var header = new RequestHeaderData()
                 .setRequestApiKey(ApiKeys.PRODUCE.id)

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
@@ -28,11 +28,15 @@ import io.netty.channel.embedded.EmbeddedChannel;
 
 import io.kroxylicious.proxy.authentication.Subject;
 import io.kroxylicious.proxy.config.TargetCluster;
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.frame.OpaqueRequestFrame;
 import io.kroxylicious.proxy.internal.ClientConnectionStateMachine;
+import io.kroxylicious.proxy.internal.InternalRequestFrame;
+import io.kroxylicious.proxy.internal.InternalResponseFrame;
 import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.router.RouterResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -53,6 +57,9 @@ class RouterDispatchHandlerTest {
 
     @Mock
     private ClientConnectionStateMachine ccsm;
+
+    @Mock
+    private Filter filter;
 
     private EmbeddedChannel channel;
 
@@ -631,5 +638,90 @@ class RouterDispatchHandlerTest {
         // Then
         assertThat(future.toCompletableFuture()).isCompletedExceptionally();
         assertThat(handler.pendingResponses).isEmpty();
+    }
+
+    @Test
+    void oobFrameRespondWithShouldDeliverInternalResponseFrame() {
+        // Given
+        var promise = new CompletableFuture<ProduceResponseData>();
+        var oob = oobProduceFrame(CORRELATION_ID, promise);
+        oob.setRouteName(DEFAULT_ROUTE);
+        var body = new ProduceResponseData();
+        when(router.onRequest(any(), anyShort(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(new RouterResponseImpl.RespondWith(null, body, false)));
+        when(ccsm.sessionId()).thenReturn("test-session");
+        when(ccsm.authenticatedSubject()).thenReturn(Subject.anonymous());
+
+        var handler = handlerWithRoute(DEFAULT_ROUTE);
+        channel = new EmbeddedChannel(handler);
+
+        // When
+        channel.writeInbound(oob);
+        channel.runPendingTasks();
+
+        // Then: InternalResponseFrame delivered directly (not a plain DecodedResponseFrame)
+        var out = channel.readOutbound();
+        assertThat(out).isInstanceOf(InternalResponseFrame.class);
+        InternalResponseFrame<?> irf = (InternalResponseFrame<?>) out;
+        assertThat(irf.correlationId()).isEqualTo(CORRELATION_ID);
+        assertThat(irf.routeName()).isEqualTo(DEFAULT_ROUTE);
+        assertThat(irf.promise()).isSameAs(promise);
+    }
+
+    @Test
+    void oobFrameShouldSkipSequenceImmediately() {
+        // Given: first request is an OOB whose router future is held pending; second is a regular request
+        var pendingOobFuture = new CompletableFuture<RouterResponse>();
+        var oob = oobProduceFrame(CORRELATION_ID, new CompletableFuture<>());
+        var regularFrame = produceFrame(CORRELATION_ID + 1);
+        when(router.onRequest(any(), anyShort(), any(), any(), any()))
+                .thenReturn(pendingOobFuture.minimalCompletionStage())
+                .thenReturn(CompletableFuture.completedFuture(
+                        new RouterResponseImpl.RespondWith(null, new ProduceResponseData(), false)));
+        when(ccsm.sessionId()).thenReturn("test-session");
+        when(ccsm.authenticatedSubject()).thenReturn(Subject.anonymous());
+
+        var handler = handlerWithRoute(DEFAULT_ROUTE);
+        channel = new EmbeddedChannel(handler);
+
+        // When: OOB is sent first (pending), then a regular frame is sent
+        channel.writeInbound(oob);
+        channel.writeInbound(regularFrame);
+        channel.runPendingTasks();
+
+        // Then: regular frame's response arrives immediately — not blocked by the pending OOB sequence
+        DecodedResponseFrame<?> out = channel.readOutbound();
+        assertThat(out)
+                .as("regular frame response must not be blocked by the pending OOB sequence slot")
+                .isNotNull();
+        assertThat(out.correlationId()).isEqualTo(CORRELATION_ID + 1);
+    }
+
+    @Test
+    void oobFrameErrorShouldCloseChannelWithoutDoubleSkip() {
+        // Given
+        var oob = oobProduceFrame(CORRELATION_ID, new CompletableFuture<>());
+        when(router.onRequest(any(), anyShort(), any(), any(), any()))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("boom")));
+        when(ccsm.sessionId()).thenReturn("test-session");
+        when(ccsm.authenticatedSubject()).thenReturn(Subject.anonymous());
+
+        var handler = handlerWithRoute(DEFAULT_ROUTE);
+        channel = new EmbeddedChannel(handler);
+
+        // When
+        channel.writeInbound(oob);
+        channel.runPendingTasks();
+
+        // Then: channel is closed; no exception (sequence not skipped twice)
+        assertThat(channel.isOpen()).isFalse();
+    }
+
+    private InternalRequestFrame<ProduceRequestData> oobProduceFrame(int correlationId, CompletableFuture<?> promise) {
+        var header = new RequestHeaderData()
+                .setRequestApiKey(ApiKeys.PRODUCE.id)
+                .setRequestApiVersion((short) 9)
+                .setCorrelationId(correlationId);
+        return new InternalRequestFrame<>((short) 9, correlationId, true, filter, promise, header, new ProduceRequestData());
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
@@ -679,6 +679,52 @@ class RouterDispatchHandlerTest {
     }
 
     @Test
+    void oobFrameRespondWithErrorShouldCompletePromiseExceptionally() {
+        // Given: OOB whose router returns RespondWithError — sequence slot was already skipped for OOB;
+        // deliverResponse must NOT call responseSequencer.submit() with the already-skipped slot.
+        var promise = new CompletableFuture<ProduceResponseData>();
+        var oob = oobProduceFrame(CORRELATION_ID, promise);
+        oob.setRouteName(DEFAULT_ROUTE);
+        when(router.onRequest(any(), anyShort(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(
+                        new RouterResponseImpl.RespondWithError(new RequestHeaderData(), new ProduceRequestData(), new UnknownServerException("oob-error"), false)));
+        when(ccsm.sessionId()).thenReturn("test-session");
+        when(ccsm.authenticatedSubject()).thenReturn(Subject.anonymous());
+
+        var handler = handlerWithRoute(DEFAULT_ROUTE);
+        channel = new EmbeddedChannel(handler);
+
+        // When
+        channel.writeInbound(oob);
+        channel.runPendingTasks();
+
+        // Then: OOB promise must be completed exceptionally — not orphaned in the sequencer
+        assertThat(promise).isCompletedExceptionally();
+    }
+
+    @Test
+    void oobFrameRespondWithoutReplyShouldCompletePromise() {
+        // Given: OOB whose router returns RespondWithoutReply — same orphan risk as RespondWithError.
+        var promise = new CompletableFuture<ProduceResponseData>();
+        var oob = oobProduceFrame(CORRELATION_ID, promise);
+        oob.setRouteName(DEFAULT_ROUTE);
+        when(router.onRequest(any(), anyShort(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(new RouterResponseImpl.RespondWithoutReply(false)));
+        when(ccsm.sessionId()).thenReturn("test-session");
+        when(ccsm.authenticatedSubject()).thenReturn(Subject.anonymous());
+
+        var handler = handlerWithRoute(DEFAULT_ROUTE);
+        channel = new EmbeddedChannel(handler);
+
+        // When
+        channel.writeInbound(oob);
+        channel.runPendingTasks();
+
+        // Then: OOB promise must be completed — not orphaned in the sequencer
+        assertThat(promise).isDone();
+    }
+
+    @Test
     void oobFrameRespondWithShouldDeliverInternalResponseFrame() {
         // Given
         var promise = new CompletableFuture<ProduceResponseData>();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
@@ -5,6 +5,7 @@
  */
 package io.kroxylicious.proxy.internal.routing;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -37,6 +38,7 @@ import io.kroxylicious.proxy.internal.InternalRequestFrame;
 import io.kroxylicious.proxy.internal.InternalResponseFrame;
 import io.kroxylicious.proxy.router.Router;
 import io.kroxylicious.proxy.router.RouterResponse;
+import io.kroxylicious.proxy.service.HostPort;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -469,6 +471,42 @@ class RouterDispatchHandlerTest {
         // Then: frame was consumed by the handler, not forwarded to the client
         assertThat((Object) channel.readOutbound()).isNull();
         assertThat(pendingFuture).isCompletedWithValueMatching(ProduceResponseData.class::isInstance);
+    }
+
+    @Test
+    void metadataRoutingResponseShouldPopulateSharedNodeAddressMap() {
+        // Given
+        when(ccsm.sessionId()).thenReturn("test-session");
+        var sharedAddresses = new HashMap<Integer, HostPort>();
+        var handler = new RouterDispatchHandler(
+                router,
+                Map.of(DEFAULT_ROUTE, new RouteDescriptor(DEFAULT_ROUTE, 0, new TargetCluster("localhost:9092", null), null, List.of())),
+                Map.of(), sharedAddresses, ccsm, "test-cluster", new IdentityNodeIdMapping(DEFAULT_ROUTE), null);
+        channel = channelWithTerminal(handler);
+
+        var header = new RequestHeaderData()
+                .setRequestApiKey(ApiKeys.METADATA.id)
+                .setRequestApiVersion((short) 12);
+        handler.sendToAnyNode(DEFAULT_ROUTE, header, new MetadataRequestData(), "test-session", 100);
+
+        int routingCorrelationId = Integer.MIN_VALUE / 2;
+        var broker = new MetadataResponseData.MetadataResponseBroker()
+                .setNodeId(0).setHost("broker0").setPort(9092);
+        var md = new MetadataResponseData();
+        md.brokers().add(broker);
+        var responseFrame = new DecodedResponseFrame<>((short) 12, routingCorrelationId, new ResponseHeaderData(), md);
+
+        // When
+        channel.writeOutbound(responseFrame);
+
+        // Then: shared map contains the address learned from the METADATA response
+        assertThat(handler.resolveRouterNodeAddress(0))
+                .isPresent()
+                .hasValueSatisfying(hp -> {
+                    assertThat(hp.host()).isEqualTo("broker0");
+                    assertThat(hp.port()).isEqualTo(9092);
+                });
+        assertThat(sharedAddresses).containsKey(0);
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandlerTest.java
@@ -173,7 +173,7 @@ class RoutingTerminalHandlerTest {
     }
 
     @Test
-    void shouldNotRecordCorrelationIdForRouterInternalRequest() {
+    void writeShouldSetRouteNameForRoutingCorrelationId() {
         // Given
         when(ccsm.sessionId()).thenReturn("test-session");
         var handler = new RoutingTerminalHandler(ccsm);
@@ -197,7 +197,9 @@ class RoutingTerminalHandlerTest {
         // Then
         DecodedResponseFrame<?> out = channel.readOutbound();
         assertThat(out).isNotNull();
-        assertThat(out.routeName()).as("router-internal correlation IDs must not be recorded, so no route name is set on the response").isNull();
+        assertThat(out.routeName())
+                .as("routing-range correlation IDs must be tracked so the route name is stamped on routing responses, enabling RouteFilterHandler.onResponse")
+                .isEqualTo(ROUTE_A);
     }
 
     private DecodedRequestFrame<FetchRequestData> fetchRequest() {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Four bugs in dynamic routing (#4154) together prevent route-filter `onResponse` from running and cause OOB `FilterContext.sendRequest()` calls to hang for 20 seconds before timing out.

**Fix**

Full fix across four sites:

- `RoutingTerminalHandler.channelRead()`: the `!isRouterInternal` guard on `correlationIdToRoute.put()` prevented tracking of routing requests. Responses arrived at `RouteFilterHandler` without a route name; `matchesRoute()` returned false and skipped `onResponse`.
- `RouterDispatchHandler.dispatchDynamically()`: for `InternalRequestFrame` (OOB from `FilterContext.sendRequest()`), skip the sequencer slot immediately and deliver the response via `channel.writeAndFlush(InternalResponseFrame)`. Previously the OOB response entered `ResponseSequencer`, where `FilterHandler` dispatched `onResponse` instead of completing the filter promise. OOB calls fired from within `onResponse` deadlocked: the enclosing response waited for `onResponse` to return; `onResponse` waited for the OOB promise; the OOB response sat queued behind the enclosing response.
- `KafkaProxyInitializer`: hold a per-virtual-cluster `ConcurrentHashMap<Integer, HostPort>` and inject it into each new `RouterDispatchHandler` rather than letting each handler own a private map. Previously each connection discarded its learned addresses on close; `forwardToNode()` on a fresh connection then threw "Upstream address not yet known for virtual node ID N".
- `RouterDispatchHandler` OOB outcomes: for `RespondWithError` or `RespondWithoutReply`, complete the OOB promise exceptionally rather than falling through to `deliverResponse()`. The fallthrough re-submitted a sequencer slot that OOB-skipping had already handled, creating an orphan entry and leaving the promise pending until the 20-second `FilterHandler` timeout.

**Impact**

User-facing for dynamic routing users on #4154. Route-filter `onResponse` callbacks were silently skipped; OOB requests hung 20 seconds before failing; node-address resolution failed across connection boundaries. Integration tests cover all four paths.

Closes: #4512
Relates-to: #4154

### Checklist

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [ ] For user facing changes, add a logchange entry YAML file to `changelog/unreleased/`.