### PR TITLE
feat(sasl-termination): add SASL termination filter with OAUTHBEARER

### DIFF
--- a/changelog/unreleased/04519-sasl-termination-filter.yaml
+++ b/changelog/unreleased/04519-sasl-termination-filter.yaml
@@ -1,0 +1,4 @@
+title: "feat(sasl-termination): add SASL termination filter with OAUTHBEARER"
+type: added
+issues:
+  - 4519

--- a/kroxylicious-bom/pom.xml
+++ b/kroxylicious-bom/pom.xml
@@ -186,6 +186,12 @@
 
             <dependency>
                 <groupId>io.kroxylicious</groupId>
+                <artifactId>kroxylicious-sasl-termination</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.kroxylicious</groupId>
                 <artifactId>kroxylicious-sasl-inspection</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/kroxylicious-filters/kroxylicious-sasl-termination/pom.xml
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kroxylicious</groupId>
+        <artifactId>kroxylicious-filter-parent</artifactId>
+        <version>0.24.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kroxylicious-sasl-termination</artifactId>
+    <name>SASL termination filter</name>
+    <description>A filter that performs SASL termination, authenticating clients against pluggable credential stores.</description>
+
+    <dependencies>
+        <!-- project dependencies - runtime and compile -->
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-api</artifactId>
+        </dependency>
+
+        <!-- third party dependencies - runtime and compile -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
+
+        <!-- project dependencies - test -->
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-runtime</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- third party dependencies - test -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/MechanismConfig.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/MechanismConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.sasl.termination;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Base type for mechanism-specific configuration.
+ * <p>
+ * Jackson uses name-based polymorphism with the {@code mechanism} field as the
+ * type discriminator. The mechanism name is the IANA-registered SASL mechanism
+ * name (e.g. {@code OAUTHBEARER}).
+ * </p>
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "mechanism")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = OauthBearerMechanismConfig.class, name = "OAUTHBEARER")
+})
+public sealed interface MechanismConfig
+        permits OauthBearerMechanismConfig {
+
+    /**
+     * Returns the IANA-registered mechanism name.
+     *
+     * @return the IANA-registered mechanism name
+     */
+    String mechanismName();
+}

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/MechanismConfig.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/MechanismConfig.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "mechanism")
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = OauthBearerMechanismConfig.class, name = "OAUTHBEARER")
+        @JsonSubTypes.Type(value = OauthBearerMechanismConfig.class, name = OauthBearerMechanismConfig.MECHANISM_NAME)
 })
 public sealed interface MechanismConfig
         permits OauthBearerMechanismConfig {

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/MechanismStateMachine.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/MechanismStateMachine.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.sasl.termination;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Mechanism-specific transition function for the {@link io.kroxylicious.filter.sasl.termination.State State} state machine.
+ * <p>
+ * When the filter is in the {@link io.kroxylicious.filter.sasl.termination.State.RequiringAuthenticate RequiringAuthenticate}
+ * state, it delegates each {@code SaslAuthenticate} request to the {@code MechanismStateMachine} for the
+ * negotiated mechanism. The returned {@link RoundResult} tells the filter which state transition to make:
+ * {@linkplain RoundResult.Challenge continue authenticating},
+ * {@linkplain RoundResult.Success transition to authenticated}, or
+ * {@linkplain RoundResult.Failure fail}.
+ * </p>
+ * <p>
+ * Implementations may maintain internal state across rounds (e.g.&nbsp;SCRAM tracks
+ * nonces and proofs), but this state is private to the mechanism and invisible to the
+ * filter-level state machine.
+ * </p>
+ *
+ * <h2>Multi-Round Authentication</h2>
+ * <p>
+ * Some mechanisms (like SCRAM) require multiple rounds of exchange. The state machine
+ * must return {@link RoundResult.Challenge} until the final round,
+ * then {@link RoundResult.Success} or {@link RoundResult.Failure}.
+ * </p>
+ *
+ * <h2>Thread Safety</h2>
+ * <p>
+ * Implementations are NOT required to be thread-safe. Each instance is used
+ * for a single connection and is accessed only from that connection's event loop thread.
+ * </p>
+ *
+ * <h2>Lifecycle</h2>
+ * <ol>
+ *     <li>Instance created per authentication session</li>
+ *     <li>{@link #evaluateRound} called one or more times</li>
+ *     <li>{@link #dispose()} called to clean up resources</li>
+ * </ol>
+ */
+interface MechanismStateMachine {
+
+    /**
+     * Get the IANA-registered mechanism name.
+     *
+     * @return the mechanism name (e.g., "SCRAM-SHA-256")
+     */
+    String mechanismName();
+
+    /**
+     * Maximum size in bytes of the {@code authBytes} field in a
+     * {@code SaslAuthenticateRequest} that this mechanism will accept.
+     * Payloads exceeding this limit are rejected before processing.
+     *
+     * @return the maximum auth bytes size
+     */
+    int maxAuthBytes();
+
+    /**
+     * Process one authentication round and return the resulting state transition.
+     * <p>
+     * This method is called for each authenticate request from the client.
+     * For multi-round mechanisms, it will be called multiple times with different
+     * request bytes.
+     * </p>
+     * <p>
+     * The returned {@link CompletionStage} must not block. Any I/O (credential
+     * lookups, token validation) should be asynchronous. Mechanism-specific
+     * resources (credential stores, callback handlers) are injected at
+     * construction time via the factory.
+     * </p>
+     * <p>
+     * <strong>Timing side-channel mitigation:</strong> The filter applies a fixed
+     * delay to each round to prevent timing-based username enumeration. For this
+     * mitigation to be effective, multi-round implementations that detect an authentication
+     * failure in an early round (e.g. unknown user) must not fail fast. Instead,
+     * they should continue to return {@link RoundResult.Challenge}
+     * responses for intermediate rounds and defer the
+     * {@link RoundResult.Failure} until the final round, so that
+     * the number of rounds is indistinguishable from a legitimate exchange.
+     * </p>
+     *
+     * @param authBytes the SASL authentication bytes from the client
+     * @return a completion stage that completes with the authentication result
+     */
+    CompletionStage<RoundResult> evaluateRound(byte[] authBytes);
+
+    /**
+     * Dispose of resources used by this state machine.
+     * <p>
+     * Called when authentication completes (successfully or not) or when the
+     * connection is closed. Must be idempotent.
+     * </p>
+     * <p>
+     * Implementations should dispose of any SASL server instances, clear sensitive
+     * data from memory, etc.
+     * </p>
+     */
+    void dispose();
+}

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerMechanismConfig.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerMechanismConfig.java
@@ -37,6 +37,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * @param jwksEndpointRefresh JWKS endpoint refresh interval
  * @param jwksEndpointRetryBackoff initial retry backoff
  * @param jwksEndpointRetryBackoffMax maximum retry backoff
+ * @param maxAuthBytes maximum size in bytes of the auth payload accepted per round, null = 128KB default
  */
 @JsonIgnoreProperties("mechanism")
 public record OauthBearerMechanismConfig(
@@ -47,10 +48,14 @@ public record OauthBearerMechanismConfig(
                                          @Nullable String subClaimName,
                                          @Nullable Duration jwksEndpointRefresh,
                                          @Nullable Duration jwksEndpointRetryBackoff,
-                                         @Nullable Duration jwksEndpointRetryBackoffMax)
+                                         @Nullable Duration jwksEndpointRetryBackoffMax,
+                                         @Nullable Integer maxAuthBytes)
         implements MechanismConfig {
 
     public static final String MECHANISM_NAME = "OAUTHBEARER";
+    // 128KB accommodates large enterprise JWT tokens with many group/role claims
+    // while rejecting multi-MB payloads before token parsing and validation.
+    static final int DEFAULT_MAX_AUTH_BYTES = 128 * 1024;
 
     /** Validates that required fields are present and non-blank. */
     public OauthBearerMechanismConfig {
@@ -63,6 +68,18 @@ public record OauthBearerMechanismConfig(
         if (expectedIssuer == null || expectedIssuer.isBlank()) {
             throw new IllegalArgumentException("expectedIssuer must not be null or blank");
         }
+        if (maxAuthBytes != null && maxAuthBytes <= 0) {
+            throw new IllegalArgumentException("maxAuthBytes must be positive");
+        }
+    }
+
+    /**
+     * Returns the effective maximum auth bytes, defaulting to 128KB if not configured.
+     *
+     * @return the maximum auth bytes size
+     */
+    public int effectiveMaxAuthBytes() {
+        return maxAuthBytes != null ? maxAuthBytes : DEFAULT_MAX_AUTH_BYTES;
     }
 
     @Override

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerMechanismConfig.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerMechanismConfig.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.sasl.termination;
+
+import java.net.URI;
+import java.time.Duration;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Configuration for the {@code OAUTHBEARER} mechanism.
+ * <p>
+ * Specifies the JWKS endpoint and optional JWT validation settings for
+ * OAuth 2.0 bearer token authentication.
+ * </p>
+ *
+ * <h2>Example Configuration</h2>
+ * <pre>{@code
+ *   mechanism: OAUTHBEARER
+ *   jwksEndpointUrl: https://idp.example.com/.well-known/jwks.json
+ *   expectedAudience: kafka
+ *   expectedIssuer: https://idp.example.com
+ * }</pre>
+ *
+ * @param jwksEndpointUrl the JWKS endpoint URL for fetching signing keys
+ * @param expectedAudience the expected audience claim (comma-separated for multiple)
+ * @param expectedIssuer the expected issuer claim
+ * @param scopeClaimName custom claim name for scope (default: "scope")
+ * @param subClaimName custom claim name for subject (default: "sub")
+ * @param jwksEndpointRefresh JWKS endpoint refresh interval
+ * @param jwksEndpointRetryBackoff initial retry backoff
+ * @param jwksEndpointRetryBackoffMax maximum retry backoff
+ */
+@JsonIgnoreProperties("mechanism")
+public record OauthBearerMechanismConfig(
+                                         @JsonProperty(required = true) URI jwksEndpointUrl,
+                                         @JsonProperty(required = true) String expectedAudience,
+                                         @JsonProperty(required = true) String expectedIssuer,
+                                         @Nullable String scopeClaimName,
+                                         @Nullable String subClaimName,
+                                         @Nullable Duration jwksEndpointRefresh,
+                                         @Nullable Duration jwksEndpointRetryBackoff,
+                                         @Nullable Duration jwksEndpointRetryBackoffMax)
+        implements MechanismConfig {
+
+    private static final String MECHANISM_NAME = "OAUTHBEARER";
+
+    /** Validates that required fields are present and non-blank. */
+    public OauthBearerMechanismConfig {
+        if (jwksEndpointUrl == null) {
+            throw new IllegalArgumentException("jwksEndpointUrl must not be null");
+        }
+        if (expectedAudience == null || expectedAudience.isBlank()) {
+            throw new IllegalArgumentException("expectedAudience must not be null or blank");
+        }
+        if (expectedIssuer == null || expectedIssuer.isBlank()) {
+            throw new IllegalArgumentException("expectedIssuer must not be null or blank");
+        }
+    }
+
+    @Override
+    public String mechanismName() {
+        return MECHANISM_NAME;
+    }
+}

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerMechanismConfig.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerMechanismConfig.java
@@ -50,7 +50,7 @@ public record OauthBearerMechanismConfig(
                                          @Nullable Duration jwksEndpointRetryBackoffMax)
         implements MechanismConfig {
 
-    private static final String MECHANISM_NAME = "OAUTHBEARER";
+    public static final String MECHANISM_NAME = "OAUTHBEARER";
 
     /** Validates that required fields are present and non-blank. */
     public OauthBearerMechanismConfig {

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachine.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachine.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.filter.sasl.termination;
 
-import java.time.Clock;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -52,7 +51,6 @@ class OauthBearerStateMachine implements MechanismStateMachine {
     private static final Logger LOGGER = LoggerFactory.getLogger(OauthBearerStateMachine.class);
 
     private final OAuthBearerValidatorCallbackHandler callbackHandler;
-    private final Clock clock;
     private final int maxAuthBytes;
 
     @Nullable
@@ -62,12 +60,10 @@ class OauthBearerStateMachine implements MechanismStateMachine {
      * Create an OAUTHBEARER state machine.
      *
      * @param callbackHandler the configured callback handler for JWT validation
-     * @param clock clock for computing token remaining lifetime
      * @param maxAuthBytes maximum auth payload size in bytes
      */
-    OauthBearerStateMachine(OAuthBearerValidatorCallbackHandler callbackHandler, Clock clock, int maxAuthBytes) {
+    OauthBearerStateMachine(OAuthBearerValidatorCallbackHandler callbackHandler, int maxAuthBytes) {
         this.callbackHandler = Objects.requireNonNull(callbackHandler);
-        this.clock = Objects.requireNonNull(clock);
         this.maxAuthBytes = maxAuthBytes;
     }
 

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachine.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachine.java
@@ -52,6 +52,7 @@ class OauthBearerStateMachine implements MechanismStateMachine {
 
     private final OAuthBearerValidatorCallbackHandler callbackHandler;
     private final Clock clock;
+    private final int maxAuthBytes;
 
     @Nullable
     private SaslServer saslServer;
@@ -61,10 +62,12 @@ class OauthBearerStateMachine implements MechanismStateMachine {
      *
      * @param callbackHandler the configured callback handler for JWT validation
      * @param clock clock for computing token remaining lifetime
+     * @param maxAuthBytes maximum auth payload size in bytes
      */
-    OauthBearerStateMachine(OAuthBearerValidatorCallbackHandler callbackHandler, Clock clock) {
+    OauthBearerStateMachine(OAuthBearerValidatorCallbackHandler callbackHandler, Clock clock, int maxAuthBytes) {
         this.callbackHandler = Objects.requireNonNull(callbackHandler);
         this.clock = Objects.requireNonNull(clock);
+        this.maxAuthBytes = maxAuthBytes;
     }
 
     @Override
@@ -72,9 +75,12 @@ class OauthBearerStateMachine implements MechanismStateMachine {
         return OAUTHBEARER_MECHANISM;
     }
 
+    // Limits the processing cost (JWT parsing, JWKS validation) of oversized payloads.
+    // This is defense-in-depth: the byte[] is already allocated from the network buffer
+    // before the filter is called, so this cannot prevent the allocation itself.
     @Override
     public int maxAuthBytes() {
-        return 128 * 1024;
+        return maxAuthBytes;
     }
 
     @Override

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachine.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachine.java
@@ -84,6 +84,9 @@ class OauthBearerStateMachine implements MechanismStateMachine {
                 saslServer = Sasl.createSaslServer(
                         OAUTHBEARER_MECHANISM,
                         "kafka",
+                        // ^^ align with
+                        // o.a.k.common.security.oauthbearer.internals.OAuthBearerSaslServer.OAuthBearerSaslServerFactory#createSaslServer
+                        // which uses "kafka", but the kafka internals don't depend on it.
                         null,
                         null,
                         callbackHandler);

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachine.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachine.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.sasl.termination;
+
+import java.time.Clock;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
+
+/**
+ * Handles OAUTHBEARER authentication using JWT bearer tokens.
+ * <p>
+ * Uses Kafka's {@link SaslServer} implementation with
+ * {@link OAuthBearerValidatorCallbackHandler} to validate JWT tokens
+ * against a JWKS endpoint.
+ * </p>
+ *
+ * <h2>Authentication Flow</h2>
+ * <p>
+ * OAUTHBEARER (RFC 7628) is typically single-round:
+ * </p>
+ * <ol>
+ *     <li>Client sends initial response containing the bearer token</li>
+ *     <li>Server validates the token and responds with success or failure</li>
+ * </ol>
+ *
+ * <h2>Thread Safety</h2>
+ * <p>
+ * Not thread-safe. Each instance is used for a single connection
+ * on that connection's event loop thread.
+ * </p>
+ */
+class OauthBearerStateMachine implements MechanismStateMachine {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OauthBearerStateMachine.class);
+
+    private final OAuthBearerValidatorCallbackHandler callbackHandler;
+    private final Clock clock;
+
+    @Nullable
+    private SaslServer saslServer;
+
+    /**
+     * Create an OAUTHBEARER state machine.
+     *
+     * @param callbackHandler the configured callback handler for JWT validation
+     * @param clock clock for computing token remaining lifetime
+     */
+    OauthBearerStateMachine(OAuthBearerValidatorCallbackHandler callbackHandler, Clock clock) {
+        this.callbackHandler = Objects.requireNonNull(callbackHandler);
+        this.clock = Objects.requireNonNull(clock);
+    }
+
+    @Override
+    public String mechanismName() {
+        return OAUTHBEARER_MECHANISM;
+    }
+
+    @Override
+    public int maxAuthBytes() {
+        return 128 * 1024;
+    }
+
+    @Override
+    public CompletionStage<RoundResult> evaluateRound(byte[] authBytes) {
+        try {
+            if (saslServer == null) {
+                saslServer = Sasl.createSaslServer(
+                        OAUTHBEARER_MECHANISM,
+                        "kafka",
+                        null,
+                        null,
+                        callbackHandler);
+
+                if (saslServer == null) {
+                    return CompletableFuture.completedFuture(
+                            RoundResult.failure(new byte[0],
+                                    new SaslException("Failed to create OAUTHBEARER SASL server")));
+                }
+            }
+
+            byte[] response = saslServer.evaluateResponse(authBytes);
+
+            if (saslServer.isComplete()) {
+                String authorizationId = saslServer.getAuthorizationID();
+                long sessionLifetimeMs = extractTokenLifetimeMs();
+                return CompletableFuture.completedFuture(
+                        RoundResult.success(
+                                response != null ? response : new byte[0],
+                                authorizationId,
+                                sessionLifetimeMs));
+            }
+            else {
+                return CompletableFuture.completedFuture(
+                        RoundResult.challenge(
+                                response != null ? response : new byte[0]));
+            }
+        }
+        catch (Exception e) {
+            LOGGER.atDebug()
+                    .setCause(e)
+                    .addKeyValue("error", e.getMessage())
+                    .log("OAUTHBEARER authentication failed");
+            return CompletableFuture.completedFuture(
+                    RoundResult.failure(new byte[0], e));
+        }
+    }
+
+    private long extractTokenLifetimeMs() {
+        try {
+            // CREDENTIAL.LIFETIME.MS has a misleading name — it is actually an absolute epoch timestamp
+            Object credentialExpiryEpochMs = saslServer.getNegotiatedProperty("CREDENTIAL.LIFETIME.MS");
+            if (credentialExpiryEpochMs instanceof Long expiryEpochMs) {
+                return Math.max(0, expiryEpochMs - clock.millis());
+            }
+        }
+        catch (Exception e) {
+            LOGGER.atDebug()
+                    .setCause(e)
+                    .log("Could not extract token lifetime");
+        }
+        return 0;
+    }
+
+    @Override
+    public void dispose() {
+        if (saslServer != null) {
+            try {
+                saslServer.dispose();
+            }
+            catch (SaslException e) {
+                LOGGER.atDebug()
+                        .setCause(e)
+                        .log("Error disposing OAUTHBEARER SASL server");
+            }
+            finally {
+                saslServer = null;
+            }
+        }
+    }
+}

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachine.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachine.java
@@ -132,19 +132,16 @@ class OauthBearerStateMachine implements MechanismStateMachine {
     }
 
     private long extractTokenLifetimeMs() {
-        try {
-            // CREDENTIAL.LIFETIME.MS has a misleading name — it is actually an absolute epoch timestamp
-            Object credentialExpiryEpochMs = saslServer.getNegotiatedProperty("CREDENTIAL.LIFETIME.MS");
-            if (credentialExpiryEpochMs instanceof Long expiryEpochMs) {
-                return Math.max(0, expiryEpochMs - clock.millis());
-            }
+        // CREDENTIAL.LIFETIME.MS has a misleading name — it is actually an absolute epoch timestamp
+        Object credentialExpiryEpochMs = saslServer.getNegotiatedProperty("CREDENTIAL.LIFETIME.MS");
+        if (credentialExpiryEpochMs == null) {
+            return 0;
         }
-        catch (Exception e) {
-            LOGGER.atDebug()
-                    .setCause(e)
-                    .log("Could not extract token lifetime");
+        if (credentialExpiryEpochMs instanceof Long expiryEpochMs) {
+            return Math.max(0, expiryEpochMs - clock.millis());
         }
-        return 0;
+        throw new IllegalStateException(
+                "Expected CREDENTIAL.LIFETIME.MS to be Long but was " + credentialExpiryEpochMs.getClass().getName());
     }
 
     @Override

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachine.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachine.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.filter.sasl.termination;
 
 import java.time.Clock;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -108,12 +109,12 @@ class OauthBearerStateMachine implements MechanismStateMachine {
 
             if (saslServer.isComplete()) {
                 String authorizationId = saslServer.getAuthorizationID();
-                long sessionLifetimeMs = extractTokenLifetimeMs();
+                Instant sessionExpiry = extractTokenExpiry();
                 return CompletableFuture.completedFuture(
                         RoundResult.success(
                                 response != null ? response : new byte[0],
                                 authorizationId,
-                                sessionLifetimeMs));
+                                sessionExpiry));
             }
             else {
                 return CompletableFuture.completedFuture(
@@ -131,14 +132,15 @@ class OauthBearerStateMachine implements MechanismStateMachine {
         }
     }
 
-    private long extractTokenLifetimeMs() {
+    @Nullable
+    private Instant extractTokenExpiry() {
         // CREDENTIAL.LIFETIME.MS has a misleading name — it is actually an absolute epoch timestamp
         Object credentialExpiryEpochMs = saslServer.getNegotiatedProperty("CREDENTIAL.LIFETIME.MS");
         if (credentialExpiryEpochMs == null) {
-            return 0;
+            return null;
         }
         if (credentialExpiryEpochMs instanceof Long expiryEpochMs) {
-            return Math.max(0, expiryEpochMs - clock.millis());
+            return Instant.ofEpochMilli(expiryEpochMs);
         }
         throw new IllegalStateException(
                 "Expected CREDENTIAL.LIFETIME.MS to be Long but was " + credentialExpiryEpochMs.getClass().getName());

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/RoundResult.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/RoundResult.java
@@ -100,8 +100,8 @@ sealed interface RoundResult
             if (this == o) {
                 return true;
             }
-            return o instanceof Challenge that
-                    && Arrays.equals(responseBytes, that.responseBytes);
+            return o instanceof Challenge(byte[] thatResponseBytes)
+                    && Arrays.equals(responseBytes, thatResponseBytes);
         }
 
         @Override
@@ -147,10 +147,10 @@ sealed interface RoundResult
             if (this == o) {
                 return true;
             }
-            return o instanceof Success that
-                    && sessionLifetimeMs == that.sessionLifetimeMs
-                    && Arrays.equals(responseBytes, that.responseBytes)
-                    && Objects.equals(authorizationId, that.authorizationId);
+            return o instanceof Success(byte[] thatResponseBytes, String thatAuthorizationId, long thatSessionLifetimeMs)
+                    && sessionLifetimeMs == thatSessionLifetimeMs
+                    && Arrays.equals(responseBytes, thatResponseBytes)
+                    && Objects.equals(authorizationId, thatAuthorizationId);
         }
 
         @Override
@@ -194,9 +194,9 @@ sealed interface RoundResult
             if (this == o) {
                 return true;
             }
-            return o instanceof Failure that
-                    && Arrays.equals(responseBytes, that.responseBytes)
-                    && Objects.equals(exception, that.exception);
+            return o instanceof Failure(byte[] thatResponseBytes, Exception thatException)
+                    && Arrays.equals(responseBytes, thatResponseBytes)
+                    && Objects.equals(exception, thatException);
         }
 
         @Override

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/RoundResult.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/RoundResult.java
@@ -6,8 +6,11 @@
 
 package io.kroxylicious.filter.sasl.termination;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Objects;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Outcome of a single authentication round, encoding the state transition
@@ -40,26 +43,26 @@ sealed interface RoundResult
     }
 
     /**
-     * Create a success result with no session lifetime (no reauthentication).
+     * Create a success result with no session expiry (no reauthentication).
      *
      * @param responseBytes the final response bytes
      * @param authorizationId the authenticated user's authorization ID
      * @return the round result
      */
     static Success success(byte[] responseBytes, String authorizationId) {
-        return new Success(responseBytes, authorizationId, 0);
+        return new Success(responseBytes, authorizationId, null);
     }
 
     /**
-     * Create a success result with a session lifetime for reauthentication (KIP-368).
+     * Create a success result with a session expiry for reauthentication (KIP-368).
      *
      * @param responseBytes the final response bytes
      * @param authorizationId the authenticated user's authorization ID
-     * @param sessionLifetimeMs session lifetime in milliseconds (0 = no expiry)
+     * @param sessionExpiry absolute time at which the credential expires, null = no expiry
      * @return the round result
      */
-    static Success success(byte[] responseBytes, String authorizationId, long sessionLifetimeMs) {
-        return new Success(responseBytes, authorizationId, sessionLifetimeMs);
+    static Success success(byte[] responseBytes, String authorizationId, @Nullable Instant sessionExpiry) {
+        return new Success(responseBytes, authorizationId, sessionExpiry);
     }
 
     /**
@@ -120,10 +123,10 @@ sealed interface RoundResult
      *
      * @param responseBytes the final response bytes to send to the client
      * @param authorizationId the authenticated user's authorization ID
-     * @param sessionLifetimeMs session lifetime in milliseconds for reauthentication (KIP-368), 0 = no expiry
+     * @param sessionExpiry absolute time at which the credential expires (KIP-368), null = no expiry
      */
     @SuppressWarnings("ArrayRecordComponent") // defensive copies, equals and hashCode are overridden
-    record Success(byte[] responseBytes, String authorizationId, long sessionLifetimeMs) implements RoundResult {
+    record Success(byte[] responseBytes, String authorizationId, @Nullable Instant sessionExpiry) implements RoundResult {
 
         /**
          * Canonical constructor with validation and defensive copy.
@@ -132,9 +135,6 @@ sealed interface RoundResult
             Objects.requireNonNull(responseBytes);
             Objects.requireNonNull(authorizationId);
             responseBytes = responseBytes.clone();
-            if (sessionLifetimeMs < 0) {
-                throw new IllegalArgumentException("sessionLifetimeMs must not be negative");
-            }
         }
 
         @Override
@@ -147,22 +147,22 @@ sealed interface RoundResult
             if (this == o) {
                 return true;
             }
-            return o instanceof Success(byte[] thatResponseBytes, String thatAuthorizationId, long thatSessionLifetimeMs)
-                    && sessionLifetimeMs == thatSessionLifetimeMs
+            return o instanceof Success(byte[] thatResponseBytes, String thatAuthorizationId, Instant thatSessionExpiry)
+                    && Objects.equals(sessionExpiry, thatSessionExpiry)
                     && Arrays.equals(responseBytes, thatResponseBytes)
                     && Objects.equals(authorizationId, thatAuthorizationId);
         }
 
         @Override
         public int hashCode() {
-            int result = Objects.hash(authorizationId, sessionLifetimeMs);
+            int result = Objects.hash(authorizationId, sessionExpiry);
             result = 31 * result + Arrays.hashCode(responseBytes);
             return result;
         }
 
         @Override
         public String toString() {
-            return "Success{authorizationId='" + authorizationId + "', sessionLifetimeMs=" + sessionLifetimeMs + '}';
+            return "Success{authorizationId='" + authorizationId + "', sessionExpiry=" + sessionExpiry + '}';
         }
     }
 

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/RoundResult.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/RoundResult.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.sasl.termination;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Outcome of a single authentication round, encoding the state transition
+ * that the filter-level state machine should make.
+ * <ul>
+ *     <li>{@link Challenge} &mdash; remain in {@link io.kroxylicious.filter.sasl.termination.State.RequiringAuthenticate RequiringAuthenticate}
+ *         (another round is needed)</li>
+ *     <li>{@link Success} &mdash; transition to {@link io.kroxylicious.filter.sasl.termination.State.Authenticated Authenticated}</li>
+ *     <li>{@link Failure} &mdash; transition to {@link io.kroxylicious.filter.sasl.termination.State.Failed Failed}</li>
+ * </ul>
+ */
+sealed interface RoundResult
+        permits RoundResult.Challenge, RoundResult.Success, RoundResult.Failure {
+
+    /**
+     * The bytes to send in the SASL authenticate response.
+     *
+     * @return a defensive copy of the response bytes
+     */
+    byte[] responseBytes();
+
+    /**
+     * Create a challenge result.
+     *
+     * @param responseBytes the challenge bytes
+     * @return the round result
+     */
+    static Challenge challenge(byte[] responseBytes) {
+        return new Challenge(responseBytes);
+    }
+
+    /**
+     * Create a success result with no session lifetime (no reauthentication).
+     *
+     * @param responseBytes the final response bytes
+     * @param authorizationId the authenticated user's authorization ID
+     * @return the round result
+     */
+    static Success success(byte[] responseBytes, String authorizationId) {
+        return new Success(responseBytes, authorizationId, 0);
+    }
+
+    /**
+     * Create a success result with a session lifetime for reauthentication (KIP-368).
+     *
+     * @param responseBytes the final response bytes
+     * @param authorizationId the authenticated user's authorization ID
+     * @param sessionLifetimeMs session lifetime in milliseconds (0 = no expiry)
+     * @return the round result
+     */
+    static Success success(byte[] responseBytes, String authorizationId, long sessionLifetimeMs) {
+        return new Success(responseBytes, authorizationId, sessionLifetimeMs);
+    }
+
+    /**
+     * Create a failure result.
+     *
+     * @param responseBytes the error response bytes (may be empty)
+     * @param exception the exception describing the authentication failure
+     * @return the round result
+     */
+    static Failure failure(byte[] responseBytes, Exception exception) {
+        return new Failure(responseBytes, exception);
+    }
+
+    /**
+     * Authentication requires another round (e.g. SCRAM).
+     * The client must send another authenticate request.
+     *
+     * @param responseBytes the challenge bytes to send to the client
+     */
+    @SuppressWarnings("ArrayRecordComponent") // defensive copies, equals and hashCode are overridden
+    record Challenge(byte[] responseBytes) implements RoundResult {
+
+        /**
+         * Canonical constructor with validation and defensive copy.
+         */
+        public Challenge {
+            Objects.requireNonNull(responseBytes);
+            responseBytes = responseBytes.clone();
+        }
+
+        @Override
+        public byte[] responseBytes() {
+            return responseBytes.clone();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            return o instanceof Challenge that
+                    && Arrays.equals(responseBytes, that.responseBytes);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(responseBytes);
+        }
+
+        @Override
+        public String toString() {
+            return "Challenge{}";
+        }
+    }
+
+    /**
+     * Authentication succeeded.
+     *
+     * @param responseBytes the final response bytes to send to the client
+     * @param authorizationId the authenticated user's authorization ID
+     * @param sessionLifetimeMs session lifetime in milliseconds for reauthentication (KIP-368), 0 = no expiry
+     */
+    @SuppressWarnings("ArrayRecordComponent") // defensive copies, equals and hashCode are overridden
+    record Success(byte[] responseBytes, String authorizationId, long sessionLifetimeMs) implements RoundResult {
+
+        /**
+         * Canonical constructor with validation and defensive copy.
+         */
+        public Success {
+            Objects.requireNonNull(responseBytes);
+            Objects.requireNonNull(authorizationId);
+            responseBytes = responseBytes.clone();
+            if (sessionLifetimeMs < 0) {
+                throw new IllegalArgumentException("sessionLifetimeMs must not be negative");
+            }
+        }
+
+        @Override
+        public byte[] responseBytes() {
+            return responseBytes.clone();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            return o instanceof Success that
+                    && sessionLifetimeMs == that.sessionLifetimeMs
+                    && Arrays.equals(responseBytes, that.responseBytes)
+                    && Objects.equals(authorizationId, that.authorizationId);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = Objects.hash(authorizationId, sessionLifetimeMs);
+            result = 31 * result + Arrays.hashCode(responseBytes);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "Success{authorizationId='" + authorizationId + "', sessionLifetimeMs=" + sessionLifetimeMs + '}';
+        }
+    }
+
+    /**
+     * Authentication failed.
+     *
+     * @param responseBytes the error response bytes to send to the client (may be empty)
+     * @param exception the exception describing the authentication failure
+     */
+    @SuppressWarnings("ArrayRecordComponent") // defensive copies, equals and hashCode are overridden
+    record Failure(byte[] responseBytes, Exception exception) implements RoundResult {
+
+        /**
+         * Canonical constructor with validation and defensive copy.
+         */
+        public Failure {
+            Objects.requireNonNull(responseBytes);
+            Objects.requireNonNull(exception);
+            responseBytes = responseBytes.clone();
+        }
+
+        @Override
+        public byte[] responseBytes() {
+            return responseBytes.clone();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            return o instanceof Failure that
+                    && Arrays.equals(responseBytes, that.responseBytes)
+                    && Objects.equals(exception, that.exception);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = Objects.hash(exception);
+            result = 31 * result + Arrays.hashCode(responseBytes);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "Failure{exception=" + exception.getMessage() + '}';
+        }
+    }
+}

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
@@ -177,13 +177,14 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
         OAuthBearerSaslServerProvider.initialize();
         String jwksUrl = config.jwksEndpointUrl().toString();
 
+        addAllowedSaslOauthbearerUrl(jwksUrl, closeables);
+
         OAuthBearerValidatorCallbackHandler callbackHandler = new OAuthBearerValidatorCallbackHandler();
         callbackHandler.configure(
                 createOauthSaslConfigMap(config),
                 OAUTHBEARER_MECHANISM,
                 createDefaultJaasConfig());
         closeables.add(callbackHandler::close);
-        addAllowedSaslOauthbearerUrl(jwksUrl, closeables);
 
         LOGGER.atInfo()
                 .addKeyValue("jwksEndpointUrl", jwksUrl)

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
@@ -41,6 +41,7 @@ import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
@@ -136,7 +137,7 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
     @Override
     public SaslTerminationContext initialize(
                                              FilterFactoryContext context,
-                                             SaslTerminationConfig config)
+                                             @NonNull SaslTerminationConfig config)
             throws PluginConfigurationException {
 
         Objects.requireNonNull(config);
@@ -209,13 +210,13 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
     @SuppressWarnings("java:S2638") // Tightening UnknownNullness
     @Override
     public Filter createFilter(FilterFactoryContext context,
-                               SaslTerminationContext filterContext) {
+                               @NonNull SaslTerminationContext filterContext) {
         return new SaslTerminationFilter(context.filterDispatchExecutor(), filterContext);
     }
 
     @SuppressWarnings("java:S2638") // Tightening UnknownNullness
     @Override
-    public void close(SaslTerminationContext initializationData) {
+    public void close(@NonNull SaslTerminationContext initializationData) {
         initializationData.close();
     }
 

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
@@ -80,6 +80,7 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
      * Context for the SASL termination filter.
      *
      * @param oauthCallbackHandler initialized callback handler for OAUTHBEARER, null if not configured
+     * @param oauthMaxAuthBytes maximum auth payload size for OAUTHBEARER
      * @param supportedMechanisms set of configured mechanism names
      * @param maxTimeBeforeReauth maximum session lifetime, null if disabled
      * @param clock clock for session expiry computation
@@ -89,6 +90,7 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
      */
     public record SaslTerminationContext(
                                          @Nullable OAuthBearerValidatorCallbackHandler oauthCallbackHandler,
+                                         int oauthMaxAuthBytes,
                                          Set<String> supportedMechanisms,
                                          List<AutoCloseable> closeables,
                                          @Nullable Duration maxTimeBeforeReauth,
@@ -142,6 +144,7 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
         Objects.requireNonNull(config);
 
         OAuthBearerValidatorCallbackHandler oauthCallbackHandler = null;
+        int oauthMaxAuthBytes = OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES;
         Set<String> supportedMechanisms = new LinkedHashSet<>();
         Duration fixedAuthDelay = config.effectiveFixedAuthDelay();
 
@@ -150,7 +153,10 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
         for (MechanismConfig mechanismConfig : config.mechanisms()) {
             supportedMechanisms.add(mechanismConfig.mechanismName());
             switch (mechanismConfig) {
-                case OauthBearerMechanismConfig oauthConfig -> oauthCallbackHandler = initializeOauthBearer(oauthConfig, closeables);
+                case OauthBearerMechanismConfig oauthConfig -> {
+                    oauthCallbackHandler = initializeOauthBearer(oauthConfig, closeables);
+                    oauthMaxAuthBytes = oauthConfig.effectiveMaxAuthBytes();
+                }
             }
         }
 
@@ -163,7 +169,7 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
             closeables.add(builderService);
             subjectBuilder = builderService.build();
         }
-        return new SaslTerminationContext(oauthCallbackHandler, supportedMechanisms, closeables,
+        return new SaslTerminationContext(oauthCallbackHandler, oauthMaxAuthBytes, supportedMechanisms, closeables,
                 config.maxTimeBeforeReauth(), clock, fixedAuthDelay, subjectBuilder);
     }
 

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -40,8 +41,8 @@ import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import edu.umd.cs.findbugs.annotations.UnknownNullness;
 
 import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
 
@@ -134,12 +135,15 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
         }
     }
 
-    @UnknownNullness
+    @SuppressWarnings("java:S2638") // Tightening UnknownNullness
+    @NonNull
     @Override
     public SaslTerminationContext initialize(
                                              FilterFactoryContext context,
-                                             @UnknownNullness SaslTerminationConfig config)
+                                             @NonNull SaslTerminationConfig config)
             throws PluginConfigurationException {
+
+        Objects.requireNonNull(config);
 
         OAuthBearerValidatorCallbackHandler oauthCallbackHandler = null;
         Set<String> supportedMechanisms = new LinkedHashSet<>();
@@ -196,18 +200,20 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
         }
         SaslSubjectBuilderService<Object> service = context.pluginInstance(
                 SaslSubjectBuilderService.class, config.subjectBuilder());
-        service.initialize(config.subjectBuilderConfig());
+        service.initialize(Objects.requireNonNull(config.subjectBuilderConfig()));
         return service;
     }
 
+    @SuppressWarnings("java:S2638") // Tightening UnknownNullness
     @Override
     public Filter createFilter(FilterFactoryContext context,
-                               @UnknownNullness SaslTerminationContext filterContext) {
+                               @NonNull SaslTerminationContext filterContext) {
         return new SaslTerminationFilter(context.filterDispatchExecutor(), filterContext);
     }
 
+    @SuppressWarnings("java:S2638") // Tightening UnknownNullness
     @Override
-    public void close(@UnknownNullness SaslTerminationContext initializationData) {
+    public void close(@NonNull SaslTerminationContext initializationData) {
         initializationData.close();
     }
 

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.sasl.termination;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import javax.security.auth.login.AppConfigurationEntry;
+
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.security.oauthbearer.BrokerJwtValidator;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslServerProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.proxy.authentication.SaslSubjectBuilder;
+import io.kroxylicious.proxy.authentication.SaslSubjectBuilderService;
+import io.kroxylicious.proxy.authentication.Subject;
+import io.kroxylicious.proxy.authentication.User;
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.plugin.PluginConfigurationException;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
+
+/**
+ * FilterFactory for SASL termination.
+ * <p>
+ * Terminates SASL authentication at the proxy, authenticating clients
+ * against pluggable credential stores or token validators without forwarding
+ * authentication to the broker.
+ * </p>
+ */
+@Plugin(configType = SaslTerminationConfig.class)
+public class SaslTermination implements FilterFactory<SaslTerminationConfig, SaslTermination.SaslTerminationContext> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SaslTermination.class);
+    static final String ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG = "org.apache.kafka.sasl.oauthbearer.allowed.urls";
+
+    static final SaslSubjectBuilder DEFAULT_SUBJECT_BUILDER = context -> CompletableFuture
+            .completedStage(new Subject(Set.of(new User(context.clientSaslContext().authorizationId()))));
+
+    private final Clock clock;
+
+    /** Constructs a SaslTermination using the system UTC clock. */
+    @SuppressWarnings("unused") // ServiceLoader uses this constructor
+    public SaslTermination() {
+        this(Clock.systemUTC());
+    }
+
+    @VisibleForTesting
+    SaslTermination(Clock clock) {
+        this.clock = clock;
+    }
+
+    /**
+     * Context for the SASL termination filter.
+     *
+     * @param oauthCallbackHandler initialized callback handler for OAUTHBEARER, null if not configured
+     * @param supportedMechanisms set of configured mechanism names
+     * @param maxTimeBeforeReauth maximum session lifetime, null if disabled
+     * @param clock clock for session expiry computation
+     * @param fixedAuthDelay fixed delay applied to all authentication rounds for timing side-channel mitigation
+     * @param subjectBuilder builder for constructing the Subject after authentication
+     * @param closeables Things to close
+     */
+    record SaslTerminationContext(
+                                  @Nullable OAuthBearerValidatorCallbackHandler oauthCallbackHandler,
+                                  Set<String> supportedMechanisms,
+                                  List<AutoCloseable> closeables,
+                                  @Nullable Duration maxTimeBeforeReauth,
+                                  Clock clock,
+                                  Duration fixedAuthDelay,
+                                  SaslSubjectBuilder subjectBuilder)
+            implements AutoCloseable {
+        @Override
+        public void close() {
+            RuntimeException firstException = closeSafely(() -> {
+                if (oauthCallbackHandler != null) {
+                    oauthCallbackHandler.close();
+                }
+            }, null);
+            for (var closeable : closeables()) {
+                firstException = closeSafely(closeable, firstException);
+            }
+            if (firstException != null) {
+                throw firstException;
+            }
+        }
+
+        private static @Nullable RuntimeException closeSafely(AutoCloseable closeable,
+                                                              @Nullable RuntimeException firstException) {
+            try {
+                closeable.close();
+            }
+            catch (Exception e) {
+                RuntimeException re;
+                if (e instanceof RuntimeException e1) {
+                    re = e1;
+                }
+                else {
+                    re = new RuntimeException(e);
+                }
+                if (firstException == null) {
+                    firstException = re;
+                }
+                else {
+                    firstException.addSuppressed(re);
+                }
+            }
+            return firstException;
+        }
+    }
+
+    @Override
+    @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", justification = "Framework guarantees non-null parameters")
+    public SaslTerminationContext initialize(
+                                             @NonNull FilterFactoryContext context,
+                                             @NonNull SaslTerminationConfig config)
+            throws PluginConfigurationException {
+
+        OAuthBearerValidatorCallbackHandler oauthCallbackHandler = null;
+        Set<String> supportedMechanisms = new LinkedHashSet<>();
+        Duration fixedAuthDelay = config.effectiveFixedAuthDelay();
+
+        List<AutoCloseable> closeables = new ArrayList<>(2);
+
+        for (MechanismConfig mechanismConfig : config.mechanisms()) {
+            supportedMechanisms.add(mechanismConfig.mechanismName());
+            switch (mechanismConfig) {
+                case OauthBearerMechanismConfig oauthConfig -> oauthCallbackHandler = initializeOauthBearer(oauthConfig, closeables);
+            }
+        }
+
+        var builderService = initSubjectBuilderService(context, config);
+        SaslSubjectBuilder subjectBuilder;
+        if (builderService == null) {
+            subjectBuilder = DEFAULT_SUBJECT_BUILDER;
+        }
+        else {
+            closeables.add(builderService);
+            subjectBuilder = builderService.build();
+        }
+        return new SaslTerminationContext(oauthCallbackHandler, supportedMechanisms, closeables,
+                config.maxTimeBeforeReauth(), clock, fixedAuthDelay, subjectBuilder);
+    }
+
+    private static OAuthBearerValidatorCallbackHandler initializeOauthBearer(
+                                                                             OauthBearerMechanismConfig config,
+                                                                             List<AutoCloseable> closeables) {
+        OAuthBearerSaslServerProvider.initialize();
+        String jwksUrl = config.jwksEndpointUrl().toString();
+        addAllowedSaslOauthbearerUrl(jwksUrl, closeables);
+
+        OAuthBearerValidatorCallbackHandler callbackHandler = new OAuthBearerValidatorCallbackHandler();
+        callbackHandler.configure(
+                createOauthSaslConfigMap(config),
+                OAUTHBEARER_MECHANISM,
+                createDefaultJaasConfig());
+
+        LOGGER.atInfo()
+                .addKeyValue("jwksEndpointUrl", jwksUrl)
+                .log("Initialized OAUTHBEARER mechanism");
+
+        return callbackHandler;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    private static SaslSubjectBuilderService<Object> initSubjectBuilderService(FilterFactoryContext context, SaslTerminationConfig config) {
+        if (config.subjectBuilder() == null) {
+            LOGGER.atDebug().log("No subjectBuilder configured, using default");
+            return null;
+        }
+        SaslSubjectBuilderService<Object> service = (SaslSubjectBuilderService<Object>) context.pluginInstance(
+                SaslSubjectBuilderService.class, config.subjectBuilder());
+        service.initialize(config.subjectBuilderConfig());
+        return service;
+    }
+
+    @Override
+    @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", justification = "Framework guarantees non-null parameters")
+    public SaslTerminationFilter createFilter(
+                                              @NonNull FilterFactoryContext context,
+                                              @NonNull SaslTerminationContext filterContext) {
+        return new SaslTerminationFilter(context.filterDispatchExecutor(), filterContext);
+    }
+
+    @Override
+    @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", justification = "Framework guarantees non-null parameters")
+    public void close(@NonNull SaslTerminationContext initializationData) {
+        initializationData.close();
+    }
+
+    // Serializes our own read-modify-write on the allowed URLs system property.
+    // Cannot protect against other code mutating the same property concurrently
+    // (Properties.getProperty reads a ConcurrentHashMap without synchronization).
+    private static final Object ALLOWED_URLS_LOCK = new Object();
+
+    // Reference counts for URLs added to the system property, guarded by ALLOWED_URLS_LOCK.
+    private static final Map<String, Integer> allowedUrlRefCounts = new HashMap<>();
+
+    @VisibleForTesting
+    static void addAllowedSaslOauthbearerUrl(String jwksUrl, List<AutoCloseable> closeables) {
+        synchronized (ALLOWED_URLS_LOCK) {
+            int prev = allowedUrlRefCounts.getOrDefault(jwksUrl, 0);
+            allowedUrlRefCounts.put(jwksUrl, prev + 1);
+            if (prev == 0) {
+                mutateAllowedUrls(urls -> urls.add(jwksUrl));
+            }
+            closeables.add(() -> {
+                synchronized (ALLOWED_URLS_LOCK) {
+                    int count = allowedUrlRefCounts.getOrDefault(jwksUrl, 0);
+                    if (count <= 1) {
+                        allowedUrlRefCounts.remove(jwksUrl);
+                        mutateAllowedUrls(urls -> urls.remove(jwksUrl));
+                    }
+                    else {
+                        allowedUrlRefCounts.put(jwksUrl, count - 1);
+                    }
+                }
+            });
+        }
+    }
+
+    private static void mutateAllowedUrls(Consumer<List<String>> mutation) {
+        String property = System.getProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG);
+        List<String> urls = Optional.ofNullable(property)
+                .map(p -> Arrays.stream(p.split(","))
+                        .map(String::trim)
+                        .collect(Collectors.toCollection(ArrayList::new)))
+                .orElseGet(ArrayList::new);
+        mutation.accept(urls);
+        if (urls.isEmpty()) {
+            System.clearProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG);
+        }
+        else {
+            System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, String.join(",", urls));
+        }
+    }
+
+    @VisibleForTesting
+    static Map<String, Object> createOauthSaslConfigMap(OauthBearerMechanismConfig config) {
+        Map<String, Object> saslConfig = new HashMap<>();
+        saslConfig.put(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, config.jwksEndpointUrl().toString());
+
+        putIfNotNull(saslConfig, SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS,
+                durationMsOrDefault(config.jwksEndpointRefresh(),
+                        SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS));
+        putIfNotNull(saslConfig, SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS,
+                durationMsOrDefault(config.jwksEndpointRetryBackoff(),
+                        SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS));
+        putIfNotNull(saslConfig, SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS,
+                durationMsOrDefault(config.jwksEndpointRetryBackoffMax(),
+                        SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS));
+
+        String scopeClaimName = config.scopeClaimName();
+        saslConfig.put(SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME,
+                scopeClaimName != null && !scopeClaimName.isBlank() ? scopeClaimName
+                        : SaslConfigs.DEFAULT_SASL_OAUTHBEARER_SCOPE_CLAIM_NAME);
+
+        String subClaimName = config.subClaimName();
+        saslConfig.put(SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME,
+                subClaimName != null && !subClaimName.isBlank() ? subClaimName
+                        : SaslConfigs.DEFAULT_SASL_OAUTHBEARER_SUB_CLAIM_NAME);
+
+        saslConfig.put(SaslConfigs.SASL_OAUTHBEARER_JWT_VALIDATOR_CLASS, BrokerJwtValidator.class.getName());
+
+        List<String> audience = Arrays.stream(config.expectedAudience().split(","))
+                .map(String::trim)
+                .filter(element -> !element.isEmpty())
+                .toList();
+        saslConfig.put(SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE, audience);
+        saslConfig.put(SaslConfigs.SASL_OAUTHBEARER_EXPECTED_ISSUER, config.expectedIssuer());
+
+        return saslConfig;
+    }
+
+    private static void putIfNotNull(Map<String, Object> map, String key, Object value) {
+        if (value != null) {
+            map.put(key, value);
+        }
+    }
+
+    private static Long durationMsOrDefault(@Nullable Duration duration, Long defaultValue) {
+        return duration != null ? duration.toMillis() : defaultValue;
+    }
+
+    private static List<AppConfigurationEntry> createDefaultJaasConfig() {
+        return List.of(new AppConfigurationEntry(
+                "OAuthBearerLoginModule",
+                AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+                Map.of()));
+    }
+}

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
@@ -203,7 +203,7 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
         }
         SaslSubjectBuilderService<Object> service = context.pluginInstance(
                 SaslSubjectBuilderService.class, config.subjectBuilder());
-        service.initialize(Objects.requireNonNull(config.subjectBuilderConfig()));
+        service.initialize(config.subjectBuilderConfig());
         return service;
     }
 

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
@@ -33,15 +33,15 @@ import io.kroxylicious.proxy.authentication.SaslSubjectBuilder;
 import io.kroxylicious.proxy.authentication.SaslSubjectBuilderService;
 import io.kroxylicious.proxy.authentication.Subject;
 import io.kroxylicious.proxy.authentication.User;
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterFactory;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import edu.umd.cs.findbugs.annotations.UnknownNullness;
 
 import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
 
@@ -86,14 +86,14 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
      * @param subjectBuilder builder for constructing the Subject after authentication
      * @param closeables Things to close
      */
-    record SaslTerminationContext(
-                                  @Nullable OAuthBearerValidatorCallbackHandler oauthCallbackHandler,
-                                  Set<String> supportedMechanisms,
-                                  List<AutoCloseable> closeables,
-                                  @Nullable Duration maxTimeBeforeReauth,
-                                  Clock clock,
-                                  Duration fixedAuthDelay,
-                                  SaslSubjectBuilder subjectBuilder)
+    public record SaslTerminationContext(
+                                         @Nullable OAuthBearerValidatorCallbackHandler oauthCallbackHandler,
+                                         Set<String> supportedMechanisms,
+                                         List<AutoCloseable> closeables,
+                                         @Nullable Duration maxTimeBeforeReauth,
+                                         Clock clock,
+                                         Duration fixedAuthDelay,
+                                         SaslSubjectBuilder subjectBuilder)
             implements AutoCloseable {
         @Override
         public void close() {
@@ -134,11 +134,11 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
         }
     }
 
+    @UnknownNullness
     @Override
-    @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", justification = "Framework guarantees non-null parameters")
     public SaslTerminationContext initialize(
-                                             @NonNull FilterFactoryContext context,
-                                             @NonNull SaslTerminationConfig config)
+                                             FilterFactoryContext context,
+                                             @UnknownNullness SaslTerminationConfig config)
             throws PluginConfigurationException {
 
         OAuthBearerValidatorCallbackHandler oauthCallbackHandler = null;
@@ -194,23 +194,20 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
             LOGGER.atDebug().log("No subjectBuilder configured, using default");
             return null;
         }
-        SaslSubjectBuilderService<Object> service = (SaslSubjectBuilderService<Object>) context.pluginInstance(
+        SaslSubjectBuilderService<Object> service = context.pluginInstance(
                 SaslSubjectBuilderService.class, config.subjectBuilder());
         service.initialize(config.subjectBuilderConfig());
         return service;
     }
 
     @Override
-    @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", justification = "Framework guarantees non-null parameters")
-    public SaslTerminationFilter createFilter(
-                                              @NonNull FilterFactoryContext context,
-                                              @NonNull SaslTerminationContext filterContext) {
+    public Filter createFilter(FilterFactoryContext context,
+                               @UnknownNullness SaslTerminationContext filterContext) {
         return new SaslTerminationFilter(context.filterDispatchExecutor(), filterContext);
     }
 
     @Override
-    @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", justification = "Framework guarantees non-null parameters")
-    public void close(@NonNull SaslTerminationContext initializationData) {
+    public void close(@UnknownNullness SaslTerminationContext initializationData) {
         initializationData.close();
     }
 
@@ -298,7 +295,7 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
         return saslConfig;
     }
 
-    private static void putIfNotNull(Map<String, Object> map, String key, Object value) {
+    private static void putIfNotNull(Map<String, Object> map, String key, @Nullable Object value) {
         if (value != null) {
             map.put(key, value);
         }

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
@@ -41,7 +41,6 @@ import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
@@ -134,11 +133,10 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
     }
 
     @SuppressWarnings("java:S2638") // Tightening UnknownNullness
-    @NonNull
     @Override
     public SaslTerminationContext initialize(
                                              FilterFactoryContext context,
-                                             @NonNull SaslTerminationConfig config)
+                                             SaslTerminationConfig config)
             throws PluginConfigurationException {
 
         Objects.requireNonNull(config);
@@ -210,13 +208,13 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
     @SuppressWarnings("java:S2638") // Tightening UnknownNullness
     @Override
     public Filter createFilter(FilterFactoryContext context,
-                               @NonNull SaslTerminationContext filterContext) {
+                               SaslTerminationContext filterContext) {
         return new SaslTerminationFilter(context.filterDispatchExecutor(), filterContext);
     }
 
     @SuppressWarnings("java:S2638") // Tightening UnknownNullness
     @Override
-    public void close(@NonNull SaslTerminationContext initializationData) {
+    public void close(SaslTerminationContext initializationData) {
         initializationData.close();
     }
 

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTermination.java
@@ -98,11 +98,7 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
             implements AutoCloseable {
         @Override
         public void close() {
-            RuntimeException firstException = closeSafely(() -> {
-                if (oauthCallbackHandler != null) {
-                    oauthCallbackHandler.close();
-                }
-            }, null);
+            RuntimeException firstException = null;
             for (var closeable : closeables()) {
                 firstException = closeSafely(closeable, firstException);
             }
@@ -176,13 +172,14 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
                                                                              List<AutoCloseable> closeables) {
         OAuthBearerSaslServerProvider.initialize();
         String jwksUrl = config.jwksEndpointUrl().toString();
-        addAllowedSaslOauthbearerUrl(jwksUrl, closeables);
 
         OAuthBearerValidatorCallbackHandler callbackHandler = new OAuthBearerValidatorCallbackHandler();
         callbackHandler.configure(
                 createOauthSaslConfigMap(config),
                 OAUTHBEARER_MECHANISM,
                 createDefaultJaasConfig());
+        closeables.add(callbackHandler::close);
+        addAllowedSaslOauthbearerUrl(jwksUrl, closeables);
 
         LOGGER.atInfo()
                 .addKeyValue("jwksEndpointUrl", jwksUrl)
@@ -295,6 +292,9 @@ public class SaslTermination implements FilterFactory<SaslTerminationConfig, Sas
                 .map(String::trim)
                 .filter(element -> !element.isEmpty())
                 .toList();
+        if (audience.isEmpty()) {
+            throw new PluginConfigurationException("expectedAudience must contain at least one non-empty audience value");
+        }
         saslConfig.put(SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE, audience);
         saslConfig.put(SaslConfigs.SASL_OAUTHBEARER_EXPECTED_ISSUER, config.expectedIssuer());
 

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationConfig.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.sasl.termination;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.kroxylicious.proxy.authentication.SaslSubjectBuilderService;
+import io.kroxylicious.proxy.plugin.PluginImplConfig;
+import io.kroxylicious.proxy.plugin.PluginImplName;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Configuration for the SASL termination filter.
+ *
+ * @param mechanisms list of mechanism configurations
+ * @param maxTimeBeforeReauth maximum session lifetime before reauthentication is required (KIP-368), null = disabled
+ * @param fixedAuthDelay fixed delay applied to all authentication rounds to prevent timing side-channels, null = 200ms default
+ * @param subjectBuilder plugin name for the SaslSubjectBuilderService, null = default builder
+ * @param subjectBuilderConfig configuration for the subject builder plugin
+ */
+public record SaslTerminationConfig(
+                                    @JsonProperty(required = true) List<MechanismConfig> mechanisms,
+                                    @Nullable Duration maxTimeBeforeReauth,
+                                    @Nullable Duration fixedAuthDelay,
+                                    @Nullable @PluginImplName(SaslSubjectBuilderService.class) String subjectBuilder,
+                                    @Nullable @PluginImplConfig(implNameProperty = "subjectBuilder") Object subjectBuilderConfig) {
+
+    private static final Duration DEFAULT_FIXED_AUTH_DELAY = Duration.ofMillis(200);
+
+    /**
+     * Returns the effective fixed auth delay, defaulting to 200ms if not configured.
+     *
+     * @return the fixed auth delay duration, never null
+     */
+    public Duration effectiveFixedAuthDelay() {
+        return fixedAuthDelay != null ? fixedAuthDelay : DEFAULT_FIXED_AUTH_DELAY;
+    }
+
+    /** Validates that at least one mechanism is configured and there are no duplicates. */
+    public SaslTerminationConfig {
+        if (mechanisms == null || mechanisms.isEmpty()) {
+            throw new IllegalArgumentException("At least one mechanism must be configured");
+        }
+
+        Set<String> seen = new HashSet<>();
+        for (MechanismConfig mechanism : mechanisms) {
+            if (!seen.add(mechanism.mechanismName())) {
+                throw new IllegalArgumentException(
+                        "Duplicate mechanism: " + mechanism.mechanismName());
+            }
+        }
+    }
+}

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -355,12 +355,6 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
             return rejectAuthenticateIdChanged(filterContext, stateMachine, previousAuthorizationId, authorizationId);
         }
 
-        // capture the duration here, but only record it on the acceptAuthenticateDone path
-        // because rejectAuthenticateInternalError also records the duration, so we don't
-        // want to record a second duration for the same authentication if the subjectBuilder
-        // returned a failed CompletionStage.
-        Duration authDuration = Duration.ofNanos(authenticating.accumulatedAuthWorkNanos());
-        state = authenticating.nextStateSuccess(authorizationId, mechanism, sessionExpiry);
         stateMachine.dispose();
 
         return subjectBuilder.buildSaslSubject(new SubjectContext(filterContext, mechanism, authorizationId))
@@ -369,8 +363,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                         subject,
                         mechanism,
                         reauthentication,
-                        sessionExpiry,
-                        authDuration))
+                        sessionExpiry))
                 .exceptionallyCompose(throwable -> rejectAuthenticateInternalError(filterContext, stateMachine,
                         "subjectBuilder",
                         throwable));
@@ -397,10 +390,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                                                                       Subject subject,
                                                                       String mechanism,
                                                                       boolean reauthentication,
-                                                                      @Nullable Instant sessionExpiry,
-                                                                      Duration authDuration) {
-        recordAuthDuration(mechanism, filterContext.getVirtualClusterName(), authDuration);
-
+                                                                      @Nullable Instant sessionExpiry) {
         if (sessionExpiry != null && !clock.instant().isBefore(sessionExpiry)) {
             LOGGER.atWarn()
                     .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
@@ -420,6 +410,12 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                                                                         String mechanism,
                                                                         boolean reauthentication,
                                                                         @Nullable Instant sessionExpiry) {
+        if (state instanceof State.RequiringAuthenticate authenticating) {
+            recordAuthDuration(mechanism, filterContext.getVirtualClusterName(),
+                    Duration.ofNanos(authenticating.accumulatedAuthWorkNanos()));
+            state = authenticating.nextStateSuccess(success.authorizationId(), mechanism, sessionExpiry);
+        }
+
         String authorizationId = success.authorizationId();
         LOGGER.atDebug()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.common.errors.InvalidRequestException;
+import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
@@ -85,6 +86,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
             ApiKeys.RENEW_DELEGATION_TOKEN.id,
             ApiKeys.EXPIRE_DELEGATION_TOKEN.id,
             ApiKeys.DESCRIBE_DELEGATION_TOKEN.id);
+    public static final String LOG_KEY_REAUTHENTICATION = "reauthentication";
 
     private final ScheduledExecutorService executorService;
     private final SaslTermination.SaslTerminationContext context;
@@ -210,7 +212,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
 
     @NonNull
     private static CompletionStage<RequestFilterResult> reauthenticationRejectedResponseAndClose(FilterContext filterContext, State.Authenticated authenticated,
-                                                                                              String mechanism) {
+                                                                                                 String mechanism) {
         LOGGER.atWarn()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
                 .addKeyValue(LOG_KEY_MECHANISM, mechanism)
@@ -316,11 +318,13 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
                                                                RoundResult.Success success) {
         String authorizationId = success.authorizationId();
         String mechanism = stateMachine.mechanismName();
+        boolean reauthentication = state instanceof State.RequiringAuthenticate req && req.previousAuthorizationId() != null;
         LOGGER.atDebug()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
                 .addKeyValue(LOG_KEY_MECHANISM, stateMachine.mechanismName())
+                .addKeyValue(LOG_KEY_REAUTHENTICATION, reauthentication)
                 .addKeyValue("authorizationId", authorizationId)
-                .log("Authentication successful");
+                .log("Credential validation successful");
 
         long sessionLifetimeMs = computeSessionLifetimeMs(success.sessionLifetimeMs());
         @Nullable
@@ -331,12 +335,19 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
             if (previousAuthorizationId != null && !previousAuthorizationId.equals(authorizationId)) {
                 LOGGER.atWarn()
                         .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                        .addKeyValue(LOG_KEY_REAUTHENTICATION, true)
                         .addKeyValue("previousAuthorizationId", previousAuthorizationId)
                         .addKeyValue("newAuthorizationId", authorizationId)
                         .log("Reauthentication rejected: authorization ID changed");
                 return handleAuthenticationFailure(stateMachine, filterContext,
-                        new org.apache.kafka.common.errors.SaslAuthenticationException("Reauthentication failed: authorization identity changed"));
+                        new SaslAuthenticationException("Reauthentication failed: authorization identity changed"));
             }
+            LOGGER.atDebug()
+                    .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                    .addKeyValue(LOG_KEY_MECHANISM, mechanism)
+                    .addKeyValue("authorizationId", authorizationId)
+                    .addKeyValue(LOG_KEY_REAUTHENTICATION, reauthentication)
+                    .log("Authentication successful");
             recordAuthDuration(mechanism, filterContext.getVirtualClusterName(), authenticating.authStartNanos());
             state = authenticating.nextStateSuccess(authorizationId, mechanism, sessionExpiry);
         }
@@ -404,9 +415,11 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
 
     private CompletionStage<RequestFilterResult> handleAuthenticationFailure(
                                                                              MechanismStateMachine stateMachine, FilterContext filterContext, Exception exception) {
+        boolean reauthentication = state instanceof State.RequiringAuthenticate req && req.previousAuthorizationId() != null;
         LOGGER.atDebug()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
                 .addKeyValue(LOG_KEY_ERROR, exception.getMessage())
+                .addKeyValue(LOG_KEY_REAUTHENTICATION, reauthentication)
                 .log("Authentication failed");
 
         if (state instanceof State.RequiringAuthenticate authenticating) {

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -449,6 +449,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
         return delayUntil(start.plus(fixedAuthDelay), result);
     }
 
+    @SuppressWarnings("FutureReturnValueIgnored") // the ScheduledFuture is not needed; completion is observed via the returned CompletableFuture
     private CompletionStage<RoundResult> delayUntil(Instant deadline, RoundResult result) {
         long remainingMs = Duration.between(clock.instant(), deadline).toMillis();
         if (remainingMs <= 0) {

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -32,7 +32,6 @@ import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.Errors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.spi.LoggingEventBuilder;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
@@ -515,8 +514,6 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                                                                    RequestHeaderData header,
                                                                    ApiMessage request,
                                                                    FilterContext filterContext) {
-        LoggingEventBuilder loggingEventBuilder = LOGGER.atWarn();
-
         if (state instanceof State.Authenticated authenticated) {
             Instant expiry = authenticated.sessionExpiry();
             if (expiry == null || !clock.instant().isAfter(expiry)) {
@@ -531,25 +528,27 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                     return filterContext.forwardRequest(header, request);
                 }
             }
-            else {
-                Counter.builder(SESSION_EXPIRED_METRIC)
-                        .description("Number of sessions that expired without the client reauthenticating in time.")
-                        .tag(MECHANISM_TAG, authenticated.mechanismName())
-                        .tag(VIRTUAL_CLUSTER_TAG, filterContext.getVirtualClusterName())
-                        .register(Metrics.globalRegistry)
-                        .increment();
-                loggingEventBuilder = loggingEventBuilder.addKeyValue(LOG_KEY_REASON, "SASL session expired")
-                        .addKeyValue("sessionExpiry", expiry);
-            }
+            Counter.builder(SESSION_EXPIRED_METRIC)
+                    .description("Number of sessions that expired without the client reauthenticating in time.")
+                    .tag(MECHANISM_TAG, authenticated.mechanismName())
+                    .tag(VIRTUAL_CLUSTER_TAG, filterContext.getVirtualClusterName())
+                    .register(Metrics.globalRegistry)
+                    .increment();
+            LOGGER.atWarn()
+                    .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                    .addKeyValue(LOG_KEY_REASON, "SASL session expired")
+                    .addKeyValue("sessionExpiry", expiry)
+                    .addKeyValue("requestType", request.getClass().getSimpleName())
+                    .log("Rejecting request from unauthenticated client");
         }
         else {
-            loggingEventBuilder = loggingEventBuilder.addKeyValue(LOG_KEY_REASON, "Client is not authenticated")
-                    .addKeyValue(LOG_KEY_STATE, state);
+            LOGGER.atWarn()
+                    .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                    .addKeyValue(LOG_KEY_REASON, "Client is not authenticated")
+                    .addKeyValue(LOG_KEY_STATE, state)
+                    .addKeyValue("requestType", request.getClass().getSimpleName())
+                    .log("Rejecting request from unauthenticated client");
         }
-
-        loggingEventBuilder.addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
-                .addKeyValue("requestType", request.getClass().getSimpleName())
-                .log("Rejecting request from unauthenticated client");
 
         return filterContext.requestFilterResultBuilder()
                 .errorResponse(header, request, Errors.SASL_AUTHENTICATION_FAILED.exception())

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -415,7 +415,8 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
                 .addKeyValue(LOG_KEY_MECHANISM, stateMachine.mechanismName())
                 .setCause(throwable)
-                .log("Authentication error: {}", origin);
+                .addKeyValue("origin", origin)
+                .log("Authentication error");
         Exception exception = throwable instanceof Exception e ? e : new RuntimeException(throwable);
         return rejectAuthenticateAndClose(stateMachine,
                 filterContext,

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -77,6 +77,8 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
     private static final String LOG_KEY_MECHANISM = "mechanism";
     private static final String LOG_KEY_STATE = "state";
     private static final String LOG_KEY_ERROR = "error";
+    private static final String LOG_KEY_REAUTHENTICATION = "reauthentication";
+    private static final String LOG_KEY_REASON = "reason";
 
     static final String AUTH_DURATION_METRIC = "kroxylicious_filter_sasl_termination_auth_duration_seconds";
     static final String SESSION_EXPIRED_METRIC = "kroxylicious_filter_sasl_termination_session_expired_total";
@@ -88,8 +90,6 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
             ApiKeys.RENEW_DELEGATION_TOKEN.id,
             ApiKeys.EXPIRE_DELEGATION_TOKEN.id,
             ApiKeys.DESCRIBE_DELEGATION_TOKEN.id);
-    public static final String LOG_KEY_REAUTHENTICATION = "reauthentication";
-    public static final String LOG_KEY_REASON = "reason";
 
     private final ScheduledExecutorService executorService;
     private final SaslTermination.SaslTerminationContext context;
@@ -97,6 +97,11 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
     private final long maxTimeBeforeReauthMs;
     private final SaslSubjectBuilder subjectBuilder;
     private State state;
+
+    @VisibleForTesting
+    void forceState(State state) {
+        this.state = state;
+    }
 
     /**
      * Constructs the filter.
@@ -243,7 +248,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
             return null;
         }
         return switch (mechanism) {
-            case "OAUTHBEARER" -> new OauthBearerStateMachine(Objects.requireNonNull(context.oauthCallbackHandler()),
+            case OauthBearerMechanismConfig.MECHANISM_NAME -> new OauthBearerStateMachine(Objects.requireNonNull(context.oauthCallbackHandler()),
                     context.clock());
             default -> throw new IllegalStateException("No state machine for configured mechanism: " + mechanism);
         };

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -43,6 +43,7 @@ import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.RequestFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
 import io.kroxylicious.proxy.tls.ClientTlsContext;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -348,6 +349,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
      * Compute the effective session lifetime as the minimum of the configured
      * maximum and the mechanism-reported lifetime (KIP-368).
      */
+    @VisibleForTesting
     long computeSessionLifetimeMs(long handlerLifetimeMs) {
         if (maxTimeBeforeReauthMs > 0 && handlerLifetimeMs > 0) {
             return Math.min(maxTimeBeforeReauthMs, handlerLifetimeMs);

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -118,8 +118,8 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
     public boolean shouldHandleRequest(ApiKeys apiKey, short apiVersion) {
         if (state instanceof State.Authenticated authenticated && authenticated.sessionExpiry() == null) {
             return switch (apiKey) {
-                case API_VERSIONS, SASL_HANDSHAKE, SASL_AUTHENTICATE, CREATE_DELEGATION_TOKEN, RENEW_DELEGATION_TOKEN, EXPIRE_DELEGATION_TOKEN, DESCRIBE_DELEGATION_TOKEN -> true;
-                default -> false;
+                case API_VERSIONS, SASL_HANDSHAKE, SASL_AUTHENTICATE -> true;
+                default -> FILTERED_API_KEYS.contains(apiKey.id);
             };
         }
         return true;
@@ -327,7 +327,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
         boolean reauthentication = authenticating.previousAuthorizationId() != null;
         LOGGER.atDebug()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
-                .addKeyValue(LOG_KEY_MECHANISM, stateMachine.mechanismName())
+                .addKeyValue(LOG_KEY_MECHANISM, mechanism)
                 .addKeyValue(LOG_KEY_REAUTHENTICATION, reauthentication)
                 .addKeyValue("authorizationId", authorizationId)
                 .log("Credential validation successful");
@@ -492,14 +492,16 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
         if (state instanceof State.Authenticated authenticated) {
             Instant expiry = authenticated.sessionExpiry();
             if (expiry == null || !clock.instant().isAfter(expiry)) {
-                return switch (apiKey) {
-                    case CREATE_DELEGATION_TOKEN, RENEW_DELEGATION_TOKEN, EXPIRE_DELEGATION_TOKEN, DESCRIBE_DELEGATION_TOKEN -> rejectUnsupportedApi(header,
+                if (FILTERED_API_KEYS.contains(apiKey.id)) {
+                    return rejectUnsupportedApi(header,
                             request,
                             apiKey,
-                            "Delegation tokens are not supported when SASL is terminated at the proxy",
+                            apiKey + " is not supported when SASL is terminated at the proxy",
                             filterContext);
-                    default -> filterContext.forwardRequest(header, request);
-                };
+                }
+                else {
+                    return filterContext.forwardRequest(header, request);
+                }
             }
             else {
                 Counter.builder(SESSION_EXPIRED_METRIC)

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -249,7 +249,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
         }
         return switch (mechanism) {
             case OauthBearerMechanismConfig.MECHANISM_NAME -> new OauthBearerStateMachine(Objects.requireNonNull(context.oauthCallbackHandler()),
-                    context.clock());
+                    context.clock(), context.oauthMaxAuthBytes());
             default -> throw new IllegalStateException("No state machine for configured mechanism: " + mechanism);
         };
     }

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -48,7 +48,6 @@ import io.kroxylicious.proxy.filter.ResponseFilterResult;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 import io.kroxylicious.proxy.tls.ClientTlsContext;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
@@ -183,7 +182,6 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
         }
     }
 
-    @NonNull
     private CompletionStage<RequestFilterResult> acceptHandshake(FilterContext filterContext,
                                                                  MechanismStateMachine stateMachine,
                                                                  String mechanism) {
@@ -300,7 +298,6 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                         throwable));
     }
 
-    @NonNull
     private CompletionStage<RequestFilterResult> rejectAuthenticateBytesTooLarge(FilterContext filterContext,
                                                                                  SaslAuthenticateRequestData request,
                                                                                  MechanismStateMachine stateMachine,
@@ -379,7 +376,6 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                         throwable));
     }
 
-    @NonNull
     private CompletionStage<RequestFilterResult> rejectAuthenticateIdChanged(FilterContext filterContext,
                                                                              MechanismStateMachine stateMachine,
                                                                              String previousAuthorizationId,

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -348,7 +348,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
      * Compute the effective session lifetime as the minimum of the configured
      * maximum and the mechanism-reported lifetime (KIP-368).
      */
-    private long computeSessionLifetimeMs(long handlerLifetimeMs) {
+    long computeSessionLifetimeMs(long handlerLifetimeMs) {
         if (maxTimeBeforeReauthMs > 0 && handlerLifetimeMs > 0) {
             return Math.min(maxTimeBeforeReauthMs, handlerLifetimeMs);
         }
@@ -454,9 +454,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
             return CompletableFuture.completedFuture(result);
         }
         CompletableFuture<RoundResult> future = new CompletableFuture<>();
-        executorService.schedule(() -> {
-            future.complete(result);
-        }, remainingMs, TimeUnit.MILLISECONDS);
+        executorService.schedule(() -> future.complete(result), remainingMs, TimeUnit.MILLISECONDS);
         return future;
     }
 

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -78,6 +78,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
     static final String AUTH_DURATION_METRIC = "kroxylicious_filter_sasl_termination_auth_duration_seconds";
     static final String SESSION_EXPIRED_METRIC = "kroxylicious_filter_sasl_termination_session_expired_total";
     private static final String MECHANISM_TAG = "mechanism";
+    static final String VIRTUAL_CLUSTER_TAG = "virtual_cluster";
 
     private static final Set<Short> FILTERED_API_KEYS = Set.of(
             ApiKeys.CREATE_DELEGATION_TOKEN.id,
@@ -159,21 +160,20 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
                                                                         FilterContext filterContext) {
 
         if (!(state instanceof State.RequiringHandshake) && !(state instanceof State.Authenticated)) {
-            LOGGER.atWarn()
-                    .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
-                    .addKeyValue(LOG_KEY_STATE, state)
-                    .log("Received SASL handshake in unexpected state");
-            return filterContext.requestFilterResultBuilder()
-                    .shortCircuitResponse(new SaslHandshakeResponseData()
-                            .setErrorCode(Errors.ILLEGAL_SASL_STATE.code())
-                            .setMechanisms(List.of()))
-                    .completed();
+            return unexpectedHandshakeErrorResponse(filterContext);
         }
 
         String mechanism = request.mechanism();
 
+        if (state instanceof State.Authenticated authenticated && !mechanism.equals(authenticated.mechanismName())) {
+            return reauthenticationRejectedResponseAndClose(filterContext, authenticated, mechanism);
+        }
+
         MechanismStateMachine stateMachine = createStateMachine(mechanism);
-        if (stateMachine != null) {
+        if (stateMachine == null) {
+            return unsupportedMechanismResponseAndClose(filterContext, mechanism);
+        }
+        else {
             long authStartNanos = System.nanoTime();
             if (state instanceof State.RequiringHandshake handshake) {
                 state = handshake.nextState(stateMachine, authStartNanos);
@@ -192,18 +192,49 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
                             .setMechanisms(List.of()))
                     .completed();
         }
-        else {
-            LOGGER.atDebug()
-                    .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
-                    .addKeyValue(LOG_KEY_MECHANISM, mechanism)
-                    .log("Unsupported mechanism");
-            return filterContext.requestFilterResultBuilder()
-                    .shortCircuitResponse(new SaslHandshakeResponseData()
-                            .setErrorCode(Errors.UNSUPPORTED_SASL_MECHANISM.code())
-                            .setMechanisms(List.copyOf(context.supportedMechanisms())))
-                    .withCloseConnection()
-                    .completed();
-        }
+    }
+
+    @NonNull
+    private CompletionStage<RequestFilterResult> unsupportedMechanismResponseAndClose(FilterContext filterContext, String mechanism) {
+        LOGGER.atDebug()
+                .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_MECHANISM, mechanism)
+                .log("Unsupported mechanism");
+        return filterContext.requestFilterResultBuilder()
+                .shortCircuitResponse(new SaslHandshakeResponseData()
+                        .setErrorCode(Errors.UNSUPPORTED_SASL_MECHANISM.code())
+                        .setMechanisms(List.copyOf(context.supportedMechanisms())))
+                .withCloseConnection()
+                .completed();
+    }
+
+    @NonNull
+    private static CompletionStage<RequestFilterResult> reauthenticationRejectedResponseAndClose(FilterContext filterContext, State.Authenticated authenticated,
+                                                                                              String mechanism) {
+        LOGGER.atWarn()
+                .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_MECHANISM, mechanism)
+                .addKeyValue("previousMechanism", authenticated.mechanismName())
+                .log("Reauthentication rejected: mechanism change not permitted");
+        return filterContext.requestFilterResultBuilder()
+                .shortCircuitResponse(new SaslHandshakeResponseData()
+                        .setErrorCode(Errors.ILLEGAL_SASL_STATE.code())
+                        .setMechanisms(List.of()))
+                .withCloseConnection()
+                .completed();
+    }
+
+    @NonNull
+    private CompletionStage<RequestFilterResult> unexpectedHandshakeErrorResponse(FilterContext filterContext) {
+        LOGGER.atWarn()
+                .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_STATE, state)
+                .log("Received SASL handshake in unexpected state");
+        return filterContext.requestFilterResultBuilder()
+                .shortCircuitResponse(new SaslHandshakeResponseData()
+                        .setErrorCode(Errors.ILLEGAL_SASL_STATE.code())
+                        .setMechanisms(List.of()))
+                .completed();
     }
 
     @Nullable
@@ -223,16 +254,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
                                                                            FilterContext filterContext) {
 
         if (!(state instanceof State.RequiringAuthenticate authenticating)) {
-            LOGGER.atWarn()
-                    .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
-                    .addKeyValue(LOG_KEY_STATE, state)
-                    .log("Received SASL authenticate in unexpected state");
-            return filterContext.requestFilterResultBuilder()
-                    .shortCircuitResponse(new SaslAuthenticateResponseData()
-                            .setErrorCode(Errors.ILLEGAL_SASL_STATE.code())
-                            .setErrorMessage("Authentication not in progress")
-                            .setAuthBytes(new byte[0]))
-                    .completed();
+            return unexpectedAuthenticatedErrorResponse(filterContext);
         }
 
         MechanismStateMachine stateMachine = authenticating.mechanismStateMachine();
@@ -263,6 +285,20 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
                 });
     }
 
+    @NonNull
+    private CompletionStage<RequestFilterResult> unexpectedAuthenticatedErrorResponse(FilterContext filterContext) {
+        LOGGER.atWarn()
+                .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_STATE, state)
+                .log("Received SASL authenticate in unexpected state");
+        return filterContext.requestFilterResultBuilder()
+                .shortCircuitResponse(new SaslAuthenticateResponseData()
+                        .setErrorCode(Errors.ILLEGAL_SASL_STATE.code())
+                        .setErrorMessage("Authentication not in progress")
+                        .setAuthBytes(new byte[0]))
+                .completed();
+    }
+
     private CompletionStage<RequestFilterResult> processRoundResult(
                                                                     RoundResult result,
                                                                     MechanismStateMachine stateMachine,
@@ -291,7 +327,17 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
         Instant sessionExpiry = sessionLifetimeMs > 0 ? clock.instant().plusMillis(sessionLifetimeMs) : null;
 
         if (state instanceof State.RequiringAuthenticate authenticating) {
-            recordAuthDuration(mechanism, authenticating.authStartNanos());
+            String previousAuthorizationId = authenticating.previousAuthorizationId();
+            if (previousAuthorizationId != null && !previousAuthorizationId.equals(authorizationId)) {
+                LOGGER.atWarn()
+                        .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                        .addKeyValue("previousAuthorizationId", previousAuthorizationId)
+                        .addKeyValue("newAuthorizationId", authorizationId)
+                        .log("Reauthentication rejected: authorization ID changed");
+                return handleAuthenticationFailure(stateMachine, filterContext,
+                        new org.apache.kafka.common.errors.SaslAuthenticationException("Reauthentication failed: authorization identity changed"));
+            }
+            recordAuthDuration(mechanism, filterContext.getVirtualClusterName(), authenticating.authStartNanos());
             state = authenticating.nextStateSuccess(authorizationId, mechanism, sessionExpiry);
         }
 
@@ -364,7 +410,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
                 .log("Authentication failed");
 
         if (state instanceof State.RequiringAuthenticate authenticating) {
-            recordAuthDuration(stateMachine.mechanismName(), authenticating.authStartNanos());
+            recordAuthDuration(stateMachine.mechanismName(), filterContext.getVirtualClusterName(), authenticating.authStartNanos());
             state = authenticating.nextStateFailure(exception.getMessage());
         }
 
@@ -391,6 +437,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
             if (expiry != null && clock.instant().isAfter(expiry)) {
                 Counter.builder(SESSION_EXPIRED_METRIC)
                         .tag(MECHANISM_TAG, authenticated.mechanismName())
+                        .tag(VIRTUAL_CLUSTER_TAG, filterContext.getVirtualClusterName())
                         .register(Metrics.globalRegistry)
                         .increment();
                 LOGGER.atDebug()
@@ -460,10 +507,11 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
         return future;
     }
 
-    private static void recordAuthDuration(String mechanism, long authStartNanos) {
+    private static void recordAuthDuration(String mechanism, String virtualClusterName, long authStartNanos) {
         long durationNanos = System.nanoTime() - authStartNanos;
         Timer.builder(AUTH_DURATION_METRIC)
                 .tag(MECHANISM_TAG, mechanism)
+                .tag(VIRTUAL_CLUSTER_TAG, virtualClusterName)
                 .register(Metrics.globalRegistry)
                 .record(durationNanos, TimeUnit.NANOSECONDS);
     }

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -359,7 +359,6 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
                         success,
                         subject,
                         mechanism,
-                        authorizationId,
                         reauthentication,
                         sessionLifetimeMs,
                         authDuration))
@@ -386,11 +385,11 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
                                                                         RoundResult.Success success,
                                                                         Subject subject,
                                                                         String mechanism,
-                                                                        String authorizationId,
                                                                         boolean reauthentication,
                                                                         long sessionLifetimeMs,
                                                                         Duration authDuration) {
         recordAuthDuration(mechanism, filterContext.getVirtualClusterName(), authDuration);
+        String authorizationId = success.authorizationId();
         LOGGER.atDebug()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
                 .addKeyValue(LOG_KEY_MECHANISM, mechanism)

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -287,15 +287,20 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
         long roundStartNanos = System.nanoTime();
         return stateMachine.evaluateRound(request.authBytes())
                 .whenComplete((result, ex) -> authenticating.addRoundDuration(System.nanoTime() - roundStartNanos))
-                .thenCompose(result -> applyFixedAuthDelay(filterContext, result, authRoundStart, stateMachine.mechanismName()))
-                .thenCompose(result -> switch (result) {
-                    case RoundResult.Challenge challenge -> acceptAuthenticateContinue(filterContext, challenge);
-                    case RoundResult.Success success -> processMechanismSuccess(filterContext, stateMachine, success);
-                    case RoundResult.Failure failure -> rejectAuthenticateMechanismFailed(filterContext, stateMachine, failure.exception());
-                })
-                .exceptionallyCompose(throwable -> rejectAuthenticateInternalError(filterContext, stateMachine,
-                        "stateMachine",
-                        throwable));
+                .handle((result, ex) -> new RoundOutcome(result, ex))
+                .thenCompose(outcome -> applyFixedAuthDelay(filterContext, outcome, authRoundStart, stateMachine.mechanismName()))
+                .thenCompose(outcome -> {
+                    if (outcome.exception() != null) {
+                        return rejectAuthenticateInternalError(filterContext, stateMachine,
+                                "stateMachine",
+                                outcome.exception());
+                    }
+                    return switch (outcome.result()) {
+                        case RoundResult.Challenge challenge -> acceptAuthenticateContinue(filterContext, challenge);
+                        case RoundResult.Success success -> processMechanismSuccess(filterContext, stateMachine, success);
+                        case RoundResult.Failure failure -> rejectAuthenticateMechanismFailed(filterContext, stateMachine, failure.exception());
+                    };
+                });
     }
 
     private CompletionStage<RequestFilterResult> rejectAuthenticateBytesTooLarge(FilterContext filterContext,
@@ -584,13 +589,13 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                 .completed();
     }
 
-    private CompletionStage<RoundResult> applyFixedAuthDelay(FilterContext filterContext,
-                                                             RoundResult result,
-                                                             Instant start,
-                                                             String mechanismName) {
+    private CompletionStage<RoundOutcome> applyFixedAuthDelay(FilterContext filterContext,
+                                                              RoundOutcome outcome,
+                                                              Instant start,
+                                                              String mechanismName) {
         Duration fixedAuthDelay = context.fixedAuthDelay();
         if (fixedAuthDelay.isZero()) {
-            return CompletableFuture.completedFuture(result);
+            return CompletableFuture.completedFuture(outcome);
         }
         Duration elapsed = Duration.between(start, clock.instant());
         if (elapsed.compareTo(fixedAuthDelay) > 0) {
@@ -602,19 +607,21 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                     .addKeyValue("fixedAuthDelay", fixedAuthDelay)
                     .log("Authentication took longer than fixedAuthDelay, consider increasing fixedAuthDelay");
         }
-        return delayUntil(start.plus(fixedAuthDelay), result);
+        return delayUntil(start.plus(fixedAuthDelay), outcome);
     }
 
     @SuppressWarnings("FutureReturnValueIgnored") // the ScheduledFuture is not needed; completion is observed via the returned CompletableFuture
-    private CompletionStage<RoundResult> delayUntil(Instant deadline, RoundResult result) {
+    private CompletionStage<RoundOutcome> delayUntil(Instant deadline, RoundOutcome outcome) {
         long remainingMs = Duration.between(clock.instant(), deadline).toMillis();
         if (remainingMs <= 0) {
-            return CompletableFuture.completedFuture(result);
+            return CompletableFuture.completedFuture(outcome);
         }
-        CompletableFuture<RoundResult> future = new CompletableFuture<>();
-        executorService.schedule(() -> future.complete(result), remainingMs, TimeUnit.MILLISECONDS);
+        CompletableFuture<RoundOutcome> future = new CompletableFuture<>();
+        executorService.schedule(() -> future.complete(outcome), remainingMs, TimeUnit.MILLISECONDS);
         return future;
     }
+
+    record RoundOutcome(@Nullable RoundResult result, @Nullable Throwable exception) {}
 
     private static void recordAuthDuration(String mechanism,
                                            String virtualClusterName,

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -78,6 +78,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
     private static final String LOG_KEY_ERROR = "error";
     private static final String LOG_KEY_REAUTHENTICATION = "reauthentication";
     private static final String LOG_KEY_REASON = "reason";
+    private static final String LOG_KEY_VIRTUAL_CLUSTER = "virtualCluster";
 
     static final String AUTH_DURATION_METRIC = "kroxylicious_filter_sasl_termination_auth_duration_seconds";
     static final String SESSION_EXPIRED_METRIC = "kroxylicious_filter_sasl_termination_session_expired_total";
@@ -153,11 +154,14 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
     }
 
     private CompletionStage<RequestFilterResult> onSaslHandshakeRequest(
-                                                                        ApiKeys apiKey, short apiVersion, RequestHeaderData header, SaslHandshakeRequestData request,
+                                                                        ApiKeys apiKey,
+                                                                        short apiVersion,
+                                                                        RequestHeaderData header,
+                                                                        SaslHandshakeRequestData request,
                                                                         FilterContext filterContext) {
 
         if (isUnsupportedApiVersion(ApiKeys.SASL_HANDSHAKE, apiVersion)) {
-            return rejectUnsupportedVersionAndClose(apiKey, apiVersion, header, request, filterContext);
+            return rejectUnsupportedVersionAndClose(filterContext, apiKey, apiVersion, header, request);
         }
 
         if (!(state instanceof State.RequiringHandshake) && !(state instanceof State.Authenticated)) {
@@ -180,7 +184,8 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
     }
 
     @NonNull
-    private CompletionStage<RequestFilterResult> acceptHandshake(FilterContext filterContext, MechanismStateMachine stateMachine,
+    private CompletionStage<RequestFilterResult> acceptHandshake(FilterContext filterContext,
+                                                                 MechanismStateMachine stateMachine,
                                                                  String mechanism) {
         if (state instanceof State.RequiringHandshake handshake) {
             state = handshake.nextState(stateMachine);
@@ -188,6 +193,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
         else if (state instanceof State.Authenticated authenticated) {
             LOGGER.atDebug()
                     .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                    .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, filterContext.getVirtualClusterName())
                     .addKeyValue(LOG_KEY_MECHANISM, mechanism)
                     .log("Reauthentication initiated");
             state = authenticated.nextStateReauthenticate(stateMachine);
@@ -200,9 +206,11 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                 .completed();
     }
 
-    private CompletionStage<RequestFilterResult> rejectHandshakeUnsupportedMechanism(FilterContext filterContext, String mechanism) {
+    private CompletionStage<RequestFilterResult> rejectHandshakeUnsupportedMechanism(FilterContext filterContext,
+                                                                                     String mechanism) {
         LOGGER.atDebug()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, filterContext.getVirtualClusterName())
                 .addKeyValue(LOG_KEY_MECHANISM, mechanism)
                 .log("Unsupported mechanism");
         return filterContext.requestFilterResultBuilder()
@@ -218,6 +226,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                                                                                              String mechanism) {
         LOGGER.atWarn()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, filterContext.getVirtualClusterName())
                 .addKeyValue(LOG_KEY_MECHANISM, mechanism)
                 .addKeyValue("previousMechanism", authenticated.mechanismName())
                 .log("Reauthentication rejected: mechanism change not permitted");
@@ -232,6 +241,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
     private CompletionStage<RequestFilterResult> rejectHandshakeNotExpected(FilterContext filterContext) {
         LOGGER.atWarn()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, filterContext.getVirtualClusterName())
                 .addKeyValue(LOG_KEY_STATE, state)
                 .log("Received SASL handshake in unexpected state");
         return filterContext.requestFilterResultBuilder()
@@ -256,11 +266,12 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
     private CompletionStage<RequestFilterResult> onSaslAuthenticateRequest(
                                                                            ApiKeys apiKey,
                                                                            short apiVersion,
-                                                                           RequestHeaderData header, SaslAuthenticateRequestData request,
+                                                                           RequestHeaderData header,
+                                                                           SaslAuthenticateRequestData request,
                                                                            FilterContext filterContext) {
 
         if (isUnsupportedApiVersion(ApiKeys.SASL_AUTHENTICATE, apiVersion)) {
-            return rejectUnsupportedVersionAndClose(apiKey, apiVersion, header, request, filterContext);
+            return rejectUnsupportedVersionAndClose(filterContext, apiKey, apiVersion, header, request);
         }
 
         if (!(state instanceof State.RequiringAuthenticate authenticating)) {
@@ -271,43 +282,45 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
 
         int maxAuthBytes = stateMachine.maxAuthBytes();
         if (request.authBytes().length > maxAuthBytes) {
-            return rejectAuthenticateBytesTooLarge(request, filterContext, stateMachine, maxAuthBytes);
+            return rejectAuthenticateBytesTooLarge(filterContext, request, stateMachine, maxAuthBytes);
         }
 
         Instant authRoundStart = clock.instant();
         long roundStartNanos = System.nanoTime();
         return stateMachine.evaluateRound(request.authBytes())
                 .whenComplete((result, ex) -> authenticating.addRoundDuration(System.nanoTime() - roundStartNanos))
-                .thenCompose(result -> applyFixedAuthDelay(result, authRoundStart, stateMachine.mechanismName()))
+                .thenCompose(result -> applyFixedAuthDelay(filterContext, result, authRoundStart, stateMachine.mechanismName()))
                 .thenCompose(result -> switch (result) {
                     case RoundResult.Challenge challenge -> acceptAuthenticateContinue(filterContext, challenge);
-                    case RoundResult.Success success -> processMechanismSuccess(stateMachine, filterContext, success);
-                    case RoundResult.Failure failure -> rejectAuthenticateMechanismFailed(stateMachine, filterContext, failure.exception());
+                    case RoundResult.Success success -> processMechanismSuccess(filterContext, stateMachine, success);
+                    case RoundResult.Failure failure -> rejectAuthenticateMechanismFailed(filterContext, stateMachine, failure.exception());
                 })
-                .exceptionallyCompose(throwable -> rejectAuthenticateInternalError(stateMachine,
-                        filterContext,
+                .exceptionallyCompose(throwable -> rejectAuthenticateInternalError(filterContext, stateMachine,
                         "stateMachine",
                         throwable));
     }
 
     @NonNull
-    private CompletionStage<RequestFilterResult> rejectAuthenticateBytesTooLarge(SaslAuthenticateRequestData request, FilterContext filterContext,
-                                                                                 MechanismStateMachine stateMachine, int maxAuthBytes) {
+    private CompletionStage<RequestFilterResult> rejectAuthenticateBytesTooLarge(FilterContext filterContext,
+                                                                                 SaslAuthenticateRequestData request,
+                                                                                 MechanismStateMachine stateMachine,
+                                                                                 int maxAuthBytes) {
         LOGGER.atWarn()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, filterContext.getVirtualClusterName())
                 .addKeyValue(LOG_KEY_MECHANISM, stateMachine.mechanismName())
                 .addKeyValue("payloadSize", request.authBytes().length)
                 .addKeyValue("maxPayloadSize", maxAuthBytes)
                 .log("Rejecting oversized SASL authenticate payload");
         return rejectAuthenticateAndClose(
-                stateMachine,
-                filterContext,
+                filterContext, stateMachine,
                 new InvalidRequestException("Authentication payload exceeds maximum size"));
     }
 
     private CompletionStage<RequestFilterResult> rejectAuthenticateNotExpected(FilterContext filterContext) {
         LOGGER.atWarn()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, filterContext.getVirtualClusterName())
                 .addKeyValue(LOG_KEY_STATE, state)
                 .log("Received SASL authenticate in unexpected state");
         return filterContext.requestFilterResultBuilder()
@@ -318,8 +331,8 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                 .completed();
     }
 
-    private CompletionStage<RequestFilterResult> processMechanismSuccess(MechanismStateMachine stateMachine,
-                                                                         FilterContext filterContext,
+    private CompletionStage<RequestFilterResult> processMechanismSuccess(FilterContext filterContext,
+                                                                         MechanismStateMachine stateMachine,
                                                                          RoundResult.Success success) {
 
         if (!(state instanceof State.RequiringAuthenticate authenticating)) {
@@ -331,6 +344,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
         boolean reauthentication = authenticating.previousAuthorizationId() != null;
         LOGGER.atDebug()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, filterContext.getVirtualClusterName())
                 .addKeyValue(LOG_KEY_MECHANISM, mechanism)
                 .addKeyValue(LOG_KEY_REAUTHENTICATION, reauthentication)
                 .addKeyValue("authorizationId", authorizationId)
@@ -341,7 +355,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
         String previousAuthorizationId = authenticating.previousAuthorizationId();
         if (previousAuthorizationId != null
                 && !previousAuthorizationId.equals(authorizationId)) {
-            return rejectAuthenticateIdChanged(stateMachine, filterContext, previousAuthorizationId, authorizationId);
+            return rejectAuthenticateIdChanged(filterContext, stateMachine, previousAuthorizationId, authorizationId);
         }
 
         // capture the duration here, but only record it on the acceptAuthenticateDone path
@@ -353,35 +367,36 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
         stateMachine.dispose();
 
         return subjectBuilder.buildSaslSubject(new SubjectContext(filterContext, mechanism, authorizationId))
-                .thenCompose(subject -> completeSubjectBuild(stateMachine,
-                        filterContext,
+                .thenCompose(subject -> completeSubjectBuild(filterContext, stateMachine,
                         success,
                         subject,
                         mechanism,
                         reauthentication,
                         sessionExpiry,
                         authDuration))
-                .exceptionallyCompose(throwable -> rejectAuthenticateInternalError(stateMachine,
-                        filterContext,
+                .exceptionallyCompose(throwable -> rejectAuthenticateInternalError(filterContext, stateMachine,
                         "subjectBuilder",
                         throwable));
     }
 
     @NonNull
-    private CompletionStage<RequestFilterResult> rejectAuthenticateIdChanged(MechanismStateMachine stateMachine, FilterContext filterContext,
-                                                                             String previousAuthorizationId, String authorizationId) {
+    private CompletionStage<RequestFilterResult> rejectAuthenticateIdChanged(FilterContext filterContext,
+                                                                             MechanismStateMachine stateMachine,
+                                                                             String previousAuthorizationId,
+                                                                             String authorizationId) {
         LOGGER.atWarn()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, filterContext.getVirtualClusterName())
                 .addKeyValue(LOG_KEY_REAUTHENTICATION, true)
                 .addKeyValue("previousAuthorizationId", previousAuthorizationId)
                 .addKeyValue("newAuthorizationId", authorizationId)
                 .log("Reauthentication rejected: authorization ID changed");
-        return rejectAuthenticateAndClose(stateMachine, filterContext,
+        return rejectAuthenticateAndClose(filterContext, stateMachine,
                 new SaslAuthenticationException("Reauthentication failed: authorization identity changed"));
     }
 
-    private CompletionStage<RequestFilterResult> completeSubjectBuild(MechanismStateMachine stateMachine,
-                                                                      FilterContext filterContext,
+    private CompletionStage<RequestFilterResult> completeSubjectBuild(FilterContext filterContext,
+                                                                      MechanismStateMachine stateMachine,
                                                                       RoundResult.Success success,
                                                                       Subject subject,
                                                                       String mechanism,
@@ -393,9 +408,10 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
         if (sessionExpiry != null && !clock.instant().isBefore(sessionExpiry)) {
             LOGGER.atWarn()
                     .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                    .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, filterContext.getVirtualClusterName())
                     .addKeyValue(LOG_KEY_MECHANISM, mechanism)
                     .log("Token expired during authentication");
-            return rejectAuthenticateAndClose(stateMachine, filterContext,
+            return rejectAuthenticateAndClose(filterContext, stateMachine,
                     new SaslAuthenticationException("Token expired during authentication"));
         }
 
@@ -411,6 +427,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
         String authorizationId = success.authorizationId();
         LOGGER.atDebug()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, filterContext.getVirtualClusterName())
                 .addKeyValue(LOG_KEY_MECHANISM, mechanism)
                 .addKeyValue("authorizationId", authorizationId)
                 .addKeyValue(LOG_KEY_REAUTHENTICATION, reauthentication)
@@ -427,23 +444,24 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                 .completed();
     }
 
-    private CompletionStage<RequestFilterResult> rejectAuthenticateInternalError(MechanismStateMachine stateMachine,
-                                                                                 FilterContext filterContext,
+    private CompletionStage<RequestFilterResult> rejectAuthenticateInternalError(FilterContext filterContext,
+                                                                                 MechanismStateMachine stateMachine,
                                                                                  String origin,
                                                                                  Throwable throwable) {
         LOGGER.atError()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, filterContext.getVirtualClusterName())
                 .addKeyValue(LOG_KEY_MECHANISM, stateMachine.mechanismName())
                 .setCause(throwable)
                 .addKeyValue("origin", origin)
                 .log("Authentication error");
         Exception exception = throwable instanceof Exception e ? e : new RuntimeException(throwable);
-        return rejectAuthenticateAndClose(stateMachine,
-                filterContext,
+        return rejectAuthenticateAndClose(filterContext, stateMachine,
                 exception);
     }
 
-    private CompletionStage<RequestFilterResult> acceptAuthenticateContinue(FilterContext filterContext, RoundResult.Challenge challenge) {
+    private CompletionStage<RequestFilterResult> acceptAuthenticateContinue(FilterContext filterContext,
+                                                                            RoundResult.Challenge challenge) {
         if (state instanceof State.RequiringAuthenticate authenticating) {
             state = authenticating.nextStateChallenge();
         }
@@ -470,22 +488,22 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
     }
 
     private CompletionStage<RequestFilterResult> rejectAuthenticateMechanismFailed(
-                                                                                   MechanismStateMachine stateMachine,
-                                                                                   FilterContext filterContext,
+                                                                                   FilterContext filterContext, MechanismStateMachine stateMachine,
                                                                                    Exception exception) {
         boolean reauthentication = state instanceof State.RequiringAuthenticate req
                 && req.previousAuthorizationId() != null;
         LOGGER.atDebug()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, filterContext.getVirtualClusterName())
                 .addKeyValue(LOG_KEY_ERROR, exception.getMessage())
                 .addKeyValue(LOG_KEY_REAUTHENTICATION, reauthentication)
                 .log("Authentication failed");
-        return rejectAuthenticateAndClose(stateMachine, filterContext, exception);
+        return rejectAuthenticateAndClose(filterContext, stateMachine, exception);
     }
 
     private CompletionStage<RequestFilterResult> rejectAuthenticateAndClose(
-                                                                            MechanismStateMachine stateMachine,
                                                                             FilterContext filterContext,
+                                                                            MechanismStateMachine stateMachine,
                                                                             Exception exception) {
 
         if (state instanceof State.RequiringAuthenticate authenticating) {
@@ -518,11 +536,10 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
             Instant expiry = authenticated.sessionExpiry();
             if (expiry == null || !clock.instant().isAfter(expiry)) {
                 if (FILTERED_API_KEYS.contains(apiKey.id)) {
-                    return rejectUnsupportedApi(header,
+                    return rejectUnsupportedApi(filterContext, header,
                             request,
                             apiKey,
-                            apiKey + " is not supported when SASL is terminated at the proxy",
-                            filterContext);
+                            apiKey + " is not supported when SASL is terminated at the proxy");
                 }
                 else {
                     return filterContext.forwardRequest(header, request);
@@ -536,6 +553,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                     .increment();
             LOGGER.atWarn()
                     .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                    .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, filterContext.getVirtualClusterName())
                     .addKeyValue(LOG_KEY_REASON, "SASL session expired")
                     .addKeyValue("sessionExpiry", expiry)
                     .addKeyValue("requestType", request.getClass().getSimpleName())
@@ -544,6 +562,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
         else {
             LOGGER.atWarn()
                     .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                    .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, filterContext.getVirtualClusterName())
                     .addKeyValue(LOG_KEY_REASON, "Client is not authenticated")
                     .addKeyValue(LOG_KEY_STATE, state)
                     .addKeyValue("requestType", request.getClass().getSimpleName())
@@ -557,13 +576,14 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
     }
 
     private static CompletionStage<RequestFilterResult> rejectUnsupportedApi(
+                                                                             FilterContext filterContext,
                                                                              RequestHeaderData header,
                                                                              ApiMessage request,
                                                                              ApiKeys apiKey,
-                                                                             String reason,
-                                                                             FilterContext filterContext) {
+                                                                             String reason) {
         LOGGER.atDebug()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, filterContext.getVirtualClusterName())
                 .addKeyValue("apiKey", apiKey)
                 .addKeyValue(LOG_KEY_REASON, reason)
                 .log("Rejecting unsupported API request");
@@ -572,7 +592,10 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                 .completed();
     }
 
-    private CompletionStage<RoundResult> applyFixedAuthDelay(RoundResult result, Instant start, String mechanismName) {
+    private CompletionStage<RoundResult> applyFixedAuthDelay(FilterContext filterContext,
+                                                             RoundResult result,
+                                                             Instant start,
+                                                             String mechanismName) {
         Duration fixedAuthDelay = context.fixedAuthDelay();
         if (fixedAuthDelay.isZero()) {
             return CompletableFuture.completedFuture(result);
@@ -580,6 +603,8 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
         Duration elapsed = Duration.between(start, clock.instant());
         if (elapsed.compareTo(fixedAuthDelay) > 0) {
             LOGGER.atWarn()
+                    .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                    .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, filterContext.getVirtualClusterName())
                     .addKeyValue(LOG_KEY_MECHANISM, mechanismName)
                     .addKeyValue("elapsed", elapsed)
                     .addKeyValue("fixedAuthDelay", fixedAuthDelay)
@@ -616,11 +641,14 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
     }
 
     private CompletionStage<RequestFilterResult> rejectUnsupportedVersionAndClose(
-                                                                                  ApiKeys apiKey, short apiVersion, RequestHeaderData header,
-                                                                                  ApiMessage request,
-                                                                                  FilterContext filterContext) {
+                                                                                  FilterContext filterContext,
+                                                                                  ApiKeys apiKey,
+                                                                                  short apiVersion,
+                                                                                  RequestHeaderData header,
+                                                                                  ApiMessage request) {
         LOGGER.atWarn()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, filterContext.getVirtualClusterName())
                 .addKeyValue("apiKey", apiKey)
                 .addKeyValue("apiVersion", apiVersion)
                 .log("Rejecting SASL request with unsupported API version");

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -178,16 +178,15 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
     @NonNull
     private CompletionStage<RequestFilterResult> acceptHandshake(FilterContext filterContext, MechanismStateMachine stateMachine,
                                                                  String mechanism) {
-        long authStartNanos = System.nanoTime();
         if (state instanceof State.RequiringHandshake handshake) {
-            state = handshake.nextState(stateMachine, authStartNanos);
+            state = handshake.nextState(stateMachine);
         }
         else if (state instanceof State.Authenticated authenticated) {
             LOGGER.atDebug()
                     .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
                     .addKeyValue(LOG_KEY_MECHANISM, mechanism)
                     .log("Reauthentication initiated");
-            state = authenticated.nextStateReauthenticate(stateMachine, authStartNanos);
+            state = authenticated.nextStateReauthenticate(stateMachine);
         }
 
         return filterContext.requestFilterResultBuilder()
@@ -272,7 +271,9 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
         }
 
         Instant authRoundStart = clock.instant();
+        long roundStartNanos = System.nanoTime();
         return stateMachine.evaluateRound(request.authBytes())
+                .whenComplete((result, ex) -> authenticating.addRoundDuration(System.nanoTime() - roundStartNanos))
                 .thenCompose(result -> applyFixedAuthDelay(result, authRoundStart, stateMachine.mechanismName()))
                 .thenCompose(result -> switch (result) {
                     case RoundResult.Challenge challenge -> acceptAuthenticateContinue(filterContext, challenge);
@@ -344,7 +345,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
         // because rejectAuthenticateInternalError also records the duration, so we don't
         // want to record a second duration for the same authentication if the subjectBuilder
         // returned a failed CompletionStage.
-        Duration authDuration = Duration.ofNanos(System.nanoTime() - authenticating.authStartNanos());
+        Duration authDuration = Duration.ofNanos(authenticating.accumulatedAuthWorkNanos());
         state = authenticating.nextStateSuccess(authorizationId, mechanism, sessionExpiry);
         stateMachine.dispose();
 
@@ -463,7 +464,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
         if (state instanceof State.RequiringAuthenticate authenticating) {
             String mechanism = stateMachine.mechanismName();
             String virtualClusterName = filterContext.getVirtualClusterName();
-            Duration authDuration = Duration.ofNanos(System.nanoTime() - authenticating.authStartNanos());
+            Duration authDuration = Duration.ofNanos(authenticating.accumulatedAuthWorkNanos());
             recordAuthDuration(mechanism, virtualClusterName, authDuration);
             state = authenticating.nextStateFailure(exception.getMessage());
         }

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.Errors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.spi.LoggingEventBuilder;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
@@ -39,6 +40,7 @@ import io.micrometer.core.instrument.Timer;
 
 import io.kroxylicious.proxy.authentication.ClientSaslContext;
 import io.kroxylicious.proxy.authentication.SaslSubjectBuilder;
+import io.kroxylicious.proxy.authentication.Subject;
 import io.kroxylicious.proxy.filter.ApiVersionsResponseFilter;
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.RequestFilter;
@@ -87,6 +89,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
             ApiKeys.EXPIRE_DELEGATION_TOKEN.id,
             ApiKeys.DESCRIBE_DELEGATION_TOKEN.id);
     public static final String LOG_KEY_REAUTHENTICATION = "reauthentication";
+    public static final String LOG_KEY_REASON = "reason";
 
     private final ScheduledExecutorService executorService;
     private final SaslTermination.SaslTerminationContext context;
@@ -132,21 +135,9 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
 
         return switch (apiKey) {
             case API_VERSIONS -> filterContext.forwardRequest(header, request);
-            case SASL_HANDSHAKE -> {
-                if (isUnsupportedApiVersion(ApiKeys.SASL_HANDSHAKE, apiVersion)) {
-                    yield rejectUnsupportedVersionAndClose(header, request, apiKey, apiVersion, filterContext);
-                }
-                yield onSaslHandshakeRequest((SaslHandshakeRequestData) request, filterContext);
-            }
-            case SASL_AUTHENTICATE -> {
-                if (isUnsupportedApiVersion(ApiKeys.SASL_AUTHENTICATE, apiVersion)) {
-                    yield rejectUnsupportedVersionAndClose(header, request, apiKey, apiVersion, filterContext);
-                }
-                yield onSaslAuthenticateRequest((SaslAuthenticateRequestData) request, filterContext);
-            }
-            case CREATE_DELEGATION_TOKEN, RENEW_DELEGATION_TOKEN, EXPIRE_DELEGATION_TOKEN, DESCRIBE_DELEGATION_TOKEN -> rejectUnsupportedApi(header, request, apiKey,
-                    "Delegation tokens are not supported when SASL is terminated at the proxy", filterContext);
-            default -> handleDefaultRequest(header, request, filterContext);
+            case SASL_HANDSHAKE -> onSaslHandshakeRequest(apiKey, apiVersion, header, (SaslHandshakeRequestData) request, filterContext);
+            case SASL_AUTHENTICATE -> onSaslAuthenticateRequest(apiKey, apiVersion, header, (SaslAuthenticateRequestData) request, filterContext);
+            default -> onAnyOtherRequest(apiKey, header, request, filterContext);
         };
     }
 
@@ -158,46 +149,55 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
     }
 
     private CompletionStage<RequestFilterResult> onSaslHandshakeRequest(
-                                                                        SaslHandshakeRequestData request,
+                                                                        ApiKeys apiKey, short apiVersion, RequestHeaderData header, SaslHandshakeRequestData request,
                                                                         FilterContext filterContext) {
 
+        if (isUnsupportedApiVersion(ApiKeys.SASL_HANDSHAKE, apiVersion)) {
+            return rejectUnsupportedVersionAndClose(apiKey, apiVersion, header, request, filterContext);
+        }
+
         if (!(state instanceof State.RequiringHandshake) && !(state instanceof State.Authenticated)) {
-            return unexpectedHandshakeErrorResponse(filterContext);
+            return rejectHandshakeNotExpected(filterContext);
         }
 
         String mechanism = request.mechanism();
 
         if (state instanceof State.Authenticated authenticated && !mechanism.equals(authenticated.mechanismName())) {
-            return reauthenticationRejectedResponseAndClose(filterContext, authenticated, mechanism);
+            return rejectHandshakeReauthMechanismChange(filterContext, authenticated, mechanism);
         }
 
         MechanismStateMachine stateMachine = createStateMachine(mechanism);
         if (stateMachine == null) {
-            return unsupportedMechanismResponseAndClose(filterContext, mechanism);
+            return rejectHandshakeUnsupportedMechanism(filterContext, mechanism);
         }
         else {
-            long authStartNanos = System.nanoTime();
-            if (state instanceof State.RequiringHandshake handshake) {
-                state = handshake.nextState(stateMachine, authStartNanos);
-            }
-            else if (state instanceof State.Authenticated authenticated) {
-                LOGGER.atDebug()
-                        .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
-                        .addKeyValue(LOG_KEY_MECHANISM, mechanism)
-                        .log("Reauthentication initiated");
-                state = authenticated.nextStateReauthenticate(stateMachine, authStartNanos);
-            }
-
-            return filterContext.requestFilterResultBuilder()
-                    .shortCircuitResponse(new SaslHandshakeResponseData()
-                            .setErrorCode(Errors.NONE.code())
-                            .setMechanisms(List.of()))
-                    .completed();
+            return acceptHandshake(filterContext, stateMachine, mechanism);
         }
     }
 
     @NonNull
-    private CompletionStage<RequestFilterResult> unsupportedMechanismResponseAndClose(FilterContext filterContext, String mechanism) {
+    private CompletionStage<RequestFilterResult> acceptHandshake(FilterContext filterContext, MechanismStateMachine stateMachine,
+                                                                 String mechanism) {
+        long authStartNanos = System.nanoTime();
+        if (state instanceof State.RequiringHandshake handshake) {
+            state = handshake.nextState(stateMachine, authStartNanos);
+        }
+        else if (state instanceof State.Authenticated authenticated) {
+            LOGGER.atDebug()
+                    .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                    .addKeyValue(LOG_KEY_MECHANISM, mechanism)
+                    .log("Reauthentication initiated");
+            state = authenticated.nextStateReauthenticate(stateMachine, authStartNanos);
+        }
+
+        return filterContext.requestFilterResultBuilder()
+                .shortCircuitResponse(new SaslHandshakeResponseData()
+                        .setErrorCode(Errors.NONE.code())
+                        .setMechanisms(List.of()))
+                .completed();
+    }
+
+    private CompletionStage<RequestFilterResult> rejectHandshakeUnsupportedMechanism(FilterContext filterContext, String mechanism) {
         LOGGER.atDebug()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
                 .addKeyValue(LOG_KEY_MECHANISM, mechanism)
@@ -210,9 +210,9 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
                 .completed();
     }
 
-    @NonNull
-    private static CompletionStage<RequestFilterResult> reauthenticationRejectedResponseAndClose(FilterContext filterContext, State.Authenticated authenticated,
-                                                                                                 String mechanism) {
+    private static CompletionStage<RequestFilterResult> rejectHandshakeReauthMechanismChange(FilterContext filterContext,
+                                                                                             State.Authenticated authenticated,
+                                                                                             String mechanism) {
         LOGGER.atWarn()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
                 .addKeyValue(LOG_KEY_MECHANISM, mechanism)
@@ -226,8 +226,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
                 .completed();
     }
 
-    @NonNull
-    private CompletionStage<RequestFilterResult> unexpectedHandshakeErrorResponse(FilterContext filterContext) {
+    private CompletionStage<RequestFilterResult> rejectHandshakeNotExpected(FilterContext filterContext) {
         LOGGER.atWarn()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
                 .addKeyValue(LOG_KEY_STATE, state)
@@ -252,43 +251,56 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
     }
 
     private CompletionStage<RequestFilterResult> onSaslAuthenticateRequest(
-                                                                           SaslAuthenticateRequestData request,
+                                                                           ApiKeys apiKey,
+                                                                           short apiVersion,
+                                                                           RequestHeaderData header, SaslAuthenticateRequestData request,
                                                                            FilterContext filterContext) {
 
+        if (isUnsupportedApiVersion(ApiKeys.SASL_AUTHENTICATE, apiVersion)) {
+            return rejectUnsupportedVersionAndClose(apiKey, apiVersion, header, request, filterContext);
+        }
+
         if (!(state instanceof State.RequiringAuthenticate authenticating)) {
-            return unexpectedAuthenticatedErrorResponse(filterContext);
+            return rejectAuthenticateNotExpected(filterContext);
         }
 
         MechanismStateMachine stateMachine = authenticating.mechanismStateMachine();
 
         int maxAuthBytes = stateMachine.maxAuthBytes();
         if (request.authBytes().length > maxAuthBytes) {
-            LOGGER.atWarn()
-                    .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
-                    .addKeyValue(LOG_KEY_MECHANISM, stateMachine.mechanismName())
-                    .addKeyValue("payloadSize", request.authBytes().length)
-                    .addKeyValue("maxPayloadSize", maxAuthBytes)
-                    .log("Rejecting oversized SASL authenticate payload");
-            return handleAuthenticationFailure(
-                    stateMachine, filterContext, new InvalidRequestException("Authentication payload exceeds maximum size"));
+            return rejectAuthenticateBytesTooLarge(request, filterContext, stateMachine, maxAuthBytes);
         }
 
         Instant authRoundStart = clock.instant();
         return stateMachine.evaluateRound(request.authBytes())
                 .thenCompose(result -> applyFixedAuthDelay(result, authRoundStart, stateMachine.mechanismName()))
-                .thenCompose(result -> processRoundResult(result, stateMachine, filterContext))
-                .exceptionallyCompose(throwable -> {
-                    LOGGER.atError()
-                            .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
-                            .setCause(throwable)
-                            .log("Authentication error");
-                    Exception exception = throwable instanceof Exception e ? e : new RuntimeException(throwable);
-                    return handleAuthenticationFailure(stateMachine, filterContext, exception);
-                });
+                .thenCompose(result -> switch (result) {
+                    case RoundResult.Challenge challenge -> acceptAuthenticateContinue(filterContext, challenge);
+                    case RoundResult.Success success -> processMechanismSuccess(stateMachine, filterContext, success);
+                    case RoundResult.Failure failure -> rejectAuthenticateMechanismFailed(stateMachine, filterContext, failure.exception());
+                })
+                .exceptionallyCompose(throwable -> rejectAuthenticateInternalError(stateMachine,
+                        filterContext,
+                        "stateMachine",
+                        throwable));
     }
 
     @NonNull
-    private CompletionStage<RequestFilterResult> unexpectedAuthenticatedErrorResponse(FilterContext filterContext) {
+    private CompletionStage<RequestFilterResult> rejectAuthenticateBytesTooLarge(SaslAuthenticateRequestData request, FilterContext filterContext,
+                                                                                 MechanismStateMachine stateMachine, int maxAuthBytes) {
+        LOGGER.atWarn()
+                .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_MECHANISM, stateMachine.mechanismName())
+                .addKeyValue("payloadSize", request.authBytes().length)
+                .addKeyValue("maxPayloadSize", maxAuthBytes)
+                .log("Rejecting oversized SASL authenticate payload");
+        return rejectAuthenticateAndClose(
+                stateMachine,
+                filterContext,
+                new InvalidRequestException("Authentication payload exceeds maximum size"));
+    }
+
+    private CompletionStage<RequestFilterResult> rejectAuthenticateNotExpected(FilterContext filterContext) {
         LOGGER.atWarn()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
                 .addKeyValue(LOG_KEY_STATE, state)
@@ -301,24 +313,17 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
                 .completed();
     }
 
-    private CompletionStage<RequestFilterResult> processRoundResult(
-                                                                    RoundResult result,
-                                                                    MechanismStateMachine stateMachine,
-                                                                    FilterContext filterContext) {
+    private CompletionStage<RequestFilterResult> processMechanismSuccess(MechanismStateMachine stateMachine,
+                                                                         FilterContext filterContext,
+                                                                         RoundResult.Success success) {
 
-        return switch (result) {
-            case RoundResult.Challenge challenge -> handleChallenge(filterContext, challenge);
-            case RoundResult.Success success -> handleSuccess(stateMachine, filterContext, success);
-            case RoundResult.Failure failure -> handleAuthenticationFailure(stateMachine, filterContext, failure.exception());
-        };
-    }
-
-    @NonNull
-    private CompletionStage<RequestFilterResult> handleSuccess(MechanismStateMachine stateMachine, FilterContext filterContext,
-                                                               RoundResult.Success success) {
+        if (!(state instanceof State.RequiringAuthenticate authenticating)) {
+            // this should be impossible
+            throw new IllegalStateException("handleSuccess called in unexpected state: " + state);
+        }
         String authorizationId = success.authorizationId();
         String mechanism = stateMachine.mechanismName();
-        boolean reauthentication = state instanceof State.RequiringAuthenticate req && req.previousAuthorizationId() != null;
+        boolean reauthentication = authenticating.previousAuthorizationId() != null;
         LOGGER.atDebug()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
                 .addKeyValue(LOG_KEY_MECHANISM, stateMachine.mechanismName())
@@ -327,69 +332,92 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
                 .log("Credential validation successful");
 
         long sessionLifetimeMs = computeSessionLifetimeMs(success.sessionLifetimeMs());
-        @Nullable
         Instant sessionExpiry = sessionLifetimeMs > 0 ? clock.instant().plusMillis(sessionLifetimeMs) : null;
 
-        if (state instanceof State.RequiringAuthenticate authenticating) {
-            String previousAuthorizationId = authenticating.previousAuthorizationId();
-            if (previousAuthorizationId != null && !previousAuthorizationId.equals(authorizationId)) {
-                LOGGER.atWarn()
-                        .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
-                        .addKeyValue(LOG_KEY_REAUTHENTICATION, true)
-                        .addKeyValue("previousAuthorizationId", previousAuthorizationId)
-                        .addKeyValue("newAuthorizationId", authorizationId)
-                        .log("Reauthentication rejected: authorization ID changed");
-                return handleAuthenticationFailure(stateMachine, filterContext,
-                        new SaslAuthenticationException("Reauthentication failed: authorization identity changed"));
-            }
-            LOGGER.atDebug()
-                    .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
-                    .addKeyValue(LOG_KEY_MECHANISM, mechanism)
-                    .addKeyValue("authorizationId", authorizationId)
-                    .addKeyValue(LOG_KEY_REAUTHENTICATION, reauthentication)
-                    .log("Authentication successful");
-            recordAuthDuration(mechanism, filterContext.getVirtualClusterName(), authenticating.authStartNanos());
-            state = authenticating.nextStateSuccess(authorizationId, mechanism, sessionExpiry);
+        String previousAuthorizationId = authenticating.previousAuthorizationId();
+        if (previousAuthorizationId != null
+                && !previousAuthorizationId.equals(authorizationId)) {
+            return rejectAuthenticateIdChanged(stateMachine, filterContext, previousAuthorizationId, authorizationId);
         }
 
+        // capture the duration here, but only record it on the acceptAuthenticateDone path
+        // because rejectAuthenticateInternalError also records the duration, so we don't
+        // want to record a second duration for the same authentication if the subjectBuilder
+        // returned a failed CompletionStage.
+        Duration authDuration = Duration.ofNanos(System.nanoTime() - authenticating.authStartNanos());
+        state = authenticating.nextStateSuccess(authorizationId, mechanism, sessionExpiry);
         stateMachine.dispose();
 
-        SaslSubjectBuilder.Context subjectContext = new SaslSubjectBuilder.Context() {
-            @Override
-            public Optional<ClientTlsContext> clientTlsContext() {
-                return filterContext.clientTlsContext();
-            }
-
-            @Override
-            public ClientSaslContext clientSaslContext() {
-                return new ClientSaslContext() {
-                    @Override
-                    public String mechanismName() {
-                        return mechanism;
-                    }
-
-                    @Override
-                    public String authorizationId() {
-                        return authorizationId;
-                    }
-                };
-            }
-        };
-
-        return subjectBuilder.buildSaslSubject(subjectContext)
-                .thenCompose(subject -> {
-                    filterContext.clientSaslAuthenticationSuccess(mechanism, subject);
-                    return filterContext.requestFilterResultBuilder()
-                            .shortCircuitResponse(new SaslAuthenticateResponseData()
-                                    .setErrorCode(Errors.NONE.code())
-                                    .setAuthBytes(success.responseBytes())
-                                    .setSessionLifetimeMs(sessionLifetimeMs))
-                            .completed();
-                });
+        return subjectBuilder.buildSaslSubject(new SubjectContext(filterContext, mechanism, authorizationId))
+                .thenCompose(subject -> acceptAuthenticateDone(filterContext,
+                        success,
+                        subject,
+                        mechanism,
+                        authorizationId,
+                        reauthentication,
+                        sessionLifetimeMs,
+                        authDuration))
+                .exceptionallyCompose(throwable -> rejectAuthenticateInternalError(stateMachine,
+                        filterContext,
+                        "subjectBuilder",
+                        throwable));
     }
 
     @NonNull
-    private CompletionStage<RequestFilterResult> handleChallenge(FilterContext filterContext, RoundResult.Challenge challenge) {
+    private CompletionStage<RequestFilterResult> rejectAuthenticateIdChanged(MechanismStateMachine stateMachine, FilterContext filterContext,
+                                                                             String previousAuthorizationId, String authorizationId) {
+        LOGGER.atWarn()
+                .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_REAUTHENTICATION, true)
+                .addKeyValue("previousAuthorizationId", previousAuthorizationId)
+                .addKeyValue("newAuthorizationId", authorizationId)
+                .log("Reauthentication rejected: authorization ID changed");
+        return rejectAuthenticateAndClose(stateMachine, filterContext,
+                new SaslAuthenticationException("Reauthentication failed: authorization identity changed"));
+    }
+
+    private CompletionStage<RequestFilterResult> acceptAuthenticateDone(FilterContext filterContext,
+                                                                        RoundResult.Success success,
+                                                                        Subject subject,
+                                                                        String mechanism,
+                                                                        String authorizationId,
+                                                                        boolean reauthentication,
+                                                                        long sessionLifetimeMs,
+                                                                        Duration authDuration) {
+        recordAuthDuration(mechanism, filterContext.getVirtualClusterName(), authDuration);
+        LOGGER.atDebug()
+                .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_MECHANISM, mechanism)
+                .addKeyValue("authorizationId", authorizationId)
+                .addKeyValue(LOG_KEY_REAUTHENTICATION, reauthentication)
+                .log("Authentication successful");
+
+        filterContext.clientSaslAuthenticationSuccess(mechanism, subject);
+
+        return filterContext.requestFilterResultBuilder()
+                .shortCircuitResponse(new SaslAuthenticateResponseData()
+                        .setErrorCode(Errors.NONE.code())
+                        .setAuthBytes(success.responseBytes())
+                        .setSessionLifetimeMs(sessionLifetimeMs))
+                .completed();
+    }
+
+    private CompletionStage<RequestFilterResult> rejectAuthenticateInternalError(MechanismStateMachine stateMachine,
+                                                                                 FilterContext filterContext,
+                                                                                 String origin,
+                                                                                 Throwable throwable) {
+        LOGGER.atError()
+                .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_MECHANISM, stateMachine.mechanismName())
+                .setCause(throwable)
+                .log("Authentication error: {}", origin);
+        Exception exception = throwable instanceof Exception e ? e : new RuntimeException(throwable);
+        return rejectAuthenticateAndClose(stateMachine,
+                filterContext,
+                exception);
+    }
+
+    private CompletionStage<RequestFilterResult> acceptAuthenticateContinue(FilterContext filterContext, RoundResult.Challenge challenge) {
         if (state instanceof State.RequiringAuthenticate authenticating) {
             state = authenticating.nextStateChallenge();
         }
@@ -413,17 +441,30 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
         return Math.max(maxTimeBeforeReauthMs, handlerLifetimeMs);
     }
 
-    private CompletionStage<RequestFilterResult> handleAuthenticationFailure(
-                                                                             MechanismStateMachine stateMachine, FilterContext filterContext, Exception exception) {
-        boolean reauthentication = state instanceof State.RequiringAuthenticate req && req.previousAuthorizationId() != null;
+    private CompletionStage<RequestFilterResult> rejectAuthenticateMechanismFailed(
+                                                                                   MechanismStateMachine stateMachine,
+                                                                                   FilterContext filterContext,
+                                                                                   Exception exception) {
+        boolean reauthentication = state instanceof State.RequiringAuthenticate req
+                && req.previousAuthorizationId() != null;
         LOGGER.atDebug()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
                 .addKeyValue(LOG_KEY_ERROR, exception.getMessage())
                 .addKeyValue(LOG_KEY_REAUTHENTICATION, reauthentication)
                 .log("Authentication failed");
+        return rejectAuthenticateAndClose(stateMachine, filterContext, exception);
+    }
+
+    private CompletionStage<RequestFilterResult> rejectAuthenticateAndClose(
+                                                                            MechanismStateMachine stateMachine,
+                                                                            FilterContext filterContext,
+                                                                            Exception exception) {
 
         if (state instanceof State.RequiringAuthenticate authenticating) {
-            recordAuthDuration(stateMachine.mechanismName(), filterContext.getVirtualClusterName(), authenticating.authStartNanos());
+            String mechanism = stateMachine.mechanismName();
+            String virtualClusterName = filterContext.getVirtualClusterName();
+            Duration authDuration = Duration.ofNanos(System.nanoTime() - authenticating.authStartNanos());
+            recordAuthDuration(mechanism, virtualClusterName, authDuration);
             state = authenticating.nextStateFailure(exception.getMessage());
         }
 
@@ -440,41 +481,49 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
                 .completed();
     }
 
-    private CompletionStage<RequestFilterResult> handleDefaultRequest(
-                                                                      RequestHeaderData header,
-                                                                      ApiMessage request,
-                                                                      FilterContext filterContext) {
+    private CompletionStage<RequestFilterResult> onAnyOtherRequest(
+                                                                   ApiKeys apiKey,
+                                                                   RequestHeaderData header,
+                                                                   ApiMessage request,
+                                                                   FilterContext filterContext) {
+        LoggingEventBuilder loggingEventBuilder = LOGGER.atWarn();
 
         if (state instanceof State.Authenticated authenticated) {
             Instant expiry = authenticated.sessionExpiry();
-            if (expiry != null && clock.instant().isAfter(expiry)) {
+            if (expiry == null || !clock.instant().isAfter(expiry)) {
+                return switch (apiKey) {
+                    case CREATE_DELEGATION_TOKEN, RENEW_DELEGATION_TOKEN, EXPIRE_DELEGATION_TOKEN, DESCRIBE_DELEGATION_TOKEN -> rejectUnsupportedApi(header,
+                            request,
+                            apiKey,
+                            "Delegation tokens are not supported when SASL is terminated at the proxy",
+                            filterContext);
+                    default -> filterContext.forwardRequest(header, request);
+                };
+            }
+            else {
                 Counter.builder(SESSION_EXPIRED_METRIC)
+                        .description("Number of sessions that expired without the client reauthenticating in time.")
                         .tag(MECHANISM_TAG, authenticated.mechanismName())
                         .tag(VIRTUAL_CLUSTER_TAG, filterContext.getVirtualClusterName())
                         .register(Metrics.globalRegistry)
                         .increment();
-                LOGGER.atDebug()
-                        .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
-                        .addKeyValue("sessionExpiry", expiry)
-                        .log("Session expired, rejecting request");
-                return filterContext.requestFilterResultBuilder()
-                        .errorResponse(header, request, Errors.SASL_AUTHENTICATION_FAILED.exception())
-                        .withCloseConnection()
-                        .completed();
+                loggingEventBuilder = loggingEventBuilder.addKeyValue(LOG_KEY_REASON, "SASL session expired")
+                        .addKeyValue("sessionExpiry", expiry);
             }
-            return filterContext.forwardRequest(header, request);
         }
         else {
-            LOGGER.atDebug()
-                    .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
-                    .addKeyValue("requestType", request.getClass().getSimpleName())
-                    .log("Rejecting unauthenticated request");
-
-            return filterContext.requestFilterResultBuilder()
-                    .errorResponse(header, request, Errors.SASL_AUTHENTICATION_FAILED.exception())
-                    .withCloseConnection()
-                    .completed();
+            loggingEventBuilder = loggingEventBuilder.addKeyValue(LOG_KEY_REASON, "Client is not authenticated")
+                    .addKeyValue(LOG_KEY_STATE, state);
         }
+
+        loggingEventBuilder.addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue("requestType", request.getClass().getSimpleName())
+                .log("Rejecting request from unauthenticated client");
+
+        return filterContext.requestFilterResultBuilder()
+                .errorResponse(header, request, Errors.SASL_AUTHENTICATION_FAILED.exception())
+                .withCloseConnection()
+                .completed();
     }
 
     private static CompletionStage<RequestFilterResult> rejectUnsupportedApi(
@@ -486,7 +535,7 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
         LOGGER.atDebug()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
                 .addKeyValue("apiKey", apiKey)
-                .addKeyValue("reason", reason)
+                .addKeyValue(LOG_KEY_REASON, reason)
                 .log("Rejecting unsupported API request");
         return filterContext.requestFilterResultBuilder()
                 .errorResponse(header, request, Errors.UNSUPPORTED_VERSION.exception(reason))
@@ -520,13 +569,16 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
         return future;
     }
 
-    private static void recordAuthDuration(String mechanism, String virtualClusterName, long authStartNanos) {
-        long durationNanos = System.nanoTime() - authStartNanos;
+    private static void recordAuthDuration(String mechanism,
+                                           String virtualClusterName,
+                                           Duration authDuration) {
         Timer.builder(AUTH_DURATION_METRIC)
+                .description(
+                        "Authentication latency, exclusive of the configured fixed timing delay. Measures the real work: credential store lookup, token validation, SCRAM rounds.")
                 .tag(MECHANISM_TAG, mechanism)
                 .tag(VIRTUAL_CLUSTER_TAG, virtualClusterName)
                 .register(Metrics.globalRegistry)
-                .record(durationNanos, TimeUnit.NANOSECONDS);
+                .record(authDuration);
     }
 
     private static boolean isUnsupportedApiVersion(ApiKeys apiKey, short apiVersion) {
@@ -534,10 +586,8 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
     }
 
     private CompletionStage<RequestFilterResult> rejectUnsupportedVersionAndClose(
-                                                                                  RequestHeaderData header,
+                                                                                  ApiKeys apiKey, short apiVersion, RequestHeaderData header,
                                                                                   ApiMessage request,
-                                                                                  ApiKeys apiKey,
-                                                                                  short apiVersion,
                                                                                   FilterContext filterContext) {
         LOGGER.atWarn()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
@@ -548,5 +598,37 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
                 .errorResponse(header, request, Errors.UNSUPPORTED_VERSION.exception())
                 .withCloseConnection()
                 .completed();
+    }
+
+    private static class SubjectContext implements SaslSubjectBuilder.Context {
+        private final FilterContext filterContext;
+        private final String mechanism;
+        private final String authorizationId;
+
+        SubjectContext(FilterContext filterContext, String mechanism, String authorizationId) {
+            this.filterContext = filterContext;
+            this.mechanism = mechanism;
+            this.authorizationId = authorizationId;
+        }
+
+        @Override
+        public Optional<ClientTlsContext> clientTlsContext() {
+            return filterContext.clientTlsContext();
+        }
+
+        @Override
+        public ClientSaslContext clientSaslContext() {
+            return new ClientSaslContext() {
+                @Override
+                public String mechanismName() {
+                    return mechanism;
+                }
+
+                @Override
+                public String authorizationId() {
+                    return authorizationId;
+                }
+            };
+        }
     }
 }

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -287,7 +287,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
         long roundStartNanos = System.nanoTime();
         return stateMachine.evaluateRound(request.authBytes())
                 .whenComplete((result, ex) -> authenticating.addRoundDuration(System.nanoTime() - roundStartNanos))
-                .handle((result, ex) -> new RoundOutcome(result, ex))
+                .handle(RoundOutcome::new)
                 .thenCompose(outcome -> applyFixedAuthDelay(filterContext, outcome, authRoundStart, stateMachine.mechanismName()))
                 .thenCompose(outcome -> {
                     if (outcome.exception() != null) {

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -1,0 +1,491 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.sasl.termination;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.errors.InvalidRequestException;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.message.SaslAuthenticateRequestData;
+import org.apache.kafka.common.message.SaslAuthenticateResponseData;
+import org.apache.kafka.common.message.SaslHandshakeRequestData;
+import org.apache.kafka.common.message.SaslHandshakeResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+
+import io.kroxylicious.proxy.authentication.ClientSaslContext;
+import io.kroxylicious.proxy.authentication.SaslSubjectBuilder;
+import io.kroxylicious.proxy.filter.ApiVersionsResponseFilter;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.RequestFilter;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.tls.ClientTlsContext;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * <p>SASL termination filter.</p>
+ * <p>
+ * Terminates SASL authentication at the proxy, authenticating clients against
+ * pluggable credential stores. Enforces a security barrier preventing unauthenticated
+ * requests. Supports reauthentication (KIP-368).
+ * </p>
+ * <p>The Kafka protocol uses two APIs for SASL authentication: </p>
+ * <ol>
+ * <li>the client chooses its preferred SASL mechanism using {@code SaslHandshake}</li>
+ * <li>the client then makes one or more {@code SaslAuthenticate} requests</li>
+ * </ol>
+ * <p>This class is responsible for understanding the Kafka-specific parts.
+ * It drives a state machine (see {@link State}) that models the expected sequence of Kafka requests.
+ * During authentication, the mechanism-specific transition logic is provided by a
+ * {@link MechanismStateMachine}.</p>
+ */
+public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SaslTerminationFilter.class);
+
+    private static final String LOG_KEY_SESSION_ID = "sessionId";
+    private static final String LOG_KEY_MECHANISM = "mechanism";
+    private static final String LOG_KEY_STATE = "state";
+    private static final String LOG_KEY_ERROR = "error";
+
+    static final String AUTH_DURATION_METRIC = "kroxylicious_filter_sasl_termination_auth_duration_seconds";
+    static final String SESSION_EXPIRED_METRIC = "kroxylicious_filter_sasl_termination_session_expired_total";
+    private static final String MECHANISM_TAG = "mechanism";
+
+    private static final Set<Short> FILTERED_API_KEYS = Set.of(
+            ApiKeys.CREATE_DELEGATION_TOKEN.id,
+            ApiKeys.RENEW_DELEGATION_TOKEN.id,
+            ApiKeys.EXPIRE_DELEGATION_TOKEN.id,
+            ApiKeys.DESCRIBE_DELEGATION_TOKEN.id);
+
+    private final ScheduledExecutorService executorService;
+    private final SaslTermination.SaslTerminationContext context;
+    private final Clock clock;
+    private final long maxTimeBeforeReauthMs;
+    private final SaslSubjectBuilder subjectBuilder;
+    private State state;
+
+    /**
+     * Constructs the filter.
+     *
+     * @param executorService the executor for scheduling delayed responses
+     * @param context the SASL termination context
+     */
+    SaslTerminationFilter(ScheduledExecutorService executorService, SaslTermination.SaslTerminationContext context) {
+        this.executorService = executorService;
+        this.context = context;
+        this.clock = context.clock();
+        Duration maxReauth = context.maxTimeBeforeReauth();
+        this.maxTimeBeforeReauthMs = maxReauth != null ? maxReauth.toMillis() : 0;
+        this.subjectBuilder = context.subjectBuilder();
+        this.state = State.start();
+    }
+
+    @Override
+    public boolean shouldHandleRequest(ApiKeys apiKey, short apiVersion) {
+        if (state instanceof State.Authenticated authenticated && authenticated.sessionExpiry() == null) {
+            return switch (apiKey) {
+                case API_VERSIONS, SASL_HANDSHAKE, SASL_AUTHENTICATE, CREATE_DELEGATION_TOKEN, RENEW_DELEGATION_TOKEN, EXPIRE_DELEGATION_TOKEN, DESCRIBE_DELEGATION_TOKEN -> true;
+                default -> false;
+            };
+        }
+        return true;
+    }
+
+    @Override
+    public CompletionStage<RequestFilterResult> onRequest(
+                                                          ApiKeys apiKey,
+                                                          short apiVersion,
+                                                          RequestHeaderData header,
+                                                          ApiMessage request,
+                                                          FilterContext filterContext) {
+
+        return switch (apiKey) {
+            case API_VERSIONS -> filterContext.forwardRequest(header, request);
+            case SASL_HANDSHAKE -> {
+                if (isUnsupportedApiVersion(ApiKeys.SASL_HANDSHAKE, apiVersion)) {
+                    yield rejectUnsupportedVersionAndClose(header, request, apiKey, apiVersion, filterContext);
+                }
+                yield onSaslHandshakeRequest((SaslHandshakeRequestData) request, filterContext);
+            }
+            case SASL_AUTHENTICATE -> {
+                if (isUnsupportedApiVersion(ApiKeys.SASL_AUTHENTICATE, apiVersion)) {
+                    yield rejectUnsupportedVersionAndClose(header, request, apiKey, apiVersion, filterContext);
+                }
+                yield onSaslAuthenticateRequest((SaslAuthenticateRequestData) request, filterContext);
+            }
+            case CREATE_DELEGATION_TOKEN, RENEW_DELEGATION_TOKEN, EXPIRE_DELEGATION_TOKEN, DESCRIBE_DELEGATION_TOKEN -> rejectUnsupportedApi(header, request, apiKey,
+                    "Delegation tokens are not supported when SASL is terminated at the proxy", filterContext);
+            default -> handleDefaultRequest(header, request, filterContext);
+        };
+    }
+
+    @Override
+    public CompletionStage<ResponseFilterResult> onApiVersionsResponse(short apiVersion, ResponseHeaderData header,
+                                                                       ApiVersionsResponseData response, FilterContext context) {
+        response.apiKeys().removeIf(apiVersion1 -> FILTERED_API_KEYS.contains(apiVersion1.apiKey()));
+        return context.forwardResponse(header, response);
+    }
+
+    private CompletionStage<RequestFilterResult> onSaslHandshakeRequest(
+                                                                        SaslHandshakeRequestData request,
+                                                                        FilterContext filterContext) {
+
+        if (!(state instanceof State.RequiringHandshake) && !(state instanceof State.Authenticated)) {
+            LOGGER.atWarn()
+                    .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                    .addKeyValue(LOG_KEY_STATE, state)
+                    .log("Received SASL handshake in unexpected state");
+            return filterContext.requestFilterResultBuilder()
+                    .shortCircuitResponse(new SaslHandshakeResponseData()
+                            .setErrorCode(Errors.ILLEGAL_SASL_STATE.code())
+                            .setMechanisms(List.of()))
+                    .completed();
+        }
+
+        String mechanism = request.mechanism();
+        Errors errorCode;
+        List<String> supportedMechanisms;
+
+        MechanismStateMachine stateMachine = createStateMachine(mechanism);
+        if (stateMachine != null) {
+            long authStartNanos = System.nanoTime();
+            if (state instanceof State.RequiringHandshake handshake) {
+                state = handshake.nextState(stateMachine, authStartNanos);
+            }
+            else if (state instanceof State.Authenticated authenticated) {
+                LOGGER.atDebug()
+                        .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                        .addKeyValue(LOG_KEY_MECHANISM, mechanism)
+                        .log("Reauthentication initiated");
+                state = authenticated.nextStateReauthenticate(stateMachine, authStartNanos);
+            }
+
+            errorCode = Errors.NONE;
+            supportedMechanisms = List.of();
+        }
+        else {
+            LOGGER.atDebug()
+                    .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                    .addKeyValue(LOG_KEY_MECHANISM, mechanism)
+                    .log("Unsupported mechanism");
+            errorCode = Errors.UNSUPPORTED_SASL_MECHANISM;
+            supportedMechanisms = List.copyOf(context.supportedMechanisms());
+        }
+
+        return filterContext.requestFilterResultBuilder()
+                .shortCircuitResponse(new SaslHandshakeResponseData()
+                        .setErrorCode(errorCode.code())
+                        .setMechanisms(supportedMechanisms))
+                .completed();
+    }
+
+    @Nullable
+    private MechanismStateMachine createStateMachine(String mechanism) {
+        if (!context.supportedMechanisms().contains(mechanism)) {
+            return null;
+        }
+        return switch (mechanism) {
+            case "OAUTHBEARER" -> new OauthBearerStateMachine(Objects.requireNonNull(context.oauthCallbackHandler()),
+                    context.clock());
+            default -> throw new IllegalStateException("No state machine for configured mechanism: " + mechanism);
+        };
+    }
+
+    private CompletionStage<RequestFilterResult> onSaslAuthenticateRequest(
+                                                                           SaslAuthenticateRequestData request,
+                                                                           FilterContext filterContext) {
+
+        if (!(state instanceof State.RequiringAuthenticate authenticating)) {
+            LOGGER.atWarn()
+                    .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                    .addKeyValue(LOG_KEY_STATE, state)
+                    .log("Received SASL authenticate in unexpected state");
+            return filterContext.requestFilterResultBuilder()
+                    .shortCircuitResponse(new SaslAuthenticateResponseData()
+                            .setErrorCode(Errors.ILLEGAL_SASL_STATE.code())
+                            .setErrorMessage("Authentication not in progress")
+                            .setAuthBytes(new byte[0]))
+                    .completed();
+        }
+
+        MechanismStateMachine stateMachine = authenticating.mechanismStateMachine();
+
+        int maxAuthBytes = stateMachine.maxAuthBytes();
+        if (request.authBytes().length > maxAuthBytes) {
+            LOGGER.atWarn()
+                    .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                    .addKeyValue(LOG_KEY_MECHANISM, stateMachine.mechanismName())
+                    .addKeyValue("payloadSize", request.authBytes().length)
+                    .addKeyValue("maxPayloadSize", maxAuthBytes)
+                    .log("Rejecting oversized SASL authenticate payload");
+            return handleAuthenticationFailure(
+                    stateMachine, filterContext, new InvalidRequestException("Authentication payload exceeds maximum size"));
+        }
+
+        Instant authRoundStart = clock.instant();
+        return stateMachine.evaluateRound(request.authBytes())
+                .thenCompose(result -> applyFixedAuthDelay(result, authRoundStart, stateMachine.mechanismName()))
+                .thenCompose(result -> processRoundResult(result, stateMachine, filterContext))
+                .exceptionallyCompose(throwable -> {
+                    LOGGER.atError()
+                            .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                            .setCause(throwable)
+                            .log("Authentication error");
+                    Exception exception = throwable instanceof Exception e ? e : new RuntimeException(throwable);
+                    return handleAuthenticationFailure(stateMachine, filterContext, exception);
+                });
+    }
+
+    private CompletionStage<RequestFilterResult> processRoundResult(
+                                                                    RoundResult result,
+                                                                    MechanismStateMachine stateMachine,
+                                                                    FilterContext filterContext) {
+
+        return switch (result) {
+            case RoundResult.Challenge challenge -> handleChallenge(filterContext, challenge);
+            case RoundResult.Success success -> handleSuccess(stateMachine, filterContext, success);
+            case RoundResult.Failure failure -> handleAuthenticationFailure(stateMachine, filterContext, failure.exception());
+        };
+    }
+
+    @NonNull
+    private CompletionStage<RequestFilterResult> handleSuccess(MechanismStateMachine stateMachine, FilterContext filterContext,
+                                                               RoundResult.Success success) {
+        String authorizationId = success.authorizationId();
+        String mechanism = stateMachine.mechanismName();
+        LOGGER.atDebug()
+                .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_MECHANISM, stateMachine.mechanismName())
+                .addKeyValue("authorizationId", authorizationId)
+                .log("Authentication successful");
+
+        long sessionLifetimeMs = computeSessionLifetimeMs(success.sessionLifetimeMs());
+        @Nullable
+        Instant sessionExpiry = sessionLifetimeMs > 0 ? clock.instant().plusMillis(sessionLifetimeMs) : null;
+
+        if (state instanceof State.RequiringAuthenticate authenticating) {
+            recordAuthDuration(mechanism, authenticating.authStartNanos());
+            state = authenticating.nextStateSuccess(authorizationId, mechanism, sessionExpiry);
+        }
+
+        stateMachine.dispose();
+
+        SaslSubjectBuilder.Context subjectContext = new SaslSubjectBuilder.Context() {
+            @Override
+            public Optional<ClientTlsContext> clientTlsContext() {
+                return filterContext.clientTlsContext();
+            }
+
+            @Override
+            public ClientSaslContext clientSaslContext() {
+                return new ClientSaslContext() {
+                    @Override
+                    public String mechanismName() {
+                        return mechanism;
+                    }
+
+                    @Override
+                    public String authorizationId() {
+                        return authorizationId;
+                    }
+                };
+            }
+        };
+
+        return subjectBuilder.buildSaslSubject(subjectContext)
+                .thenCompose(subject -> {
+                    filterContext.clientSaslAuthenticationSuccess(mechanism, subject);
+                    return filterContext.requestFilterResultBuilder()
+                            .shortCircuitResponse(new SaslAuthenticateResponseData()
+                                    .setErrorCode(Errors.NONE.code())
+                                    .setAuthBytes(success.responseBytes())
+                                    .setSessionLifetimeMs(sessionLifetimeMs))
+                            .completed();
+                });
+    }
+
+    @NonNull
+    private CompletionStage<RequestFilterResult> handleChallenge(FilterContext filterContext, RoundResult.Challenge challenge) {
+        if (state instanceof State.RequiringAuthenticate authenticating) {
+            state = authenticating.nextStateChallenge();
+        }
+
+        return filterContext.requestFilterResultBuilder()
+                .shortCircuitResponse(new SaslAuthenticateResponseData()
+                        .setErrorCode(Errors.NONE.code())
+                        .setAuthBytes(challenge.responseBytes()))
+                .completed();
+    }
+
+    /**
+     * Compute the effective session lifetime as the minimum of the configured
+     * maximum and the mechanism-reported lifetime (KIP-368).
+     */
+    private long computeSessionLifetimeMs(long handlerLifetimeMs) {
+        if (maxTimeBeforeReauthMs > 0 && handlerLifetimeMs > 0) {
+            return Math.min(maxTimeBeforeReauthMs, handlerLifetimeMs);
+        }
+        return Math.max(maxTimeBeforeReauthMs, handlerLifetimeMs);
+    }
+
+    private CompletionStage<RequestFilterResult> handleAuthenticationFailure(
+                                                                             MechanismStateMachine stateMachine, FilterContext filterContext, Exception exception) {
+        LOGGER.atDebug()
+                .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue(LOG_KEY_ERROR, exception.getMessage())
+                .log("Authentication failed");
+
+        if (state instanceof State.RequiringAuthenticate authenticating) {
+            recordAuthDuration(stateMachine.mechanismName(), authenticating.authStartNanos());
+            state = authenticating.nextStateFailure(exception.getMessage());
+        }
+
+        stateMachine.dispose();
+
+        filterContext.clientSaslAuthenticationFailure(stateMachine.mechanismName(), null, exception);
+
+        return filterContext.requestFilterResultBuilder()
+                .shortCircuitResponse(new SaslAuthenticateResponseData()
+                        .setErrorCode(Errors.SASL_AUTHENTICATION_FAILED.code())
+                        .setErrorMessage("Authentication failed")
+                        .setAuthBytes(new byte[0]))
+                .withCloseConnection()
+                .completed();
+    }
+
+    private CompletionStage<RequestFilterResult> handleDefaultRequest(
+                                                                      RequestHeaderData header,
+                                                                      ApiMessage request,
+                                                                      FilterContext filterContext) {
+
+        if (state instanceof State.Authenticated authenticated) {
+            Instant expiry = authenticated.sessionExpiry();
+            if (expiry != null && clock.instant().isAfter(expiry)) {
+                Counter.builder(SESSION_EXPIRED_METRIC)
+                        .tag(MECHANISM_TAG, authenticated.mechanismName())
+                        .register(Metrics.globalRegistry)
+                        .increment();
+                LOGGER.atDebug()
+                        .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                        .addKeyValue("sessionExpiry", expiry)
+                        .log("Session expired, rejecting request");
+                return filterContext.requestFilterResultBuilder()
+                        .errorResponse(header, request, Errors.SASL_AUTHENTICATION_FAILED.exception())
+                        .withCloseConnection()
+                        .completed();
+            }
+            return filterContext.forwardRequest(header, request);
+        }
+        else {
+            LOGGER.atDebug()
+                    .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                    .addKeyValue("requestType", request.getClass().getSimpleName())
+                    .log("Rejecting unauthenticated request");
+
+            return filterContext.requestFilterResultBuilder()
+                    .errorResponse(header, request, Errors.SASL_AUTHENTICATION_FAILED.exception())
+                    .withCloseConnection()
+                    .completed();
+        }
+    }
+
+    private static CompletionStage<RequestFilterResult> rejectUnsupportedApi(
+                                                                             RequestHeaderData header,
+                                                                             ApiMessage request,
+                                                                             ApiKeys apiKey,
+                                                                             String reason,
+                                                                             FilterContext filterContext) {
+        LOGGER.atDebug()
+                .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue("apiKey", apiKey)
+                .addKeyValue("reason", reason)
+                .log("Rejecting unsupported API request");
+        return filterContext.requestFilterResultBuilder()
+                .errorResponse(header, request, Errors.UNSUPPORTED_VERSION.exception(reason))
+                .completed();
+    }
+
+    private CompletionStage<RoundResult> applyFixedAuthDelay(RoundResult result, Instant start, String mechanismName) {
+        Duration fixedAuthDelay = context.fixedAuthDelay();
+        if (fixedAuthDelay.isZero()) {
+            return CompletableFuture.completedFuture(result);
+        }
+        Duration elapsed = Duration.between(start, clock.instant());
+        if (elapsed.compareTo(fixedAuthDelay) > 0) {
+            LOGGER.atWarn()
+                    .addKeyValue(LOG_KEY_MECHANISM, mechanismName)
+                    .addKeyValue("elapsed", elapsed)
+                    .addKeyValue("fixedAuthDelay", fixedAuthDelay)
+                    .log("Authentication took longer than fixedAuthDelay, consider increasing fixedAuthDelay");
+        }
+        return delayUntil(start.plus(fixedAuthDelay), result);
+    }
+
+    private CompletionStage<RoundResult> delayUntil(Instant deadline, RoundResult result) {
+        long remainingMs = Duration.between(clock.instant(), deadline).toMillis();
+        if (remainingMs <= 0) {
+            return CompletableFuture.completedFuture(result);
+        }
+        CompletableFuture<RoundResult> future = new CompletableFuture<>();
+        executorService.schedule(() -> {
+            future.complete(result);
+        }, remainingMs, TimeUnit.MILLISECONDS);
+        return future;
+    }
+
+    private static void recordAuthDuration(String mechanism, long authStartNanos) {
+        long durationNanos = System.nanoTime() - authStartNanos;
+        Timer.builder(AUTH_DURATION_METRIC)
+                .tag(MECHANISM_TAG, mechanism)
+                .register(Metrics.globalRegistry)
+                .record(durationNanos, TimeUnit.NANOSECONDS);
+    }
+
+    private static boolean isUnsupportedApiVersion(ApiKeys apiKey, short apiVersion) {
+        return apiVersion < apiKey.oldestVersion() || apiVersion > apiKey.latestVersion();
+    }
+
+    private CompletionStage<RequestFilterResult> rejectUnsupportedVersionAndClose(
+                                                                                  RequestHeaderData header,
+                                                                                  ApiMessage request,
+                                                                                  ApiKeys apiKey,
+                                                                                  short apiVersion,
+                                                                                  FilterContext filterContext) {
+        LOGGER.atWarn()
+                .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                .addKeyValue("apiKey", apiKey)
+                .addKeyValue("apiVersion", apiVersion)
+                .log("Rejecting SASL request with unsupported API version");
+        return filterContext.requestFilterResultBuilder()
+                .errorResponse(header, request, Errors.UNSUPPORTED_VERSION.exception())
+                .withCloseConnection()
+                .completed();
+    }
+}

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -69,7 +69,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * During authentication, the mechanism-specific transition logic is provided by a
  * {@link MechanismStateMachine}.</p>
  */
-public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter {
+class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SaslTerminationFilter.class);
 

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -171,8 +171,6 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
         }
 
         String mechanism = request.mechanism();
-        Errors errorCode;
-        List<String> supportedMechanisms;
 
         MechanismStateMachine stateMachine = createStateMachine(mechanism);
         if (stateMachine != null) {
@@ -188,23 +186,24 @@ public class SaslTerminationFilter implements RequestFilter, ApiVersionsResponse
                 state = authenticated.nextStateReauthenticate(stateMachine, authStartNanos);
             }
 
-            errorCode = Errors.NONE;
-            supportedMechanisms = List.of();
+            return filterContext.requestFilterResultBuilder()
+                    .shortCircuitResponse(new SaslHandshakeResponseData()
+                            .setErrorCode(Errors.NONE.code())
+                            .setMechanisms(List.of()))
+                    .completed();
         }
         else {
             LOGGER.atDebug()
                     .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
                     .addKeyValue(LOG_KEY_MECHANISM, mechanism)
                     .log("Unsupported mechanism");
-            errorCode = Errors.UNSUPPORTED_SASL_MECHANISM;
-            supportedMechanisms = List.copyOf(context.supportedMechanisms());
+            return filterContext.requestFilterResultBuilder()
+                    .shortCircuitResponse(new SaslHandshakeResponseData()
+                            .setErrorCode(Errors.UNSUPPORTED_SASL_MECHANISM.code())
+                            .setMechanisms(List.copyOf(context.supportedMechanisms())))
+                    .withCloseConnection()
+                    .completed();
         }
-
-        return filterContext.requestFilterResultBuilder()
-                .shortCircuitResponse(new SaslHandshakeResponseData()
-                        .setErrorCode(errorCode.code())
-                        .setMechanisms(supportedMechanisms))
-                .completed();
     }
 
     @Nullable

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -337,8 +337,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                 .addKeyValue("authorizationId", authorizationId)
                 .log("Credential validation successful");
 
-        long sessionLifetimeMs = computeSessionLifetimeMs(success.sessionLifetimeMs());
-        Instant sessionExpiry = sessionLifetimeMs > 0 ? clock.instant().plusMillis(sessionLifetimeMs) : null;
+        Instant sessionExpiry = computeSessionExpiry(success.sessionExpiry());
 
         String previousAuthorizationId = authenticating.previousAuthorizationId();
         if (previousAuthorizationId != null
@@ -355,12 +354,13 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
         stateMachine.dispose();
 
         return subjectBuilder.buildSaslSubject(new SubjectContext(filterContext, mechanism, authorizationId))
-                .thenCompose(subject -> acceptAuthenticateDone(filterContext,
+                .thenCompose(subject -> completeSubjectBuild(stateMachine,
+                        filterContext,
                         success,
                         subject,
                         mechanism,
                         reauthentication,
-                        sessionLifetimeMs,
+                        sessionExpiry,
                         authDuration))
                 .exceptionallyCompose(throwable -> rejectAuthenticateInternalError(stateMachine,
                         filterContext,
@@ -381,14 +381,34 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                 new SaslAuthenticationException("Reauthentication failed: authorization identity changed"));
     }
 
+    private CompletionStage<RequestFilterResult> completeSubjectBuild(MechanismStateMachine stateMachine,
+                                                                      FilterContext filterContext,
+                                                                      RoundResult.Success success,
+                                                                      Subject subject,
+                                                                      String mechanism,
+                                                                      boolean reauthentication,
+                                                                      @Nullable Instant sessionExpiry,
+                                                                      Duration authDuration) {
+        recordAuthDuration(mechanism, filterContext.getVirtualClusterName(), authDuration);
+
+        if (sessionExpiry != null && !clock.instant().isBefore(sessionExpiry)) {
+            LOGGER.atWarn()
+                    .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
+                    .addKeyValue(LOG_KEY_MECHANISM, mechanism)
+                    .log("Token expired during authentication");
+            return rejectAuthenticateAndClose(stateMachine, filterContext,
+                    new SaslAuthenticationException("Token expired during authentication"));
+        }
+
+        return acceptAuthenticateDone(filterContext, success, subject, mechanism, reauthentication, sessionExpiry);
+    }
+
     private CompletionStage<RequestFilterResult> acceptAuthenticateDone(FilterContext filterContext,
                                                                         RoundResult.Success success,
                                                                         Subject subject,
                                                                         String mechanism,
                                                                         boolean reauthentication,
-                                                                        long sessionLifetimeMs,
-                                                                        Duration authDuration) {
-        recordAuthDuration(mechanism, filterContext.getVirtualClusterName(), authDuration);
+                                                                        @Nullable Instant sessionExpiry) {
         String authorizationId = success.authorizationId();
         LOGGER.atDebug()
                 .addKeyValue(LOG_KEY_SESSION_ID, filterContext.sessionId())
@@ -399,6 +419,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
 
         filterContext.clientSaslAuthenticationSuccess(mechanism, subject);
 
+        long sessionLifetimeMs = sessionExpiry != null ? Duration.between(clock.instant(), sessionExpiry).toMillis() : 0;
         return filterContext.requestFilterResultBuilder()
                 .shortCircuitResponse(new SaslAuthenticateResponseData()
                         .setErrorCode(Errors.NONE.code())
@@ -436,15 +457,17 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
     }
 
     /**
-     * Compute the effective session lifetime as the minimum of the configured
-     * maximum and the mechanism-reported lifetime (KIP-368).
+     * Compute the effective session expiry as the earlier of the configured
+     * maximum reauth time and the mechanism-reported expiry (KIP-368).
      */
     @VisibleForTesting
-    long computeSessionLifetimeMs(long handlerLifetimeMs) {
-        if (maxTimeBeforeReauthMs > 0 && handlerLifetimeMs > 0) {
-            return Math.min(maxTimeBeforeReauthMs, handlerLifetimeMs);
+    @Nullable
+    Instant computeSessionExpiry(@Nullable Instant mechanismExpiry) {
+        Instant maxReauthExpiry = maxTimeBeforeReauthMs > 0 ? clock.instant().plusMillis(maxTimeBeforeReauthMs) : null;
+        if (maxReauthExpiry != null && mechanismExpiry != null) {
+            return maxReauthExpiry.isBefore(mechanismExpiry) ? maxReauthExpiry : mechanismExpiry;
         }
-        return Math.max(maxTimeBeforeReauthMs, handlerLifetimeMs);
+        return maxReauthExpiry != null ? maxReauthExpiry : mechanismExpiry;
     }
 
     private CompletionStage<RequestFilterResult> rejectAuthenticateMechanismFailed(

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -256,7 +256,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
         }
         return switch (mechanism) {
             case OauthBearerMechanismConfig.MECHANISM_NAME -> new OauthBearerStateMachine(Objects.requireNonNull(context.oauthCallbackHandler()),
-                    context.clock(), context.oauthMaxAuthBytes());
+                    context.oauthMaxAuthBytes());
             default -> throw new IllegalStateException("No state machine for configured mechanism: " + mechanism);
         };
     }

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/State.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/State.java
@@ -112,7 +112,7 @@ sealed interface State permits State.RequiringHandshake, State.RequiringAuthenti
          * @param authStartNanos the {@link System#nanoTime()} when authentication started
          * @return the requiring authenticate state
          */
-        public RequiringAuthenticate nextState(MechanismStateMachine mechanismStateMachine, long authStartNanos) {
+        RequiringAuthenticate nextState(MechanismStateMachine mechanismStateMachine, long authStartNanos) {
             return new RequiringAuthenticate(mechanismStateMachine, authStartNanos, null);
         }
 
@@ -146,7 +146,7 @@ sealed interface State permits State.RequiringHandshake, State.RequiringAuthenti
          *
          * @return the mechanism state machine
          */
-        public MechanismStateMachine mechanismStateMachine() {
+        MechanismStateMachine mechanismStateMachine() {
             return mechanismStateMachine;
         }
 
@@ -266,7 +266,7 @@ sealed interface State permits State.RequiringHandshake, State.RequiringAuthenti
          * @param authStartNanos the {@link System#nanoTime()} when reauthentication started
          * @return the requiring authenticate state
          */
-        public RequiringAuthenticate nextStateReauthenticate(MechanismStateMachine mechanismStateMachine, long authStartNanos) {
+        RequiringAuthenticate nextStateReauthenticate(MechanismStateMachine mechanismStateMachine, long authStartNanos) {
             return new RequiringAuthenticate(mechanismStateMachine, authStartNanos, authorizationId);
         }
 

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/State.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/State.java
@@ -109,11 +109,10 @@ sealed interface State permits State.RequiringHandshake, State.RequiringAuthenti
          * Transition to the next state after receiving handshake request.
          *
          * @param mechanismStateMachine the state machine for the negotiated mechanism
-         * @param authStartNanos the {@link System#nanoTime()} when authentication started
          * @return the requiring authenticate state
          */
-        RequiringAuthenticate nextState(MechanismStateMachine mechanismStateMachine, long authStartNanos) {
-            return new RequiringAuthenticate(mechanismStateMachine, authStartNanos, null);
+        RequiringAuthenticate nextState(MechanismStateMachine mechanismStateMachine) {
+            return new RequiringAuthenticate(mechanismStateMachine, null);
         }
 
         @Override
@@ -131,13 +130,12 @@ sealed interface State permits State.RequiringHandshake, State.RequiringAuthenti
     final class RequiringAuthenticate implements State {
 
         private final MechanismStateMachine mechanismStateMachine;
-        private final long authStartNanos;
+        private long accumulatedAuthWorkNanos;
         @Nullable
         private final String previousAuthorizationId;
 
-        private RequiringAuthenticate(MechanismStateMachine mechanismStateMachine, long authStartNanos, @Nullable String previousAuthorizationId) {
+        private RequiringAuthenticate(MechanismStateMachine mechanismStateMachine, @Nullable String previousAuthorizationId) {
             this.mechanismStateMachine = mechanismStateMachine;
-            this.authStartNanos = authStartNanos;
             this.previousAuthorizationId = previousAuthorizationId;
         }
 
@@ -151,12 +149,21 @@ sealed interface State permits State.RequiringHandshake, State.RequiringAuthenti
         }
 
         /**
-         * Get the {@link System#nanoTime()} when authentication started.
+         * Add the duration of an {@code evaluateRound()} call to the accumulated authentication work time.
          *
-         * @return the auth start time in nanos
+         * @param nanos the duration in nanoseconds
          */
-        public long authStartNanos() {
-            return authStartNanos;
+        void addRoundDuration(long nanos) {
+            accumulatedAuthWorkNanos += nanos;
+        }
+
+        /**
+         * Get the total time spent in {@code evaluateRound()} calls across all rounds.
+         *
+         * @return accumulated authentication work time in nanoseconds
+         */
+        long accumulatedAuthWorkNanos() {
+            return accumulatedAuthWorkNanos;
         }
 
         /**
@@ -263,11 +270,10 @@ sealed interface State permits State.RequiringHandshake, State.RequiringAuthenti
          * Transition to reauthentication after receiving a new SASL handshake.
          *
          * @param mechanismStateMachine the state machine for the new authentication session
-         * @param authStartNanos the {@link System#nanoTime()} when reauthentication started
          * @return the requiring authenticate state
          */
-        RequiringAuthenticate nextStateReauthenticate(MechanismStateMachine mechanismStateMachine, long authStartNanos) {
-            return new RequiringAuthenticate(mechanismStateMachine, authStartNanos, authorizationId);
+        RequiringAuthenticate nextStateReauthenticate(MechanismStateMachine mechanismStateMachine) {
+            return new RequiringAuthenticate(mechanismStateMachine, authorizationId);
         }
 
         @Override

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/State.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/State.java
@@ -44,8 +44,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  *         is required to negotiate the mechanism.</li>
  *     <li><strong>RequiringAuthenticate</strong> - Handshake complete. Waiting for
  *         authentication request(s). May loop for multi-round mechanisms like SCRAM.</li>
- *     <li><strong>Authenticated</strong> - Terminal state. Authentication succeeded.
- *         Client may now send other Kafka requests.</li>
+ *     <li><strong>Authenticated</strong> - Authentication succeeded.
+ *         Client may now send other Kafka requests. Not terminal: reauthentication (KIP-368) is permitted.</li>
  *     <li><strong>Failed</strong> - Terminal state. Authentication failed. Connection
  *         should be closed.</li>
  * </ul>
@@ -89,9 +89,9 @@ sealed interface State permits State.RequiringHandshake, State.RequiringAuthenti
     }
 
     /**
-     * Check if in a terminal state (success or failure).
+     * Check if in a terminal (failure) state.
      *
-     * @return true if authenticated or failed
+     * @return true if in the Failed state
      */
     default boolean isTerminal() {
         return isFailed();
@@ -113,7 +113,7 @@ sealed interface State permits State.RequiringHandshake, State.RequiringAuthenti
          * @return the requiring authenticate state
          */
         public RequiringAuthenticate nextState(MechanismStateMachine mechanismStateMachine, long authStartNanos) {
-            return new RequiringAuthenticate(mechanismStateMachine, authStartNanos);
+            return new RequiringAuthenticate(mechanismStateMachine, authStartNanos, null);
         }
 
         @Override
@@ -132,10 +132,13 @@ sealed interface State permits State.RequiringHandshake, State.RequiringAuthenti
 
         private final MechanismStateMachine mechanismStateMachine;
         private final long authStartNanos;
+        @Nullable
+        private final String previousAuthorizationId;
 
-        private RequiringAuthenticate(MechanismStateMachine mechanismStateMachine, long authStartNanos) {
+        private RequiringAuthenticate(MechanismStateMachine mechanismStateMachine, long authStartNanos, @Nullable String previousAuthorizationId) {
             this.mechanismStateMachine = mechanismStateMachine;
             this.authStartNanos = authStartNanos;
+            this.previousAuthorizationId = previousAuthorizationId;
         }
 
         /**
@@ -154,6 +157,16 @@ sealed interface State permits State.RequiringHandshake, State.RequiringAuthenti
          */
         public long authStartNanos() {
             return authStartNanos;
+        }
+
+        /**
+         * Get the authorization ID from the previous authentication, if this is a reauthentication.
+         *
+         * @return the previous authorization ID, or null if this is an initial authentication
+         */
+        @Nullable
+        public String previousAuthorizationId() {
+            return previousAuthorizationId;
         }
 
         /**
@@ -199,6 +212,10 @@ sealed interface State permits State.RequiringHandshake, State.RequiringAuthenti
     /**
      * Authentication succeeded. Allows reauthentication (KIP-368) by
      * transitioning back to {@link RequiringAuthenticate}.
+     * Note that {@link Authenticated} is never truly terminal in the state machine sense.
+     * The reauthentication transition is allowed unconditionally, because even when
+     * {@link SaslTerminationConfig#maxTimeBeforeReauth()} is null or zero a client is
+     * free to reauthenticate voluntarily.
      */
     final class Authenticated implements State {
 
@@ -250,7 +267,7 @@ sealed interface State permits State.RequiringHandshake, State.RequiringAuthenti
          * @return the requiring authenticate state
          */
         public RequiringAuthenticate nextStateReauthenticate(MechanismStateMachine mechanismStateMachine, long authStartNanos) {
-            return new RequiringAuthenticate(mechanismStateMachine, authStartNanos);
+            return new RequiringAuthenticate(mechanismStateMachine, authStartNanos, authorizationId);
         }
 
         @Override

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/State.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/State.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.sasl.termination;
+
+import java.time.Instant;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * States of the {@link SaslTerminationFilter} state machine.
+ * <p>
+ * The filter authenticates clients before allowing other Kafka requests.
+ * Transitions between states are driven by Kafka protocol messages
+ * ({@code SaslHandshake} and {@code SaslAuthenticate} requests).
+ * While in {@link RequiringAuthenticate}, the mechanism-specific logic is
+ * delegated to a {@link MechanismStateMachine}, whose {@link RoundResult}
+ * determines the next state transition.
+ * </p>
+ *
+ * <h2>State Diagram</h2>
+ * <pre><code>
+ * START ──→ RequiringHandshake
+ *                   │
+ *                   ↓
+ *          RequiringAuthenticate ←────╮
+ *                   │                 │
+ *                   ├─ (multi-round) ─╯
+ *                   │
+ *                   ├──→ Authenticated ──→ (reauth) ──→ RequiringAuthenticate
+ *                   │         │
+ *                   │         └──→ (expired + non-SASL request) ──→ reject &amp; close
+ *                   │
+ *                   └──→ Failed (terminal, failure)
+ * </code></pre>
+ *
+ * <h2>State Descriptions</h2>
+ * <ul>
+ *     <li><strong>RequiringHandshake</strong> - Initial state. A SASL handshake request
+ *         is required to negotiate the mechanism.</li>
+ *     <li><strong>RequiringAuthenticate</strong> - Handshake complete. Waiting for
+ *         authentication request(s). May loop for multi-round mechanisms like SCRAM.</li>
+ *     <li><strong>Authenticated</strong> - Terminal state. Authentication succeeded.
+ *         Client may now send other Kafka requests.</li>
+ *     <li><strong>Failed</strong> - Terminal state. Authentication failed. Connection
+ *         should be closed.</li>
+ * </ul>
+ *
+ * <h2>Security Barrier</h2>
+ * <p>
+ * Only {@link Authenticated} state allows non-SASL Kafka requests. All other states
+ * must reject such requests with {@code SASL_AUTHENTICATION_FAILED} and close the connection.
+ * </p>
+ * <p>
+ * {@code API_VERSIONS} requests are always allowed (clients need to discover capabilities).
+ * </p>
+ */
+sealed interface State permits State.RequiringHandshake, State.RequiringAuthenticate, State.Authenticated, State.Failed {
+
+    /**
+     * Create the initial state.
+     *
+     * @return the requiring handshake state
+     */
+    static RequiringHandshake start() {
+        return new RequiringHandshake();
+    }
+
+    /**
+     * Check if authentication has completed successfully.
+     *
+     * @return true if in the Authenticated state
+     */
+    default boolean isAuthenticated() {
+        return this instanceof Authenticated;
+    }
+
+    /**
+     * Check if authentication has failed.
+     *
+     * @return true if in the Failed state
+     */
+    default boolean isFailed() {
+        return this instanceof Failed;
+    }
+
+    /**
+     * Check if in a terminal state (success or failure).
+     *
+     * @return true if authenticated or failed
+     */
+    default boolean isTerminal() {
+        return isFailed();
+    }
+
+    /**
+     * Initial state - waiting for SASL handshake request.
+     */
+    final class RequiringHandshake implements State {
+
+        private RequiringHandshake() {
+        }
+
+        /**
+         * Transition to the next state after receiving handshake request.
+         *
+         * @param mechanismStateMachine the state machine for the negotiated mechanism
+         * @param authStartNanos the {@link System#nanoTime()} when authentication started
+         * @return the requiring authenticate state
+         */
+        public RequiringAuthenticate nextState(MechanismStateMachine mechanismStateMachine, long authStartNanos) {
+            return new RequiringAuthenticate(mechanismStateMachine, authStartNanos);
+        }
+
+        @Override
+        public String toString() {
+            return "RequiringHandshake";
+        }
+    }
+
+    /**
+     * Waiting for SASL authenticate request.
+     * <p>
+     * May loop back to this state for multi-round mechanisms (SCRAM).
+     * </p>
+     */
+    final class RequiringAuthenticate implements State {
+
+        private final MechanismStateMachine mechanismStateMachine;
+        private final long authStartNanos;
+
+        private RequiringAuthenticate(MechanismStateMachine mechanismStateMachine, long authStartNanos) {
+            this.mechanismStateMachine = mechanismStateMachine;
+            this.authStartNanos = authStartNanos;
+        }
+
+        /**
+         * Get the mechanism state machine for this authentication session.
+         *
+         * @return the mechanism state machine
+         */
+        public MechanismStateMachine mechanismStateMachine() {
+            return mechanismStateMachine;
+        }
+
+        /**
+         * Get the {@link System#nanoTime()} when authentication started.
+         *
+         * @return the auth start time in nanos
+         */
+        public long authStartNanos() {
+            return authStartNanos;
+        }
+
+        /**
+         * Transition to the next state after a challenge round.
+         * <p>
+         * Used for multi-round mechanisms that require additional exchanges.
+         * </p>
+         *
+         * @return a new requiring authenticate state (loop)
+         */
+        public RequiringAuthenticate nextStateChallenge() {
+            return this; // Stay in same state for next round
+        }
+
+        /**
+         * Transition to authenticated state after successful authentication.
+         *
+         * @param authorizationId the authenticated user's authorization ID
+         * @param mechanismName the name of the mechanism used for authentication
+         * @param sessionExpiry when the session expires, or null if no expiry
+         * @return the authenticated state
+         */
+        public Authenticated nextStateSuccess(String authorizationId, String mechanismName, @Nullable Instant sessionExpiry) {
+            return new Authenticated(authorizationId, mechanismName, sessionExpiry);
+        }
+
+        /**
+         * Transition to failed state after authentication failure.
+         *
+         * @param errorMessage the error message
+         * @return the failed state
+         */
+        public Failed nextStateFailure(String errorMessage) {
+            return new Failed(errorMessage);
+        }
+
+        @Override
+        public String toString() {
+            return "RequiringAuthenticate{mechanism=" + mechanismStateMachine.mechanismName() + "}";
+        }
+    }
+
+    /**
+     * Authentication succeeded. Allows reauthentication (KIP-368) by
+     * transitioning back to {@link RequiringAuthenticate}.
+     */
+    final class Authenticated implements State {
+
+        private final String authorizationId;
+        private final String mechanismName;
+
+        @Nullable
+        private final Instant sessionExpiry;
+
+        private Authenticated(String authorizationId, String mechanismName, @Nullable Instant sessionExpiry) {
+            this.authorizationId = authorizationId;
+            this.mechanismName = mechanismName;
+            this.sessionExpiry = sessionExpiry;
+        }
+
+        /**
+         * Get the authenticated user's authorization ID.
+         *
+         * @return the authorization ID
+         */
+        public String authorizationId() {
+            return authorizationId;
+        }
+
+        /**
+         * Get the mechanism used for authentication.
+         *
+         * @return the mechanism name
+         */
+        public String mechanismName() {
+            return mechanismName;
+        }
+
+        /**
+         * Get the session expiry time.
+         *
+         * @return the session expiry instant, or null if no expiry
+         */
+        @Nullable
+        public Instant sessionExpiry() {
+            return sessionExpiry;
+        }
+
+        /**
+         * Transition to reauthentication after receiving a new SASL handshake.
+         *
+         * @param mechanismStateMachine the state machine for the new authentication session
+         * @param authStartNanos the {@link System#nanoTime()} when reauthentication started
+         * @return the requiring authenticate state
+         */
+        public RequiringAuthenticate nextStateReauthenticate(MechanismStateMachine mechanismStateMachine, long authStartNanos) {
+            return new RequiringAuthenticate(mechanismStateMachine, authStartNanos);
+        }
+
+        @Override
+        public String toString() {
+            return "Authenticated{user=" + authorizationId + ", sessionExpiry=" + sessionExpiry + "}";
+        }
+    }
+
+    /**
+     * Terminal state - authentication failed.
+     */
+    final class Failed implements State {
+
+        private final String errorMessage;
+
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", justification = "errorMessage is intentionally nullable - null is printed as 'null' in toString()")
+        private Failed(@Nullable String errorMessage) {
+            this.errorMessage = errorMessage;
+        }
+
+        /**
+         * Get the error message describing why authentication failed.
+         *
+         * @return the error message (may be null)
+         */
+        @Nullable
+        public String errorMessage() {
+            return errorMessage;
+        }
+
+        @Override
+        public String toString() {
+            return "Failed{error=" + errorMessage + "}";
+        }
+    }
+}

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/package-info.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * SASL termination filter for Kroxylicious.
+ */
+@ReturnValuesAreNonnullByDefault
+@DefaultAnnotationForParameters(NonNull.class)
+@DefaultAnnotation(NonNull.class)
+package io.kroxylicious.filter.sasl.termination;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotationForParameters;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
@@ -1,0 +1,1 @@
+io.kroxylicious.filter.sasl.termination.SaslTermination

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/OauthBearerMechanismConfigTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/OauthBearerMechanismConfigTest.java
@@ -22,7 +22,7 @@ class OauthBearerMechanismConfigTest {
     void shouldCreateWithRequiredFieldsOnly() {
         // When
         var config = new OauthBearerMechanismConfig(VALID_JWKS_URL, "kafka", "https://idp.example.com",
-                null, null, null, null, null);
+                null, null, null, null, null, null);
 
         // Then
         assertThat(config.jwksEndpointUrl()).isEqualTo(VALID_JWKS_URL);
@@ -39,7 +39,7 @@ class OauthBearerMechanismConfigTest {
     void shouldCreateWithAllFields() {
         // When
         var config = new OauthBearerMechanismConfig(VALID_JWKS_URL, "kafka", "https://idp.example.com",
-                "scp", "subject", Duration.ofMinutes(5), Duration.ofSeconds(1), Duration.ofSeconds(30));
+                "scp", "subject", Duration.ofMinutes(5), Duration.ofSeconds(1), Duration.ofSeconds(30), null);
 
         // Then
         assertThat(config.scopeClaimName()).isEqualTo("scp");
@@ -53,7 +53,7 @@ class OauthBearerMechanismConfigTest {
     @Test
     void shouldRejectNullJwksEndpointUrl() {
         assertThatThrownBy(() -> new OauthBearerMechanismConfig(null, "kafka", "https://idp.example.com",
-                null, null, null, null, null))
+                null, null, null, null, null, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("jwksEndpointUrl must not be null");
     }
@@ -62,7 +62,7 @@ class OauthBearerMechanismConfigTest {
     @Test
     void shouldRejectNullExpectedAudience() {
         assertThatThrownBy(() -> new OauthBearerMechanismConfig(VALID_JWKS_URL, null, "https://idp.example.com",
-                null, null, null, null, null))
+                null, null, null, null, null, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("expectedAudience must not be null or blank");
     }
@@ -70,7 +70,7 @@ class OauthBearerMechanismConfigTest {
     @Test
     void shouldRejectBlankExpectedAudience() {
         assertThatThrownBy(() -> new OauthBearerMechanismConfig(VALID_JWKS_URL, "  ", "https://idp.example.com",
-                null, null, null, null, null))
+                null, null, null, null, null, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("expectedAudience must not be null or blank");
     }
@@ -79,7 +79,7 @@ class OauthBearerMechanismConfigTest {
     @Test
     void shouldRejectNullExpectedIssuer() {
         assertThatThrownBy(() -> new OauthBearerMechanismConfig(VALID_JWKS_URL, "kafka", null,
-                null, null, null, null, null))
+                null, null, null, null, null, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("expectedIssuer must not be null or blank");
     }
@@ -87,7 +87,7 @@ class OauthBearerMechanismConfigTest {
     @Test
     void shouldRejectBlankExpectedIssuer() {
         assertThatThrownBy(() -> new OauthBearerMechanismConfig(VALID_JWKS_URL, "kafka", "  ",
-                null, null, null, null, null))
+                null, null, null, null, null, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("expectedIssuer must not be null or blank");
     }
@@ -96,7 +96,7 @@ class OauthBearerMechanismConfigTest {
     void shouldReturnOauthbearerMechanismName() {
         // Given
         var config = new OauthBearerMechanismConfig(VALID_JWKS_URL, "kafka", "https://idp.example.com",
-                null, null, null, null, null);
+                null, null, null, null, null, null);
 
         // Then
         assertThat(config.mechanismName()).isEqualTo("OAUTHBEARER");

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/OauthBearerMechanismConfigTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/OauthBearerMechanismConfigTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.sasl.termination;
+
+import java.net.URI;
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OauthBearerMechanismConfigTest {
+
+    private static final URI VALID_JWKS_URL = URI.create("https://idp.example.com/.well-known/jwks.json");
+
+    @Test
+    void shouldCreateWithRequiredFieldsOnly() {
+        // When
+        var config = new OauthBearerMechanismConfig(VALID_JWKS_URL, "kafka", "https://idp.example.com",
+                null, null, null, null, null);
+
+        // Then
+        assertThat(config.jwksEndpointUrl()).isEqualTo(VALID_JWKS_URL);
+        assertThat(config.expectedAudience()).isEqualTo("kafka");
+        assertThat(config.expectedIssuer()).isEqualTo("https://idp.example.com");
+        assertThat(config.scopeClaimName()).isNull();
+        assertThat(config.subClaimName()).isNull();
+        assertThat(config.jwksEndpointRefresh()).isNull();
+        assertThat(config.jwksEndpointRetryBackoff()).isNull();
+        assertThat(config.jwksEndpointRetryBackoffMax()).isNull();
+    }
+
+    @Test
+    void shouldCreateWithAllFields() {
+        // When
+        var config = new OauthBearerMechanismConfig(VALID_JWKS_URL, "kafka", "https://idp.example.com",
+                "scp", "subject", Duration.ofMinutes(5), Duration.ofSeconds(1), Duration.ofSeconds(30));
+
+        // Then
+        assertThat(config.scopeClaimName()).isEqualTo("scp");
+        assertThat(config.subClaimName()).isEqualTo("subject");
+        assertThat(config.jwksEndpointRefresh()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(config.jwksEndpointRetryBackoff()).isEqualTo(Duration.ofSeconds(1));
+        assertThat(config.jwksEndpointRetryBackoffMax()).isEqualTo(Duration.ofSeconds(30));
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void shouldRejectNullJwksEndpointUrl() {
+        assertThatThrownBy(() -> new OauthBearerMechanismConfig(null, "kafka", "https://idp.example.com",
+                null, null, null, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("jwksEndpointUrl must not be null");
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void shouldRejectNullExpectedAudience() {
+        assertThatThrownBy(() -> new OauthBearerMechanismConfig(VALID_JWKS_URL, null, "https://idp.example.com",
+                null, null, null, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expectedAudience must not be null or blank");
+    }
+
+    @Test
+    void shouldRejectBlankExpectedAudience() {
+        assertThatThrownBy(() -> new OauthBearerMechanismConfig(VALID_JWKS_URL, "  ", "https://idp.example.com",
+                null, null, null, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expectedAudience must not be null or blank");
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void shouldRejectNullExpectedIssuer() {
+        assertThatThrownBy(() -> new OauthBearerMechanismConfig(VALID_JWKS_URL, "kafka", null,
+                null, null, null, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expectedIssuer must not be null or blank");
+    }
+
+    @Test
+    void shouldRejectBlankExpectedIssuer() {
+        assertThatThrownBy(() -> new OauthBearerMechanismConfig(VALID_JWKS_URL, "kafka", "  ",
+                null, null, null, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expectedIssuer must not be null or blank");
+    }
+
+    @Test
+    void shouldReturnOauthbearerMechanismName() {
+        // Given
+        var config = new OauthBearerMechanismConfig(VALID_JWKS_URL, "kafka", "https://idp.example.com",
+                null, null, null, null, null);
+
+        // Then
+        assertThat(config.mechanismName()).isEqualTo("OAUTHBEARER");
+    }
+}

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachineTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachineTest.java
@@ -41,7 +41,7 @@ class OauthBearerStateMachineTest {
     @BeforeEach
     void setUp() {
         callbackHandler = new OAuthBearerValidatorCallbackHandler();
-        handler = new OauthBearerStateMachine(callbackHandler, Clock.systemUTC());
+        handler = new OauthBearerStateMachine(callbackHandler, Clock.systemUTC(), OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES);
     }
 
     @AfterEach
@@ -70,14 +70,14 @@ class OauthBearerStateMachineTest {
         var clock = Clock.systemUTC();
 
         // When/Then
-        assertThatThrownBy(() -> new OauthBearerStateMachine(null, clock))
+        assertThatThrownBy(() -> new OauthBearerStateMachine(null, clock, OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES))
                 .isInstanceOf(NullPointerException.class);
     }
 
     @SuppressWarnings("DataFlowIssue")
     @Test
     void shouldRejectNullClock() {
-        assertThatThrownBy(() -> new OauthBearerStateMachine(callbackHandler, null))
+        assertThatThrownBy(() -> new OauthBearerStateMachine(callbackHandler, null, OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES))
                 .isInstanceOf(NullPointerException.class);
     }
 
@@ -117,7 +117,7 @@ class OauthBearerStateMachineTest {
     void shouldReturnChallengeWithJsonErrorWhenTokenIsRejected() throws Exception {
         // Given
         handler = new OauthBearerStateMachine(
-                rejectingCallbackHandler("invalid_token", null, null), Clock.systemUTC());
+                rejectingCallbackHandler("invalid_token", null, null), Clock.systemUTC(), OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES);
 
         // When
         RoundResult result = handler.evaluateRound(clientInitialResponse())
@@ -136,7 +136,7 @@ class OauthBearerStateMachineTest {
         handler = new OauthBearerStateMachine(
                 rejectingCallbackHandler("insufficient_scope", "email profile",
                         "https://example.com/.well-known/openid-configuration"),
-                Clock.systemUTC());
+                Clock.systemUTC(), OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES);
 
         // When
         RoundResult result = handler.evaluateRound(clientInitialResponse())
@@ -155,7 +155,7 @@ class OauthBearerStateMachineTest {
     void shouldFailAfterClientAcknowledgesErrorWithControlA() throws Exception {
         // Given
         handler = new OauthBearerStateMachine(
-                rejectingCallbackHandler("invalid_token", null, null), Clock.systemUTC());
+                rejectingCallbackHandler("invalid_token", null, null), Clock.systemUTC(), OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES);
         handler.evaluateRound(clientInitialResponse()).toCompletableFuture().get();
 
         // When

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachineTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachineTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.sasl.termination;
+
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslServerProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OauthBearerStateMachineTest {
+
+    private OauthBearerStateMachine handler;
+    private OAuthBearerValidatorCallbackHandler callbackHandler;
+
+    @BeforeAll
+    static void registerProvider() {
+        OAuthBearerSaslServerProvider.initialize();
+    }
+
+    @BeforeEach
+    void setUp() {
+        callbackHandler = new OAuthBearerValidatorCallbackHandler();
+        handler = new OauthBearerStateMachine(callbackHandler, java.time.Clock.systemUTC());
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (handler != null) {
+            handler.dispose();
+        }
+    }
+
+    @Test
+    void shouldReturnCorrectMechanismName() {
+        assertThat(handler.mechanismName()).isEqualTo(OAUTHBEARER_MECHANISM);
+    }
+
+    @Test
+    void shouldDisposeIdempotently() {
+        // When/Then
+        handler.dispose();
+        handler.dispose();
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void shouldRejectNullCallbackHandler() {
+        assertThatThrownBy(() -> new OauthBearerStateMachine(null, java.time.Clock.systemUTC()))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void shouldRejectNullClock() {
+        assertThatThrownBy(() -> new OauthBearerStateMachine(callbackHandler, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldReturnMaxAuthBytes() {
+        assertThat(handler.maxAuthBytes()).isEqualTo(128 * 1024);
+    }
+
+    @Test
+    void shouldDisposeAfterEvaluateRound() throws Exception {
+        // Given
+        byte[] invalidToken = "n,,auth=Bearer invalid-token".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        handler.evaluateRound(invalidToken).toCompletableFuture().get();
+
+        // When/Then
+        handler.dispose();
+        handler.dispose();
+    }
+
+    @Test
+    void shouldFailForInvalidToken() throws Exception {
+        // Given
+        // The callback handler is not configured, so token validation will fail
+        byte[] invalidToken = "n,,auth=Bearer invalid-token".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+        // When
+        RoundResult result = handler.evaluateRound(invalidToken)
+                .toCompletableFuture().get();
+
+        // Then
+        assertThat(result).isInstanceOf(RoundResult.Failure.class);
+        assertThat(((RoundResult.Failure) result).exception()).isNotNull();
+    }
+}

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachineTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachineTest.java
@@ -8,7 +8,6 @@ package io.kroxylicious.filter.sasl.termination;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.time.Clock;
 
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.UnsupportedCallbackException;
@@ -41,7 +40,7 @@ class OauthBearerStateMachineTest {
     @BeforeEach
     void setUp() {
         callbackHandler = new OAuthBearerValidatorCallbackHandler();
-        handler = new OauthBearerStateMachine(callbackHandler, Clock.systemUTC(), OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES);
+        handler = new OauthBearerStateMachine(callbackHandler, OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES);
     }
 
     @AfterEach
@@ -66,18 +65,8 @@ class OauthBearerStateMachineTest {
     @SuppressWarnings("DataFlowIssue")
     @Test
     void shouldRejectNullCallbackHandler() {
-        // Given
-        var clock = Clock.systemUTC();
-
         // When/Then
-        assertThatThrownBy(() -> new OauthBearerStateMachine(null, clock, OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES))
-                .isInstanceOf(NullPointerException.class);
-    }
-
-    @SuppressWarnings("DataFlowIssue")
-    @Test
-    void shouldRejectNullClock() {
-        assertThatThrownBy(() -> new OauthBearerStateMachine(callbackHandler, null, OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES))
+        assertThatThrownBy(() -> new OauthBearerStateMachine(null, OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES))
                 .isInstanceOf(NullPointerException.class);
     }
 
@@ -117,7 +106,7 @@ class OauthBearerStateMachineTest {
     void shouldReturnChallengeWithJsonErrorWhenTokenIsRejected() throws Exception {
         // Given
         handler = new OauthBearerStateMachine(
-                rejectingCallbackHandler("invalid_token", null, null), Clock.systemUTC(), OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES);
+                rejectingCallbackHandler("invalid_token", null, null), OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES);
 
         // When
         RoundResult result = handler.evaluateRound(clientInitialResponse())
@@ -136,7 +125,7 @@ class OauthBearerStateMachineTest {
         handler = new OauthBearerStateMachine(
                 rejectingCallbackHandler("insufficient_scope", "email profile",
                         "https://example.com/.well-known/openid-configuration"),
-                Clock.systemUTC(), OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES);
+                OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES);
 
         // When
         RoundResult result = handler.evaluateRound(clientInitialResponse())
@@ -155,7 +144,7 @@ class OauthBearerStateMachineTest {
     void shouldFailAfterClientAcknowledgesErrorWithControlA() throws Exception {
         // Given
         handler = new OauthBearerStateMachine(
-                rejectingCallbackHandler("invalid_token", null, null), Clock.systemUTC(), OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES);
+                rejectingCallbackHandler("invalid_token", null, null), OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES);
         handler.evaluateRound(clientInitialResponse()).toCompletableFuture().get();
 
         // When

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachineTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachineTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class OauthBearerStateMachineTest {
@@ -49,13 +50,17 @@ class OauthBearerStateMachineTest {
     void shouldDisposeIdempotently() {
         // When/Then
         handler.dispose();
-        handler.dispose();
+        assertThatCode(() -> handler.dispose()).doesNotThrowAnyException();
     }
 
     @SuppressWarnings("DataFlowIssue")
     @Test
     void shouldRejectNullCallbackHandler() {
-        assertThatThrownBy(() -> new OauthBearerStateMachine(null, java.time.Clock.systemUTC()))
+        // Given
+        var clock = java.time.Clock.systemUTC();
+
+        // When/Then
+        assertThatThrownBy(() -> new OauthBearerStateMachine(null, clock))
                 .isInstanceOf(NullPointerException.class);
     }
 
@@ -79,7 +84,7 @@ class OauthBearerStateMachineTest {
 
         // When/Then
         handler.dispose();
-        handler.dispose();
+        assertThatCode(() -> handler.dispose()).doesNotThrowAnyException();
     }
 
     @Test

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachineTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/OauthBearerStateMachineTest.java
@@ -6,6 +6,14 @@
 
 package io.kroxylicious.filter.sasl.termination;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallback;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
 import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslServerProvider;
 import org.junit.jupiter.api.AfterEach;
@@ -20,6 +28,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class OauthBearerStateMachineTest {
 
+    private static final byte[] CONTROL_A = new byte[]{ 0x01 };
+
     private OauthBearerStateMachine handler;
     private OAuthBearerValidatorCallbackHandler callbackHandler;
 
@@ -31,7 +41,7 @@ class OauthBearerStateMachineTest {
     @BeforeEach
     void setUp() {
         callbackHandler = new OAuthBearerValidatorCallbackHandler();
-        handler = new OauthBearerStateMachine(callbackHandler, java.time.Clock.systemUTC());
+        handler = new OauthBearerStateMachine(callbackHandler, Clock.systemUTC());
     }
 
     @AfterEach
@@ -57,7 +67,7 @@ class OauthBearerStateMachineTest {
     @Test
     void shouldRejectNullCallbackHandler() {
         // Given
-        var clock = java.time.Clock.systemUTC();
+        var clock = Clock.systemUTC();
 
         // When/Then
         assertThatThrownBy(() -> new OauthBearerStateMachine(null, clock))
@@ -79,7 +89,7 @@ class OauthBearerStateMachineTest {
     @Test
     void shouldDisposeAfterEvaluateRound() throws Exception {
         // Given
-        byte[] invalidToken = "n,,auth=Bearer invalid-token".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        byte[] invalidToken = "n,,auth=Bearer invalid-token".getBytes(StandardCharsets.UTF_8);
         handler.evaluateRound(invalidToken).toCompletableFuture().get();
 
         // When/Then
@@ -90,8 +100,7 @@ class OauthBearerStateMachineTest {
     @Test
     void shouldFailForInvalidToken() throws Exception {
         // Given
-        // The callback handler is not configured, so token validation will fail
-        byte[] invalidToken = "n,,auth=Bearer invalid-token".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        byte[] invalidToken = "n,,auth=Bearer invalid-token".getBytes(StandardCharsets.UTF_8);
 
         // When
         RoundResult result = handler.evaluateRound(invalidToken)
@@ -100,5 +109,82 @@ class OauthBearerStateMachineTest {
         // Then
         assertThat(result).isInstanceOf(RoundResult.Failure.class);
         assertThat(((RoundResult.Failure) result).exception()).isNotNull();
+    }
+
+    // RFC 7628 §3.2.2-3.2.3: multi-round error sequence
+
+    @Test
+    void shouldReturnChallengeWithJsonErrorWhenTokenIsRejected() throws Exception {
+        // Given
+        handler = new OauthBearerStateMachine(
+                rejectingCallbackHandler("invalid_token", null, null), Clock.systemUTC());
+
+        // When
+        RoundResult result = handler.evaluateRound(clientInitialResponse())
+                .toCompletableFuture().get();
+
+        // Then
+        assertThat(result).isInstanceOf(RoundResult.Challenge.class);
+        var challenge = (RoundResult.Challenge) result;
+        assertThat(new String(challenge.responseBytes(), StandardCharsets.UTF_8))
+                .contains("\"status\":\"invalid_token\"");
+    }
+
+    @Test
+    void shouldIncludeScopeAndOpenIdConfigInErrorChallenge() throws Exception {
+        // Given
+        handler = new OauthBearerStateMachine(
+                rejectingCallbackHandler("insufficient_scope", "email profile",
+                        "https://example.com/.well-known/openid-configuration"),
+                Clock.systemUTC());
+
+        // When
+        RoundResult result = handler.evaluateRound(clientInitialResponse())
+                .toCompletableFuture().get();
+
+        // Then
+        assertThat(result).isInstanceOf(RoundResult.Challenge.class);
+        String errorJson = new String(((RoundResult.Challenge) result).responseBytes(), StandardCharsets.UTF_8);
+        assertThat(errorJson)
+                .contains("\"status\":\"insufficient_scope\"")
+                .contains("\"scope\":\"email profile\"")
+                .contains("\"openid-configuration\":\"https://example.com/.well-known/openid-configuration\"");
+    }
+
+    @Test
+    void shouldFailAfterClientAcknowledgesErrorWithControlA() throws Exception {
+        // Given
+        handler = new OauthBearerStateMachine(
+                rejectingCallbackHandler("invalid_token", null, null), Clock.systemUTC());
+        handler.evaluateRound(clientInitialResponse()).toCompletableFuture().get();
+
+        // When
+        RoundResult result = handler.evaluateRound(CONTROL_A)
+                .toCompletableFuture().get();
+
+        // Then
+        assertThat(result).isInstanceOf(RoundResult.Failure.class);
+        assertThat(((RoundResult.Failure) result).exception()).isNotNull();
+    }
+
+    private static byte[] clientInitialResponse() {
+        return "n,,auth=Bearer sometoken".getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static OAuthBearerValidatorCallbackHandler rejectingCallbackHandler(
+                                                                                String errorStatus, String errorScope, String errorOpenIDConfiguration) {
+        return new OAuthBearerValidatorCallbackHandler() {
+            @Override
+            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                for (Callback cb : callbacks) {
+                    if (cb instanceof OAuthBearerValidatorCallback vcb) {
+                        vcb.error(errorStatus, errorScope, errorOpenIDConfiguration);
+                    }
+                    else {
+                        throw new UnsupportedCallbackException(cb);
+                    }
+                }
+            }
+        };
     }
 }

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/RoundResultTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/RoundResultTest.java
@@ -68,7 +68,7 @@ class RoundResultTest {
 
         // Then
         assertThat(a).isEqualTo(b);
-        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+        assertThat(a).hasSameHashCodeAs(b);
     }
 
     @SuppressWarnings("SelfAssertion")
@@ -198,7 +198,7 @@ class RoundResultTest {
 
         // Then
         assertThat(a).isEqualTo(b);
-        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+        assertThat(a).hasSameHashCodeAs(b);
     }
 
     @Test
@@ -278,7 +278,11 @@ class RoundResultTest {
     @SuppressWarnings("DataFlowIssue")
     @Test
     void shouldRejectNullResponseBytesForFailure() {
-        assertThatThrownBy(() -> new RoundResult.Failure(null, new Exception("x")))
+        // Given
+        var exception = new Exception("x");
+
+        // When/Then
+        assertThatThrownBy(() -> new RoundResult.Failure(null, exception))
                 .isInstanceOf(NullPointerException.class);
     }
 
@@ -325,7 +329,7 @@ class RoundResultTest {
 
         // Then
         assertThat(a).isEqualTo(b);
-        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+        assertThat(a).hasSameHashCodeAs(b);
     }
 
     @Test

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/RoundResultTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/RoundResultTest.java
@@ -67,8 +67,8 @@ class RoundResultTest {
         var b = new RoundResult.Challenge(new byte[]{ 1, 2, 3 });
 
         // Then
-        assertThat(a).isEqualTo(b);
-        assertThat(a).hasSameHashCodeAs(b);
+        assertThat(a).isEqualTo(b)
+                .hasSameHashCodeAs(b);
     }
 
     @SuppressWarnings("SelfAssertion")
@@ -197,8 +197,8 @@ class RoundResultTest {
         var b = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 3600);
 
         // Then
-        assertThat(a).isEqualTo(b);
-        assertThat(a).hasSameHashCodeAs(b);
+        assertThat(a).isEqualTo(b)
+                .hasSameHashCodeAs(b);
     }
 
     @Test
@@ -328,8 +328,8 @@ class RoundResultTest {
         var b = new RoundResult.Failure(new byte[]{ 1, 2 }, exception);
 
         // Then
-        assertThat(a).isEqualTo(b);
-        assertThat(a).hasSameHashCodeAs(b);
+        assertThat(a).isEqualTo(b)
+                .hasSameHashCodeAs(b);
     }
 
     @Test

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/RoundResultTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/RoundResultTest.java
@@ -1,0 +1,422 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.sasl.termination;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RoundResultTest {
+
+    // --- Challenge ---
+
+    @Test
+    void shouldCreateChallenge() {
+        // Given
+        byte[] bytes = { 1, 2, 3 };
+
+        // When
+        var challenge = new RoundResult.Challenge(bytes);
+
+        // Then
+        assertThat(challenge.responseBytes()).containsExactly(1, 2, 3);
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void shouldRejectNullResponseBytesForChallenge() {
+        assertThatThrownBy(() -> new RoundResult.Challenge(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldDefensivelyCopyInputForChallenge() {
+        // Given
+        byte[] input = { 1, 2, 3 };
+
+        // When
+        var challenge = new RoundResult.Challenge(input);
+        input[0] = 99;
+
+        // Then
+        assertThat(challenge.responseBytes()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void shouldDefensivelyCopyOutputForChallenge() {
+        // Given
+        var challenge = new RoundResult.Challenge(new byte[]{ 1, 2, 3 });
+
+        // When
+        byte[] out = challenge.responseBytes();
+        out[0] = 99;
+
+        // Then
+        assertThat(challenge.responseBytes()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void shouldBeEqualForSameContentChallenge() {
+        // Given
+        var a = new RoundResult.Challenge(new byte[]{ 1, 2, 3 });
+        var b = new RoundResult.Challenge(new byte[]{ 1, 2, 3 });
+
+        // Then
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @SuppressWarnings("SelfAssertion")
+    @Test
+    void shouldBeReflexivelyEqualChallenge() {
+        // Given
+        var c = new RoundResult.Challenge(new byte[]{ 1, 2, 3 });
+
+        // Then
+        assertThat(c).isEqualTo(c);
+    }
+
+    @Test
+    void shouldNotBeEqualForDifferentContentChallenge() {
+        // Given
+        var a = new RoundResult.Challenge(new byte[]{ 1, 2, 3 });
+        var b = new RoundResult.Challenge(new byte[]{ 4, 5, 6 });
+
+        // Then
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    void shouldNotBeEqualToNullChallenge() {
+        // Given
+        var c = new RoundResult.Challenge(new byte[]{ 1, 2, 3 });
+
+        // Then
+        assertThat(c).isNotEqualTo(null);
+    }
+
+    @Test
+    void shouldNotBeEqualToDifferentTypeChallenge() {
+        // Given
+        var c = new RoundResult.Challenge(new byte[]{ 1, 2, 3 });
+
+        // Then
+        assertThat(c).isNotEqualTo("a string");
+    }
+
+    @Test
+    void shouldReturnOpaqueToStringForChallenge() {
+        // Given
+        var c = new RoundResult.Challenge(new byte[]{ 1, 2, 3 });
+
+        // Then
+        assertThat(c).hasToString("Challenge{}");
+    }
+
+    // --- Success ---
+
+    @Test
+    void shouldCreateSuccess() {
+        // Given
+        byte[] bytes = { 10, 20 };
+
+        // When
+        var success = new RoundResult.Success(bytes, "alice", 3600);
+
+        // Then
+        assertThat(success.responseBytes()).containsExactly(10, 20);
+        assertThat(success.authorizationId()).isEqualTo("alice");
+        assertThat(success.sessionLifetimeMs()).isEqualTo(3600);
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void shouldRejectNullResponseBytesForSuccess() {
+        assertThatThrownBy(() -> new RoundResult.Success(null, "alice", 0))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void shouldRejectNullAuthorizationIdForSuccess() {
+        assertThatThrownBy(() -> new RoundResult.Success(new byte[0], null, 0))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldRejectNegativeSessionLifetimeMs() {
+        assertThatThrownBy(() -> new RoundResult.Success(new byte[0], "alice", -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("sessionLifetimeMs must not be negative");
+    }
+
+    @Test
+    void shouldAcceptZeroSessionLifetimeMs() {
+        // When
+        var success = new RoundResult.Success(new byte[0], "alice", 0);
+
+        // Then
+        assertThat(success.sessionLifetimeMs()).isZero();
+    }
+
+    @Test
+    void shouldDefensivelyCopyInputForSuccess() {
+        // Given
+        byte[] input = { 1, 2, 3 };
+
+        // When
+        var success = new RoundResult.Success(input, "alice", 0);
+        input[0] = 99;
+
+        // Then
+        assertThat(success.responseBytes()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void shouldDefensivelyCopyOutputForSuccess() {
+        // Given
+        var success = new RoundResult.Success(new byte[]{ 1, 2, 3 }, "alice", 0);
+
+        // When
+        byte[] out = success.responseBytes();
+        out[0] = 99;
+
+        // Then
+        assertThat(success.responseBytes()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void shouldBeEqualForSameContentSuccess() {
+        // Given
+        var a = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 3600);
+        var b = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 3600);
+
+        // Then
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void shouldNotBeEqualForDifferentResponseBytesSuccess() {
+        // Given
+        var a = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 3600);
+        var b = new RoundResult.Success(new byte[]{ 3, 4 }, "alice", 3600);
+
+        // Then
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    void shouldNotBeEqualForDifferentAuthorizationIdSuccess() {
+        // Given
+        var a = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 3600);
+        var b = new RoundResult.Success(new byte[]{ 1, 2 }, "bob", 3600);
+
+        // Then
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    void shouldNotBeEqualForDifferentSessionLifetimeMsSuccess() {
+        // Given
+        var a = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 3600);
+        var b = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 7200);
+
+        // Then
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    void shouldNotBeEqualToNullSuccess() {
+        // Given
+        var s = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 0);
+
+        // Then
+        assertThat(s).isNotEqualTo(null);
+    }
+
+    @Test
+    void shouldNotBeEqualToDifferentTypeSuccess() {
+        // Given
+        var s = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 0);
+        var c = new RoundResult.Challenge(new byte[]{ 1, 2 });
+
+        // Then
+        assertThat(s).isNotEqualTo(c);
+    }
+
+    @Test
+    void shouldReturnDescriptiveToStringForSuccess() {
+        // Given
+        var s = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 3600);
+
+        // Then
+        assertThat(s).hasToString("Success{authorizationId='alice', sessionLifetimeMs=3600}");
+    }
+
+    // --- Failure ---
+
+    @Test
+    void shouldCreateFailure() {
+        // Given
+        byte[] bytes = { 7, 8 };
+        var exception = new Exception("auth failed");
+
+        // When
+        var failure = new RoundResult.Failure(bytes, exception);
+
+        // Then
+        assertThat(failure.responseBytes()).containsExactly(7, 8);
+        assertThat(failure.exception()).isSameAs(exception);
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void shouldRejectNullResponseBytesForFailure() {
+        assertThatThrownBy(() -> new RoundResult.Failure(null, new Exception("x")))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void shouldRejectNullExceptionForFailure() {
+        assertThatThrownBy(() -> new RoundResult.Failure(new byte[0], null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldDefensivelyCopyInputForFailure() {
+        // Given
+        byte[] input = { 1, 2, 3 };
+        var exception = new Exception("x");
+
+        // When
+        var failure = new RoundResult.Failure(input, exception);
+        input[0] = 99;
+
+        // Then
+        assertThat(failure.responseBytes()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void shouldDefensivelyCopyOutputForFailure() {
+        // Given
+        var failure = new RoundResult.Failure(new byte[]{ 1, 2, 3 }, new Exception("x"));
+
+        // When
+        byte[] out = failure.responseBytes();
+        out[0] = 99;
+
+        // Then
+        assertThat(failure.responseBytes()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void shouldBeEqualForSameContentFailure() {
+        // Given
+        var exception = new Exception("auth failed");
+        var a = new RoundResult.Failure(new byte[]{ 1, 2 }, exception);
+        var b = new RoundResult.Failure(new byte[]{ 1, 2 }, exception);
+
+        // Then
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void shouldNotBeEqualForDifferentExceptionFailure() {
+        // Given
+        var a = new RoundResult.Failure(new byte[]{ 1, 2 }, new Exception("auth failed"));
+        var b = new RoundResult.Failure(new byte[]{ 1, 2 }, new Exception("auth failed"));
+
+        // Then
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    void shouldNotBeEqualForDifferentResponseBytesFailure() {
+        // Given
+        var exception = new Exception("auth failed");
+        var a = new RoundResult.Failure(new byte[]{ 1, 2 }, exception);
+        var b = new RoundResult.Failure(new byte[]{ 3, 4 }, exception);
+
+        // Then
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    void shouldNotBeEqualToNullFailure() {
+        // Given
+        var f = new RoundResult.Failure(new byte[]{ 1, 2 }, new Exception("x"));
+
+        // Then
+        assertThat(f).isNotEqualTo(null);
+    }
+
+    @Test
+    void shouldReturnExceptionMessageInToStringForFailure() {
+        // Given
+        var f = new RoundResult.Failure(new byte[0], new Exception("Something went wrong"));
+
+        // Then
+        assertThat(f).hasToString("Failure{exception=Something went wrong}");
+    }
+
+    // --- Factory methods ---
+
+    @Test
+    void shouldCreateChallengeViaFactoryMethod() {
+        // When
+        RoundResult result = RoundResult.challenge(new byte[]{ 1, 2, 3 });
+
+        // Then
+        assertThat(result).isInstanceOf(RoundResult.Challenge.class);
+        assertThat(result.responseBytes()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void shouldCreateSuccessViaTwoArgFactoryMethod() {
+        // When
+        RoundResult result = RoundResult.success(new byte[]{ 10, 20 }, "alice");
+
+        // Then
+        assertThat(result).isInstanceOf(RoundResult.Success.class);
+        var success = (RoundResult.Success) result;
+        assertThat(success.responseBytes()).containsExactly(10, 20);
+        assertThat(success.authorizationId()).isEqualTo("alice");
+        assertThat(success.sessionLifetimeMs()).isZero();
+    }
+
+    @Test
+    void shouldCreateSuccessViaThreeArgFactoryMethod() {
+        // When
+        RoundResult result = RoundResult.success(new byte[]{ 10, 20 }, "alice", 5000);
+
+        // Then
+        assertThat(result).isInstanceOf(RoundResult.Success.class);
+        var success = (RoundResult.Success) result;
+        assertThat(success.responseBytes()).containsExactly(10, 20);
+        assertThat(success.authorizationId()).isEqualTo("alice");
+        assertThat(success.sessionLifetimeMs()).isEqualTo(5000);
+    }
+
+    @Test
+    void shouldCreateFailureViaFactoryMethod() {
+        // Given
+        var exception = new Exception("failed");
+
+        // When
+        RoundResult result = RoundResult.failure(new byte[]{ 7, 8 }, exception);
+
+        // Then
+        assertThat(result).isInstanceOf(RoundResult.Failure.class);
+        var failure = (RoundResult.Failure) result;
+        assertThat(failure.responseBytes()).containsExactly(7, 8);
+        assertThat(failure.exception()).isSameAs(exception);
+    }
+}

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/RoundResultTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/RoundResultTest.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.filter.sasl.termination;
 
+import java.time.Instant;
+
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -126,42 +128,35 @@ class RoundResultTest {
         byte[] bytes = { 10, 20 };
 
         // When
-        var success = new RoundResult.Success(bytes, "alice", 3600);
+        var success = new RoundResult.Success(bytes, "alice", Instant.ofEpochMilli(3600));
 
         // Then
         assertThat(success.responseBytes()).containsExactly(10, 20);
         assertThat(success.authorizationId()).isEqualTo("alice");
-        assertThat(success.sessionLifetimeMs()).isEqualTo(3600);
+        assertThat(success.sessionExpiry()).isEqualTo(Instant.ofEpochMilli(3600));
     }
 
     @SuppressWarnings("DataFlowIssue")
     @Test
     void shouldRejectNullResponseBytesForSuccess() {
-        assertThatThrownBy(() -> new RoundResult.Success(null, "alice", 0))
+        assertThatThrownBy(() -> new RoundResult.Success(null, "alice", null))
                 .isInstanceOf(NullPointerException.class);
     }
 
     @SuppressWarnings("DataFlowIssue")
     @Test
     void shouldRejectNullAuthorizationIdForSuccess() {
-        assertThatThrownBy(() -> new RoundResult.Success(new byte[0], null, 0))
+        assertThatThrownBy(() -> new RoundResult.Success(new byte[0], null, null))
                 .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    void shouldRejectNegativeSessionLifetimeMs() {
-        assertThatThrownBy(() -> new RoundResult.Success(new byte[0], "alice", -1))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("sessionLifetimeMs must not be negative");
-    }
-
-    @Test
-    void shouldAcceptZeroSessionLifetimeMs() {
+    void shouldAcceptNullSessionExpiry() {
         // When
-        var success = new RoundResult.Success(new byte[0], "alice", 0);
+        var success = new RoundResult.Success(new byte[0], "alice", null);
 
         // Then
-        assertThat(success.sessionLifetimeMs()).isZero();
+        assertThat(success.sessionExpiry()).isNull();
     }
 
     @Test
@@ -170,7 +165,7 @@ class RoundResultTest {
         byte[] input = { 1, 2, 3 };
 
         // When
-        var success = new RoundResult.Success(input, "alice", 0);
+        var success = new RoundResult.Success(input, "alice", null);
         input[0] = 99;
 
         // Then
@@ -180,7 +175,7 @@ class RoundResultTest {
     @Test
     void shouldDefensivelyCopyOutputForSuccess() {
         // Given
-        var success = new RoundResult.Success(new byte[]{ 1, 2, 3 }, "alice", 0);
+        var success = new RoundResult.Success(new byte[]{ 1, 2, 3 }, "alice", null);
 
         // When
         byte[] out = success.responseBytes();
@@ -193,8 +188,8 @@ class RoundResultTest {
     @Test
     void shouldBeEqualForSameContentSuccess() {
         // Given
-        var a = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 3600);
-        var b = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 3600);
+        var a = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", Instant.ofEpochMilli(3600));
+        var b = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", Instant.ofEpochMilli(3600));
 
         // Then
         assertThat(a).isEqualTo(b)
@@ -204,8 +199,8 @@ class RoundResultTest {
     @Test
     void shouldNotBeEqualForDifferentResponseBytesSuccess() {
         // Given
-        var a = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 3600);
-        var b = new RoundResult.Success(new byte[]{ 3, 4 }, "alice", 3600);
+        var a = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", Instant.ofEpochMilli(3600));
+        var b = new RoundResult.Success(new byte[]{ 3, 4 }, "alice", Instant.ofEpochMilli(3600));
 
         // Then
         assertThat(a).isNotEqualTo(b);
@@ -214,18 +209,18 @@ class RoundResultTest {
     @Test
     void shouldNotBeEqualForDifferentAuthorizationIdSuccess() {
         // Given
-        var a = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 3600);
-        var b = new RoundResult.Success(new byte[]{ 1, 2 }, "bob", 3600);
+        var a = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", Instant.ofEpochMilli(3600));
+        var b = new RoundResult.Success(new byte[]{ 1, 2 }, "bob", Instant.ofEpochMilli(3600));
 
         // Then
         assertThat(a).isNotEqualTo(b);
     }
 
     @Test
-    void shouldNotBeEqualForDifferentSessionLifetimeMsSuccess() {
+    void shouldNotBeEqualForDifferentSessionExpirySuccess() {
         // Given
-        var a = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 3600);
-        var b = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 7200);
+        var a = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", Instant.ofEpochMilli(3600));
+        var b = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", Instant.ofEpochMilli(7200));
 
         // Then
         assertThat(a).isNotEqualTo(b);
@@ -234,7 +229,7 @@ class RoundResultTest {
     @Test
     void shouldNotBeEqualToNullSuccess() {
         // Given
-        var s = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 0);
+        var s = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", null);
 
         // Then
         assertThat(s).isNotEqualTo(null);
@@ -243,7 +238,7 @@ class RoundResultTest {
     @Test
     void shouldNotBeEqualToDifferentTypeSuccess() {
         // Given
-        var s = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 0);
+        var s = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", null);
         var c = new RoundResult.Challenge(new byte[]{ 1, 2 });
 
         // Then
@@ -253,10 +248,10 @@ class RoundResultTest {
     @Test
     void shouldReturnDescriptiveToStringForSuccess() {
         // Given
-        var s = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", 3600);
+        var s = new RoundResult.Success(new byte[]{ 1, 2 }, "alice", Instant.ofEpochMilli(3600));
 
         // Then
-        assertThat(s).hasToString("Success{authorizationId='alice', sessionLifetimeMs=3600}");
+        assertThat(s).hasToString("Success{authorizationId='alice', sessionExpiry=" + Instant.ofEpochMilli(3600) + "}");
     }
 
     // --- Failure ---
@@ -393,20 +388,20 @@ class RoundResultTest {
         var success = (RoundResult.Success) result;
         assertThat(success.responseBytes()).containsExactly(10, 20);
         assertThat(success.authorizationId()).isEqualTo("alice");
-        assertThat(success.sessionLifetimeMs()).isZero();
+        assertThat(success.sessionExpiry()).isNull();
     }
 
     @Test
     void shouldCreateSuccessViaThreeArgFactoryMethod() {
         // When
-        RoundResult result = RoundResult.success(new byte[]{ 10, 20 }, "alice", 5000);
+        RoundResult result = RoundResult.success(new byte[]{ 10, 20 }, "alice", Instant.ofEpochMilli(5000));
 
         // Then
         assertThat(result).isInstanceOf(RoundResult.Success.class);
         var success = (RoundResult.Success) result;
         assertThat(success.responseBytes()).containsExactly(10, 20);
         assertThat(success.authorizationId()).isEqualTo("alice");
-        assertThat(success.sessionLifetimeMs()).isEqualTo(5000);
+        assertThat(success.sessionExpiry()).isEqualTo(Instant.ofEpochMilli(5000));
     }
 
     @Test

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
@@ -14,9 +14,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.security.sasl.SaslException;
 
 import org.apache.kafka.common.errors.ApiException;
+import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.MetadataRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
@@ -323,7 +328,7 @@ class SaslTerminationFilterTest {
     @Test
     void shouldReturnFailureAndCloseConnection() throws Exception {
         // Given
-        var exception = new javax.security.sasl.SaslException("bad credentials");
+        var exception = new SaslException("bad credentials");
         var handler = mock(MechanismStateMachine.class);
         when(handler.mechanismName()).thenReturn("OAUTHBEARER");
         when(handler.maxAuthBytes()).thenReturn(4 * 1024);
@@ -447,8 +452,8 @@ class SaslTerminationFilterTest {
                 CompletableFuture.completedFuture(RoundResult.success(new byte[0], "alice", 0)));
 
         Duration fixedDelay = Duration.ofMillis(200);
-        var executor = java.util.concurrent.Executors.newSingleThreadScheduledExecutor();
-        try {
+
+        try (var executor = Executors.newSingleThreadScheduledExecutor()) {
             var context = new SaslTermination.SaslTerminationContext(
                     null, Set.of("OAUTHBEARER"), List.of(),
                     null, Clock.systemUTC(), fixedDelay,
@@ -470,11 +475,8 @@ class SaslTerminationFilterTest {
                     .tags(List.of(Tag.of("mechanism", "OAUTHBEARER"), Tag.of(SaslTerminationFilter.VIRTUAL_CLUSTER_TAG, TEST_VIRTUAL_CLUSTER)))
                     .timer();
             assertThat(timer).isNotNull();
-            assertThat(timer.totalTime(java.util.concurrent.TimeUnit.MILLISECONDS))
+            assertThat(timer.totalTime(TimeUnit.MILLISECONDS))
                     .isLessThan(fixedDelay.toMillis());
-        }
-        finally {
-            executor.shutdownNow();
         }
     }
 
@@ -556,7 +558,7 @@ class SaslTerminationFilterTest {
                 filterContext).toCompletableFuture().get();
 
         // Then
-        assertThat(exceptionCaptor.getValue()).isInstanceOf(org.apache.kafka.common.errors.SaslAuthenticationException.class);
+        assertThat(exceptionCaptor.getValue()).isInstanceOf(SaslAuthenticationException.class);
     }
 
     @Test
@@ -619,7 +621,7 @@ class SaslTerminationFilterTest {
                 filterContext).toCompletableFuture().get();
 
         // Then
-        assertThat(exceptionCaptor.getValue()).isInstanceOf(org.apache.kafka.common.errors.SaslAuthenticationException.class);
+        assertThat(exceptionCaptor.getValue()).isInstanceOf(SaslAuthenticationException.class);
         assertThat(meterRegistry.find(SaslTerminationFilter.SESSION_EXPIRED_METRIC)
                 .tags(List.of(Tag.of("mechanism", "OAUTHBEARER"), Tag.of(SaslTerminationFilter.VIRTUAL_CLUSTER_TAG, TEST_VIRTUAL_CLUSTER)))
                 .counter()).isNotNull()

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
@@ -1,0 +1,689 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.sasl.termination;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.apache.kafka.common.errors.ApiException;
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.SaslAuthenticateRequestData;
+import org.apache.kafka.common.message.SaslAuthenticateResponseData;
+import org.apache.kafka.common.message.SaslHandshakeRequestData;
+import org.apache.kafka.common.message.SaslHandshakeResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslServerProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+
+import io.kroxylicious.proxy.authentication.Subject;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.filter.RequestFilterResultBuilder;
+import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
+import io.kroxylicious.proxy.filter.filterresultbuilder.TerminalStage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SaslTerminationFilterTest {
+
+    private static final Instant FIXED_INSTANT = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC);
+
+    @BeforeAll
+    static void registerProvider() {
+        OAuthBearerSaslServerProvider.initialize();
+    }
+
+    // --- Handshake flow ---
+
+    @Test
+    void shouldRespondWithNoneForSupportedHandshake() throws Exception {
+        // Given
+        var filter = createFilter();
+        var captor = ArgumentCaptor.forClass(ApiMessage.class);
+        var filterContext = mockShortCircuitFilterContext(captor);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_HANDSHAKE, ApiKeys.SASL_HANDSHAKE.latestVersion(),
+                new RequestHeaderData(),
+                new SaslHandshakeRequestData().setMechanism("OAUTHBEARER"),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        var response = (SaslHandshakeResponseData) captor.getValue();
+        assertThat(response.errorCode()).isEqualTo(Errors.NONE.code());
+    }
+
+    @Test
+    void shouldListSupportedMechanismsForUnsupportedHandshake() throws Exception {
+        // Given
+        var filter = createFilter();
+        var captor = ArgumentCaptor.forClass(ApiMessage.class);
+        var filterContext = mockShortCircuitFilterContext(captor);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_HANDSHAKE, ApiKeys.SASL_HANDSHAKE.latestVersion(),
+                new RequestHeaderData(),
+                new SaslHandshakeRequestData().setMechanism("PLAIN"),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        var response = (SaslHandshakeResponseData) captor.getValue();
+        assertThat(response.errorCode()).isEqualTo(Errors.UNSUPPORTED_SASL_MECHANISM.code());
+        assertThat(response.mechanisms()).contains("OAUTHBEARER");
+    }
+
+    @Test
+    void shouldRejectHandshakeInRequiringAuthenticateState() throws Exception {
+        // Given
+        var filter = createFilter();
+        var handler = mock(MechanismStateMachine.class);
+        setFilterState(filter, State.start().nextState(handler, 0L));
+
+        var captor = ArgumentCaptor.forClass(ApiMessage.class);
+        var filterContext = mockShortCircuitFilterContext(captor);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_HANDSHAKE, ApiKeys.SASL_HANDSHAKE.latestVersion(),
+                new RequestHeaderData(),
+                new SaslHandshakeRequestData().setMechanism("OAUTHBEARER"),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        var response = (SaslHandshakeResponseData) captor.getValue();
+        assertThat(response.errorCode()).isEqualTo(Errors.ILLEGAL_SASL_STATE.code());
+    }
+
+    @Test
+    void shouldRejectHandshakeInFailedState() throws Exception {
+        // Given
+        var filter = createFilter();
+        var handler = mock(MechanismStateMachine.class);
+        var authenticating = State.start().nextState(handler, 0L);
+        setFilterState(filter, authenticating.nextStateFailure("previous failure"));
+
+        var captor = ArgumentCaptor.forClass(ApiMessage.class);
+        var filterContext = mockShortCircuitFilterContext(captor);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_HANDSHAKE, ApiKeys.SASL_HANDSHAKE.latestVersion(),
+                new RequestHeaderData(),
+                new SaslHandshakeRequestData().setMechanism("OAUTHBEARER"),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        var response = (SaslHandshakeResponseData) captor.getValue();
+        assertThat(response.errorCode()).isEqualTo(Errors.ILLEGAL_SASL_STATE.code());
+    }
+
+    @Test
+    void shouldAllowReauthenticationHandshake() throws Exception {
+        // Given
+        var filter = createFilter();
+        var handler = mock(MechanismStateMachine.class);
+        var authenticating = State.start().nextState(handler, 0L);
+        setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", null));
+
+        var captor = ArgumentCaptor.forClass(ApiMessage.class);
+        var filterContext = mockShortCircuitFilterContext(captor);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_HANDSHAKE, ApiKeys.SASL_HANDSHAKE.latestVersion(),
+                new RequestHeaderData(),
+                new SaslHandshakeRequestData().setMechanism("OAUTHBEARER"),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        var response = (SaslHandshakeResponseData) captor.getValue();
+        assertThat(response.errorCode()).isEqualTo(Errors.NONE.code());
+    }
+
+    // --- Authenticate flow ---
+
+    @Test
+    void shouldRejectAuthenticateInRequiringHandshakeState() throws Exception {
+        // Given
+        var filter = createFilter();
+        var captor = ArgumentCaptor.forClass(ApiMessage.class);
+        var filterContext = mockShortCircuitFilterContext(captor);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_AUTHENTICATE, ApiKeys.SASL_AUTHENTICATE.latestVersion(),
+                new RequestHeaderData(),
+                new SaslAuthenticateRequestData().setAuthBytes(new byte[0]),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        var response = (SaslAuthenticateResponseData) captor.getValue();
+        assertThat(response.errorCode()).isEqualTo(Errors.ILLEGAL_SASL_STATE.code());
+        assertThat(response.errorMessage()).isEqualTo("Authentication not in progress");
+    }
+
+    @Test
+    void shouldRejectAuthenticateInAuthenticatedState() throws Exception {
+        // Given
+        var filter = createFilter();
+        var handler = mock(MechanismStateMachine.class);
+        var authenticating = State.start().nextState(handler, 0L);
+        setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", null));
+
+        var captor = ArgumentCaptor.forClass(ApiMessage.class);
+        var filterContext = mockShortCircuitFilterContext(captor);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_AUTHENTICATE, ApiKeys.SASL_AUTHENTICATE.latestVersion(),
+                new RequestHeaderData(),
+                new SaslAuthenticateRequestData().setAuthBytes(new byte[0]),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        var response = (SaslAuthenticateResponseData) captor.getValue();
+        assertThat(response.errorCode()).isEqualTo(Errors.ILLEGAL_SASL_STATE.code());
+        assertThat(response.errorMessage()).isEqualTo("Authentication not in progress");
+    }
+
+    @Test
+    void shouldReturnChallengeBytes() throws Exception {
+        // Given
+        byte[] challengeBytes = { 10, 20, 30 };
+        var handler = mock(MechanismStateMachine.class);
+        when(handler.mechanismName()).thenReturn("OAUTHBEARER");
+        when(handler.maxAuthBytes()).thenReturn(4 * 1024);
+        when(handler.evaluateRound(any())).thenReturn(
+                CompletableFuture.completedFuture(RoundResult.challenge(challengeBytes)));
+
+        var filter = createFilterWithZeroDelay();
+        setFilterState(filter, State.start().nextState(handler, System.nanoTime()));
+
+        var captor = ArgumentCaptor.forClass(ApiMessage.class);
+        var filterContext = mockShortCircuitFilterContext(captor);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_AUTHENTICATE, ApiKeys.SASL_AUTHENTICATE.latestVersion(),
+                new RequestHeaderData(),
+                new SaslAuthenticateRequestData().setAuthBytes(new byte[]{ 1, 2 }),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        var response = (SaslAuthenticateResponseData) captor.getValue();
+        assertThat(response.errorCode()).isEqualTo(Errors.NONE.code());
+        assertThat(response.authBytes()).containsExactly(10, 20, 30);
+    }
+
+    @Test
+    void shouldReturnSuccessResponse() throws Exception {
+        // Given
+        byte[] responseBytes = { 40, 50 };
+        var handler = mock(MechanismStateMachine.class);
+        when(handler.mechanismName()).thenReturn("OAUTHBEARER");
+        when(handler.maxAuthBytes()).thenReturn(4 * 1024);
+        when(handler.evaluateRound(any())).thenReturn(
+                CompletableFuture.completedFuture(RoundResult.success(responseBytes, "alice", 3600000)));
+
+        var filter = createFilterWithZeroDelay();
+        setFilterState(filter, State.start().nextState(handler, System.nanoTime()));
+
+        var captor = ArgumentCaptor.forClass(ApiMessage.class);
+        var filterContext = mockShortCircuitFilterContextForSuccess(captor);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_AUTHENTICATE, ApiKeys.SASL_AUTHENTICATE.latestVersion(),
+                new RequestHeaderData(),
+                new SaslAuthenticateRequestData().setAuthBytes(new byte[]{ 1, 2 }),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        var response = (SaslAuthenticateResponseData) captor.getValue();
+        assertThat(response.errorCode()).isEqualTo(Errors.NONE.code());
+        assertThat(response.authBytes()).containsExactly(40, 50);
+        assertThat(response.sessionLifetimeMs()).isEqualTo(3600000);
+    }
+
+    @Test
+    void shouldCallClientSaslAuthenticationSuccessOnSuccess() throws Exception {
+        // Given
+        var handler = mock(MechanismStateMachine.class);
+        when(handler.mechanismName()).thenReturn("OAUTHBEARER");
+        when(handler.maxAuthBytes()).thenReturn(4 * 1024);
+        when(handler.evaluateRound(any())).thenReturn(
+                CompletableFuture.completedFuture(RoundResult.success(new byte[0], "alice", 0)));
+
+        var filter = createFilterWithZeroDelay();
+        setFilterState(filter, State.start().nextState(handler, System.nanoTime()));
+
+        var captor = ArgumentCaptor.forClass(ApiMessage.class);
+        var filterContext = mockShortCircuitFilterContextForSuccess(captor);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_AUTHENTICATE, ApiKeys.SASL_AUTHENTICATE.latestVersion(),
+                new RequestHeaderData(),
+                new SaslAuthenticateRequestData().setAuthBytes(new byte[0]),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        verify(filterContext).clientSaslAuthenticationSuccess(eq("OAUTHBEARER"), any(Subject.class));
+    }
+
+    @Test
+    void shouldReturnFailureAndCloseConnection() throws Exception {
+        // Given
+        var exception = new javax.security.sasl.SaslException("bad credentials");
+        var handler = mock(MechanismStateMachine.class);
+        when(handler.mechanismName()).thenReturn("OAUTHBEARER");
+        when(handler.maxAuthBytes()).thenReturn(4 * 1024);
+        when(handler.evaluateRound(any())).thenReturn(
+                CompletableFuture.completedFuture(RoundResult.failure(new byte[0], exception)));
+
+        var filter = createFilterWithZeroDelay();
+        setFilterState(filter, State.start().nextState(handler, System.nanoTime()));
+
+        var captor = ArgumentCaptor.forClass(ApiMessage.class);
+        var closeOrTerminal = mock(CloseOrTerminalStage.class);
+        var terminal = mock(TerminalStage.class);
+        var filterContext = mockShortCircuitFilterContextWithCloseTracking(captor, closeOrTerminal, terminal);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_AUTHENTICATE, ApiKeys.SASL_AUTHENTICATE.latestVersion(),
+                new RequestHeaderData(),
+                new SaslAuthenticateRequestData().setAuthBytes(new byte[0]),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        var response = (SaslAuthenticateResponseData) captor.getValue();
+        assertThat(response.errorCode()).isEqualTo(Errors.SASL_AUTHENTICATION_FAILED.code());
+        assertThat(response.errorMessage()).isEqualTo("Authentication failed");
+        verify(closeOrTerminal).withCloseConnection();
+        verify(filterContext).clientSaslAuthenticationFailure(eq("OAUTHBEARER"), isNull(), eq(exception));
+    }
+
+    @Test
+    void shouldHandleEvaluateRoundException() throws Exception {
+        // Given
+        var handler = mock(MechanismStateMachine.class);
+        when(handler.mechanismName()).thenReturn("OAUTHBEARER");
+        when(handler.maxAuthBytes()).thenReturn(4 * 1024);
+        var failedFuture = new CompletableFuture<RoundResult>();
+        failedFuture.completeExceptionally(new RuntimeException("credential store unavailable"));
+        when(handler.evaluateRound(any())).thenReturn(failedFuture);
+
+        var filter = createFilterWithZeroDelay();
+        setFilterState(filter, State.start().nextState(handler, System.nanoTime()));
+
+        var captor = ArgumentCaptor.forClass(ApiMessage.class);
+        var closeOrTerminal = mock(CloseOrTerminalStage.class);
+        var terminal = mock(TerminalStage.class);
+        var filterContext = mockShortCircuitFilterContextWithCloseTracking(captor, closeOrTerminal, terminal);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_AUTHENTICATE, ApiKeys.SASL_AUTHENTICATE.latestVersion(),
+                new RequestHeaderData(),
+                new SaslAuthenticateRequestData().setAuthBytes(new byte[0]),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        var response = (SaslAuthenticateResponseData) captor.getValue();
+        assertThat(response.errorCode()).isEqualTo(Errors.SASL_AUTHENTICATION_FAILED.code());
+        verify(closeOrTerminal).withCloseConnection();
+    }
+
+    @Test
+    void shouldDisposeStateMachineOnSuccess() throws Exception {
+        // Given
+        var handler = mock(MechanismStateMachine.class);
+        when(handler.mechanismName()).thenReturn("OAUTHBEARER");
+        when(handler.maxAuthBytes()).thenReturn(4 * 1024);
+        when(handler.evaluateRound(any())).thenReturn(
+                CompletableFuture.completedFuture(RoundResult.success(new byte[0], "alice", 0)));
+
+        var filter = createFilterWithZeroDelay();
+        setFilterState(filter, State.start().nextState(handler, System.nanoTime()));
+
+        var captor = ArgumentCaptor.forClass(ApiMessage.class);
+        var filterContext = mockShortCircuitFilterContextForSuccess(captor);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_AUTHENTICATE, ApiKeys.SASL_AUTHENTICATE.latestVersion(),
+                new RequestHeaderData(),
+                new SaslAuthenticateRequestData().setAuthBytes(new byte[0]),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        verify(handler).dispose();
+    }
+
+    @Test
+    void shouldDisposeStateMachineOnFailure() throws Exception {
+        // Given
+        var handler = mock(MechanismStateMachine.class);
+        when(handler.mechanismName()).thenReturn("OAUTHBEARER");
+        when(handler.maxAuthBytes()).thenReturn(4 * 1024);
+        when(handler.evaluateRound(any())).thenReturn(
+                CompletableFuture.completedFuture(RoundResult.failure(new byte[0], new Exception("fail"))));
+
+        var filter = createFilterWithZeroDelay();
+        setFilterState(filter, State.start().nextState(handler, System.nanoTime()));
+
+        var captor = ArgumentCaptor.forClass(ApiMessage.class);
+        var closeOrTerminal = mock(CloseOrTerminalStage.class);
+        var terminal = mock(TerminalStage.class);
+        var filterContext = mockShortCircuitFilterContextWithCloseTracking(captor, closeOrTerminal, terminal);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_AUTHENTICATE, ApiKeys.SASL_AUTHENTICATE.latestVersion(),
+                new RequestHeaderData(),
+                new SaslAuthenticateRequestData().setAuthBytes(new byte[0]),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        verify(handler).dispose();
+    }
+
+    // --- Default request / security barrier ---
+
+    @Test
+    void shouldRejectUnauthenticatedDefaultRequest() throws Exception {
+        // Given
+        var filter = createFilter();
+        var exceptionCaptor = ArgumentCaptor.forClass(ApiException.class);
+        var filterContext = mockErrorFilterContextWithClose(exceptionCaptor);
+
+        // When
+        filter.onRequest(ApiKeys.METADATA, ApiKeys.METADATA.latestVersion(),
+                new RequestHeaderData(),
+                new MetadataRequestData(),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        assertThat(exceptionCaptor.getValue()).isInstanceOf(org.apache.kafka.common.errors.SaslAuthenticationException.class);
+    }
+
+    @Test
+    void shouldForwardAuthenticatedRequestWithNoExpiry() throws Exception {
+        // Given
+        var filter = createFilter();
+        var handler = mock(MechanismStateMachine.class);
+        var authenticating = State.start().nextState(handler, 0L);
+        setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", null));
+
+        var filterContext = mockForwardingFilterContext();
+
+        // When
+        filter.onRequest(ApiKeys.METADATA, ApiKeys.METADATA.latestVersion(),
+                new RequestHeaderData(),
+                new MetadataRequestData(),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        verify(filterContext).forwardRequest(any(), any());
+    }
+
+    @Test
+    void shouldForwardAuthenticatedRequestWithFutureExpiry() throws Exception {
+        // Given
+        var filter = createFilterWithClock(FIXED_CLOCK);
+        var handler = mock(MechanismStateMachine.class);
+        var authenticating = State.start().nextState(handler, 0L);
+        Instant futureExpiry = FIXED_INSTANT.plusSeconds(3600);
+        setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", futureExpiry));
+
+        var filterContext = mockForwardingFilterContext();
+
+        // When
+        filter.onRequest(ApiKeys.METADATA, ApiKeys.METADATA.latestVersion(),
+                new RequestHeaderData(),
+                new MetadataRequestData(),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        verify(filterContext).forwardRequest(any(), any());
+    }
+
+    @Test
+    void shouldRejectExpiredSession() throws Exception {
+        // Given
+        var filter = createFilterWithClock(FIXED_CLOCK);
+        var handler = mock(MechanismStateMachine.class);
+        var authenticating = State.start().nextState(handler, 0L);
+        Instant pastExpiry = FIXED_INSTANT.minusSeconds(60);
+        setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", pastExpiry));
+
+        var exceptionCaptor = ArgumentCaptor.forClass(ApiException.class);
+        var filterContext = mockErrorFilterContextWithClose(exceptionCaptor);
+
+        // When
+        filter.onRequest(ApiKeys.METADATA, ApiKeys.METADATA.latestVersion(),
+                new RequestHeaderData(),
+                new MetadataRequestData(),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        assertThat(exceptionCaptor.getValue()).isInstanceOf(org.apache.kafka.common.errors.SaslAuthenticationException.class);
+    }
+
+    // --- Filtered API rejection ---
+
+    @ParameterizedTest
+    @EnumSource(value = ApiKeys.class, names = {
+            "CREATE_DELEGATION_TOKEN", "RENEW_DELEGATION_TOKEN",
+            "EXPIRE_DELEGATION_TOKEN", "DESCRIBE_DELEGATION_TOKEN"
+    })
+    void shouldRejectDelegationTokenApiWithCorrectMessage(ApiKeys apiKey) throws Exception {
+        // Given
+        var filter = createFilter();
+        var exceptionCaptor = ArgumentCaptor.forClass(ApiException.class);
+        var filterContext = mockErrorFilterContextWithoutClose(exceptionCaptor);
+
+        // When
+        filter.onRequest(apiKey, apiKey.latestVersion(),
+                new RequestHeaderData(),
+                apiKey.messageType.newRequest(),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        assertThat(exceptionCaptor.getValue().getMessage())
+                .isEqualTo("Delegation tokens are not supported when SASL is terminated at the proxy");
+    }
+
+    // --- API_VERSIONS ---
+
+    @Test
+    void shouldForwardApiVersionsRequest() throws Exception {
+        // Given
+        var filter = createFilter();
+        var filterContext = mockForwardingFilterContext();
+
+        // When
+        filter.onRequest(ApiKeys.API_VERSIONS, ApiKeys.API_VERSIONS.latestVersion(),
+                new RequestHeaderData(),
+                new ApiVersionsRequestData(),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        verify(filterContext).forwardRequest(any(), any());
+    }
+
+    // --- computeSessionLifetimeMs ---
+
+    @ParameterizedTest
+    @CsvSource({
+            "0, 0, 0",
+            "5000, 0, 5000",
+            "0, 3000, 3000",
+            "5000, 3000, 3000",
+            "3000, 5000, 3000"
+    })
+    void shouldComputeSessionLifetimeMs(long maxTimeBeforeReauthMs, long handlerLifetimeMs, long expected) {
+        // Given
+        Duration maxReauth = maxTimeBeforeReauthMs > 0 ? Duration.ofMillis(maxTimeBeforeReauthMs) : null;
+        var context = new SaslTermination.SaslTerminationContext(
+                null, Set.of("OAUTHBEARER"), List.of(),
+                maxReauth, Clock.systemUTC(), Duration.ZERO,
+                SaslTermination.DEFAULT_SUBJECT_BUILDER);
+        var filter = new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
+
+        // When
+        long result = filter.computeSessionLifetimeMs(handlerLifetimeMs);
+
+        // Then
+        assertThat(result).isEqualTo(expected);
+    }
+
+    // --- Helper methods ---
+
+    private static SaslTerminationFilter createFilter() {
+        var callbackHandler = new OAuthBearerValidatorCallbackHandler();
+        var context = new SaslTermination.SaslTerminationContext(
+                callbackHandler,
+                Set.of("OAUTHBEARER"), List.of(),
+                null, Clock.systemUTC(), Duration.ofMillis(200),
+                SaslTermination.DEFAULT_SUBJECT_BUILDER);
+        return new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
+    }
+
+    private static SaslTerminationFilter createFilterWithZeroDelay() {
+        var context = new SaslTermination.SaslTerminationContext(
+                null, Set.of("OAUTHBEARER"), List.of(),
+                null, Clock.systemUTC(), Duration.ZERO,
+                SaslTermination.DEFAULT_SUBJECT_BUILDER);
+        return new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
+    }
+
+    private static SaslTerminationFilter createFilterWithClock(Clock clock) {
+        var callbackHandler = new OAuthBearerValidatorCallbackHandler();
+        var context = new SaslTermination.SaslTerminationContext(
+                callbackHandler,
+                Set.of("OAUTHBEARER"), List.of(),
+                null, clock, Duration.ofMillis(200),
+                SaslTermination.DEFAULT_SUBJECT_BUILDER);
+        return new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static FilterContext mockShortCircuitFilterContext(ArgumentCaptor<ApiMessage> captor) {
+        var filterContext = mock(FilterContext.class);
+        var builder = mock(RequestFilterResultBuilder.class);
+        var closeOrTerminal = mock(CloseOrTerminalStage.class);
+        var result = mock(RequestFilterResult.class);
+
+        when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
+        when(filterContext.sessionId()).thenReturn("test-session");
+        when(builder.shortCircuitResponse(captor.capture())).thenReturn(closeOrTerminal);
+        when(closeOrTerminal.completed()).thenReturn(CompletableFuture.completedFuture(result));
+
+        return filterContext;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static FilterContext mockShortCircuitFilterContextForSuccess(ArgumentCaptor<ApiMessage> captor) {
+        var filterContext = mock(FilterContext.class);
+        var builder = mock(RequestFilterResultBuilder.class);
+        var closeOrTerminal = mock(CloseOrTerminalStage.class);
+        var result = mock(RequestFilterResult.class);
+
+        when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
+        when(filterContext.sessionId()).thenReturn("test-session");
+        when(filterContext.clientTlsContext()).thenReturn(Optional.empty());
+        when(builder.shortCircuitResponse(captor.capture())).thenReturn(closeOrTerminal);
+        when(closeOrTerminal.completed()).thenReturn(CompletableFuture.completedFuture(result));
+
+        return filterContext;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static FilterContext mockShortCircuitFilterContextWithCloseTracking(
+                                                                                ArgumentCaptor<ApiMessage> captor,
+                                                                                CloseOrTerminalStage<RequestFilterResult> closeOrTerminal,
+                                                                                TerminalStage<RequestFilterResult> terminal) {
+        var filterContext = mock(FilterContext.class);
+        var builder = mock(RequestFilterResultBuilder.class);
+        var result = mock(RequestFilterResult.class);
+
+        when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
+        when(filterContext.sessionId()).thenReturn("test-session");
+        when(builder.shortCircuitResponse(captor.capture())).thenReturn(closeOrTerminal);
+        when(closeOrTerminal.withCloseConnection()).thenReturn(terminal);
+        when(terminal.completed()).thenReturn(CompletableFuture.completedFuture(result));
+
+        return filterContext;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static FilterContext mockErrorFilterContextWithClose(ArgumentCaptor<ApiException> exceptionCaptor) {
+        var filterContext = mock(FilterContext.class);
+        var builder = mock(RequestFilterResultBuilder.class);
+        var closeOrTerminal = mock(CloseOrTerminalStage.class);
+        var terminal = mock(TerminalStage.class);
+        var result = mock(RequestFilterResult.class);
+
+        when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
+        when(filterContext.sessionId()).thenReturn("test-session");
+        when(builder.errorResponse(any(), any(), exceptionCaptor.capture())).thenReturn(closeOrTerminal);
+        when(closeOrTerminal.withCloseConnection()).thenReturn(terminal);
+        when(terminal.completed()).thenReturn(CompletableFuture.completedFuture(result));
+
+        return filterContext;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static FilterContext mockErrorFilterContextWithoutClose(ArgumentCaptor<ApiException> exceptionCaptor) {
+        var filterContext = mock(FilterContext.class);
+        var builder = mock(RequestFilterResultBuilder.class);
+        var closeOrTerminal = mock(CloseOrTerminalStage.class);
+        var result = mock(RequestFilterResult.class);
+
+        when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
+        when(filterContext.sessionId()).thenReturn("test-session");
+        when(builder.errorResponse(any(), any(), exceptionCaptor.capture())).thenReturn(closeOrTerminal);
+        when(closeOrTerminal.completed()).thenReturn(CompletableFuture.completedFuture(result));
+
+        return filterContext;
+    }
+
+    private static FilterContext mockForwardingFilterContext() {
+        var filterContext = mock(FilterContext.class);
+        var result = mock(RequestFilterResult.class);
+
+        when(filterContext.sessionId()).thenReturn("test-session");
+        when(filterContext.forwardRequest(any(), any())).thenReturn(CompletableFuture.completedFuture(result));
+
+        return filterContext;
+    }
+
+    private static void setFilterState(SaslTerminationFilter filter, State state) {
+        try {
+            var field = SaslTerminationFilter.class.getDeclaredField("state");
+            field.setAccessible(true);
+            field.set(filter, state);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
@@ -29,12 +29,18 @@ import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
 import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslServerProvider;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
+
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 import io.kroxylicious.proxy.authentication.Subject;
 import io.kroxylicious.proxy.filter.FilterContext;
@@ -55,10 +61,27 @@ class SaslTerminationFilterTest {
 
     private static final Instant FIXED_INSTANT = Instant.parse("2026-01-01T00:00:00Z");
     private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC);
+    private static final String TEST_VIRTUAL_CLUSTER = "test-cluster";
+
+    private SimpleMeterRegistry meterRegistry;
 
     @BeforeAll
     static void registerProvider() {
         OAuthBearerSaslServerProvider.initialize();
+    }
+
+    @BeforeEach
+    void setUpMetrics() {
+        meterRegistry = new SimpleMeterRegistry();
+        Metrics.globalRegistry.add(meterRegistry);
+    }
+
+    @AfterEach
+    void tearDownMetrics() {
+        if (meterRegistry != null) {
+            meterRegistry.getMeters().forEach(Metrics.globalRegistry::remove);
+            Metrics.globalRegistry.remove(meterRegistry);
+        }
     }
 
     // --- Handshake flow ---
@@ -267,6 +290,9 @@ class SaslTerminationFilterTest {
         assertThat(response.errorCode()).isEqualTo(Errors.NONE.code());
         assertThat(response.authBytes()).containsExactly(40, 50);
         assertThat(response.sessionLifetimeMs()).isEqualTo(3600000);
+        assertThat(meterRegistry.find(SaslTerminationFilter.AUTH_DURATION_METRIC)
+                .tags(List.of(Tag.of("mechanism", "OAUTHBEARER"), Tag.of(SaslTerminationFilter.VIRTUAL_CLUSTER_TAG, TEST_VIRTUAL_CLUSTER)))
+                .timer()).isNotNull();
     }
 
     @Test
@@ -324,6 +350,9 @@ class SaslTerminationFilterTest {
         assertThat(response.errorMessage()).isEqualTo("Authentication failed");
         verify(closeOrTerminal).withCloseConnection();
         verify(filterContext).clientSaslAuthenticationFailure(eq("OAUTHBEARER"), isNull(), eq(exception));
+        assertThat(meterRegistry.find(SaslTerminationFilter.AUTH_DURATION_METRIC)
+                .tags(List.of(Tag.of("mechanism", "OAUTHBEARER"), Tag.of(SaslTerminationFilter.VIRTUAL_CLUSTER_TAG, TEST_VIRTUAL_CLUSTER)))
+                .timer()).isNotNull();
     }
 
     @Test
@@ -408,6 +437,68 @@ class SaslTerminationFilterTest {
         verify(handler).dispose();
     }
 
+    // --- Reauthentication consistency ---
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldRejectReauthenticationWithDifferentMechanism() throws Exception {
+        // Given
+        var filter = createFilterWithZeroDelay();
+        var handler = mock(MechanismStateMachine.class);
+        var authenticating = State.start().nextState(handler, 0L);
+        setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", null));
+
+        var captor = ArgumentCaptor.forClass(ApiMessage.class);
+        var closeOrTerminal = mock(CloseOrTerminalStage.class);
+        var terminal = mock(TerminalStage.class);
+        var filterContext = mockShortCircuitFilterContextWithCloseTracking(captor, closeOrTerminal, terminal);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_HANDSHAKE, ApiKeys.SASL_HANDSHAKE.latestVersion(),
+                new RequestHeaderData(),
+                new SaslHandshakeRequestData().setMechanism("SCRAM-SHA-256"),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        var response = (SaslHandshakeResponseData) captor.getValue();
+        assertThat(response.errorCode()).isEqualTo(Errors.ILLEGAL_SASL_STATE.code());
+        verify(closeOrTerminal).withCloseConnection();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldRejectReauthenticationWithDifferentAuthorizationId() throws Exception {
+        // Given
+        var handler = mock(MechanismStateMachine.class);
+        when(handler.mechanismName()).thenReturn("OAUTHBEARER");
+        when(handler.maxAuthBytes()).thenReturn(4 * 1024);
+        when(handler.evaluateRound(any())).thenReturn(
+                CompletableFuture.completedFuture(RoundResult.success(new byte[0], "bob", 0)));
+
+        var filter = createFilterWithZeroDelay();
+        var initialHandler = mock(MechanismStateMachine.class);
+        var authenticating = State.start().nextState(initialHandler, 0L);
+        var authenticated = authenticating.nextStateSuccess("alice", "OAUTHBEARER", null);
+        var reauthenticating = authenticated.nextStateReauthenticate(handler, System.nanoTime());
+        setFilterState(filter, reauthenticating);
+
+        var captor = ArgumentCaptor.forClass(ApiMessage.class);
+        var closeOrTerminal = mock(CloseOrTerminalStage.class);
+        var terminal = mock(TerminalStage.class);
+        var filterContext = mockShortCircuitFilterContextWithCloseTracking(captor, closeOrTerminal, terminal);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_AUTHENTICATE, ApiKeys.SASL_AUTHENTICATE.latestVersion(),
+                new RequestHeaderData(),
+                new SaslAuthenticateRequestData().setAuthBytes(new byte[0]),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        var response = (SaslAuthenticateResponseData) captor.getValue();
+        assertThat(response.errorCode()).isEqualTo(Errors.SASL_AUTHENTICATION_FAILED.code());
+        verify(closeOrTerminal).withCloseConnection();
+    }
+
     // --- Default request / security barrier ---
 
     @Test
@@ -488,6 +579,10 @@ class SaslTerminationFilterTest {
 
         // Then
         assertThat(exceptionCaptor.getValue()).isInstanceOf(org.apache.kafka.common.errors.SaslAuthenticationException.class);
+        assertThat(meterRegistry.find(SaslTerminationFilter.SESSION_EXPIRED_METRIC)
+                .tags(List.of(Tag.of("mechanism", "OAUTHBEARER"), Tag.of(SaslTerminationFilter.VIRTUAL_CLUSTER_TAG, TEST_VIRTUAL_CLUSTER)))
+                .counter()).isNotNull()
+                .satisfies(counter -> assertThat(counter.count()).isEqualTo(1));
     }
 
     // --- Filtered API rejection ---
@@ -612,6 +707,7 @@ class SaslTerminationFilterTest {
 
         when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
         when(filterContext.sessionId()).thenReturn("test-session");
+        when(filterContext.getVirtualClusterName()).thenReturn(TEST_VIRTUAL_CLUSTER);
         when(filterContext.clientTlsContext()).thenReturn(Optional.empty());
         when(builder.shortCircuitResponse(captor.capture())).thenReturn(closeOrTerminal);
         when(closeOrTerminal.completed()).thenReturn(CompletableFuture.completedFuture(result));
@@ -630,6 +726,7 @@ class SaslTerminationFilterTest {
 
         when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
         when(filterContext.sessionId()).thenReturn("test-session");
+        when(filterContext.getVirtualClusterName()).thenReturn(TEST_VIRTUAL_CLUSTER);
         when(builder.shortCircuitResponse(captor.capture())).thenReturn(closeOrTerminal);
         when(closeOrTerminal.withCloseConnection()).thenReturn(terminal);
         when(terminal.completed()).thenReturn(CompletableFuture.completedFuture(result));
@@ -647,6 +744,7 @@ class SaslTerminationFilterTest {
 
         when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
         when(filterContext.sessionId()).thenReturn("test-session");
+        when(filterContext.getVirtualClusterName()).thenReturn(TEST_VIRTUAL_CLUSTER);
         when(builder.errorResponse(any(), any(), exceptionCaptor.capture())).thenReturn(closeOrTerminal);
         when(closeOrTerminal.withCloseConnection()).thenReturn(terminal);
         when(terminal.completed()).thenReturn(CompletableFuture.completedFuture(result));

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
@@ -82,11 +82,13 @@ class SaslTerminationFilterTest {
     }
 
     @Test
-    void shouldListSupportedMechanismsForUnsupportedHandshake() throws Exception {
+    void shouldCloseConnectionForUnsupportedHandshake() throws Exception {
         // Given
         var filter = createFilter();
         var captor = ArgumentCaptor.forClass(ApiMessage.class);
-        var filterContext = mockShortCircuitFilterContext(captor);
+        var closeOrTerminal = mock(CloseOrTerminalStage.class);
+        var terminal = mock(TerminalStage.class);
+        var filterContext = mockShortCircuitFilterContextWithCloseTracking(captor, closeOrTerminal, terminal);
 
         // When
         filter.onRequest(ApiKeys.SASL_HANDSHAKE, ApiKeys.SASL_HANDSHAKE.latestVersion(),
@@ -98,6 +100,7 @@ class SaslTerminationFilterTest {
         var response = (SaslHandshakeResponseData) captor.getValue();
         assertThat(response.errorCode()).isEqualTo(Errors.UNSUPPORTED_SASL_MECHANISM.code());
         assertThat(response.mechanisms()).contains("OAUTHBEARER");
+        verify(closeOrTerminal).withCloseConnection();
     }
 
     @Test

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
@@ -509,7 +509,7 @@ class SaslTerminationFilterTest {
                     .timer();
             assertThat(timer).isNotNull();
             assertThat(timer.totalTime(TimeUnit.MILLISECONDS))
-                    .isLessThan(fixedDelay.toMillis());
+                    .isLessThan((double) fixedDelay.toMillis());
         }
     }
 
@@ -723,20 +723,20 @@ class SaslTerminationFilterTest {
     @Test
     void shouldReturnMaxReauthExpiryWhenMechanismExpiryIsNull() {
         // Given
-        var filter = createFilterWithMaxReauth(Duration.ofMillis(5000));
+        var filter = createFilterWithMaxReauth(Duration.ofSeconds(5));
 
         // When
         Instant result = filter.computeSessionExpiry(null);
 
         // Then
-        assertThat(result).isEqualTo(FIXED_INSTANT.plusMillis(5000));
+        assertThat(result).isEqualTo(FIXED_INSTANT.plusSeconds(5));
     }
 
     @Test
     void shouldReturnMechanismExpiryWhenMaxReauthIsNull() {
         // Given
         var filter = createFilterWithMaxReauth(null);
-        Instant mechanismExpiry = FIXED_INSTANT.plusMillis(3000);
+        Instant mechanismExpiry = FIXED_INSTANT.plusSeconds(3);
 
         // When
         Instant result = filter.computeSessionExpiry(mechanismExpiry);
@@ -748,8 +748,8 @@ class SaslTerminationFilterTest {
     @Test
     void shouldReturnEarlierOfMaxReauthAndMechanismExpiryWhenMechanismIsEarlier() {
         // Given
-        var filter = createFilterWithMaxReauth(Duration.ofMillis(5000));
-        Instant mechanismExpiry = FIXED_INSTANT.plusMillis(3000);
+        var filter = createFilterWithMaxReauth(Duration.ofSeconds(5));
+        Instant mechanismExpiry = FIXED_INSTANT.plusSeconds(3);
 
         // When
         Instant result = filter.computeSessionExpiry(mechanismExpiry);
@@ -761,14 +761,14 @@ class SaslTerminationFilterTest {
     @Test
     void shouldReturnEarlierOfMaxReauthAndMechanismExpiryWhenMaxReauthIsEarlier() {
         // Given
-        var filter = createFilterWithMaxReauth(Duration.ofMillis(3000));
-        Instant mechanismExpiry = FIXED_INSTANT.plusMillis(5000);
+        var filter = createFilterWithMaxReauth(Duration.ofSeconds(3));
+        Instant mechanismExpiry = FIXED_INSTANT.plusSeconds(5);
 
         // When
         Instant result = filter.computeSessionExpiry(mechanismExpiry);
 
         // Then
-        assertThat(result).isEqualTo(FIXED_INSTANT.plusMillis(3000));
+        assertThat(result).isEqualTo(FIXED_INSTANT.plusSeconds(3));
     }
 
     // --- Helper methods ---

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
@@ -650,7 +650,7 @@ class SaslTerminationFilterTest {
 
         // Then
         assertThat(exceptionCaptor.getValue().getMessage())
-                .isEqualTo("Delegation tokens are not supported when SASL is terminated at the proxy");
+                .isEqualTo(apiKey + " is not supported when SASL is terminated at the proxy");
     }
 
     // --- API_VERSIONS ---

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
@@ -595,6 +595,9 @@ class SaslTerminationFilterTest {
     void shouldRejectDelegationTokenApiWithCorrectMessage(ApiKeys apiKey) throws Exception {
         // Given
         var filter = createFilter();
+        var handler = mock(MechanismStateMachine.class);
+        var authenticating = State.start().nextState(handler, 0L);
+        setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", null));
         var exceptionCaptor = ArgumentCaptor.forClass(ApiException.class);
         var filterContext = mockErrorFilterContextWithoutClose(exceptionCaptor);
 

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 
@@ -53,6 +52,8 @@ import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.RequestFilterResultBuilder;
 import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
 import io.kroxylicious.proxy.filter.filterresultbuilder.TerminalStage;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -275,10 +276,11 @@ class SaslTerminationFilterTest {
         var handler = mock(MechanismStateMachine.class);
         when(handler.mechanismName()).thenReturn("OAUTHBEARER");
         when(handler.maxAuthBytes()).thenReturn(4 * 1024);
+        Instant sessionExpiry = FIXED_INSTANT.plusMillis(3600000);
         when(handler.evaluateRound(any())).thenReturn(
-                CompletableFuture.completedFuture(RoundResult.success(responseBytes, "alice", 3600000)));
+                CompletableFuture.completedFuture(RoundResult.success(responseBytes, "alice", sessionExpiry)));
 
-        var filter = createFilterWithZeroDelay();
+        var filter = createFilterWithZeroDelayAndClock(FIXED_CLOCK);
         setFilterState(filter, State.start().nextState(handler));
 
         var captor = ArgumentCaptor.forClass(ApiMessage.class);
@@ -307,7 +309,7 @@ class SaslTerminationFilterTest {
         when(handler.mechanismName()).thenReturn("OAUTHBEARER");
         when(handler.maxAuthBytes()).thenReturn(4 * 1024);
         when(handler.evaluateRound(any())).thenReturn(
-                CompletableFuture.completedFuture(RoundResult.success(new byte[0], "alice", 0)));
+                CompletableFuture.completedFuture(RoundResult.success(new byte[0], "alice")));
 
         var filter = createFilterWithZeroDelay();
         setFilterState(filter, State.start().nextState(handler));
@@ -391,13 +393,44 @@ class SaslTerminationFilterTest {
     }
 
     @Test
+    void shouldRejectAuthenticationWhenTokenExpiresBeforeResponseIsSent() throws Exception {
+        // Given
+        var handler = mock(MechanismStateMachine.class);
+        when(handler.mechanismName()).thenReturn("OAUTHBEARER");
+        when(handler.maxAuthBytes()).thenReturn(4 * 1024);
+        Instant alreadyExpired = FIXED_INSTANT.minusMillis(1);
+        when(handler.evaluateRound(any())).thenReturn(
+                CompletableFuture.completedFuture(RoundResult.success(new byte[0], "alice", alreadyExpired)));
+
+        var filter = createFilterWithZeroDelayAndClock(FIXED_CLOCK);
+        setFilterState(filter, State.start().nextState(handler));
+
+        var captor = ArgumentCaptor.forClass(ApiMessage.class);
+        var closeOrTerminal = mock(CloseOrTerminalStage.class);
+        var terminal = mock(TerminalStage.class);
+        var filterContext = mockShortCircuitFilterContextWithCloseTracking(captor, closeOrTerminal, terminal);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_AUTHENTICATE, ApiKeys.SASL_AUTHENTICATE.latestVersion(),
+                new RequestHeaderData(),
+                new SaslAuthenticateRequestData().setAuthBytes(new byte[0]),
+                filterContext).toCompletableFuture().get();
+
+        // Then
+        var response = (SaslAuthenticateResponseData) captor.getValue();
+        assertThat(response.errorCode()).isEqualTo(Errors.SASL_AUTHENTICATION_FAILED.code());
+        verify(closeOrTerminal).withCloseConnection();
+        verify(filterContext).clientSaslAuthenticationFailure(eq("OAUTHBEARER"), isNull(), any(Exception.class));
+    }
+
+    @Test
     void shouldDisposeStateMachineOnSuccess() throws Exception {
         // Given
         var handler = mock(MechanismStateMachine.class);
         when(handler.mechanismName()).thenReturn("OAUTHBEARER");
         when(handler.maxAuthBytes()).thenReturn(4 * 1024);
         when(handler.evaluateRound(any())).thenReturn(
-                CompletableFuture.completedFuture(RoundResult.success(new byte[0], "alice", 0)));
+                CompletableFuture.completedFuture(RoundResult.success(new byte[0], "alice")));
 
         var filter = createFilterWithZeroDelay();
         setFilterState(filter, State.start().nextState(handler));
@@ -449,7 +482,7 @@ class SaslTerminationFilterTest {
         when(handler.mechanismName()).thenReturn("OAUTHBEARER");
         when(handler.maxAuthBytes()).thenReturn(4 * 1024);
         when(handler.evaluateRound(any())).thenReturn(
-                CompletableFuture.completedFuture(RoundResult.success(new byte[0], "alice", 0)));
+                CompletableFuture.completedFuture(RoundResult.success(new byte[0], "alice")));
 
         Duration fixedDelay = Duration.ofMillis(200);
 
@@ -516,7 +549,7 @@ class SaslTerminationFilterTest {
         when(handler.mechanismName()).thenReturn("OAUTHBEARER");
         when(handler.maxAuthBytes()).thenReturn(4 * 1024);
         when(handler.evaluateRound(any())).thenReturn(
-                CompletableFuture.completedFuture(RoundResult.success(new byte[0], "bob", 0)));
+                CompletableFuture.completedFuture(RoundResult.success(new byte[0], "bob")));
 
         var filter = createFilterWithZeroDelay();
         var initialHandler = mock(MechanismStateMachine.class);
@@ -673,30 +706,69 @@ class SaslTerminationFilterTest {
         verify(filterContext).forwardRequest(any(), any());
     }
 
-    // --- computeSessionLifetimeMs ---
+    // --- computeSessionExpiry ---
 
-    @ParameterizedTest
-    @CsvSource({
-            "0, 0, 0",
-            "5000, 0, 5000",
-            "0, 3000, 3000",
-            "5000, 3000, 3000",
-            "3000, 5000, 3000"
-    })
-    void shouldComputeSessionLifetimeMs(long maxTimeBeforeReauthMs, long handlerLifetimeMs, long expected) {
+    @Test
+    void shouldReturnNullWhenBothExpiriesAreNull() {
         // Given
-        Duration maxReauth = maxTimeBeforeReauthMs > 0 ? Duration.ofMillis(maxTimeBeforeReauthMs) : null;
-        var context = new SaslTermination.SaslTerminationContext(
-                null, OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES, Set.of("OAUTHBEARER"), List.of(),
-                maxReauth, Clock.systemUTC(), Duration.ZERO,
-                SaslTermination.DEFAULT_SUBJECT_BUILDER);
-        var filter = new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
+        var filter = createFilterWithMaxReauth(null);
 
         // When
-        long result = filter.computeSessionLifetimeMs(handlerLifetimeMs);
+        Instant result = filter.computeSessionExpiry(null);
 
         // Then
-        assertThat(result).isEqualTo(expected);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void shouldReturnMaxReauthExpiryWhenMechanismExpiryIsNull() {
+        // Given
+        var filter = createFilterWithMaxReauth(Duration.ofMillis(5000));
+
+        // When
+        Instant result = filter.computeSessionExpiry(null);
+
+        // Then
+        assertThat(result).isEqualTo(FIXED_INSTANT.plusMillis(5000));
+    }
+
+    @Test
+    void shouldReturnMechanismExpiryWhenMaxReauthIsNull() {
+        // Given
+        var filter = createFilterWithMaxReauth(null);
+        Instant mechanismExpiry = FIXED_INSTANT.plusMillis(3000);
+
+        // When
+        Instant result = filter.computeSessionExpiry(mechanismExpiry);
+
+        // Then
+        assertThat(result).isEqualTo(mechanismExpiry);
+    }
+
+    @Test
+    void shouldReturnEarlierOfMaxReauthAndMechanismExpiryWhenMechanismIsEarlier() {
+        // Given
+        var filter = createFilterWithMaxReauth(Duration.ofMillis(5000));
+        Instant mechanismExpiry = FIXED_INSTANT.plusMillis(3000);
+
+        // When
+        Instant result = filter.computeSessionExpiry(mechanismExpiry);
+
+        // Then
+        assertThat(result).isEqualTo(mechanismExpiry);
+    }
+
+    @Test
+    void shouldReturnEarlierOfMaxReauthAndMechanismExpiryWhenMaxReauthIsEarlier() {
+        // Given
+        var filter = createFilterWithMaxReauth(Duration.ofMillis(3000));
+        Instant mechanismExpiry = FIXED_INSTANT.plusMillis(5000);
+
+        // When
+        Instant result = filter.computeSessionExpiry(mechanismExpiry);
+
+        // Then
+        assertThat(result).isEqualTo(FIXED_INSTANT.plusMillis(3000));
     }
 
     // --- Helper methods ---
@@ -715,6 +787,22 @@ class SaslTerminationFilterTest {
         var context = new SaslTermination.SaslTerminationContext(
                 null, OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES, Set.of("OAUTHBEARER"), List.of(),
                 null, Clock.systemUTC(), Duration.ZERO,
+                SaslTermination.DEFAULT_SUBJECT_BUILDER);
+        return new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
+    }
+
+    private static SaslTerminationFilter createFilterWithZeroDelayAndClock(Clock clock) {
+        var context = new SaslTermination.SaslTerminationContext(
+                null, OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES, Set.of("OAUTHBEARER"), List.of(),
+                null, clock, Duration.ZERO,
+                SaslTermination.DEFAULT_SUBJECT_BUILDER);
+        return new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
+    }
+
+    private static SaslTerminationFilter createFilterWithMaxReauth(@Nullable Duration maxReauth) {
+        var context = new SaslTermination.SaslTerminationContext(
+                null, OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES, Set.of("OAUTHBEARER"), List.of(),
+                maxReauth, FIXED_CLOCK, Duration.ZERO,
                 SaslTermination.DEFAULT_SUBJECT_BUILDER);
         return new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
     }

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
@@ -131,7 +131,7 @@ class SaslTerminationFilterTest {
         // Given
         var filter = createFilter();
         var handler = mock(MechanismStateMachine.class);
-        setFilterState(filter, State.start().nextState(handler, 0L));
+        setFilterState(filter, State.start().nextState(handler));
 
         var captor = ArgumentCaptor.forClass(ApiMessage.class);
         var filterContext = mockShortCircuitFilterContext(captor);
@@ -152,7 +152,7 @@ class SaslTerminationFilterTest {
         // Given
         var filter = createFilter();
         var handler = mock(MechanismStateMachine.class);
-        var authenticating = State.start().nextState(handler, 0L);
+        var authenticating = State.start().nextState(handler);
         setFilterState(filter, authenticating.nextStateFailure("previous failure"));
 
         var captor = ArgumentCaptor.forClass(ApiMessage.class);
@@ -174,7 +174,7 @@ class SaslTerminationFilterTest {
         // Given
         var filter = createFilter();
         var handler = mock(MechanismStateMachine.class);
-        var authenticating = State.start().nextState(handler, 0L);
+        var authenticating = State.start().nextState(handler);
         setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", null));
 
         var captor = ArgumentCaptor.forClass(ApiMessage.class);
@@ -217,7 +217,7 @@ class SaslTerminationFilterTest {
         // Given
         var filter = createFilter();
         var handler = mock(MechanismStateMachine.class);
-        var authenticating = State.start().nextState(handler, 0L);
+        var authenticating = State.start().nextState(handler);
         setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", null));
 
         var captor = ArgumentCaptor.forClass(ApiMessage.class);
@@ -246,7 +246,7 @@ class SaslTerminationFilterTest {
                 CompletableFuture.completedFuture(RoundResult.challenge(challengeBytes)));
 
         var filter = createFilterWithZeroDelay();
-        setFilterState(filter, State.start().nextState(handler, System.nanoTime()));
+        setFilterState(filter, State.start().nextState(handler));
 
         var captor = ArgumentCaptor.forClass(ApiMessage.class);
         var filterContext = mockShortCircuitFilterContext(captor);
@@ -274,7 +274,7 @@ class SaslTerminationFilterTest {
                 CompletableFuture.completedFuture(RoundResult.success(responseBytes, "alice", 3600000)));
 
         var filter = createFilterWithZeroDelay();
-        setFilterState(filter, State.start().nextState(handler, System.nanoTime()));
+        setFilterState(filter, State.start().nextState(handler));
 
         var captor = ArgumentCaptor.forClass(ApiMessage.class);
         var filterContext = mockShortCircuitFilterContextForSuccess(captor);
@@ -305,7 +305,7 @@ class SaslTerminationFilterTest {
                 CompletableFuture.completedFuture(RoundResult.success(new byte[0], "alice", 0)));
 
         var filter = createFilterWithZeroDelay();
-        setFilterState(filter, State.start().nextState(handler, System.nanoTime()));
+        setFilterState(filter, State.start().nextState(handler));
 
         var captor = ArgumentCaptor.forClass(ApiMessage.class);
         var filterContext = mockShortCircuitFilterContextForSuccess(captor);
@@ -331,7 +331,7 @@ class SaslTerminationFilterTest {
                 CompletableFuture.completedFuture(RoundResult.failure(new byte[0], exception)));
 
         var filter = createFilterWithZeroDelay();
-        setFilterState(filter, State.start().nextState(handler, System.nanoTime()));
+        setFilterState(filter, State.start().nextState(handler));
 
         var captor = ArgumentCaptor.forClass(ApiMessage.class);
         var closeOrTerminal = mock(CloseOrTerminalStage.class);
@@ -366,7 +366,7 @@ class SaslTerminationFilterTest {
         when(handler.evaluateRound(any())).thenReturn(failedFuture);
 
         var filter = createFilterWithZeroDelay();
-        setFilterState(filter, State.start().nextState(handler, System.nanoTime()));
+        setFilterState(filter, State.start().nextState(handler));
 
         var captor = ArgumentCaptor.forClass(ApiMessage.class);
         var closeOrTerminal = mock(CloseOrTerminalStage.class);
@@ -395,7 +395,7 @@ class SaslTerminationFilterTest {
                 CompletableFuture.completedFuture(RoundResult.success(new byte[0], "alice", 0)));
 
         var filter = createFilterWithZeroDelay();
-        setFilterState(filter, State.start().nextState(handler, System.nanoTime()));
+        setFilterState(filter, State.start().nextState(handler));
 
         var captor = ArgumentCaptor.forClass(ApiMessage.class);
         var filterContext = mockShortCircuitFilterContextForSuccess(captor);
@@ -420,7 +420,7 @@ class SaslTerminationFilterTest {
                 CompletableFuture.completedFuture(RoundResult.failure(new byte[0], new Exception("fail"))));
 
         var filter = createFilterWithZeroDelay();
-        setFilterState(filter, State.start().nextState(handler, System.nanoTime()));
+        setFilterState(filter, State.start().nextState(handler));
 
         var captor = ArgumentCaptor.forClass(ApiMessage.class);
         var closeOrTerminal = mock(CloseOrTerminalStage.class);
@@ -437,6 +437,47 @@ class SaslTerminationFilterTest {
         verify(handler).dispose();
     }
 
+    @Test
+    void shouldRecordAuthDurationExcludingFixedDelay() throws Exception {
+        // Given
+        var handler = mock(MechanismStateMachine.class);
+        when(handler.mechanismName()).thenReturn("OAUTHBEARER");
+        when(handler.maxAuthBytes()).thenReturn(4 * 1024);
+        when(handler.evaluateRound(any())).thenReturn(
+                CompletableFuture.completedFuture(RoundResult.success(new byte[0], "alice", 0)));
+
+        Duration fixedDelay = Duration.ofMillis(200);
+        var executor = java.util.concurrent.Executors.newSingleThreadScheduledExecutor();
+        try {
+            var context = new SaslTermination.SaslTerminationContext(
+                    null, Set.of("OAUTHBEARER"), List.of(),
+                    null, Clock.systemUTC(), fixedDelay,
+                    SaslTermination.DEFAULT_SUBJECT_BUILDER);
+            var filter = new SaslTerminationFilter(executor, context);
+            setFilterState(filter, State.start().nextState(handler));
+
+            var captor = ArgumentCaptor.forClass(ApiMessage.class);
+            var filterContext = mockShortCircuitFilterContextForSuccess(captor);
+
+            // When
+            filter.onRequest(ApiKeys.SASL_AUTHENTICATE, ApiKeys.SASL_AUTHENTICATE.latestVersion(),
+                    new RequestHeaderData(),
+                    new SaslAuthenticateRequestData().setAuthBytes(new byte[0]),
+                    filterContext).toCompletableFuture().get();
+
+            // Then
+            var timer = meterRegistry.find(SaslTerminationFilter.AUTH_DURATION_METRIC)
+                    .tags(List.of(Tag.of("mechanism", "OAUTHBEARER"), Tag.of(SaslTerminationFilter.VIRTUAL_CLUSTER_TAG, TEST_VIRTUAL_CLUSTER)))
+                    .timer();
+            assertThat(timer).isNotNull();
+            assertThat(timer.totalTime(java.util.concurrent.TimeUnit.MILLISECONDS))
+                    .isLessThan(fixedDelay.toMillis());
+        }
+        finally {
+            executor.shutdownNow();
+        }
+    }
+
     // --- Reauthentication consistency ---
 
     @SuppressWarnings("unchecked")
@@ -445,7 +486,7 @@ class SaslTerminationFilterTest {
         // Given
         var filter = createFilterWithZeroDelay();
         var handler = mock(MechanismStateMachine.class);
-        var authenticating = State.start().nextState(handler, 0L);
+        var authenticating = State.start().nextState(handler);
         setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", null));
 
         var captor = ArgumentCaptor.forClass(ApiMessage.class);
@@ -477,9 +518,9 @@ class SaslTerminationFilterTest {
 
         var filter = createFilterWithZeroDelay();
         var initialHandler = mock(MechanismStateMachine.class);
-        var authenticating = State.start().nextState(initialHandler, 0L);
+        var authenticating = State.start().nextState(initialHandler);
         var authenticated = authenticating.nextStateSuccess("alice", "OAUTHBEARER", null);
-        var reauthenticating = authenticated.nextStateReauthenticate(handler, System.nanoTime());
+        var reauthenticating = authenticated.nextStateReauthenticate(handler);
         setFilterState(filter, reauthenticating);
 
         var captor = ArgumentCaptor.forClass(ApiMessage.class);
@@ -523,7 +564,7 @@ class SaslTerminationFilterTest {
         // Given
         var filter = createFilter();
         var handler = mock(MechanismStateMachine.class);
-        var authenticating = State.start().nextState(handler, 0L);
+        var authenticating = State.start().nextState(handler);
         setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", null));
 
         var filterContext = mockForwardingFilterContext();
@@ -543,7 +584,7 @@ class SaslTerminationFilterTest {
         // Given
         var filter = createFilterWithClock(FIXED_CLOCK);
         var handler = mock(MechanismStateMachine.class);
-        var authenticating = State.start().nextState(handler, 0L);
+        var authenticating = State.start().nextState(handler);
         Instant futureExpiry = FIXED_INSTANT.plusSeconds(3600);
         setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", futureExpiry));
 
@@ -564,7 +605,7 @@ class SaslTerminationFilterTest {
         // Given
         var filter = createFilterWithClock(FIXED_CLOCK);
         var handler = mock(MechanismStateMachine.class);
-        var authenticating = State.start().nextState(handler, 0L);
+        var authenticating = State.start().nextState(handler);
         Instant pastExpiry = FIXED_INSTANT.minusSeconds(60);
         setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", pastExpiry));
 
@@ -596,7 +637,7 @@ class SaslTerminationFilterTest {
         // Given
         var filter = createFilter();
         var handler = mock(MechanismStateMachine.class);
-        var authenticating = State.start().nextState(handler, 0L);
+        var authenticating = State.start().nextState(handler);
         setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", null));
         var exceptionCaptor = ArgumentCaptor.forClass(ApiException.class);
         var filterContext = mockErrorFilterContextWithoutClose(exceptionCaptor);

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
@@ -822,13 +822,6 @@ class SaslTerminationFilterTest {
     }
 
     private static void setFilterState(SaslTerminationFilter filter, State state) {
-        try {
-            var field = SaslTerminationFilter.class.getDeclaredField("state");
-            field.setAccessible(true);
-            field.set(filter, state);
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        filter.forceState(state);
     }
 }

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
@@ -455,7 +455,7 @@ class SaslTerminationFilterTest {
 
         try (var executor = Executors.newSingleThreadScheduledExecutor()) {
             var context = new SaslTermination.SaslTerminationContext(
-                    null, Set.of("OAUTHBEARER"), List.of(),
+                    null, OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES, Set.of("OAUTHBEARER"), List.of(),
                     null, Clock.systemUTC(), fixedDelay,
                     SaslTermination.DEFAULT_SUBJECT_BUILDER);
             var filter = new SaslTerminationFilter(executor, context);
@@ -687,7 +687,7 @@ class SaslTerminationFilterTest {
         // Given
         Duration maxReauth = maxTimeBeforeReauthMs > 0 ? Duration.ofMillis(maxTimeBeforeReauthMs) : null;
         var context = new SaslTermination.SaslTerminationContext(
-                null, Set.of("OAUTHBEARER"), List.of(),
+                null, OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES, Set.of("OAUTHBEARER"), List.of(),
                 maxReauth, Clock.systemUTC(), Duration.ZERO,
                 SaslTermination.DEFAULT_SUBJECT_BUILDER);
         var filter = new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
@@ -704,7 +704,7 @@ class SaslTerminationFilterTest {
     private static SaslTerminationFilter createFilter() {
         var callbackHandler = new OAuthBearerValidatorCallbackHandler();
         var context = new SaslTermination.SaslTerminationContext(
-                callbackHandler,
+                callbackHandler, OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES,
                 Set.of("OAUTHBEARER"), List.of(),
                 null, Clock.systemUTC(), Duration.ofMillis(200),
                 SaslTermination.DEFAULT_SUBJECT_BUILDER);
@@ -713,7 +713,7 @@ class SaslTerminationFilterTest {
 
     private static SaslTerminationFilter createFilterWithZeroDelay() {
         var context = new SaslTermination.SaslTerminationContext(
-                null, Set.of("OAUTHBEARER"), List.of(),
+                null, OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES, Set.of("OAUTHBEARER"), List.of(),
                 null, Clock.systemUTC(), Duration.ZERO,
                 SaslTermination.DEFAULT_SUBJECT_BUILDER);
         return new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
@@ -722,7 +722,7 @@ class SaslTerminationFilterTest {
     private static SaslTerminationFilter createFilterWithClock(Clock clock) {
         var callbackHandler = new OAuthBearerValidatorCallbackHandler();
         var context = new SaslTermination.SaslTerminationContext(
-                callbackHandler,
+                callbackHandler, OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES,
                 Set.of("OAUTHBEARER"), List.of(),
                 null, clock, Duration.ofMillis(200),
                 SaslTermination.DEFAULT_SUBJECT_BUILDER);

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
@@ -1,0 +1,652 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.sasl.termination;
+
+import java.net.URI;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.message.SaslAuthenticateRequestData;
+import org.apache.kafka.common.message.SaslHandshakeRequestData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import io.kroxylicious.proxy.config.ConfigParser;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.filter.RequestFilterResultBuilder;
+import io.kroxylicious.proxy.filter.ResponseFilterResult;
+
+import static io.kroxylicious.filter.sasl.termination.SaslTermination.ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link SaslTermination} filter factory.
+ */
+class SaslTerminationTest {
+
+    private static final URI JWKS_URL = URI.create("https://idp.example.com/.well-known/jwks.json");
+
+    private static OauthBearerMechanismConfig oauthConfig() {
+        return new OauthBearerMechanismConfig(JWKS_URL, "kafka", "https://idp.example.com",
+                null, null, null, null, null);
+    }
+
+    private static SaslTermination.SaslTerminationContext testContext() {
+        return testContext(Set.of("OAUTHBEARER"), List.of());
+    }
+
+    private static SaslTermination.SaslTerminationContext testContext(
+                                                                      Set<String> supportedMechanisms,
+                                                                      List<AutoCloseable> closeables) {
+        return new SaslTermination.SaslTerminationContext(
+                null, supportedMechanisms, closeables, null, Clock.systemUTC(), Duration.ofMillis(200),
+                SaslTermination.DEFAULT_SUBJECT_BUILDER);
+    }
+
+    @Test
+    void shouldCloseCloseableOnFactoryClose() throws Exception {
+        // Given
+        var closeable = mock(AutoCloseable.class);
+        var context = testContext(Set.of("OAUTHBEARER"), List.of(closeable));
+
+        var factory = new SaslTermination();
+
+        // When
+        factory.close(context);
+
+        // Then
+        verify(closeable).close();
+    }
+
+    @Test
+    void shouldCloseAllCloseablesOnFactoryClose() throws Exception {
+        // Given
+        var closeable1 = mock(AutoCloseable.class);
+        var closeable2 = mock(AutoCloseable.class);
+        var context = testContext(Set.of("OAUTHBEARER"), List.of(closeable1, closeable2));
+
+        var saslTermination = new SaslTermination();
+
+        // When
+        saslTermination.close(context);
+
+        // Then
+        verify(closeable1).close();
+        verify(closeable2).close();
+    }
+
+    @Test
+    void shouldSuppressExceptionsWhenClosing() throws Exception {
+        // Given
+        var closeable = mock(AutoCloseable.class);
+        RuntimeException exception = new RuntimeException("Failed to close");
+        doThrow(exception).when(closeable).close();
+
+        var context = testContext(Set.of("OAUTHBEARER"), List.of(closeable));
+
+        var factory = new SaslTermination();
+
+        // When/Then
+        assertThatThrownBy(() -> factory.close(context))
+                .isSameAs(exception);
+    }
+
+    @Test
+    void shouldCreateFilterFromContext() {
+        // Given
+        var context = testContext();
+        var filterFactoryContext = mock(FilterFactoryContext.class);
+
+        var factory = new SaslTermination();
+
+        // When
+        var filter = factory.createFilter(filterFactoryContext, context);
+
+        // Then
+        assertThat(filter).isNotNull();
+    }
+
+    @Test
+    void shouldRejectEmptyMechanismsList() {
+        // When/Then
+        assertThatThrownBy(() -> new SaslTerminationConfig(List.of(), null, null, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("At least one mechanism must be configured");
+    }
+
+    @Test
+    void shouldRejectDuplicateMechanisms() {
+        // Given
+        var config1 = oauthConfig();
+        var config2 = oauthConfig();
+
+        // When/Then
+        assertThatThrownBy(() -> new SaslTerminationConfig(List.of(config1, config2), null, null, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Duplicate mechanism: OAUTHBEARER");
+    }
+
+    @Test
+    void shouldDeserializeOauthBearerConfigFromJson() throws Exception {
+        // Given
+        String json = """
+                {
+                  "mechanisms": [
+                    {
+                      "mechanism": "OAUTHBEARER",
+                      "jwksEndpointUrl": "https://idp.example.com/.well-known/jwks.json",
+                      "expectedAudience": "kafka",
+                      "expectedIssuer": "https://idp.example.com"
+                    }
+                  ]
+                }
+                """;
+
+        // When
+        var config = ConfigParser.createBaseObjectMapper().readValue(json, SaslTerminationConfig.class);
+
+        // Then
+        assertThat(config.mechanisms()).hasSize(1);
+        assertThat(config.mechanisms().get(0)).isInstanceOf(OauthBearerMechanismConfig.class);
+        assertThat(config.mechanisms().get(0).mechanismName()).isEqualTo("OAUTHBEARER");
+    }
+
+    @Test
+    void shouldDeserializeOauthBearerOptionalDurationFieldsFromJson() throws Exception {
+        // Given
+        String json = """
+                {
+                  "mechanisms": [
+                    {
+                      "mechanism": "OAUTHBEARER",
+                      "jwksEndpointUrl": "https://idp.example.com/.well-known/jwks.json",
+                      "expectedAudience": "kafka",
+                      "expectedIssuer": "https://idp.example.com",
+                      "jwksEndpointRefresh": "5m",
+                      "jwksEndpointRetryBackoff": "1s",
+                      "jwksEndpointRetryBackoffMax": "10s"
+                    }
+                  ]
+                }
+                """;
+
+        // When
+        var config = ConfigParser.createBaseObjectMapper().readValue(json, SaslTerminationConfig.class);
+
+        // Then
+        assertThat(config.mechanisms().get(0)).isInstanceOf(OauthBearerMechanismConfig.class);
+        var oauth = (OauthBearerMechanismConfig) config.mechanisms().get(0);
+        assertThat(oauth.jwksEndpointRefresh()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(oauth.jwksEndpointRetryBackoff()).isEqualTo(Duration.ofSeconds(1));
+        assertThat(oauth.jwksEndpointRetryBackoffMax()).isEqualTo(Duration.ofSeconds(10));
+    }
+
+    @Test
+    void shouldPassDurationFieldsToOauthSaslConfigMapAsMillis() {
+        // Given
+        var config = new OauthBearerMechanismConfig(
+                URI.create("https://idp.example.com/.well-known/jwks.json"),
+                "kafka", "https://idp.example.com",
+                null, null,
+                Duration.ofMinutes(5), Duration.ofSeconds(1), Duration.ofSeconds(10));
+
+        // When
+        var saslConfig = SaslTermination.createOauthSaslConfigMap(config);
+
+        // Then
+        assertThat(saslConfig)
+                .containsEntry(org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS, 300_000L)
+                .containsEntry(org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS, 1_000L)
+                .containsEntry(org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS, 10_000L);
+    }
+
+    @Test
+    void shouldUseDefaultsWhenDurationFieldsAreNull() {
+        // Given
+        var config = new OauthBearerMechanismConfig(
+                URI.create("https://idp.example.com/.well-known/jwks.json"),
+                "kafka", "https://idp.example.com",
+                null, null, null, null, null);
+
+        // When
+        var saslConfig = SaslTermination.createOauthSaslConfigMap(config);
+
+        // Then
+        assertThat(saslConfig)
+                .containsEntry(org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS,
+                        org.apache.kafka.common.config.SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS)
+                .containsEntry(org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS,
+                        org.apache.kafka.common.config.SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS)
+                .containsEntry(org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS,
+                        org.apache.kafka.common.config.SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS);
+    }
+
+    @Test
+    void addAllowedUrlShouldAddToSystemProperty() throws Exception {
+        // Given
+        var jwksUrl = "https://" + UUID.randomUUID() + ".invalid/jwks";
+        var closeables = new ArrayList<AutoCloseable>();
+
+        // When
+        SaslTermination.addAllowedSaslOauthbearerUrl(jwksUrl, closeables);
+
+        // Then
+        try {
+            assertThat(System.getProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG))
+                    .contains(jwksUrl);
+        }
+        finally {
+            closeAll(closeables);
+        }
+    }
+
+    @Test
+    void allowedUrlCloseableShouldRemoveFromSystemProperty() throws Exception {
+        // Given
+        var jwksUrl = "https://" + UUID.randomUUID() + ".invalid/jwks";
+        var closeables = new ArrayList<AutoCloseable>();
+        SaslTermination.addAllowedSaslOauthbearerUrl(jwksUrl, closeables);
+
+        // When
+        closeAll(closeables);
+
+        // Then
+        assertThat(System.getProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG))
+                .satisfiesAnyOf(
+                        v -> assertThat(v).isNull(),
+                        v -> assertThat(v).doesNotContain(jwksUrl));
+    }
+
+    @Test
+    void allowedUrlCloseableShouldNotRemoveWhileAnotherReferenceExists() throws Exception {
+        // Given
+        var jwksUrl = "https://" + UUID.randomUUID() + ".invalid/jwks";
+        var closeables1 = new ArrayList<AutoCloseable>();
+        var closeables2 = new ArrayList<AutoCloseable>();
+        SaslTermination.addAllowedSaslOauthbearerUrl(jwksUrl, closeables1);
+        SaslTermination.addAllowedSaslOauthbearerUrl(jwksUrl, closeables2);
+
+        try {
+            // When
+            closeAll(closeables1);
+
+            // Then
+            assertThat(System.getProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG))
+                    .contains(jwksUrl);
+        }
+        finally {
+            closeAll(closeables2);
+        }
+    }
+
+    @Test
+    void allowedUrlShouldBeRemovedOnceAllReferencesAreClosed() throws Exception {
+        // Given
+        var jwksUrl = "https://" + UUID.randomUUID() + ".invalid/jwks";
+        var closeables1 = new ArrayList<AutoCloseable>();
+        var closeables2 = new ArrayList<AutoCloseable>();
+        SaslTermination.addAllowedSaslOauthbearerUrl(jwksUrl, closeables1);
+        SaslTermination.addAllowedSaslOauthbearerUrl(jwksUrl, closeables2);
+
+        // When
+        closeAll(closeables1);
+        closeAll(closeables2);
+
+        // Then
+        assertThat(System.getProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG))
+                .satisfiesAnyOf(
+                        v -> assertThat(v).isNull(),
+                        v -> assertThat(v).doesNotContain(jwksUrl));
+    }
+
+    private static void closeAll(List<AutoCloseable> closeables) throws Exception {
+        for (var closeable : closeables) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void effectiveFixedAuthDelayShouldDefaultTo200ms() {
+        // Given
+        var config = new SaslTerminationConfig(List.of(oauthConfig()), null, null, null, null);
+
+        // When/Then
+        assertThat(config.effectiveFixedAuthDelay()).isEqualTo(Duration.ofMillis(200));
+    }
+
+    @Test
+    void effectiveFixedAuthDelayShouldUseConfiguredValue() {
+        // Given
+        var config = new SaslTerminationConfig(List.of(oauthConfig()), null, Duration.ofMillis(500), null, null);
+
+        // When/Then
+        assertThat(config.effectiveFixedAuthDelay()).isEqualTo(Duration.ofMillis(500));
+    }
+
+    @Test
+    void effectiveFixedAuthDelayShouldSupportZeroToDisable() {
+        // Given
+        var config = new SaslTerminationConfig(List.of(oauthConfig()), null, Duration.ZERO, null, null);
+
+        // When/Then
+        assertThat(config.effectiveFixedAuthDelay()).isEqualTo(Duration.ZERO);
+    }
+
+    @Test
+    void shouldRejectSaslHandshakeWithUnsupportedApiVersion() throws Exception {
+        // Given
+        var context = testContext();
+        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+
+        var filterContext = mockFilterContextForErrorResponse();
+        short unsupportedVersion = (short) (ApiKeys.SASL_HANDSHAKE.latestVersion() + 1);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_HANDSHAKE, unsupportedVersion,
+                new RequestHeaderData(), new SaslHandshakeRequestData(), filterContext);
+
+        // Then
+        verify(filterContext).requestFilterResultBuilder();
+    }
+
+    @Test
+    void shouldRejectSaslAuthenticateWithUnsupportedApiVersion() throws Exception {
+        // Given
+        var context = testContext();
+        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+
+        var filterContext = mockFilterContextForErrorResponse();
+        short unsupportedVersion = (short) (ApiKeys.SASL_AUTHENTICATE.latestVersion() + 1);
+
+        // When
+        filter.onRequest(ApiKeys.SASL_AUTHENTICATE, unsupportedVersion,
+                new RequestHeaderData(), new SaslAuthenticateRequestData(), filterContext);
+
+        // Then
+        verify(filterContext).requestFilterResultBuilder();
+    }
+
+    @Test
+    void shouldHandleRequestReturnsTrueInRequiringHandshakeState() {
+        // Given
+        var context = testContext();
+        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+
+        // When/Then
+        assertThat(filter.shouldHandleRequest(ApiKeys.PRODUCE, (short) 0)).isTrue();
+    }
+
+    @Test
+    void shouldHandleRequestReturnsFalseWhenAuthenticatedWithNoExpiry() {
+        // Given
+        var context = testContext();
+        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+
+        var start = State.start();
+        var handler = mock(MechanismStateMachine.class);
+        var authenticating = start.nextState(handler, 0L);
+        var authenticated = authenticating.nextStateSuccess("alice", "OAUTHBEARER", null);
+
+        setFilterState(filter, authenticated);
+
+        // When/Then
+        assertThat(filter.shouldHandleRequest(ApiKeys.PRODUCE, (short) 0)).isFalse();
+        assertThat(filter.shouldHandleRequest(ApiKeys.FETCH, (short) 0)).isFalse();
+        assertThat(filter.shouldHandleRequest(ApiKeys.API_VERSIONS, (short) 0)).isTrue();
+        assertThat(filter.shouldHandleRequest(ApiKeys.SASL_HANDSHAKE, (short) 0)).isTrue();
+        assertThat(filter.shouldHandleRequest(ApiKeys.SASL_AUTHENTICATE, (short) 0)).isTrue();
+    }
+
+    @Test
+    void shouldHandleRequestReturnsTrueWhenAuthenticatedWithExpiry() {
+        // Given
+        var context = testContext();
+        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+
+        var start = State.start();
+        var handler = mock(MechanismStateMachine.class);
+        var authenticating = start.nextState(handler, 0L);
+        var authenticated = authenticating.nextStateSuccess("alice", "OAUTHBEARER", java.time.Instant.now().plusSeconds(3600));
+
+        setFilterState(filter, authenticated);
+
+        // When/Then — with expiry set, all requests should be handled (for expiry checking)
+        assertThat(filter.shouldHandleRequest(ApiKeys.PRODUCE, (short) 0)).isTrue();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ApiKeys.class, names = {
+            "CREATE_DELEGATION_TOKEN", "RENEW_DELEGATION_TOKEN",
+            "EXPIRE_DELEGATION_TOKEN", "DESCRIBE_DELEGATION_TOKEN"
+    })
+    void shouldRejectUnsupportedApiRequests(ApiKeys apiKey) throws Exception {
+        // Given
+        var context = testContext();
+        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+
+        var filterContext = mockFilterContextForErrorResponseWithoutClose();
+
+        // When
+        filter.onRequest(apiKey, apiKey.latestVersion(),
+                new RequestHeaderData(), apiKey.messageType.newRequest(), filterContext);
+
+        // Then
+        verify(filterContext).requestFilterResultBuilder();
+    }
+
+    @Test
+    void shouldRemoveDelegationTokenApisFromApiVersionsResponse() throws Exception {
+        // Given
+        var context = testContext();
+        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+
+        var apiKeys = new ArrayList<>(List.of(
+                new ApiVersionsResponseData.ApiVersion().setApiKey(ApiKeys.PRODUCE.id),
+                new ApiVersionsResponseData.ApiVersion().setApiKey(ApiKeys.FETCH.id),
+                new ApiVersionsResponseData.ApiVersion().setApiKey(ApiKeys.CREATE_DELEGATION_TOKEN.id),
+                new ApiVersionsResponseData.ApiVersion().setApiKey(ApiKeys.RENEW_DELEGATION_TOKEN.id),
+                new ApiVersionsResponseData.ApiVersion().setApiKey(ApiKeys.EXPIRE_DELEGATION_TOKEN.id),
+                new ApiVersionsResponseData.ApiVersion().setApiKey(ApiKeys.DESCRIBE_DELEGATION_TOKEN.id)));
+        var response = new ApiVersionsResponseData();
+        response.apiKeys().addAll(apiKeys);
+
+        var filterContext = mock(FilterContext.class);
+        var responseResult = mock(ResponseFilterResult.class);
+        when(filterContext.forwardResponse(any(), any())).thenReturn(CompletableFuture.completedFuture(responseResult));
+
+        // When
+        filter.onApiVersionsResponse((short) 0, new ResponseHeaderData(), response, filterContext);
+
+        // Then
+        var remainingApiKeys = response.apiKeys().stream()
+                .map(ApiVersionsResponseData.ApiVersion::apiKey)
+                .toList();
+        assertThat(remainingApiKeys).containsExactly(
+                ApiKeys.PRODUCE.id,
+                ApiKeys.FETCH.id);
+    }
+
+    @Test
+    void shouldHandleApiVersionsResponseWithNoTargetApis() throws Exception {
+        // Given
+        var context = testContext();
+        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+
+        var response = new ApiVersionsResponseData();
+        response.apiKeys().add(new ApiVersionsResponseData.ApiVersion().setApiKey(ApiKeys.PRODUCE.id));
+
+        var filterContext = mock(FilterContext.class);
+        var responseResult = mock(ResponseFilterResult.class);
+        when(filterContext.forwardResponse(any(), any())).thenReturn(CompletableFuture.completedFuture(responseResult));
+
+        // When
+        filter.onApiVersionsResponse((short) 0, new ResponseHeaderData(), response, filterContext);
+
+        // Then
+        var remainingKeys = response.apiKeys().stream()
+                .map(ApiVersionsResponseData.ApiVersion::apiKey)
+                .toList();
+        assertThat(remainingKeys).containsExactly(ApiKeys.PRODUCE.id);
+    }
+
+    @Test
+    void shouldRejectOversizedOauthBearerAuthBytes() throws Exception {
+        // Given
+        int maxAuthBytes = 128 * 1024;
+        var handler = mock(MechanismStateMachine.class);
+        when(handler.mechanismName()).thenReturn("OAUTHBEARER");
+        when(handler.maxAuthBytes()).thenReturn(maxAuthBytes);
+        var context = testContext(Set.of("OAUTHBEARER"), List.of());
+        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+
+        var authenticating = State.start().nextState(handler, 0L);
+        setFilterState(filter, authenticating);
+
+        byte[] oversizedPayload = new byte[maxAuthBytes + 1];
+        var request = new SaslAuthenticateRequestData().setAuthBytes(oversizedPayload);
+        var filterContext = mockFilterContextForShortCircuitWithClose();
+
+        // When
+        filter.onRequest(ApiKeys.SASL_AUTHENTICATE, (short) 0,
+                new RequestHeaderData(), request, filterContext);
+
+        // Then
+        verify(filterContext).requestFilterResultBuilder();
+    }
+
+    @Test
+    void fixedAuthDelayShouldCompleteOnProvidedExecutor() throws Exception {
+        // Given
+        var executorThreadName = "test-filter-dispatch";
+        var executor = Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, executorThreadName));
+        try {
+            var context = new SaslTermination.SaslTerminationContext(
+                    null, Set.of("OAUTHBEARER"), List.of(), null, Clock.systemUTC(),
+                    Duration.ofMillis(100), SaslTermination.DEFAULT_SUBJECT_BUILDER);
+            var filter = new SaslTerminationFilter(executor, context);
+
+            var handler = mock(MechanismStateMachine.class);
+            when(handler.mechanismName()).thenReturn("OAUTHBEARER");
+            when(handler.maxAuthBytes()).thenReturn(128 * 1024);
+            when(handler.evaluateRound(any())).thenReturn(
+                    CompletableFuture.completedFuture(
+                            RoundResult.failure(new byte[0], new javax.security.sasl.SaslException("test"))));
+
+            var authenticating = State.start().nextState(handler, System.nanoTime());
+            setFilterState(filter, authenticating);
+
+            var request = new SaslAuthenticateRequestData().setAuthBytes(new byte[0]);
+            var filterContext = mockFilterContextForShortCircuitWithClose();
+
+            // When
+            var completingThread = new java.util.concurrent.atomic.AtomicReference<String>();
+            filter.onRequest(ApiKeys.SASL_AUTHENTICATE, (short) 0,
+                    new RequestHeaderData(), request, filterContext)
+                    .thenApply(result -> {
+                        completingThread.set(Thread.currentThread().getName());
+                        return result;
+                    })
+                    .toCompletableFuture().get(5, java.util.concurrent.TimeUnit.SECONDS);
+
+            // Then
+            assertThat(completingThread.get()).isEqualTo(executorThreadName);
+        }
+        finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static void setFilterState(SaslTerminationFilter filter, State state) {
+        try {
+            var field = SaslTerminationFilter.class.getDeclaredField("state");
+            field.setAccessible(true);
+            field.set(filter, state);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static FilterContext mockFilterContextForShortCircuitWithClose() {
+        var filterContext = mock(FilterContext.class);
+        var builder = mock(RequestFilterResultBuilder.class);
+        var closeOrTerminal = mock(io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage.class);
+        var terminal = mock(io.kroxylicious.proxy.filter.filterresultbuilder.TerminalStage.class);
+        var result = mock(RequestFilterResult.class);
+
+        when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
+        when(builder.shortCircuitResponse(any())).thenReturn(closeOrTerminal);
+        when(closeOrTerminal.withCloseConnection()).thenReturn(terminal);
+        when(terminal.completed()).thenReturn(CompletableFuture.completedFuture(result));
+
+        return filterContext;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static FilterContext mockFilterContextForShortCircuitResponse() {
+        var filterContext = mock(FilterContext.class);
+        var builder = mock(RequestFilterResultBuilder.class);
+        var closeOrTerminal = mock(io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage.class);
+        var result = mock(RequestFilterResult.class);
+
+        when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
+        when(builder.shortCircuitResponse(any())).thenReturn(closeOrTerminal);
+        when(closeOrTerminal.completed()).thenReturn(CompletableFuture.completedFuture(result));
+
+        return filterContext;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static FilterContext mockFilterContextForErrorResponse() {
+        var filterContext = mock(FilterContext.class);
+        var builder = mock(RequestFilterResultBuilder.class);
+        var closeOrTerminal = mock(io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage.class);
+        var terminal = mock(io.kroxylicious.proxy.filter.filterresultbuilder.TerminalStage.class);
+        var result = mock(RequestFilterResult.class);
+
+        when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
+        when(builder.errorResponse(any(), any(), any())).thenReturn(closeOrTerminal);
+        when(closeOrTerminal.withCloseConnection()).thenReturn(terminal);
+        when(terminal.completed()).thenReturn(CompletableFuture.completedFuture(result));
+
+        return filterContext;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static FilterContext mockFilterContextForErrorResponseWithoutClose() {
+        var filterContext = mock(FilterContext.class);
+        var builder = mock(RequestFilterResultBuilder.class);
+        var closeOrTerminal = mock(io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage.class);
+        var result = mock(RequestFilterResult.class);
+
+        when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
+        when(builder.errorResponse(any(), any(), any())).thenReturn(closeOrTerminal);
+        when(closeOrTerminal.completed()).thenReturn(CompletableFuture.completedFuture(result));
+
+        return filterContext;
+    }
+}

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
@@ -605,20 +605,6 @@ class SaslTerminationTest {
     }
 
     @SuppressWarnings("unchecked")
-    private static FilterContext mockFilterContextForShortCircuitResponse() {
-        var filterContext = mock(FilterContext.class);
-        var builder = mock(RequestFilterResultBuilder.class);
-        var closeOrTerminal = mock(io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage.class);
-        var result = mock(RequestFilterResult.class);
-
-        when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
-        when(builder.shortCircuitResponse(any())).thenReturn(closeOrTerminal);
-        when(closeOrTerminal.completed()).thenReturn(CompletableFuture.completedFuture(result));
-
-        return filterContext;
-    }
-
-    @SuppressWarnings("unchecked")
     private static FilterContext mockFilterContextForErrorResponse() {
         var filterContext = mock(FilterContext.class);
         var builder = mock(RequestFilterResultBuilder.class);

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.filter.FilterContext;
@@ -32,6 +33,7 @@ import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.RequestFilterResultBuilder;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 
 import static io.kroxylicious.filter.sasl.termination.SaslTermination.ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -244,6 +246,21 @@ class SaslTerminationTest {
                         org.apache.kafka.common.config.SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS)
                 .containsEntry(org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS,
                         org.apache.kafka.common.config.SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { ",,,  ,", ",", "  ,  ,  " })
+    void shouldRejectExpectedAudienceWithNoValidEntries(String audience) {
+        // Given
+        var config = new OauthBearerMechanismConfig(
+                URI.create("https://idp.example.com/.well-known/jwks.json"),
+                audience, "https://idp.example.com",
+                null, null, null, null, null);
+
+        // When / Then
+        assertThatThrownBy(() -> SaslTermination.createOauthSaslConfigMap(config))
+                .isInstanceOf(PluginConfigurationException.class)
+                .hasMessageContaining("expectedAudience");
     }
 
     @Test
@@ -597,6 +614,7 @@ class SaslTerminationTest {
         var result = mock(RequestFilterResult.class);
 
         when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
+        when(filterContext.getVirtualClusterName()).thenReturn("test-cluster");
         when(builder.shortCircuitResponse(any())).thenReturn(closeOrTerminal);
         when(closeOrTerminal.withCloseConnection()).thenReturn(terminal);
         when(terminal.completed()).thenReturn(CompletableFuture.completedFuture(result));

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
@@ -426,7 +426,7 @@ class SaslTerminationTest {
 
         var start = State.start();
         var handler = mock(MechanismStateMachine.class);
-        var authenticating = start.nextState(handler, 0L);
+        var authenticating = start.nextState(handler);
         var authenticated = authenticating.nextStateSuccess("alice", "OAUTHBEARER", null);
 
         setFilterState(filter, authenticated);
@@ -447,7 +447,7 @@ class SaslTerminationTest {
 
         var start = State.start();
         var handler = mock(MechanismStateMachine.class);
-        var authenticating = start.nextState(handler, 0L);
+        var authenticating = start.nextState(handler);
         var authenticated = authenticating.nextStateSuccess("alice", "OAUTHBEARER", java.time.Instant.now().plusSeconds(3600));
 
         setFilterState(filter, authenticated);
@@ -466,7 +466,7 @@ class SaslTerminationTest {
         var context = testContext();
         var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
         var handler = mock(MechanismStateMachine.class);
-        var authenticating = State.start().nextState(handler, 0L);
+        var authenticating = State.start().nextState(handler);
         setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", null));
 
         var filterContext = mockFilterContextForErrorResponseWithoutClose();
@@ -544,7 +544,7 @@ class SaslTerminationTest {
         var context = testContext(Set.of("OAUTHBEARER"), List.of());
         var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
 
-        var authenticating = State.start().nextState(handler, 0L);
+        var authenticating = State.start().nextState(handler);
         setFilterState(filter, authenticating);
 
         byte[] oversizedPayload = new byte[maxAuthBytes + 1];
@@ -576,7 +576,7 @@ class SaslTerminationTest {
                     CompletableFuture.completedFuture(
                             RoundResult.failure(new byte[0], new javax.security.sasl.SaslException("test"))));
 
-            var authenticating = State.start().nextState(handler, System.nanoTime());
+            var authenticating = State.start().nextState(handler);
             setFilterState(filter, authenticating);
 
             var request = new SaslAuthenticateRequestData().setAuthBytes(new byte[0]);

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
@@ -465,6 +465,9 @@ class SaslTerminationTest {
         // Given
         var context = testContext();
         var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+        var handler = mock(MechanismStateMachine.class);
+        var authenticating = State.start().nextState(handler, 0L);
+        setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", null));
 
         var filterContext = mockFilterContextForErrorResponseWithoutClose();
 

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
@@ -9,13 +9,20 @@ package io.kroxylicious.filter.sasl.termination;
 import java.net.URI;
 import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
+import javax.security.sasl.SaslException;
+
+import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
@@ -33,6 +40,8 @@ import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.RequestFilterResultBuilder;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
+import io.kroxylicious.proxy.filter.filterresultbuilder.TerminalStage;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 
 import static io.kroxylicious.filter.sasl.termination.SaslTermination.ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG;
@@ -222,9 +231,9 @@ class SaslTerminationTest {
 
         // Then
         assertThat(saslConfig)
-                .containsEntry(org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS, 300_000L)
-                .containsEntry(org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS, 1_000L)
-                .containsEntry(org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS, 10_000L);
+                .containsEntry(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS, 300_000L)
+                .containsEntry(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS, 1_000L)
+                .containsEntry(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS, 10_000L);
     }
 
     @Test
@@ -240,12 +249,12 @@ class SaslTerminationTest {
 
         // Then
         assertThat(saslConfig)
-                .containsEntry(org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS,
-                        org.apache.kafka.common.config.SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS)
-                .containsEntry(org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS,
-                        org.apache.kafka.common.config.SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS)
-                .containsEntry(org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS,
-                        org.apache.kafka.common.config.SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS);
+                .containsEntry(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS,
+                        SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS)
+                .containsEntry(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS,
+                        SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS)
+                .containsEntry(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS,
+                        SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS);
     }
 
     @ParameterizedTest
@@ -378,7 +387,7 @@ class SaslTerminationTest {
     void shouldRejectSaslHandshakeWithUnsupportedApiVersion() {
         // Given
         var context = testContext();
-        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+        var filter = new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
 
         var filterContext = mockFilterContextForErrorResponse();
         short unsupportedVersion = (short) (ApiKeys.SASL_HANDSHAKE.latestVersion() + 1);
@@ -395,7 +404,7 @@ class SaslTerminationTest {
     void shouldRejectSaslAuthenticateWithUnsupportedApiVersion() {
         // Given
         var context = testContext();
-        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+        var filter = new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
 
         var filterContext = mockFilterContextForErrorResponse();
         short unsupportedVersion = (short) (ApiKeys.SASL_AUTHENTICATE.latestVersion() + 1);
@@ -412,7 +421,7 @@ class SaslTerminationTest {
     void shouldHandleRequestReturnsTrueInRequiringHandshakeState() {
         // Given
         var context = testContext();
-        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+        var filter = new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
 
         // When/Then
         assertThat(filter.shouldHandleRequest(ApiKeys.PRODUCE, (short) 0)).isTrue();
@@ -422,7 +431,7 @@ class SaslTerminationTest {
     void shouldHandleRequestReturnsFalseWhenAuthenticatedWithNoExpiry() {
         // Given
         var context = testContext();
-        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+        var filter = new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
 
         var start = State.start();
         var handler = mock(MechanismStateMachine.class);
@@ -443,12 +452,12 @@ class SaslTerminationTest {
     void shouldHandleRequestReturnsTrueWhenAuthenticatedWithExpiry() {
         // Given
         var context = testContext();
-        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+        var filter = new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
 
         var start = State.start();
         var handler = mock(MechanismStateMachine.class);
         var authenticating = start.nextState(handler);
-        var authenticated = authenticating.nextStateSuccess("alice", "OAUTHBEARER", java.time.Instant.now().plusSeconds(3600));
+        var authenticated = authenticating.nextStateSuccess("alice", "OAUTHBEARER", Instant.now().plusSeconds(3600));
 
         setFilterState(filter, authenticated);
 
@@ -464,7 +473,7 @@ class SaslTerminationTest {
     void shouldRejectUnsupportedApiRequests(ApiKeys apiKey) {
         // Given
         var context = testContext();
-        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+        var filter = new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
         var handler = mock(MechanismStateMachine.class);
         var authenticating = State.start().nextState(handler);
         setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", null));
@@ -483,7 +492,7 @@ class SaslTerminationTest {
     void shouldRemoveDelegationTokenApisFromApiVersionsResponse() {
         // Given
         var context = testContext();
-        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+        var filter = new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
 
         var apiKeys = new ArrayList<>(List.of(
                 new ApiVersionsResponseData.ApiVersion().setApiKey(ApiKeys.PRODUCE.id),
@@ -515,7 +524,7 @@ class SaslTerminationTest {
     void shouldHandleApiVersionsResponseWithNoTargetApis() {
         // Given
         var context = testContext();
-        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+        var filter = new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
 
         var response = new ApiVersionsResponseData();
         response.apiKeys().add(new ApiVersionsResponseData.ApiVersion().setApiKey(ApiKeys.PRODUCE.id));
@@ -542,7 +551,7 @@ class SaslTerminationTest {
         when(handler.mechanismName()).thenReturn("OAUTHBEARER");
         when(handler.maxAuthBytes()).thenReturn(maxAuthBytes);
         var context = testContext(Set.of("OAUTHBEARER"), List.of());
-        var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
+        var filter = new SaslTerminationFilter(mock(ScheduledExecutorService.class), context);
 
         var authenticating = State.start().nextState(handler);
         setFilterState(filter, authenticating);
@@ -574,7 +583,7 @@ class SaslTerminationTest {
             when(handler.maxAuthBytes()).thenReturn(128 * 1024);
             when(handler.evaluateRound(any())).thenReturn(
                     CompletableFuture.completedFuture(
-                            RoundResult.failure(new byte[0], new javax.security.sasl.SaslException("test"))));
+                            RoundResult.failure(new byte[0], new SaslException("test"))));
 
             var authenticating = State.start().nextState(handler);
             setFilterState(filter, authenticating);
@@ -583,14 +592,14 @@ class SaslTerminationTest {
             var filterContext = mockFilterContextForShortCircuitWithClose();
 
             // When
-            var completingThread = new java.util.concurrent.atomic.AtomicReference<String>();
+            var completingThread = new AtomicReference<String>();
             filter.onRequest(ApiKeys.SASL_AUTHENTICATE, (short) 0,
                     new RequestHeaderData(), request, filterContext)
                     .thenApply(result -> {
                         completingThread.set(Thread.currentThread().getName());
                         return result;
                     })
-                    .toCompletableFuture().get(5, java.util.concurrent.TimeUnit.SECONDS);
+                    .toCompletableFuture().get(5, TimeUnit.SECONDS);
 
             // Then
             assertThat(completingThread.get()).isEqualTo(executorThreadName);
@@ -612,8 +621,8 @@ class SaslTerminationTest {
     private static FilterContext mockFilterContextForShortCircuitWithClose() {
         var filterContext = mock(FilterContext.class);
         var builder = mock(RequestFilterResultBuilder.class);
-        var closeOrTerminal = mock(io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage.class);
-        var terminal = mock(io.kroxylicious.proxy.filter.filterresultbuilder.TerminalStage.class);
+        var closeOrTerminal = mock(CloseOrTerminalStage.class);
+        var terminal = mock(TerminalStage.class);
         var result = mock(RequestFilterResult.class);
 
         when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
@@ -629,8 +638,8 @@ class SaslTerminationTest {
     private static FilterContext mockFilterContextForErrorResponse() {
         var filterContext = mock(FilterContext.class);
         var builder = mock(RequestFilterResultBuilder.class);
-        var closeOrTerminal = mock(io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage.class);
-        var terminal = mock(io.kroxylicious.proxy.filter.filterresultbuilder.TerminalStage.class);
+        var closeOrTerminal = mock(CloseOrTerminalStage.class);
+        var terminal = mock(TerminalStage.class);
         var result = mock(RequestFilterResult.class);
 
         when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
@@ -645,7 +654,7 @@ class SaslTerminationTest {
     private static FilterContext mockFilterContextForErrorResponseWithoutClose() {
         var filterContext = mock(FilterContext.class);
         var builder = mock(RequestFilterResultBuilder.class);
-        var closeOrTerminal = mock(io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage.class);
+        var closeOrTerminal = mock(CloseOrTerminalStage.class);
         var result = mock(RequestFilterResult.class);
 
         when(filterContext.requestFilterResultBuilder()).thenReturn(builder);

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
@@ -143,8 +143,10 @@ class SaslTerminationTest {
         var config1 = oauthConfig();
         var config2 = oauthConfig();
 
+        var mechanisms = List.<MechanismConfig> of(config1, config2);
+
         // When/Then
-        assertThatThrownBy(() -> new SaslTerminationConfig(List.of(config1, config2), null, null, null, null))
+        assertThatThrownBy(() -> new SaslTerminationConfig(mechanisms, null, null, null, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Duplicate mechanism: OAUTHBEARER");
     }

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
@@ -607,14 +607,7 @@ class SaslTerminationTest {
     }
 
     private static void setFilterState(SaslTerminationFilter filter, State state) {
-        try {
-            var field = SaslTerminationFilter.class.getDeclaredField("state");
-            field.setAccessible(true);
-            field.set(filter, state);
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        filter.forceState(state);
     }
 
     @SuppressWarnings("unchecked")

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
@@ -62,7 +62,7 @@ class SaslTerminationTest {
 
     private static OauthBearerMechanismConfig oauthConfig() {
         return new OauthBearerMechanismConfig(JWKS_URL, "kafka", "https://idp.example.com",
-                null, null, null, null, null);
+                null, null, null, null, null, null);
     }
 
     private static SaslTermination.SaslTerminationContext testContext() {
@@ -73,7 +73,7 @@ class SaslTerminationTest {
                                                                       Set<String> supportedMechanisms,
                                                                       List<AutoCloseable> closeables) {
         return new SaslTermination.SaslTerminationContext(
-                null, supportedMechanisms, closeables, null, Clock.systemUTC(), Duration.ofMillis(200),
+                null, OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES, supportedMechanisms, closeables, null, Clock.systemUTC(), Duration.ofMillis(200),
                 SaslTermination.DEFAULT_SUBJECT_BUILDER);
     }
 
@@ -224,7 +224,7 @@ class SaslTerminationTest {
                 URI.create("https://idp.example.com/.well-known/jwks.json"),
                 "kafka", "https://idp.example.com",
                 null, null,
-                Duration.ofMinutes(5), Duration.ofSeconds(1), Duration.ofSeconds(10));
+                Duration.ofMinutes(5), Duration.ofSeconds(1), Duration.ofSeconds(10), null);
 
         // When
         var saslConfig = SaslTermination.createOauthSaslConfigMap(config);
@@ -242,7 +242,7 @@ class SaslTerminationTest {
         var config = new OauthBearerMechanismConfig(
                 URI.create("https://idp.example.com/.well-known/jwks.json"),
                 "kafka", "https://idp.example.com",
-                null, null, null, null, null);
+                null, null, null, null, null, null);
 
         // When
         var saslConfig = SaslTermination.createOauthSaslConfigMap(config);
@@ -264,7 +264,7 @@ class SaslTerminationTest {
         var config = new OauthBearerMechanismConfig(
                 URI.create("https://idp.example.com/.well-known/jwks.json"),
                 audience, "https://idp.example.com",
-                null, null, null, null, null);
+                null, null, null, null, null, null);
 
         // When / Then
         assertThatThrownBy(() -> SaslTermination.createOauthSaslConfigMap(config))
@@ -574,7 +574,7 @@ class SaslTerminationTest {
         var executorThreadName = "test-filter-dispatch";
         try (var executor = Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, executorThreadName))) {
             var context = new SaslTermination.SaslTerminationContext(
-                    null, Set.of("OAUTHBEARER"), List.of(), null, Clock.systemUTC(),
+                    null, OauthBearerMechanismConfig.DEFAULT_MAX_AUTH_BYTES, Set.of("OAUTHBEARER"), List.of(), null, Clock.systemUTC(),
                     Duration.ofMillis(100), SaslTermination.DEFAULT_SUBJECT_BUILDER);
             var filter = new SaslTerminationFilter(executor, context);
 

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
@@ -356,7 +356,7 @@ class SaslTerminationTest {
     }
 
     @Test
-    void shouldRejectSaslHandshakeWithUnsupportedApiVersion() throws Exception {
+    void shouldRejectSaslHandshakeWithUnsupportedApiVersion() {
         // Given
         var context = testContext();
         var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
@@ -373,7 +373,7 @@ class SaslTerminationTest {
     }
 
     @Test
-    void shouldRejectSaslAuthenticateWithUnsupportedApiVersion() throws Exception {
+    void shouldRejectSaslAuthenticateWithUnsupportedApiVersion() {
         // Given
         var context = testContext();
         var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
@@ -442,7 +442,7 @@ class SaslTerminationTest {
             "CREATE_DELEGATION_TOKEN", "RENEW_DELEGATION_TOKEN",
             "EXPIRE_DELEGATION_TOKEN", "DESCRIBE_DELEGATION_TOKEN"
     })
-    void shouldRejectUnsupportedApiRequests(ApiKeys apiKey) throws Exception {
+    void shouldRejectUnsupportedApiRequests(ApiKeys apiKey) {
         // Given
         var context = testContext();
         var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
@@ -458,7 +458,7 @@ class SaslTerminationTest {
     }
 
     @Test
-    void shouldRemoveDelegationTokenApisFromApiVersionsResponse() throws Exception {
+    void shouldRemoveDelegationTokenApisFromApiVersionsResponse() {
         // Given
         var context = testContext();
         var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
@@ -490,7 +490,7 @@ class SaslTerminationTest {
     }
 
     @Test
-    void shouldHandleApiVersionsResponseWithNoTargetApis() throws Exception {
+    void shouldHandleApiVersionsResponseWithNoTargetApis() {
         // Given
         var context = testContext();
         var filter = new SaslTerminationFilter(mock(java.util.concurrent.ScheduledExecutorService.class), context);
@@ -513,7 +513,7 @@ class SaslTerminationTest {
     }
 
     @Test
-    void shouldRejectOversizedOauthBearerAuthBytes() throws Exception {
+    void shouldRejectOversizedOauthBearerAuthBytes() {
         // Given
         int maxAuthBytes = 128 * 1024;
         var handler = mock(MechanismStateMachine.class);
@@ -541,8 +541,7 @@ class SaslTerminationTest {
     void fixedAuthDelayShouldCompleteOnProvidedExecutor() throws Exception {
         // Given
         var executorThreadName = "test-filter-dispatch";
-        var executor = Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, executorThreadName));
-        try {
+        try (var executor = Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, executorThreadName))) {
             var context = new SaslTermination.SaslTerminationContext(
                     null, Set.of("OAUTHBEARER"), List.of(), null, Clock.systemUTC(),
                     Duration.ofMillis(100), SaslTermination.DEFAULT_SUBJECT_BUILDER);
@@ -573,9 +572,6 @@ class SaslTerminationTest {
 
             // Then
             assertThat(completingThread.get()).isEqualTo(executorThreadName);
-        }
-        finally {
-            executor.shutdownNow();
         }
     }
 

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/StateTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/StateTest.java
@@ -102,7 +102,7 @@ class StateTest {
     @Test
     void shouldProvideReadableToString() {
         State.RequiringHandshake handshake = State.start();
-        assertThat(handshake.toString()).isEqualTo("RequiringHandshake");
+        assertThat(handshake).hasToString("RequiringHandshake");
 
         State.RequiringAuthenticate authenticating = handshake.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"), 0L);
         assertThat(authenticating.toString()).contains("RequiringAuthenticate").contains("SCRAM-SHA-256");

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/StateTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/StateTest.java
@@ -31,7 +31,7 @@ class StateTest {
         State.RequiringHandshake initial = State.start();
         MechanismStateMachine handler = new TestMechanismStateMachine("SCRAM-SHA-256");
 
-        State.RequiringAuthenticate next = initial.nextState(handler, 0L);
+        State.RequiringAuthenticate next = initial.nextState(handler);
 
         assertThat(next.mechanismStateMachine()).isSameAs(handler);
         assertThat(next.isAuthenticated()).isFalse();
@@ -43,7 +43,7 @@ class StateTest {
     void shouldStayInAuthenticateForChallenge() {
         State.RequiringHandshake initial = State.start();
         MechanismStateMachine handler = new TestMechanismStateMachine("SCRAM-SHA-256");
-        State.RequiringAuthenticate authenticating = initial.nextState(handler, 0L);
+        State.RequiringAuthenticate authenticating = initial.nextState(handler);
 
         State.RequiringAuthenticate nextRound = authenticating.nextStateChallenge();
 
@@ -55,7 +55,7 @@ class StateTest {
     @Test
     void shouldTransitionToAuthenticatedOnSuccess() {
         State.RequiringHandshake initial = State.start();
-        State.RequiringAuthenticate authenticating = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"), 0L);
+        State.RequiringAuthenticate authenticating = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"));
 
         State.Authenticated authenticated = authenticating.nextStateSuccess("alice", "SCRAM-SHA-256", null);
 
@@ -68,7 +68,7 @@ class StateTest {
     @Test
     void shouldTransitionToFailedOnFailure() {
         State.RequiringHandshake initial = State.start();
-        State.RequiringAuthenticate authenticating = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"), 0L);
+        State.RequiringAuthenticate authenticating = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"));
 
         State.Failed failed = authenticating.nextStateFailure("Invalid credentials");
 
@@ -85,7 +85,7 @@ class StateTest {
         MechanismStateMachine handler = new TestMechanismStateMachine("SCRAM-SHA-256");
 
         // Round 1
-        State.RequiringAuthenticate round1 = initial.nextState(handler, 0L);
+        State.RequiringAuthenticate round1 = initial.nextState(handler);
         assertThat(round1.isTerminal()).isFalse();
 
         // Round 2 (challenge)
@@ -104,7 +104,7 @@ class StateTest {
         State.RequiringHandshake handshake = State.start();
         assertThat(handshake).hasToString("RequiringHandshake");
 
-        State.RequiringAuthenticate authenticating = handshake.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"), 0L);
+        State.RequiringAuthenticate authenticating = handshake.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"));
         assertThat(authenticating.toString()).contains("RequiringAuthenticate").contains("SCRAM-SHA-256");
 
         State.Authenticated authenticated = authenticating.nextStateSuccess("alice", "SCRAM-SHA-256", null);
@@ -117,7 +117,7 @@ class StateTest {
     @Test
     void shouldHandleNullErrorMessageInFailed() {
         State.RequiringHandshake initial = State.start();
-        State.RequiringAuthenticate authenticating = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"), 0L);
+        State.RequiringAuthenticate authenticating = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"));
 
         State.Failed failed = authenticating.nextStateFailure(null);
 
@@ -130,11 +130,11 @@ class StateTest {
         // Given
         State.RequiringHandshake initial = State.start();
         MechanismStateMachine handler1 = new TestMechanismStateMachine("SCRAM-SHA-256");
-        State.Authenticated authenticated = initial.nextState(handler1, 0L).nextStateSuccess("alice", "SCRAM-SHA-256", null);
+        State.Authenticated authenticated = initial.nextState(handler1).nextStateSuccess("alice", "SCRAM-SHA-256", null);
         MechanismStateMachine handler2 = new TestMechanismStateMachine("SCRAM-SHA-256");
 
         // When
-        State.RequiringAuthenticate reauth = authenticated.nextStateReauthenticate(handler2, 0L);
+        State.RequiringAuthenticate reauth = authenticated.nextStateReauthenticate(handler2);
 
         // Then
         assertThat(reauth.mechanismStateMachine()).isSameAs(handler2);
@@ -149,7 +149,7 @@ class StateTest {
         State.RequiringHandshake initial = State.start();
 
         // When
-        State.RequiringAuthenticate authenticating = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"), 0L);
+        State.RequiringAuthenticate authenticating = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"));
 
         // Then
         assertThat(authenticating.previousAuthorizationId()).isNull();
@@ -162,7 +162,7 @@ class StateTest {
         Instant expiry = Instant.now().plusSeconds(3600);
 
         // When
-        State.Authenticated authenticated = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"), 0L)
+        State.Authenticated authenticated = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"))
                 .nextStateSuccess("alice", "SCRAM-SHA-256", expiry);
 
         // Then
@@ -175,7 +175,7 @@ class StateTest {
         State.RequiringHandshake initial = State.start();
 
         // When
-        State.Authenticated authenticated = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"), 0L)
+        State.Authenticated authenticated = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"))
                 .nextStateSuccess("alice", "SCRAM-SHA-256", null);
 
         // Then
@@ -185,7 +185,7 @@ class StateTest {
     @Test
     void shouldDistinguishTerminalStates() {
         State.RequiringHandshake handshake = State.start();
-        State.RequiringAuthenticate authenticating = handshake.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"), 0L);
+        State.RequiringAuthenticate authenticating = handshake.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"));
         State.Authenticated authenticated = authenticating.nextStateSuccess("alice", "SCRAM-SHA-256", null);
         State.Failed failed = authenticating.nextStateFailure("error");
 
@@ -196,6 +196,59 @@ class StateTest {
 
         // Terminal states
         assertThat(failed.isTerminal()).isTrue();
+    }
+
+    @Test
+    void shouldStartWithZeroAccumulatedAuthWorkNanos() {
+        // Given
+        State.RequiringHandshake initial = State.start();
+
+        // When
+        State.RequiringAuthenticate authenticating = initial.nextState(new TestMechanismStateMachine("OAUTHBEARER"));
+
+        // Then
+        assertThat(authenticating.accumulatedAuthWorkNanos()).isZero();
+    }
+
+    @Test
+    void shouldAccumulateRoundDurations() {
+        // Given
+        State.RequiringAuthenticate authenticating = State.start().nextState(new TestMechanismStateMachine("SCRAM-SHA-256"));
+
+        // When
+        authenticating.addRoundDuration(100);
+        authenticating.addRoundDuration(200);
+
+        // Then
+        assertThat(authenticating.accumulatedAuthWorkNanos()).isEqualTo(300);
+    }
+
+    @Test
+    void shouldRetainAccumulatedDurationAcrossChallengeRounds() {
+        // Given
+        State.RequiringAuthenticate round1 = State.start().nextState(new TestMechanismStateMachine("SCRAM-SHA-256"));
+        round1.addRoundDuration(100);
+
+        // When
+        State.RequiringAuthenticate round2 = round1.nextStateChallenge();
+        round2.addRoundDuration(200);
+
+        // Then
+        assertThat(round2.accumulatedAuthWorkNanos()).isEqualTo(300);
+    }
+
+    @Test
+    void shouldResetAccumulatedDurationOnReauthentication() {
+        // Given
+        State.RequiringAuthenticate authenticating = State.start().nextState(new TestMechanismStateMachine("OAUTHBEARER"));
+        authenticating.addRoundDuration(500);
+        State.Authenticated authenticated = authenticating.nextStateSuccess("alice", "OAUTHBEARER", null);
+
+        // When
+        State.RequiringAuthenticate reauth = authenticated.nextStateReauthenticate(new TestMechanismStateMachine("OAUTHBEARER"));
+
+        // Then
+        assertThat(reauth.accumulatedAuthWorkNanos()).isZero();
     }
 
     // Test mechanism handler implementation

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/StateTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/StateTest.java
@@ -140,6 +140,19 @@ class StateTest {
         assertThat(reauth.mechanismStateMachine()).isSameAs(handler2);
         assertThat(reauth.isAuthenticated()).isFalse();
         assertThat(reauth.isTerminal()).isFalse();
+        assertThat(reauth.previousAuthorizationId()).isEqualTo("alice");
+    }
+
+    @Test
+    void shouldHaveNullPreviousAuthorizationIdOnInitialAuth() {
+        // Given
+        State.RequiringHandshake initial = State.start();
+
+        // When
+        State.RequiringAuthenticate authenticating = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"), 0L);
+
+        // Then
+        assertThat(authenticating.previousAuthorizationId()).isNull();
     }
 
     @Test

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/StateTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/StateTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.sasl.termination;
+
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StateTest {
+
+    @Test
+    void shouldStartInRequiringHandshakeState() {
+        State state = State.start();
+
+        assertThat(state).isInstanceOf(State.RequiringHandshake.class);
+        assertThat(state.isAuthenticated()).isFalse();
+        assertThat(state.isFailed()).isFalse();
+        assertThat(state.isTerminal()).isFalse();
+    }
+
+    @Test
+    void shouldTransitionFromHandshakeToAuthenticate() {
+        State.RequiringHandshake initial = State.start();
+        MechanismStateMachine handler = new TestMechanismStateMachine("SCRAM-SHA-256");
+
+        State.RequiringAuthenticate next = initial.nextState(handler, 0L);
+
+        assertThat(next.mechanismStateMachine()).isSameAs(handler);
+        assertThat(next.isAuthenticated()).isFalse();
+        assertThat(next.isFailed()).isFalse();
+        assertThat(next.isTerminal()).isFalse();
+    }
+
+    @Test
+    void shouldStayInAuthenticateForChallenge() {
+        State.RequiringHandshake initial = State.start();
+        MechanismStateMachine handler = new TestMechanismStateMachine("SCRAM-SHA-256");
+        State.RequiringAuthenticate authenticating = initial.nextState(handler, 0L);
+
+        State.RequiringAuthenticate nextRound = authenticating.nextStateChallenge();
+
+        // Should return same instance (stays in same state)
+        assertThat(nextRound).isSameAs(authenticating);
+        assertThat(nextRound.mechanismStateMachine()).isSameAs(handler);
+    }
+
+    @Test
+    void shouldTransitionToAuthenticatedOnSuccess() {
+        State.RequiringHandshake initial = State.start();
+        State.RequiringAuthenticate authenticating = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"), 0L);
+
+        State.Authenticated authenticated = authenticating.nextStateSuccess("alice", "SCRAM-SHA-256", null);
+
+        assertThat(authenticated.authorizationId()).isEqualTo("alice");
+        assertThat(authenticated.isAuthenticated()).isTrue();
+        assertThat(authenticated.isFailed()).isFalse();
+        assertThat(authenticated.isTerminal()).isFalse();
+    }
+
+    @Test
+    void shouldTransitionToFailedOnFailure() {
+        State.RequiringHandshake initial = State.start();
+        State.RequiringAuthenticate authenticating = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"), 0L);
+
+        State.Failed failed = authenticating.nextStateFailure("Invalid credentials");
+
+        assertThat(failed.errorMessage()).isEqualTo("Invalid credentials");
+        assertThat(failed.isAuthenticated()).isFalse();
+        assertThat(failed.isFailed()).isTrue();
+        assertThat(failed.isTerminal()).isTrue();
+    }
+
+    @Test
+    void shouldHandleMultiRoundAuthentication() {
+        // Simulate SCRAM's multi-round exchange
+        State.RequiringHandshake initial = State.start();
+        MechanismStateMachine handler = new TestMechanismStateMachine("SCRAM-SHA-256");
+
+        // Round 1
+        State.RequiringAuthenticate round1 = initial.nextState(handler, 0L);
+        assertThat(round1.isTerminal()).isFalse();
+
+        // Round 2 (challenge)
+        State.RequiringAuthenticate round2 = round1.nextStateChallenge();
+        assertThat(round2).isSameAs(round1);
+        assertThat(round2.isTerminal()).isFalse();
+
+        // Final round (success)
+        State.Authenticated authenticated = round2.nextStateSuccess("alice", "SCRAM-SHA-256", null);
+        assertThat(authenticated.isTerminal()).isFalse();
+        assertThat(authenticated.authorizationId()).isEqualTo("alice");
+    }
+
+    @Test
+    void shouldProvideReadableToString() {
+        State.RequiringHandshake handshake = State.start();
+        assertThat(handshake.toString()).isEqualTo("RequiringHandshake");
+
+        State.RequiringAuthenticate authenticating = handshake.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"), 0L);
+        assertThat(authenticating.toString()).contains("RequiringAuthenticate").contains("SCRAM-SHA-256");
+
+        State.Authenticated authenticated = authenticating.nextStateSuccess("alice", "SCRAM-SHA-256", null);
+        assertThat(authenticated.toString()).contains("Authenticated").contains("alice");
+
+        State.Failed failed = authenticating.nextStateFailure("Bad password");
+        assertThat(failed.toString()).contains("Failed").contains("Bad password");
+    }
+
+    @Test
+    void shouldHandleNullErrorMessageInFailed() {
+        State.RequiringHandshake initial = State.start();
+        State.RequiringAuthenticate authenticating = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"), 0L);
+
+        State.Failed failed = authenticating.nextStateFailure(null);
+
+        assertThat(failed.errorMessage()).isNull();
+        assertThat(failed.isFailed()).isTrue();
+    }
+
+    @Test
+    void shouldTransitionFromAuthenticatedToReauthenticate() {
+        // Given
+        State.RequiringHandshake initial = State.start();
+        MechanismStateMachine handler1 = new TestMechanismStateMachine("SCRAM-SHA-256");
+        State.Authenticated authenticated = initial.nextState(handler1, 0L).nextStateSuccess("alice", "SCRAM-SHA-256", null);
+        MechanismStateMachine handler2 = new TestMechanismStateMachine("SCRAM-SHA-256");
+
+        // When
+        State.RequiringAuthenticate reauth = authenticated.nextStateReauthenticate(handler2, 0L);
+
+        // Then
+        assertThat(reauth.mechanismStateMachine()).isSameAs(handler2);
+        assertThat(reauth.isAuthenticated()).isFalse();
+        assertThat(reauth.isTerminal()).isFalse();
+    }
+
+    @Test
+    void shouldStoreSessionExpiry() {
+        // Given
+        State.RequiringHandshake initial = State.start();
+        Instant expiry = Instant.now().plusSeconds(3600);
+
+        // When
+        State.Authenticated authenticated = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"), 0L)
+                .nextStateSuccess("alice", "SCRAM-SHA-256", expiry);
+
+        // Then
+        assertThat(authenticated.sessionExpiry()).isEqualTo(expiry);
+    }
+
+    @Test
+    void shouldStoreNullSessionExpiry() {
+        // Given
+        State.RequiringHandshake initial = State.start();
+
+        // When
+        State.Authenticated authenticated = initial.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"), 0L)
+                .nextStateSuccess("alice", "SCRAM-SHA-256", null);
+
+        // Then
+        assertThat(authenticated.sessionExpiry()).isNull();
+    }
+
+    @Test
+    void shouldDistinguishTerminalStates() {
+        State.RequiringHandshake handshake = State.start();
+        State.RequiringAuthenticate authenticating = handshake.nextState(new TestMechanismStateMachine("SCRAM-SHA-256"), 0L);
+        State.Authenticated authenticated = authenticating.nextStateSuccess("alice", "SCRAM-SHA-256", null);
+        State.Failed failed = authenticating.nextStateFailure("error");
+
+        // Non-terminal states
+        assertThat(handshake.isTerminal()).isFalse();
+        assertThat(authenticating.isTerminal()).isFalse();
+        assertThat(authenticated.isTerminal()).isFalse();
+
+        // Terminal states
+        assertThat(failed.isTerminal()).isTrue();
+    }
+
+    // Test mechanism handler implementation
+    private static class TestMechanismStateMachine implements MechanismStateMachine {
+        private final String mechanismName;
+
+        TestMechanismStateMachine(String mechanismName) {
+            this.mechanismName = mechanismName;
+        }
+
+        @Override
+        public String mechanismName() {
+            return mechanismName;
+        }
+
+        @Override
+        public int maxAuthBytes() {
+            return 4 * 1024;
+        }
+
+        @Override
+        public CompletionStage<RoundResult> evaluateRound(byte[] authBytes) {
+            return CompletableFuture.completedFuture(
+                    RoundResult.success(new byte[0], "test-user"));
+        }
+
+        @Override
+        public void dispose() {
+            // No-op for test
+        }
+    }
+}

--- a/kroxylicious-filters/pom.xml
+++ b/kroxylicious-filters/pom.xml
@@ -28,6 +28,7 @@
         <module>kroxylicious-simple-transform</module>
         <module>kroxylicious-oauthbearer-validation</module>
         <module>kroxylicious-sasl-inspection</module>
+        <module>kroxylicious-sasl-termination</module>
         <module>kroxylicious-authorization</module>
         <module>kroxylicious-connection-expiration</module>
         <module>kroxylicious-entity-isolation</module>

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -134,6 +134,11 @@
         </dependency>
         <dependency>
             <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-sasl-termination</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-authorization</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/BaseOauthBearerIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/BaseOauthBearerIT.java
@@ -52,6 +52,10 @@ public abstract class BaseOauthBearerIT extends BaseIT {
     private static final URI OAUTH_ENDPOINT_URL = URI.create(JWKS_ENDPOINT_URL).resolve("/");
     protected static final URI TOKEN_ENDPOINT_URL = OAUTH_ENDPOINT_URL.resolve("default/token");
     protected static final String EXPECTED_AUDIENCE = "default";
+    protected static final String EXPECTED_ISSUER = "http://localhost:" + OAUTH_SERVER_PORT + "/default";
+
+    protected static final String JWKS_ENDPOINT_URL_OTHER_ISSUER = "http://localhost:" + OAUTH_SERVER_PORT + "/other-issuer/jwks";
+    protected static final URI TOKEN_ENDPOINT_URL_OTHER_ISSUER = OAUTH_ENDPOINT_URL.resolve("other-issuer/token");
     protected static final String ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG = "org.apache.kafka.sasl.oauthbearer.allowed.urls";
     protected static final String CLIENT_ID = "clientId-" + UUID.randomUUID();
     protected static final String CLIENT_SECRET = "clientSecret";
@@ -66,7 +70,9 @@ public abstract class BaseOauthBearerIT extends BaseIT {
         // Kafka 4.0 requires that the org.apache.kafka.sasl.oauthbearer.allowed.urls sys property is set in order to use Oauth Bearer.
         // The Kafka Broker and Proxy requires that JWKS_ENDPOINT_URL is in the allow list.
         // The Kafka Client requires that TOKEN_ENDPOINT_URL is in the allow list.
-        System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, JWKS_ENDPOINT_URL + "," + TOKEN_ENDPOINT_URL);
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG,
+                JWKS_ENDPOINT_URL + "," + TOKEN_ENDPOINT_URL + ","
+                        + JWKS_ENDPOINT_URL_OTHER_ISSUER + "," + TOKEN_ENDPOINT_URL_OTHER_ISSUER);
 
         oauthServer = new OauthServerContainer(BaseOauthBearerIT.DOCKER_IMAGE_NAME);
         oauthServer.setWaitStrategy(new LogMessageWaitStrategy().withRegEx(".*started server on address.*"));

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/BaseOauthBearerIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/BaseOauthBearerIT.java
@@ -67,12 +67,14 @@ public abstract class BaseOauthBearerIT extends BaseIT {
 
     @BeforeAll
     static void beforeAll() {
-        // Kafka 4.0 requires that the org.apache.kafka.sasl.oauthbearer.allowed.urls sys property is set in order to use Oauth Bearer.
-        // The Kafka Client requires that TOKEN_ENDPOINT_URL is in the allow list.
-        // JWKS URLs are NOT set here: SASL termination tests rely on the production code to add them,
-        // and OauthBearerValidationIT adds them for the broker.
+        // Kafka 4.0 validates OAUTHBEARER URLs against the org.apache.kafka.sasl.oauthbearer.allowed.urls
+        // system property. The proxy's production code manages this property for its own JWKS URLs, but
+        // the in-VM test broker shares the same JVM and also needs the JWKS URLs in the allowed list.
+        // We pre-populate both JWKS and token endpoint URLs here for the broker and client respectively.
+        // SaslTerminationOauthBearerIT strips the JWKS URLs so it can verify that the production code adds them.
         System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG,
-                TOKEN_ENDPOINT_URL + "," + TOKEN_ENDPOINT_URL_OTHER_ISSUER);
+                JWKS_ENDPOINT_URL + "," + TOKEN_ENDPOINT_URL + ","
+                        + JWKS_ENDPOINT_URL_OTHER_ISSUER + "," + TOKEN_ENDPOINT_URL_OTHER_ISSUER);
 
         oauthServer = new OauthServerContainer(BaseOauthBearerIT.DOCKER_IMAGE_NAME);
         oauthServer.setWaitStrategy(new LogMessageWaitStrategy().withRegEx(".*started server on address.*"));

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/BaseOauthBearerIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/BaseOauthBearerIT.java
@@ -68,11 +68,11 @@ public abstract class BaseOauthBearerIT extends BaseIT {
     @BeforeAll
     static void beforeAll() {
         // Kafka 4.0 requires that the org.apache.kafka.sasl.oauthbearer.allowed.urls sys property is set in order to use Oauth Bearer.
-        // The Kafka Broker and Proxy requires that JWKS_ENDPOINT_URL is in the allow list.
         // The Kafka Client requires that TOKEN_ENDPOINT_URL is in the allow list.
+        // JWKS URLs are NOT set here: SASL termination tests rely on the production code to add them,
+        // and OauthBearerValidationIT adds them for the broker.
         System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG,
-                JWKS_ENDPOINT_URL + "," + TOKEN_ENDPOINT_URL + ","
-                        + JWKS_ENDPOINT_URL_OTHER_ISSUER + "," + TOKEN_ENDPOINT_URL_OTHER_ISSUER);
+                TOKEN_ENDPOINT_URL + "," + TOKEN_ENDPOINT_URL_OTHER_ISSUER);
 
         oauthServer = new OauthServerContainer(BaseOauthBearerIT.DOCKER_IMAGE_NAME);
         oauthServer.setWaitStrategy(new LogMessageWaitStrategy().withRegEx(".*started server on address.*"));

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/SaslTerminationOauthBearerIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/SaslTerminationOauthBearerIT.java
@@ -39,6 +39,7 @@ import org.jose4j.jws.AlgorithmIdentifiers;
 import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.jwt.JwtClaims;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.io.TempDir;
@@ -72,6 +73,15 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @EnabledIf(value = "isDockerAvailable", disabledReason = "docker unavailable")
 class SaslTerminationOauthBearerIT extends BaseOauthBearerIT {
+
+    @BeforeAll
+    static void removeJwksUrlsToVerifyProductionCodeAddsThem() {
+        // The base class pre-populates JWKS URLs for the in-VM test broker (see BaseOauthBearerIT).
+        // Strip them here so these tests verify that the SaslTermination filter's production code
+        // adds JWKS URLs to the allowed list itself. Token endpoint URLs are kept for the Kafka client.
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG,
+                TOKEN_ENDPOINT_URL + "," + TOKEN_ENDPOINT_URL_OTHER_ISSUER);
+    }
 
     KafkaCluster cluster;
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/SaslTerminationOauthBearerIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/SaslTerminationOauthBearerIT.java
@@ -75,7 +75,6 @@ class SaslTerminationOauthBearerIT extends BaseOauthBearerIT {
 
     KafkaCluster cluster;
 
-
     @AfterEach
     @SuppressWarnings("java:S3011")
     void afterEach() throws Exception {
@@ -354,7 +353,6 @@ class SaslTerminationOauthBearerIT extends BaseOauthBearerIT {
             }
         }
     }
-
 
     private NamedFilterDefinition createOauthTerminationFilter() {
         return createOauthTerminationFilterWithConfig(

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/SaslTerminationOauthBearerIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/SaslTerminationOauthBearerIT.java
@@ -142,7 +142,7 @@ class SaslTerminationOauthBearerIT extends BaseOauthBearerIT {
     }
 
     @Test
-    void shouldRejectTokenWithWrongAudience(@TempDir Path tempDir) {
+    void shouldRejectTokenWithWrongAudience() {
         // Given
         var config = proxy(cluster)
                 .addToFilterDefinitions(createOauthTerminationFilter())
@@ -277,6 +277,7 @@ class SaslTerminationOauthBearerIT extends BaseOauthBearerIT {
         }
     }
 
+    @SuppressWarnings("java:S2925") // Can't test Kafka re-auth (KIP-368) without Thread#sleep
     @Test
     void shouldRejectExpiredSessionWithoutReauthentication() throws Exception {
         // Given
@@ -319,6 +320,7 @@ class SaslTerminationOauthBearerIT extends BaseOauthBearerIT {
         }
     }
 
+    @SuppressWarnings("java:S2925") // Can't test Kafka re-auth (KIP-368) without Thread#sleep
     @Test
     void shouldReauthenticateWithOauthBearer(Topic topic) {
         // Given

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/SaslTerminationOauthBearerIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/SaslTerminationOauthBearerIT.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.it;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.SaslAuthenticationException;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.SaslAuthenticateRequestData;
+import org.apache.kafka.common.message.SaslAuthenticateResponseData;
+import org.apache.kafka.common.message.SaslHandshakeRequestData;
+import org.apache.kafka.common.message.SaslHandshakeResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.VerificationKeyResolverFactory;
+import org.assertj.core.api.InstanceOfAssertFactory;
+import org.jose4j.jwk.PublicJsonWebKey;
+import org.jose4j.jws.AlgorithmIdentifiers;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwt.JwtClaims;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.kroxylicious.filter.sasl.termination.SaslTermination;
+import io.kroxylicious.it.testplugins.ClientAuthAwareLawyer;
+import io.kroxylicious.it.testplugins.ClientAuthAwareLawyerFilter;
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
+import io.kroxylicious.testing.filter.assertj.KafkaAssertions;
+import io.kroxylicious.testing.filter.jws.JwsTestUtils;
+import io.kroxylicious.testing.integration.Request;
+import io.kroxylicious.testing.integration.client.KafkaClient;
+import io.kroxylicious.testing.integration.config.NamedFilterDefinitionBuilder;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.junit5ext.Topic;
+
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.proxy;
+import static io.kroxylicious.testing.integration.tester.KroxyliciousTesters.kroxyliciousTester;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for SASL termination filter with OAUTHBEARER mechanism.
+ * <p>
+ * Tests authenticate against a real OAuth server (mock-oauth2-server) and verify
+ * that JWT validation is correctly enforced: audience, issuer, expiry, key ID,
+ * and signature verification.
+ * </p>
+ */
+@EnabledIf(value = "isDockerAvailable", disabledReason = "docker unavailable")
+class SaslTerminationOauthBearerIT extends BaseOauthBearerIT {
+
+    KafkaCluster cluster;
+
+
+    @AfterEach
+    @SuppressWarnings("java:S3011")
+    void afterEach() throws Exception {
+        // https://issues.apache.org/jira/browse/KAFKA-17134
+        var cacheField = VerificationKeyResolverFactory.class.getDeclaredField("CACHE");
+        cacheField.setAccessible(true);
+        ((Map<?, ?>) cacheField.get(null)).clear();
+    }
+
+    @Test
+    void shouldAuthenticateWithValidToken() {
+        // Given
+        var config = proxy(cluster)
+                .addToFilterDefinitions(createOauthTerminationFilter())
+                .addToDefaultFilters(SaslTermination.class.getSimpleName());
+
+        // When
+        try (var tester = kroxyliciousTester(config);
+                var admin = tester.admin(getClientConfig(TOKEN_ENDPOINT_URL))) {
+
+            // Then
+            assertThat(admin.describeCluster().nodes())
+                    .succeedsWithin(10, TimeUnit.SECONDS)
+                    .isNotNull();
+        }
+    }
+
+    @Test
+    void shouldProduceAndConsumeWithValidToken(Topic topic) {
+        // Given
+        var lawyer = new NamedFilterDefinitionBuilder(
+                ClientAuthAwareLawyer.class.getName(),
+                ClientAuthAwareLawyer.class.getName())
+                .build();
+
+        var config = proxy(cluster)
+                .addToFilterDefinitions(createOauthTerminationFilter(), lawyer)
+                .addToDefaultFilters(SaslTermination.class.getSimpleName(), lawyer.name());
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(getProducerConfig());
+                var consumer = tester.consumer(getConsumerConfig())) {
+
+            // When
+            assertThat(producer.send(new ProducerRecord<>(topic.name(), "my-key", "my-value")))
+                    .succeedsWithin(Duration.ofSeconds(5));
+
+            consumer.subscribe(Set.of(topic.name()));
+            var records = consumer.poll(Duration.ofSeconds(10));
+
+            // Then
+            assertThat(records).hasSize(1);
+            var recordHeaders = assertThat(records.records(topic.name()))
+                    .as("topic %s records", topic.name())
+                    .singleElement()
+                    .asInstanceOf(new InstanceOfAssertFactory<>(ConsumerRecord.class, KafkaAssertions::assertThat))
+                    .headers();
+
+            recordHeaders.singleHeaderWithKey(ClientAuthAwareLawyerFilter.HEADER_KEY_CLIENT_SASL_CONTEXT_PRESENT)
+                    .hasByteValueSatisfying(val -> assertThat(val).isEqualTo(ClientAuthAwareLawyerFilter.trueValue()));
+
+            recordHeaders.singleHeaderWithKey(ClientAuthAwareLawyerFilter.HEADER_KEY_CLIENT_SASL_AUTHORIZATION_ID)
+                    .hasValueEqualTo(CLIENT_ID);
+        }
+    }
+
+    @Test
+    void shouldRejectTokenWithWrongAudience(@TempDir Path tempDir) {
+        // Given
+        var config = proxy(cluster)
+                .addToFilterDefinitions(createOauthTerminationFilter())
+                .addToDefaultFilters(SaslTermination.class.getSimpleName());
+
+        // Token from /other-issuer has aud:"other-issuer", but filter expects aud:"default"
+        var clientConfig = getClientConfig(TOKEN_ENDPOINT_URL_OTHER_ISSUER);
+
+        // When/Then
+        try (var tester = kroxyliciousTester(config);
+                var admin = tester.admin(clientConfig)) {
+            assertThat(admin.describeCluster().nodes())
+                    .failsWithin(10, TimeUnit.SECONDS)
+                    .withThrowableOfType(ExecutionException.class)
+                    .withCauseInstanceOf(SaslAuthenticationException.class);
+        }
+    }
+
+    @Test
+    void shouldRejectTokenWithWrongIssuer() {
+        // Given — filter validates against /other-issuer JWKS (so signature is valid)
+        // but expects issuer "http://localhost:<port>/default"
+        var filter = createOauthTerminationFilterWithConfig(
+                JWKS_ENDPOINT_URL_OTHER_ISSUER,
+                "other-issuer",
+                EXPECTED_ISSUER);
+
+        var config = proxy(cluster)
+                .addToFilterDefinitions(filter)
+                .addToDefaultFilters(SaslTermination.class.getSimpleName());
+
+        // Token from /other-issuer has iss:"http://localhost:<port>/other-issuer"
+        var clientConfig = getClientConfig(TOKEN_ENDPOINT_URL_OTHER_ISSUER);
+
+        // When/Then
+        try (var tester = kroxyliciousTester(config);
+                var admin = tester.admin(clientConfig)) {
+            assertThat(admin.describeCluster().nodes())
+                    .failsWithin(10, TimeUnit.SECONDS)
+                    .withThrowableOfType(ExecutionException.class)
+                    .withCauseInstanceOf(SaslAuthenticationException.class);
+        }
+    }
+
+    @Test
+    void shouldRejectExpiredToken(@TempDir Path tempDir) throws Exception {
+        // Given
+        var badTokenFile = Files.createTempFile(tempDir, "expiredtoken", "b64");
+        Files.writeString(badTokenFile, LONG_SINCE_EXPIRED_TOKEN);
+
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG,
+                System.getProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG) + "," + badTokenFile.toUri());
+
+        var config = proxy(cluster)
+                .addToFilterDefinitions(createOauthTerminationFilter())
+                .addToDefaultFilters(SaslTermination.class.getSimpleName());
+
+        var clientConfig = getClientConfig(badTokenFile.toUri());
+
+        // When/Then
+        try (var tester = kroxyliciousTester(config);
+                var admin = tester.admin(clientConfig)) {
+            assertThat(admin.describeCluster().nodes())
+                    .failsWithin(10, TimeUnit.SECONDS)
+                    .withThrowableOfType(ExecutionException.class)
+                    .withCauseInstanceOf(SaslAuthenticationException.class);
+        }
+    }
+
+    @Test
+    void shouldRejectTokenWithNoKeyId(@TempDir Path tempDir) throws Exception {
+        // Given
+        var badTokenFile = Files.createTempFile(tempDir, "nokidtoken", "b64");
+        Files.writeString(badTokenFile, NO_KEYID_TOKEN);
+
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG,
+                System.getProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG) + "," + badTokenFile.toUri());
+
+        var config = proxy(cluster)
+                .addToFilterDefinitions(createOauthTerminationFilter())
+                .addToDefaultFilters(SaslTermination.class.getSimpleName());
+
+        var clientConfig = getClientConfig(badTokenFile.toUri());
+
+        // When/Then
+        try (var tester = kroxyliciousTester(config);
+                var admin = tester.admin(clientConfig)) {
+            assertThat(admin.describeCluster().nodes())
+                    .failsWithin(10, TimeUnit.SECONDS)
+                    .withThrowableOfType(ExecutionException.class)
+                    .withCauseInstanceOf(SaslAuthenticationException.class);
+        }
+    }
+
+    @Test
+    void shouldRejectTokenSignedByUnknownKey(@TempDir Path tempDir) throws Exception {
+        // Given — craft a JWT with valid claims but signed by a key not in the mock server's JWKS
+        PublicJsonWebKey rsaKey = (PublicJsonWebKey) JwsTestUtils.RSA_SIGN_JWKS.getJsonWebKeys().get(0);
+
+        JwtClaims claims = new JwtClaims();
+        claims.setSubject(CLIENT_ID);
+        claims.setAudience(EXPECTED_AUDIENCE);
+        claims.setIssuer(EXPECTED_ISSUER);
+        claims.setExpirationTimeMinutesInTheFuture(60);
+        claims.setIssuedAtToNow();
+
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setKeyIdHeaderValue(rsaKey.getKeyId());
+        jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_USING_SHA256);
+        jws.setKey(rsaKey.getPrivateKey());
+        jws.setPayload(claims.toJson());
+
+        var badTokenFile = Files.createTempFile(tempDir, "unknownkey", "b64");
+        Files.writeString(badTokenFile, jws.getCompactSerialization());
+
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG,
+                System.getProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG) + "," + badTokenFile.toUri());
+
+        var config = proxy(cluster)
+                .addToFilterDefinitions(createOauthTerminationFilter())
+                .addToDefaultFilters(SaslTermination.class.getSimpleName());
+
+        var clientConfig = getClientConfig(badTokenFile.toUri());
+
+        // When/Then
+        try (var tester = kroxyliciousTester(config);
+                var admin = tester.admin(clientConfig)) {
+            assertThat(admin.describeCluster().nodes())
+                    .failsWithin(10, TimeUnit.SECONDS)
+                    .withThrowableOfType(ExecutionException.class)
+                    .withCauseInstanceOf(SaslAuthenticationException.class);
+        }
+    }
+
+    @Test
+    void shouldRejectExpiredSessionWithoutReauthentication() throws Exception {
+        // Given
+        Duration maxTimeBeforeReauth = Duration.ofSeconds(2);
+        var config = proxy(cluster)
+                .addToFilterDefinitions(createOauthTerminationFilterWithReauth(maxTimeBeforeReauth))
+                .addToDefaultFilters(SaslTermination.class.getSimpleName());
+
+        String accessToken = getAccessToken();
+
+        try (var tester = kroxyliciousTester(config)) {
+            String bootstrapAddress = tester.getBootstrapAddress();
+            String[] hostPort = bootstrapAddress.split(":"); // NOPMD
+            try (var client = new KafkaClient(hostPort[0], Integer.parseInt(hostPort[1]))) {
+                var handshakeResponse = (SaslHandshakeResponseData) client.getSync(getRequest(
+                        ApiKeys.SASL_HANDSHAKE.latestVersion(),
+                        new SaslHandshakeRequestData().setMechanism("OAUTHBEARER")))
+                        .payload().message();
+                assertThat(Errors.forCode(handshakeResponse.errorCode())).isEqualTo(Errors.NONE);
+
+                byte[] authBytes = ("n,,auth=Bearer " + accessToken + "").getBytes(StandardCharsets.UTF_8);
+                var authenticateResponse = (SaslAuthenticateResponseData) client.getSync(getRequest(
+                        ApiKeys.SASL_AUTHENTICATE.latestVersion(),
+                        new SaslAuthenticateRequestData().setAuthBytes(authBytes)))
+                        .payload().message();
+                assertThat(Errors.forCode(authenticateResponse.errorCode())).isEqualTo(Errors.NONE);
+
+                // When
+                Thread.sleep(maxTimeBeforeReauth.plusSeconds(1).toMillis());
+
+                var metadataResponse = (MetadataResponseData) client.getSync(getRequest(
+                        ApiKeys.METADATA.latestVersion(),
+                        new MetadataRequestData()))
+                        .payload().message();
+
+                // Then
+                assertThat(Errors.forCode(metadataResponse.errorCode()))
+                        .isEqualTo(Errors.SASL_AUTHENTICATION_FAILED);
+            }
+        }
+    }
+
+    @Test
+    void shouldReauthenticateWithOauthBearer(Topic topic) {
+        // Given
+        Duration maxTimeBeforeReauth = Duration.ofSeconds(2);
+        var config = proxy(cluster)
+                .addToFilterDefinitions(createOauthTerminationFilterWithReauth(maxTimeBeforeReauth))
+                .addToDefaultFilters(SaslTermination.class.getSimpleName());
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(getProducerConfig())) {
+
+            // When
+            assertThat(producer.send(new ProducerRecord<>(topic.name(), "key1", "value1")))
+                    .succeedsWithin(Duration.ofSeconds(5));
+
+            try {
+                Thread.sleep(maxTimeBeforeReauth.plusSeconds(1).toMillis());
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+
+            assertThat(producer.send(new ProducerRecord<>(topic.name(), "key2", "value2")))
+                    .succeedsWithin(Duration.ofSeconds(10));
+
+            // Then
+            try (var consumer = tester.consumer(getConsumerConfig())) {
+                consumer.subscribe(Set.of(topic.name()));
+                var records = consumer.poll(Duration.ofSeconds(10));
+                assertThat(records).hasSize(2);
+            }
+        }
+    }
+
+
+    private NamedFilterDefinition createOauthTerminationFilter() {
+        return createOauthTerminationFilterWithConfig(
+                JWKS_ENDPOINT_URL,
+                EXPECTED_AUDIENCE,
+                EXPECTED_ISSUER);
+    }
+
+    private NamedFilterDefinition createOauthTerminationFilterWithConfig(
+                                                                         String jwksUrl,
+                                                                         String audience,
+                                                                         String issuer) {
+        return new NamedFilterDefinitionBuilder(
+                SaslTermination.class.getSimpleName(),
+                SaslTermination.class.getName())
+                .withConfig("mechanisms", List.of(
+                        Map.of(
+                                "mechanism", "OAUTHBEARER",
+                                "jwksEndpointUrl", jwksUrl,
+                                "expectedAudience", audience,
+                                "expectedIssuer", issuer)))
+                .build();
+    }
+
+    private NamedFilterDefinition createOauthTerminationFilterWithReauth(Duration maxTimeBeforeReauth) {
+        return new NamedFilterDefinitionBuilder(
+                SaslTermination.class.getSimpleName(),
+                SaslTermination.class.getName())
+                .withConfig("mechanisms", List.of(
+                        Map.of("mechanism", "OAUTHBEARER",
+                                "jwksEndpointUrl", JWKS_ENDPOINT_URL,
+                                "expectedAudience", EXPECTED_AUDIENCE,
+                                "expectedIssuer", EXPECTED_ISSUER)),
+                        "maxTimeBeforeReauth", maxTimeBeforeReauth.toSeconds() + "s")
+                .build();
+    }
+
+    private String getAccessToken() throws IOException, InterruptedException {
+        try (var httpClient = HttpClient.newHttpClient()) {
+            var tokenRequest = HttpRequest.newBuilder()
+                    .uri(TOKEN_ENDPOINT_URL)
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .POST(HttpRequest.BodyPublishers.ofString(
+                            "grant_type=client_credentials&client_id=" + CLIENT_ID + "&client_secret=" + CLIENT_SECRET))
+                    .build();
+            var tokenResponse = httpClient.send(tokenRequest, HttpResponse.BodyHandlers.ofString());
+            JsonNode json = new ObjectMapper().readTree(tokenResponse.body());
+            return json.get("access_token").asText();
+        }
+    }
+
+    private static Request getRequest(short apiVersion, ApiMessage request) {
+        return new Request(
+                ApiKeys.forId(request.apiKey()),
+                apiVersion,
+                "test",
+                request);
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/oauthbearer/OauthBearerValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/oauthbearer/OauthBearerValidationIT.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.VerificationKeyResolverFactory;
 import org.assertj.core.api.InstanceOfAssertFactory;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.io.TempDir;
@@ -54,6 +55,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @EnabledIf(value = "isDockerAvailable", disabledReason = "docker unavailable")
 class OauthBearerValidationIT extends BaseOauthBearerIT {
+
+    @BeforeAll
+    static void addJwksUrlsForBroker() {
+        // The broker needs the JWKS URLs in the allowed list for its own OAUTHBEARER validation.
+        String current = System.getProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, "");
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG,
+                current + "," + JWKS_ENDPOINT_URL + "," + JWKS_ENDPOINT_URL_OTHER_ISSUER);
+    }
 
     @SaslMechanism(value = OAuthBearerLoginModule.OAUTHBEARER_MECHANISM)
     @BrokerConfig(name = "listener.name.external.oauthbearer.sasl.server.callback.handler.class", value = "org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler")

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/oauthbearer/OauthBearerValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/oauthbearer/OauthBearerValidationIT.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.VerificationKeyResolverFactory;
 import org.assertj.core.api.InstanceOfAssertFactory;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.io.TempDir;
@@ -55,14 +54,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @EnabledIf(value = "isDockerAvailable", disabledReason = "docker unavailable")
 class OauthBearerValidationIT extends BaseOauthBearerIT {
-
-    @BeforeAll
-    static void addJwksUrlsForBroker() {
-        // The broker needs the JWKS URLs in the allowed list for its own OAUTHBEARER validation.
-        String current = System.getProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, "");
-        System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG,
-                current + "," + JWKS_ENDPOINT_URL + "," + JWKS_ENDPOINT_URL_OTHER_ISSUER);
-    }
 
     @SaslMechanism(value = OAuthBearerLoginModule.OAUTHBEARER_MECHANISM)
     @BrokerConfig(name = "listener.name.external.oauthbearer.sasl.server.callback.handler.class", value = "org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler")


### PR DESCRIPTION

### Type of change

- Enhancement / new feature

### Description

Implements a filter that terminates SASL authentication at the proxy without forwarding authentication to the broker. Supports OAUTHBEARER mechanism with JWKS-based JWT validation, session lifetime enforcement (KIP-368), reauthentication, and fixed-delay timing side-channel mitigation.

### Additional Context

Part of [proposal 124](https://github.com/kroxylicious/design/blob/main/proposals/124-sasl-termination.md).
Fixes #4519
Documentation to be provided later (per separate issue #4521)

