### PR TITLE
Break the build on javadoc warnings by default, disabled per-module

### DIFF
--- a/kroxylicious-api/pom.xml
+++ b/kroxylicious-api/pom.xml
@@ -25,6 +25,7 @@
         <libs.dir>libs</libs.dir>
         <ApiCompatability.ReferenceVersion>0.23.0</ApiCompatability.ReferenceVersion>
         <ApiCompatability.EnforceForMajorVersionZero>true</ApiCompatability.EnforceForMajorVersionZero>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
     </properties>
 
     <name>Kroxylicious API</name>

--- a/kroxylicious-app/src/main/java/io/kroxylicious/app/BannerLogger.java
+++ b/kroxylicious-app/src/main/java/io/kroxylicious/app/BannerLogger.java
@@ -25,6 +25,9 @@ import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
+/**
+ * Logs the Kroxylicious startup banner.
+ */
 public class BannerLogger {
 
     private static final String DEFAULT_BANNER_LOCATION = "banner.txt";
@@ -32,6 +35,9 @@ public class BannerLogger {
     private final Supplier<Stream<String>> bannerReader;
     private final Level targetLevel;
 
+    /**
+     * Constructs a BannerLogger using the default banner resource.
+     */
     public BannerLogger() {
         this(getLogger("io.kroxylicious.proxy.StartupShutdownLogger"),
                 new BannerSupplier(DEFAULT_BANNER_LOCATION));
@@ -43,6 +49,9 @@ public class BannerLogger {
         targetLevel = Level.INFO;
     }
 
+    /**
+     * Logs the banner content.
+     */
     public void log() {
         bannerReader.get().forEach(line -> targetLogger.atLevel(targetLevel).log(line));
     }

--- a/kroxylicious-app/src/main/java/io/kroxylicious/app/package-info.java
+++ b/kroxylicious-app/src/main/java/io/kroxylicious/app/package-info.java
@@ -4,6 +4,9 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+/**
+ * Kroxylicious application entrypoint and startup utilities.
+ */
 @ReturnValuesAreNonnullByDefault
 @DefaultAnnotationForParameters(NonNull.class)
 @DefaultAnnotation(NonNull.class)

--- a/kroxylicious-authorizer-api/pom.xml
+++ b/kroxylicious-authorizer-api/pom.xml
@@ -22,6 +22,7 @@
     <name>Authorizer Plugin API</name>
 
     <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
     </properties>
 
     <dependencies>

--- a/kroxylicious-authorizer-providers/kroxylicious-authorizer-acl/pom.xml
+++ b/kroxylicious-authorizer-providers/kroxylicious-authorizer-acl/pom.xml
@@ -22,6 +22,10 @@
     <name>ACL Authorization plugin implementation</name>
     <description>An Authorization plugin implementation using Access Control Lists (ACLs)</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.kroxylicious</groupId>

--- a/kroxylicious-certificate-test-support/pom.xml
+++ b/kroxylicious-certificate-test-support/pom.xml
@@ -21,6 +21,10 @@
     <name>Certificate test support</name>
     <description>Test support for generating TLS certificates.</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/kroxylicious-filter-test-support/pom.xml
+++ b/kroxylicious-filter-test-support/pom.xml
@@ -22,6 +22,10 @@
     <name>Filter unit test support</name>
     <description>Support code to simplify writing unit tests for filter implementations</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.kroxylicious</groupId>

--- a/kroxylicious-filters/kroxylicious-authorization/pom.xml
+++ b/kroxylicious-filters/kroxylicious-authorization/pom.xml
@@ -23,6 +23,10 @@
     <name>Authorization Filter</name>
     <description>A filter providing access controls for Kafka entities such as Topics</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-filters/kroxylicious-connection-expiration/pom.xml
+++ b/kroxylicious-filters/kroxylicious-connection-expiration/pom.xml
@@ -22,6 +22,10 @@
     <name>Connection Expiration filter</name>
     <description>A filter that closes client connections after a configurable expiration age, with optional jitter, to prevent connection skew during proxy scaling.</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-filters/kroxylicious-entity-isolation/pom.xml
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/pom.xml
@@ -20,6 +20,10 @@
     <name>Entity isolation filter</name>
     <description>Entity isolation filter</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-filters/kroxylicious-multitenant/pom.xml
+++ b/kroxylicious-filters/kroxylicious-multitenant/pom.xml
@@ -24,6 +24,10 @@
     <name>Multitenancy filter</name>
     <description>A filter to implement transparent multitenancy for Apache Kafka</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/pom.xml
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/pom.xml
@@ -24,6 +24,10 @@
     <name>Oauthbearer filter</name>
     <description>Pre-validate oauth token before sending it to upstream kafka</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-filters/kroxylicious-record-encryption/pom.xml
+++ b/kroxylicious-filters/kroxylicious-record-encryption/pom.xml
@@ -25,6 +25,10 @@
     <description>Kroxylicious Filter to encrypt and decrypt records
     </description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-filters/kroxylicious-record-validation/pom.xml
+++ b/kroxylicious-filters/kroxylicious-record-validation/pom.xml
@@ -24,6 +24,10 @@
     <name>Record validation filter</name>
     <description>A filter to validate records at produce-time</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-filters/kroxylicious-sasl-inspection/pom.xml
+++ b/kroxylicious-filters/kroxylicious-sasl-inspection/pom.xml
@@ -20,6 +20,11 @@
     <artifactId>kroxylicious-sasl-inspection</artifactId>
     <name>SASL inspection filter</name>
     <description>A filter that transparently inspects SASL authentication result(s) on a channel and makes that outcome available to other filters.</description>
+
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-filters/kroxylicious-simple-transform/pom.xml
+++ b/kroxylicious-filters/kroxylicious-simple-transform/pom.xml
@@ -22,6 +22,10 @@
     <name>Simple filters</name>
     <description>Several simple filters that exist for test purposes.</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-integration-test-support/pom.xml
+++ b/kroxylicious-integration-test-support/pom.xml
@@ -25,6 +25,7 @@
 
     <properties>
         <errorprone.skip>true</errorprone.skip>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
     </properties>
 
     <dependencies>

--- a/kroxylicious-kafka-message-tools/pom.xml
+++ b/kroxylicious-kafka-message-tools/pom.xml
@@ -20,6 +20,10 @@
     <name>Kafka message tools</name>
     <description>Tools for manipulating kafka messages, depends only on kafka-clients, has no dependency on the rest of Kroxylicious</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.kroxylicious</groupId>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms-test-support/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms-test-support/pom.xml
@@ -24,6 +24,10 @@
     <name>AWS KMS test support</name>
     <description>Test support code for modules testing the AWS KMS</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/pom.xml
@@ -23,6 +23,10 @@
     <name>AWS KMS</name>
     <description>A KMS provider backed by a remote instance of AWS KMS</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.kroxylicious</groupId>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/pom.xml
@@ -24,6 +24,10 @@
     <name>Azure Key Vault KMS test support</name>
     <description>Test support code for modules testing the Azure Key Vault</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/pom.xml
@@ -22,6 +22,10 @@
     <name>Azure Key Vault KMS</name>
     <description>An Azure Key Vault KMS Implementation</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.kroxylicious</groupId>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm-test-support/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm-test-support/pom.xml
@@ -24,6 +24,10 @@
     <name>Fortanix DSM KMS test support</name>
     <description>Test support code for modules testing the Fortanix DSM KMS</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/pom.xml
@@ -23,6 +23,10 @@
     <name>Fortanix DSM KMS</name>
     <description>A KMS provider backed by a remote instance of Fortanix Data Security Manager (DSM)</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/pom.xml
@@ -21,6 +21,10 @@
     <name>HashiCorp Vault KMS test support</name>
     <description>Test support code for modules testing the HashiCorp Vault KMS</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/pom.xml
@@ -21,6 +21,11 @@
     <artifactId>kroxylicious-kms-provider-hashicorp-vault</artifactId>
     <name>HashiCorp Vault KMS</name>
     <description>A KMS provider backed by a remote instance of HashiCorp Vault</description>
+
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.kroxylicious</groupId>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-kroxylicious-inmemory-test-support/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-kroxylicious-inmemory-test-support/pom.xml
@@ -21,6 +21,10 @@
     <name>In-memory KMS test support</name>
     <description>Test support code for modules testing the in-memory KMS</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-kroxylicious-inmemory/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-kroxylicious-inmemory/pom.xml
@@ -22,6 +22,10 @@
     <name>In-memory KMS</name>
     <description>An in-memory KMS provider for test purposes</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.kroxylicious</groupId>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager-test-support/pom.xml
@@ -22,6 +22,10 @@
     <name>Thales CipherTrust Manager KMS test support</name>
     <description>Test support code for Thales CipherTrust Manager KMS</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/pom.xml
@@ -22,6 +22,10 @@
     <name>Thales CipherTrust Manager KMS</name>
     <description>A KMS provider backed by Thales CipherTrust Manager</description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <!-- Kroxylicious dependencies -->
         <dependency>

--- a/kroxylicious-kms-test-support/pom.xml
+++ b/kroxylicious-kms-test-support/pom.xml
@@ -22,6 +22,7 @@
     <description>Test support for modules testing KMS implementations.</description>
 
     <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
     </properties>
 
     <dependencies>

--- a/kroxylicious-kms-tls-support/pom.xml
+++ b/kroxylicious-kms-tls-support/pom.xml
@@ -22,6 +22,7 @@
     <description>Optional TLS support classes for KMS implementations that need to make HTTPs connections to services.</description>
 
     <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
     </properties>
 
     <dependencies>

--- a/kroxylicious-kms/pom.xml
+++ b/kroxylicious-kms/pom.xml
@@ -24,6 +24,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
     </properties>
 
     <dependencies>

--- a/kroxylicious-krpc-plugin/pom.xml
+++ b/kroxylicious-krpc-plugin/pom.xml
@@ -28,6 +28,7 @@
         <maven-plugin-annotations.version>3.15.2</maven-plugin-annotations.version>
         <plexus-build-api.version>1.2.0</plexus-build-api.version>
         <graalvm.version>25.2.4</graalvm.version>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
     </properties>
 
     <dependencies>

--- a/kroxylicious-kubernetes/kroxylicious-admission-api/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-admission-api/pom.xml
@@ -31,6 +31,7 @@
         <fabric8-client.version>7.4.0</fabric8-client.version>
         <lombok.version>1.18.46</lombok.version>
         <errorprone.skip>true</errorprone.skip>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
     </properties>
 
     <dependencyManagement>

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-api/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-api/pom.xml
@@ -31,6 +31,7 @@
         <fabric8-client.version>7.4.0</fabric8-client.version>
         <lombok.version>1.18.46</lombok.version>
         <errorprone.skip>true</errorprone.skip>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
     </properties>
 
     <dependencyManagement>

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/pom.xml
@@ -26,6 +26,10 @@
         resources easier.
     </description>
 
+    <properties>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/kroxylicious-kubernetes/kroxylicious-operator/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/pom.xml
@@ -28,6 +28,7 @@
         <sonar.projectkey>kroxylicious_kroxylicious</sonar.projectkey>
         <!-- Error Prone disabled - fabric8 builders not compatible with -XDcompilePolicy=simple -->
         <errorprone.skip>true</errorprone.skip>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
     </properties>
 
     <dependencyManagement>

--- a/kroxylicious-openmessaging-benchmarks/pom.xml
+++ b/kroxylicious-openmessaging-benchmarks/pom.xml
@@ -26,6 +26,7 @@
 
     <properties>
         <helm.chart.directory>${project.basedir}/helm/kroxylicious-benchmark</helm.chart.directory>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
     </properties>
 
     <dependencies>

--- a/kroxylicious-runtime/pom.xml
+++ b/kroxylicious-runtime/pom.xml
@@ -24,6 +24,7 @@
     <properties>
         <libs.dir>libs</libs.dir>
         <release.version>${project.version}</release.version>
+        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
     </properties>
 
     <name>Proxy runtime</name>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <skipSTs>true</skipSTs>
         <skipDocs>true</skipDocs>
         <skipContainerImageBuild>false</skipContainerImageBuild>
+        <javadoc.failOnWarnings>true</javadoc.failOnWarnings>
 
         <impsort-maven-plugin.goal>sort</impsort-maven-plugin.goal>
 
@@ -638,6 +639,16 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.12.0</version>
+                    <configuration>
+                        <failOnWarnings>${javadoc.failOnWarnings}</failOnWarnings>
+                        <additionalDependencies>
+                            <additionalDependency>
+                                <groupId>com.google.code.findbugs</groupId>
+                                <artifactId>jsr305</artifactId>
+                                <version>3.0.2</version>
+                            </additionalDependency>
+                        </additionalDependencies>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Break the build on javadoc warnings by default, disabled per-module via `javadoc.failOnWarnings` system property.

Also fixes the existing Javadoc warnings in `kroxylicious-app`.

### Additional Context

Fixes #4537 

