### PR TITLE
doc: kroxylicious-api enhance documentation across various classes

### DIFF
--- a/kroxylicious-api/pom.xml
+++ b/kroxylicious-api/pom.xml
@@ -25,7 +25,6 @@
         <libs.dir>libs</libs.dir>
         <ApiCompatability.ReferenceVersion>0.23.0</ApiCompatability.ReferenceVersion>
         <ApiCompatability.EnforceForMajorVersionZero>true</ApiCompatability.EnforceForMajorVersionZero>
-        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
     </properties>
 
     <name>Kroxylicious API</name>

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/Principal.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/Principal.java
@@ -14,5 +14,9 @@ package io.kroxylicious.proxy.authentication;
  * (according to {@code equals()}). One easy way to achieve this is to use a {@code record} class with a single {@code name} component.</p>
  */
 public interface Principal {
+    /**
+     * Returns the name of this principal.
+     * @return the name of this principal
+     */
     String name();
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/PrincipalFactory.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/PrincipalFactory.java
@@ -6,6 +6,16 @@
 
 package io.kroxylicious.proxy.authentication;
 
+/**
+ * A factory for {@link Principal} instances of a particular type.
+ *
+ * @param <P> The type of {@link Principal} created by this factory.
+ */
 public interface PrincipalFactory<P extends Principal> {
+    /**
+     * Creates a new principal with the given name.
+     * @param name The name of the principal.
+     * @return The new principal.
+     */
     P newPrincipal(String name);
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/SaslSubjectBuilder.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/SaslSubjectBuilder.java
@@ -24,7 +24,7 @@ import io.kroxylicious.proxy.tls.ClientTlsContext;
  * from the mechanism of SASL authentication.
  * SASL-authenticating filters are not obliged to use this abstraction.</p>
  *
- * <p>{@link TransportSubjectBuilder} is a similar interface use for building a
+ * <p>{@link TransportSubjectBuilder} is a similar interface used for building a
  * {@code Subject} based on transport-layer information.
  * However, note that a {@code SaslSubjectBuilder} is not specified directly
  * on a virtual cluster as a {@code TransportSubjectBuilder} is.</p>
@@ -46,11 +46,13 @@ public interface SaslSubjectBuilder {
     interface Context {
         /**
          * Returns the TLS context for the client connection, or empty if the client connection is not TLS.
+         * @return The TLS context for the client connection, or empty if the client connection is not TLS.
          */
         Optional<ClientTlsContext> clientTlsContext();
 
         /**
          * Returns the SASL context for the client connection.
+         * @return The SASL context for the client connection.
          */
         ClientSaslContext clientSaslContext();
     }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/SaslSubjectBuilderService.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/SaslSubjectBuilderService.java
@@ -6,9 +6,22 @@
 
 package io.kroxylicious.proxy.authentication;
 
+/**
+ * The service interface used to construct a {@link SaslSubjectBuilder}.
+ *
+ * @param <C> The configuration type consumed by the particular {@link SaslSubjectBuilder} implementation.
+ */
 public interface SaslSubjectBuilderService<C> extends AutoCloseable {
+    /**
+     * Initializes this service with its configuration.
+     * @param config The service configuration.
+     */
     void initialize(C config);
 
+    /**
+     * Builds a {@link SaslSubjectBuilder}.
+     * @return The builder.
+     */
     SaslSubjectBuilder build();
 
     @Override

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/SubjectBuildingException.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/SubjectBuildingException.java
@@ -10,10 +10,19 @@ package io.kroxylicious.proxy.authentication;
  * An exception to be thrown if a {@link Subject} cannot be built.
  */
 public class SubjectBuildingException extends RuntimeException {
+    /**
+     * Creates a new exception with the given message.
+     * @param message The detail message.
+     */
     public SubjectBuildingException(String message) {
         super(message);
     }
 
+    /**
+     * Creates a new exception with the given message and cause.
+     * @param message The detail message.
+     * @param cause The cause.
+     */
     public SubjectBuildingException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/TransportSubjectBuilder.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/TransportSubjectBuilder.java
@@ -18,7 +18,7 @@ import io.kroxylicious.proxy.tls.ClientTlsContext;
  * <p>A {@code TransportSubjectBuilder} instance is constructed by a {@link TransportSubjectBuilderService},
  * which in turn is specified on a virtual cluster.</p>
  *
- * <p>See {@link SaslSubjectBuilder} for a similar interface use for building a {@code Subject} based on SASL authentication.</p>
+ * <p>See {@link SaslSubjectBuilder} for a similar interface used for building a {@code Subject} based on SASL authentication.</p>
  */
 public interface TransportSubjectBuilder {
 
@@ -31,9 +31,13 @@ public interface TransportSubjectBuilder {
      */
     CompletionStage<Subject> buildTransportSubject(Context context);
 
+    /**
+     * The context that's passed to {@link #buildTransportSubject(Context)}.
+     */
     interface Context {
         /**
          * Returns the TLS context for the client connection, or empty if the client connection is not TLS.
+         * @return The TLS context for the client connection, or empty if the client connection is not TLS.
          */
         Optional<ClientTlsContext> clientTlsContext();
     }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/TransportSubjectBuilderService.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/TransportSubjectBuilderService.java
@@ -14,8 +14,16 @@ import edu.umd.cs.findbugs.annotations.UnknownNullness;
  * @param <C> The configuration type consumed by the particular {@link TransportSubjectBuilder} implementation.
  */
 public interface TransportSubjectBuilderService<C> extends AutoCloseable {
+    /**
+     * Initializes this service with its configuration.
+     * @param config The service configuration.
+     */
     void initialize(@UnknownNullness C config);
 
+    /**
+     * Builds a {@link TransportSubjectBuilder}.
+     * @return The builder.
+     */
     TransportSubjectBuilder build();
 
     @Override

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/UserFactory.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/authentication/UserFactory.java
@@ -6,7 +6,18 @@
 
 package io.kroxylicious.proxy.authentication;
 
+/**
+ * A {@link PrincipalFactory} that creates {@link User} principals.
+ */
 public class UserFactory implements PrincipalFactory<User> {
+
+    /**
+     * Creates a new factory.
+     */
+    public UserFactory() {
+        // Intentionally empty - declared only to carry documentation
+    }
+
     @Override
     public User newPrincipal(String name) {
         return new User(name);

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/secret/FilePassword.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/secret/FilePassword.java
@@ -24,6 +24,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public record FilePassword(@JsonProperty(required = true) String passwordFile) implements PasswordProvider {
 
+    /**
+     * Creates a FilePassword.
+     * @param passwordFile file containing the password.
+     */
     public FilePassword {
         Objects.requireNonNull(passwordFile);
     }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/secret/InlinePassword.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/secret/InlinePassword.java
@@ -18,6 +18,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public record InlinePassword(@JsonProperty(required = true) String password) implements PasswordProvider {
 
+    /**
+     * Creates an InlinePassword.
+     * @param password the password
+     */
     public InlinePassword {
         Objects.requireNonNull(password);
     }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/secret/PasswordProvider.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/secret/PasswordProvider.java
@@ -16,5 +16,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonSubTypes({ @JsonSubTypes.Type(InlinePassword.class), @JsonSubTypes.Type(FilePassword.class) })
 @SuppressWarnings("java:S5738") // java:S5738 warns of the use of the deprecated class.
 public interface PasswordProvider {
+    /**
+     * Returns the password supplied by this provider.
+     * @return the password
+     */
     String getProvidedPassword();
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/KeyPair.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/KeyPair.java
@@ -31,6 +31,12 @@ public record KeyPair(@JsonProperty(required = true) String privateKeyFile,
                       @JsonProperty(value = "keyPassword") @Nullable PasswordProvider keyPasswordProvider)
         implements KeyProvider {
 
+    /**
+     * Creates a KeyPair.
+     * @param privateKeyFile      location of a file containing the private key.
+     * @param certificateFile     location of a file containing the certificate and intermediates.
+     * @param keyPasswordProvider provider for the privateKeyFile password or null if key does not require a password
+     */
     public KeyPair {
         Objects.requireNonNull(privateKeyFile);
         Objects.requireNonNull(certificateFile);

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/KeyProvider.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/KeyProvider.java
@@ -23,8 +23,11 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 public interface KeyProvider {
 
     /**
-     * Visits the trust provider {@link KeyProviderVisitor}. Implementor should call one `visit` method on visitor.
+     * Accepts the given {@link KeyProviderVisitor}. Implementor should call the {@code visit} method
+     * on the visitor corresponding to this implementation.
      * @param visitor visitor.
+     * @param <T> result type of the visit
+     * @return the result of the visit
      */
     <T> T accept(KeyProviderVisitor<T> visitor);
 

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/KeyProviderVisitor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/KeyProviderVisitor.java
@@ -12,8 +12,18 @@ package io.kroxylicious.proxy.config.tls;
  */
 public interface KeyProviderVisitor<T> {
 
+    /**
+     * Visits a {@link KeyPair}.
+     * @param keyPair the key pair being visited
+     * @return the result of the visit
+     */
     T visit(KeyPair keyPair);
 
+    /**
+     * Visits a {@link KeyStore}.
+     * @param keyStore the key store being visited
+     * @return the result of the visit
+     */
     T visit(KeyStore keyStore);
 
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/KeyStore.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/KeyStore.java
@@ -16,7 +16,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
- * A {@link KeyProvider} backed by a Java Truststore.
+ * A {@link KeyProvider} backed by a Java Keystore.
  *
  * @param storeFile             location of a key store, or reference to a PEM file containing both private-key and certificate/intermediates.
  * @param storePasswordProvider provider for the store password or null if store does not require a password.
@@ -31,14 +31,30 @@ public record KeyStore(@JsonProperty(required = true) String storeFile,
                        String storeType)
         implements KeyProvider {
 
+    /**
+     * Creates a KeyStore.
+     * @param storeFile             location of a key store, or reference to a PEM file containing both private-key and certificate/intermediates.
+     * @param storePasswordProvider provider for the store password or null if store does not require a password.
+     * @param keyPasswordProvider   provider for the key password. if null the password obtained from the storePasswordProvider will be used to decrypt the key.
+     * @param storeType             specifies the server key type. Legal values are those types supported by the platform {@link java.security.KeyStore},
+     *                              and PEM (for X-509 certificates express in PEM format).
+     */
     public KeyStore {
         Objects.requireNonNull(storeFile);
     }
 
+    /**
+     * Returns the store type, defaulting to the platform default store type if no store type was specified.
+     * @return the store type
+     */
     public String getType() {
         return Tls.getStoreTypeOrPlatformDefault(storeType);
     }
 
+    /**
+     * Indicates whether the store is in PEM format.
+     * @return true if the store type is PEM
+     */
     public boolean isPemType() {
         return Objects.equals(getType(), Tls.PEM);
     }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/PlatformTrustProvider.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/PlatformTrustProvider.java
@@ -6,9 +6,15 @@
 
 package io.kroxylicious.proxy.config.tls;
 
+/**
+ * A {@link TrustProvider} that uses the platform's default trust anchors.
+ */
 @SuppressWarnings("java:S6548")
 public class PlatformTrustProvider implements TrustProvider {
 
+    /**
+     * The singleton instance of this trust provider.
+     */
     public static final PlatformTrustProvider INSTANCE = new PlatformTrustProvider();
 
     private PlatformTrustProvider() {

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/TlsClientAuth.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/TlsClientAuth.java
@@ -6,10 +6,22 @@
 
 package io.kroxylicious.proxy.config.tls;
 
+/**
+ * The TLS client authentication modes.
+ */
 public enum TlsClientAuth {
 
+    /**
+     * Client authentication is required. The connection will fail if the client does not present a valid certificate.
+     */
     REQUIRED,
+    /**
+     * Client authentication is requested. The client may decline to present a certificate.
+     */
     REQUESTED,
+    /**
+     * Client authentication is not requested.
+     */
     NONE;
 
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/TrustOptions.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/TrustOptions.java
@@ -9,8 +9,15 @@ package io.kroxylicious.proxy.config.tls;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+/**
+ * Options that control how trust is applied during TLS negotiation.
+ */
 @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
 @JsonSubTypes({ @JsonSubTypes.Type(ServerOptions.class) })
 public interface TrustOptions {
+    /**
+     * Indicates whether these options apply to the TLS client role.
+     * @return true if these options apply to the TLS client role, false if they apply to the TLS server role
+     */
     boolean forClient();
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/TrustProvider.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/TrustProvider.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
- * A TrustProvider is a source of trust anchors used to determine whether a certificate present by a peer is trusted.
+ * A TrustProvider is a source of trust anchors used to determine whether a certificate presented by a peer is trusted.
  * <ul>
  *     <li>In the TLS <em>client</em> role, it is used to validate that the server's certificate is trusted.  If the
  *     trust provider is omitted platform trust is used instead.</li>
@@ -25,13 +25,16 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 public interface TrustProvider {
 
     /**
-     * Visits the trust provider {@link TrustProviderVisitor}. Implementor should call one `visit` method on visitor.
+     * Accepts the given {@link TrustProviderVisitor}. Implementor should call the {@code visit} method
+     * on the visitor corresponding to this implementation.
      * @param visitor visitor.
+     * @param <T> result type of the visit
+     * @return the result of the visit
      */
     <T> T accept(TrustProviderVisitor<T> visitor);
 
     /**
-     * Trust options that apply to this TLS peer..
+     * Trust options that apply to this TLS peer.
      *
      * @return trust options
      */

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/TrustProviderVisitor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/TrustProviderVisitor.java
@@ -12,10 +12,25 @@ package io.kroxylicious.proxy.config.tls;
  */
 public interface TrustProviderVisitor<T> {
 
+    /**
+     * Visits a {@link TrustStore}.
+     * @param trustStore the trust store being visited
+     * @return the result of the visit
+     */
     T visit(TrustStore trustStore);
 
+    /**
+     * Visits an {@link InsecureTls}.
+     * @param insecureTls the insecure TLS configuration being visited
+     * @return the result of the visit
+     */
     T visit(InsecureTls insecureTls);
 
+    /**
+     * Visits a {@link PlatformTrustProvider}.
+     * @param platformTrustProviderTls the platform trust provider being visited
+     * @return the result of the visit
+     */
     T visit(PlatformTrustProvider platformTrustProviderTls);
 
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/TrustStore.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/TrustStore.java
@@ -32,6 +32,14 @@ public record TrustStore(@JsonProperty(required = true) String storeFile,
                          @JsonProperty(value = "trustOptions") @Nullable TrustOptions trustOptions)
         implements TrustProvider {
 
+    /**
+     * Creates a TrustStore.
+     * @param storeFile location of a key store, or reference to a PEM file containing both private-key/certificate/intermediates.
+     * @param storePasswordProvider provider for the store password or null if store does not require a password.
+     * @param storeType specifies the server key type. Legal values are those types supported by the platform {@link KeyStore},
+     *         and PEM (for X-509 certificates express in PEM format).
+     * @param trustOptions the trust options that will be applied to this peer.
+     */
     public TrustStore {
         Objects.requireNonNull(storeFile);
     }
@@ -48,10 +56,18 @@ public record TrustStore(@JsonProperty(required = true) String storeFile,
         this(storeFile, storePasswordProvider, storeType, null);
     }
 
+    /**
+     * Returns the store type, defaulting to the platform default store type if no store type was specified.
+     * @return the store type
+     */
     public String getType() {
         return Tls.getStoreTypeOrPlatformDefault(storeType);
     }
 
+    /**
+     * Indicates whether the store is in PEM format.
+     * @return true if the store type is PEM
+     */
     public boolean isPemType() {
         return Objects.equals(getType(), Tls.PEM);
     }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterDispatchExecutor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterDispatchExecutor.java
@@ -29,6 +29,7 @@ public interface FilterDispatchExecutor extends ScheduledExecutorService {
 
     /**
      * Returns true if {@link Thread#currentThread()} is this Filter Dispatch Thread.
+     * @return true if {@link Thread#currentThread()} is this Filter Dispatch Thread
      */
     boolean isInFilterDispatchThread();
 

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopLevelMetadataErrorException.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopLevelMetadataErrorException.java
@@ -9,9 +9,13 @@ package io.kroxylicious.proxy.filter.metadata;
 import org.apache.kafka.common.protocol.Errors;
 
 /**
- * Indicates that there was an {@link Error} set at the top level of {@link org.apache.kafka.common.message.MetadataResponseData}.
+ * Indicates that there was an {@link Errors error} set at the top level of {@link org.apache.kafka.common.message.MetadataResponseData}.
  */
 public class TopLevelMetadataErrorException extends TopicNameMappingException {
+    /**
+     * Creates a new exception for the given error.
+     * @param error the error set at the top level of the metadata response
+     */
     public TopLevelMetadataErrorException(Errors error) {
         super(error);
     }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopicLevelMetadataErrorException.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopicLevelMetadataErrorException.java
@@ -9,9 +9,13 @@ package io.kroxylicious.proxy.filter.metadata;
 import org.apache.kafka.common.protocol.Errors;
 
 /**
- * Indicates that there was an {@link Error} set on a {@link org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic}.
+ * Indicates that there was an {@link Errors error} set on a {@link org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic}.
  */
 public class TopicLevelMetadataErrorException extends TopicNameMappingException {
+    /**
+     * Creates a new exception for the given error.
+     * @param error the error set at the topic level of the metadata response
+     */
     public TopicLevelMetadataErrorException(Errors error) {
         super(error);
     }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopicNameMapping.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopicNameMapping.java
@@ -17,11 +17,13 @@ import org.apache.kafka.common.protocol.Errors;
 public interface TopicNameMapping {
     /**
      * Returns true if there are any failures.
+     * @return true if there are any failures
      */
     boolean anyFailures();
 
     /**
      * Returns true if all name mappings failed.
+     * @return true if all name mappings failed
      */
     default boolean allFailures() {
         return anyFailures() && topicNames().isEmpty();
@@ -29,6 +31,7 @@ public interface TopicNameMapping {
 
     /**
      * Returns an immutable map from topic id to successfully mapped topic name.
+     * @return immutable map from topic id to successfully mapped topic name
      */
     Map<Uuid, String> topicNames();
 
@@ -46,6 +49,9 @@ public interface TopicNameMapping {
      */
     Map<Uuid, TopicNameMappingException> failures();
 
+    /**
+     * A mapping containing no topic names and no failures.
+     */
     TopicNameMapping EMPTY = new TopicNameMapping() {
         @Override
         public boolean anyFailures() {

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopicNameMappingException.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopicNameMappingException.java
@@ -14,21 +14,43 @@ import org.apache.kafka.common.protocol.Errors;
  * Indicates there was some problem obtaining a name for a topic id
  */
 public class TopicNameMappingException extends RuntimeException {
+    /**
+     * The kafka error underlying this exception.
+     */
     private final Errors error;
 
+    /**
+     * Creates a new exception for the given error, using the error's default message and exception.
+     * @param error the kafka error underlying this exception
+     */
     public TopicNameMappingException(Errors error) {
         this(error, error.message(), error.exception());
     }
 
+    /**
+     * Creates a new exception for the given error with a custom message.
+     * @param error the kafka error underlying this exception
+     * @param message the detail message
+     */
     public TopicNameMappingException(Errors error, String message) {
         this(error, message, error.exception());
     }
 
+    /**
+     * Creates a new exception for the given error with a custom message and cause.
+     * @param error the kafka error underlying this exception
+     * @param message the detail message
+     * @param cause the cause
+     */
     public TopicNameMappingException(Errors error, String message, Throwable cause) {
         super(message, cause);
         this.error = Objects.requireNonNull(error);
     }
 
+    /**
+     * Returns the kafka error underlying this exception.
+     * @return the kafka error underlying this exception
+     */
     public Errors getError() {
         return error;
     }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/plugin/DeprecatedPluginName.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/plugin/DeprecatedPluginName.java
@@ -40,11 +40,13 @@ import java.lang.annotation.Target;
 public @interface DeprecatedPluginName {
     /**
      * The fully qualified class name by which this plugin was previously known.
+     * @return the fully qualified class name by which this plugin was previously known
      */
     String oldName();
 
     /**
      * Returns the version in which the name became deprecated.
+     * @return the version in which the name became deprecated, or the empty string if unspecified
      */
     String since() default "";
 

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/plugin/Plugin.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/plugin/Plugin.java
@@ -22,6 +22,7 @@ import java.lang.annotation.Target;
 public @interface Plugin {
     /**
      * Returns the type of configuration associated with the plugin implementation.
+     * @return the type of configuration associated with the plugin implementation
      */
     Class<?> configType();
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/plugin/PluginImplConfig.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/plugin/PluginImplConfig.java
@@ -23,6 +23,7 @@ public @interface PluginImplConfig {
 
     /**
      * Returns the name of the {@link PluginImplName @PluginImplName}-annotated sibling property.
+     * @return the name of the {@link PluginImplName @PluginImplName}-annotated sibling property
      */
     String implNameProperty();
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/plugin/Plugins.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/plugin/Plugins.java
@@ -8,6 +8,9 @@ package io.kroxylicious.proxy.plugin;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Utility methods for use by plugin implementations.
+ */
 public class Plugins {
     private Plugins() {
     }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/plugin/UnknownPluginInstanceException.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/plugin/UnknownPluginInstanceException.java
@@ -11,10 +11,19 @@ package io.kroxylicious.proxy.plugin;
  */
 public class UnknownPluginInstanceException extends RuntimeException {
 
+    /**
+     * Creates a new exception with the given message.
+     * @param message The detail message.
+     */
     public UnknownPluginInstanceException(String message) {
         super(message);
     }
 
+    /**
+     * Creates a new exception with the given message and cause.
+     * @param message The detail message.
+     * @param cause The cause.
+     */
     public UnknownPluginInstanceException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/tls/ClientTlsContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/tls/ClientTlsContext.java
@@ -18,11 +18,13 @@ import io.kroxylicious.proxy.filter.FilterContext;
 public interface ClientTlsContext {
     /**
      * Returns the TLS server certificate that the proxy presented to the client during TLS handshake.
+     * @return the TLS server certificate that the proxy presented to the client during TLS handshake
      */
     X509Certificate proxyServerCertificate();
 
     /**
      * Returns the client's certificate, or empty if no TLS client certificate was presented during TLS handshake.
+     * @return the client's certificate, or empty if no TLS client certificate was presented during TLS handshake
      */
     Optional<X509Certificate> clientCertificate();
 

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/authentication/UserFactoryTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/authentication/UserFactoryTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.authentication;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class UserFactoryTest {
+
+    @Test
+    void createsUserPrincipalWithGivenName() {
+        // Given
+        UserFactory factory = new UserFactory();
+
+        // When
+        User user = factory.newPrincipal("alice");
+
+        // Then
+        Assertions.assertThat(user).isEqualTo(new User("alice"));
+    }
+}


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description


- Removed javadoc fail on warnings in pom.xml
- Added method documentation for Principal interface and PrincipalFactory
- Improved javadoc comments in SaslSubjectBuilder, SaslSubjectBuilderService, and SubjectBuildingException
- Enhanced documentation in TransportSubjectBuilder and its service
- Updated UserFactory with constructor documentation
- Added javadoc comments for FilePassword and InlinePassword records
- Improved PasswordProvider and KeyProvider interfaces with method documentation
- Enhanced KeyPair and KeyStore constructors with detailed javadoc
- Updated PlatformTrustProvider and TlsClientAuth with class-level documentation
- Enhanced TrustOptions and TrustProvider interfaces with method documentation
- Improved TrustStore with constructor and method documentation
- Added javadoc comments in FilterDispatchExecutor and various metadata exception classes
- Enhanced plugin-related classes with method and class-level documentation
- Improved ClientTlsContext with method documentation

### Additional Context

_Why are you making this pull request?_

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [X] PR references related GitHub issue(s) so they are closed on merging. Closes: #4539 
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
