### PR TITLE
feat(changelog): enhance entry format to include links and authors

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -635,12 +635,19 @@ Not every commit needs a changelog entry e.g. documentation fixes, internal buil
 **Entry format:**
 ```yaml
 title: "feat(runtime): add graceful shutdown with configurable drain timeout"
-type: feat
+type: added
 merge_requests:    # use for PRs (only the first is rendered as a link prefix)
   - 1234
 # or:
 issues:            # use for issues (only the first is rendered as a link prefix)
   - 5678
+links:             # optional: links to external resources, e.g. design docs or CVE records
+  - name: CVE-2025-12345
+    url: https://www.cve.org/CVERecord?id=CVE-2025-12345
+authors:           # optional: credit the change's author(s)
+  - name: Your Name
+    nick: yourhandle
+    url: https://github.com/yourhandle
 important_notes:   # optional: appear under "Changes, deprecations and removals"
   - "Migration required: replace `oldConfig` with `newConfig`."
   - "`OldClass` is deprecated; use `NewClass` instead."
@@ -648,12 +655,17 @@ important_notes:   # optional: appear under "Changes, deprecations and removals"
 
 The `title` always appears in the main version section. If the change also requires a migration note or deprecation callout, add one or more `important_notes` - these appear as sub-bullets under the same entry in the "Changes, deprecations and removals" section.
 
-**`type`** - pick the one that best describes the change, ideally following [Conventional Commits](https://www.conventionalcommits.org/):
+Each `links` entry is rendered after the title as a bracketed link, e.g. `([CVE-2025-12345](https://...))`. Use links for design documents, CVE records, or other external resources relevant to the change. `authors` are rendered after the title as `(thanks [@yourhandle](https://github.com/yourhandle))` - the `nick` (prefixed with `@`) is preferred over `name`, and `url` is optional.
+
+**`type`** - pick the one that best describes the change (the `title` should still follow [Conventional Commits](https://www.conventionalcommits.org/), but the `type` field must be one of the values [logchange](https://github.com/logchange/logchange) accepts):
 
 | Type               | Use for                                                            |
 |--------------------|--------------------------------------------------------------------|
-| `feat`             | New features, capabilities, or configuration options               |
-| `fix`              | Bug fixes                                                          |
+| `added`            | New features, capabilities, or configuration options               |
+| `changed`          | Changes to existing behaviour                                      |
+| `deprecated`       | Deprecations of features or APIs                                   |
+| `removed`          | Removals of features or APIs                                       |
+| `fixed`            | Bug fixes                                                          |
 | `security`         | Security fixes                                                     |
 | `dependency_update`| Runtime dependency upgrades visible to users                       |
 | `other`            | Performance improvements or user-visible refactoring               |
@@ -663,7 +675,7 @@ Simple example (no migration notes):
 ```yaml
 # changelog/unreleased/01234-add-cool-feature.yaml
 title: "feat(runtime): add cool new feature"
-type: feat
+type: added
 merge_requests:
   - 1234
 ```
@@ -673,7 +685,7 @@ Example with migration notes:
 ```yaml
 # changelog/unreleased/01234-add-cool-feature.yaml
 title: "feat(runtime): add cool new feature"
-type: feat
+type: added
 merge_requests:
   - 1234
 important_notes:

--- a/changelog/.templates/CHANGELOG.md
+++ b/changelog/.templates/CHANGELOG.md
@@ -19,7 +19,10 @@ Format `<github issue/pr number>: <short description>`.
 {% if group.notEmpty %}
 {% for entry in group.entries %}
 {% if entry.mergeRequests %}{% set link_prefix = "[#" ~ entry.mergeRequests[0].value ~ "](" ~ repo ~ "/pull/" ~ entry.mergeRequests[0].value ~ "): " %}{% elif entry.issues %}{% set link_prefix = "[#" ~ entry.issues[0] ~ "](" ~ repo ~ "/issues/" ~ entry.issues[0] ~ "): " %}{% else %}{% set link_prefix = "" %}{% endif %}
-* {{ link_prefix }}{{ entry.title.value | trim }}
+{% set ns_extra = namespace(value="") %}
+{% for link in entry.links %}{% set ns_extra.value = ns_extra.value ~ " ([" ~ link.name ~ "](" ~ link.url ~ "))" %}{% endfor %}
+{% if entry.authors %}{% set ns_authors = namespace(value="") %}{% for author in entry.authors %}{% set author_label = ("@" ~ author.nick) if author.nick else author.name %}{% set author_md = ("[" ~ author_label ~ "](" ~ author.url ~ ")") if author.url else author_label %}{% set ns_authors.value = ns_authors.value ~ (", " if ns_authors.value else "") ~ author_md %}{% endfor %}{% set ns_extra.value = ns_extra.value ~ " (thanks " ~ ns_authors.value ~ ")" %}{% endif %}
+* {{ link_prefix }}{{ entry.title.value | trim }}{{ ns_extra.value }}
 {% endfor %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [X] PR references related GitHub issue(s) so they are closed on merging. Closes : #4459 
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
