### PR TITLE
fix(operator): resolve javadoc warnings and enable warnings-as-errors

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-operator/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/pom.xml
@@ -28,7 +28,6 @@
         <sonar.projectkey>kroxylicious_kroxylicious</sonar.projectkey>
         <!-- Error Prone disabled - fabric8 builders not compatible with -XDcompilePolicy=simple -->
         <errorprone.skip>true</errorprone.skip>
-        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
     </properties>
 
     <dependencyManagement>

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/AnnotationSerializationException.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/AnnotationSerializationException.java
@@ -9,8 +9,8 @@ package io.kroxylicious.kubernetes.operator;
 /**
  * Thrown when there was a problem attempting to serialize or deserialize an annotation value
  */
-public class AnnotationSerializationException extends RuntimeException {
-    public AnnotationSerializationException(Exception cause) {
+class AnnotationSerializationException extends RuntimeException {
+    AnnotationSerializationException(Exception cause) {
         super(cause);
     }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/Annotations.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/Annotations.java
@@ -34,9 +34,11 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public class Annotations {
 
+    /** Annotation key for storing bootstrap server addresses on Kubernetes resources. */
     @VisibleForTesting
     public static final String BOOTSTRAP_SERVERS_ANNOTATION_KEY = "kroxylicious.io/bootstrap-servers";
 
+    /** Annotation key for storing a checksum of the referent resources. */
     @VisibleForTesting
     public static final String REFERENT_CHECKSUM_ANNOTATION_KEY = "kroxylicious.io/referent-checksum";
 
@@ -131,12 +133,24 @@ public class Annotations {
      */
     @JsonPropertyOrder({ "clusterName", "ingressName", "bootstrapServers" })
     public record ClusterIngressBootstrapServers(String clusterName, String ingressName, String bootstrapServers) {
+        /**
+         * Creates a ClusterIngressBootstrapServers with validated the arguments.
+         * @param clusterName VirtualKafkaCluster name
+         * @param ingressName KafkaProxyIngress name
+         * @param bootstrapServers client facing bootstrap servers
+         */
         public ClusterIngressBootstrapServers {
             Objects.requireNonNull(clusterName);
             Objects.requireNonNull(ingressName);
             Objects.requireNonNull(bootstrapServers);
         }
 
+        /**
+         * Tests whether this instance matches the given ingress and cluster names.
+         * @param ingressName the ingress name to match
+         * @param clusterName the cluster name to match
+         * @return {@code true} if both names match this instance
+         */
         public boolean matchesIngress(String ingressName, String clusterName) {
             return this.ingressName.equals(ingressName) && this.clusterName.equals(clusterName);
         }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ContainerFileReference.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ContainerFileReference.java
@@ -17,10 +17,10 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 /**
  * A reference to a file in a container, which may be on a mounted volume.
  */
-public record ContainerFileReference(
-                                     @Nullable Volume volume,
-                                     @Nullable VolumeMount mount,
-                                     Path containerPath) {
+record ContainerFileReference(
+                              @Nullable Volume volume,
+                              @Nullable VolumeMount mount,
+                              Path containerPath) {
 
     /**
      * A {@code volume} and {@code mount} must either both be non-null, or both be null.

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/DeploymentReadyCondition.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/DeploymentReadyCondition.java
@@ -16,7 +16,16 @@ import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 
+/**
+ * A condition that checks whether a Deployment has all replicas ready.
+ */
 public class DeploymentReadyCondition implements Condition<Deployment, KafkaProxy> {
+
+    /** Creates a DeploymentReadyCondition. */
+    public DeploymentReadyCondition() {
+        // explicit ctor needed for javadoc.
+    }
+
     @Override
     public boolean isMet(DependentResource<Deployment, KafkaProxy> dependentResource, KafkaProxy primary, Context<KafkaProxy> context) {
         var optionalResource = dependentResource.getSecondaryResource(primary, context);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/InterpolationException.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/InterpolationException.java
@@ -6,8 +6,8 @@
 
 package io.kroxylicious.kubernetes.operator;
 
-public class InterpolationException extends RuntimeException {
-    public InterpolationException(String message) {
+class InterpolationException extends RuntimeException {
+    InterpolationException(String message) {
         super(message);
     }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/Labels.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/Labels.java
@@ -11,12 +11,20 @@ import java.util.Map;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 
+/**
+ * Provides standard Kubernetes labels for resources managed by the operator.
+ */
 public class Labels {
 
     private Labels() {
         // singleton
     }
 
+    /**
+     * Returns the standard Kubernetes labels to apply to resources owned by the given proxy.
+     * @param proxy the KafkaProxy resource
+     * @return a map of standard label key-value pairs
+     */
     public static Map<String, String> standardLabels(KafkaProxy proxy) {
         Map<String, String> labels = new LinkedHashMap<>();
         labels.put("app.kubernetes.io/managed-by", "kroxylicious-operator");

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorLoggingKeys.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorLoggingKeys.java
@@ -14,8 +14,12 @@ public class OperatorLoggingKeys {
     private OperatorLoggingKeys() {
     }
 
+    /** Structured logging key for the Kubernetes resource namespace. */
     public static final String NAMESPACE = "namespace";
+    /** Structured logging key for the Kubernetes resource name. */
     public static final String NAME = "name";
+    /** Structured logging key for the Kubernetes resource kind. */
     public static final String KIND = "kind";
+    /** Structured logging key for an error message. */
     public static final String ERROR = "error";
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -88,6 +88,10 @@ public class OperatorMain {
     @Nullable
     private SharedInformerManager sharedInformerManager;
 
+    /**
+     * Constructs an OperatorMain with default configuration.
+     * @throws IOException if the management HTTP server cannot be created
+     */
     public OperatorMain() throws IOException {
         this(createHttpServer(), null, new ControllerConfigurer());
     }
@@ -116,6 +120,10 @@ public class OperatorMain {
         return VersionInfo.fromResource(OPERATOR_METADATA_RESOURCE);
     }
 
+    /**
+     * Entrypoint for the operator process.
+     * @param args command-line arguments (currently unused)
+     */
     public static void main(String[] args) {
         try {
             new OperatorMain().start();

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigStateData.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigStateData.java
@@ -34,6 +34,7 @@ public class ProxyConfigStateData {
     // JavaTimeModule is required for java.time.Instant (used in Condition.lastTransitionTime).
     // DurationSerde must be registered after JavaTimeModule so it takes precedence for Duration,
     // overriding JavaTimeModule's ISO-8601-only DurationDeserializer with our Go-style one.
+    /** ObjectMapper configured for serializing and deserializing proxy configuration state. */
     public static final ObjectMapper CONFIG_OBJECT_MAPPER = ConfigParser.createObjectMapper()
             .registerModule(new JavaTimeModule())
             .registerModule(new SimpleModule()
@@ -57,10 +58,15 @@ public class ProxyConfigStateData {
 
     private final Map<String, String> data;
 
+    /** Constructs an empty instance with no data entries. */
     public ProxyConfigStateData() {
         this(new LinkedHashMap<>());
     }
 
+    /**
+     * Constructs an instance backed by the given data map.
+     * @param data the backing map of cluster keys to serialized status patches
+     */
     public ProxyConfigStateData(Map<String, String> data) {
         this.data = data;
     }
@@ -75,15 +81,33 @@ public class ProxyConfigStateData {
         }
     }
 
+    /**
+     * Adds a serialized status patch for the given cluster.
+     * @param clusterName the name of the virtual Kafka cluster
+     * @param patch the VirtualKafkaCluster containing the status patch to store
+     * @return this instance for chaining
+     */
     public ProxyConfigStateData addStatusPatchForCluster(String clusterName, VirtualKafkaCluster patch) {
         data.put(clusterKey(clusterName), toYaml(new VirtualKafkaClusterPatch(patch.getMetadata(), patch.getStatus())));
         return this;
     }
 
+    /**
+     * Checks whether a status patch has been stored for the given cluster name.
+     *
+     * @param clusterName the name of the virtual Kafka cluster
+     * @return true if a status patch exists for the cluster, false otherwise
+     */
     public boolean hasStatusPatchForCluster(String clusterName) {
         return data.containsKey(clusterKey(clusterName));
     }
 
+    /**
+     * Retrieves and deserializes the stored status patch for the given cluster name.
+     *
+     * @param clusterName the name of the virtual Kafka cluster
+     * @return an optional containing the deserialized VirtualKafkaCluster status patch, or empty if none exists
+     */
     public Optional<VirtualKafkaCluster> getStatusPatchForCluster(String clusterName) {
         var str = data.get(clusterKey(clusterName));
         if (str == null) {
@@ -98,6 +122,10 @@ public class ProxyConfigStateData {
         }
     }
 
+    /**
+     * Returns the accumulated data map.
+     * @return the map of cluster keys to serialized status patches
+     */
     public Map<String, String> build() {
         return data;
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigStateData.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigStateData.java
@@ -30,7 +30,7 @@ import io.kroxylicious.proxy.config.DurationSerde;
  */
 public class ProxyConfigStateData {
 
-    public static final String CLUSTER_KEY_PREFIX = "cluster-";
+    private static final String CLUSTER_KEY_PREFIX = "cluster-";
     // JavaTimeModule is required for java.time.Instant (used in Condition.lastTransitionTime).
     // DurationSerde must be registered after JavaTimeModule so it takes precedence for Duration,
     // overriding JavaTimeModule's ISO-8601-only DurationDeserializer with our Go-style one.

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourceState.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourceState.java
@@ -22,6 +22,9 @@ import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import static java.util.function.Function.identity;
 
+/**
+ * Represents the set of status conditions for a Kubernetes custom resource, supporting merging and replacement semantics.
+ */
 public class ResourceState {
 
     // we are aiming for a deterministic ordering, so we order by status if observed generation and last transition time are equal
@@ -37,6 +40,12 @@ public class ResourceState {
         this.conditions = new TreeMap<>(conditions);
     }
 
+    /**
+     * Creates a resource state containing a single condition.
+     *
+     * @param condition the condition to include
+     * @return a new resource state with the given condition
+     */
     public static ResourceState of(Condition condition) {
         return new ResourceState(Map.of(condition.getType(), condition));
     }
@@ -61,6 +70,12 @@ public class ResourceState {
         return new ResourceState(freshestConditionPerType);
     }
 
+    /**
+     * Merges this state with an existing state, preferring the freshest condition per type and preserving transition times when statuses are unchanged.
+     *
+     * @param existingState the existing resource state to merge with
+     * @return a new resource state containing the merged conditions
+     */
     public ResourceState replacementFor(ResourceState existingState) {
         Stream<Condition> allConditions = Stream.concat(this.conditions.values().stream(), existingState.conditions.values().stream());
         return new ResourceState(allConditions.collect(Collectors.toMap(Condition::getType, identity(), this::buildNewCondition, TreeMap::new)));
@@ -77,10 +92,22 @@ public class ResourceState {
         return builder.build();
     }
 
+    /**
+     * Returns the conditions in this state as an ordered list, sorted by condition type.
+     *
+     * @return an unmodifiable list of conditions
+     */
     public List<Condition> toList() {
         return conditions.values().stream().toList();
     }
 
+    /**
+     * Computes a replacement condition list by merging new status conditions into the existing ones.
+     *
+     * @param oldConditions the existing conditions from the resource status
+     * @param newStatus the new resource state to merge in
+     * @return the merged list of conditions
+     */
     public static List<Condition> newConditions(List<Condition> oldConditions, ResourceState newStatus) {
         ResourceState existingConditions = fromList(oldConditions);
         ResourceState replacement = newStatus.replacementFor(existingConditions);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -55,6 +55,9 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static io.kroxylicious.kubernetes.api.common.Condition.Type.ResolvedRefs;
 
+/**
+ * Utility methods for working with Kubernetes resources, references, and operator status conditions.
+ */
 public class ResourcesUtil {
 
     /**
@@ -81,6 +84,13 @@ public class ResourcesUtil {
                 || inRange(ch, '0', '9');
     }
 
+    /**
+     * Checks whether the given string is a valid DNS label (max 63 characters, alphanumeric with interior hyphens).
+     *
+     * @param string the string to validate
+     * @param rfc1035 if true, the first character must be a lowercase letter (RFC 1035); if false, it may also be a digit (RFC 1123)
+     * @return true if the string is a valid DNS label according to the selected RFC
+     */
     public static boolean isDnsLabel(String string, boolean rfc1035) {
         int length = string.length();
         if (length == 0 || length > 63) {
@@ -105,6 +115,15 @@ public class ResourcesUtil {
         return true;
     }
 
+    /**
+     * Validates that the given string is a valid DNS label, throwing if it is not.
+     *
+     * @param string the string to validate
+     * @param rfc1035 if true, apply RFC 1035 rules; if false, apply RFC 1123 rules
+     * @param message the exception message to use if validation fails
+     * @return the input string if it is a valid DNS label
+     * @throws IllegalArgumentException if the string is not a valid DNS label
+     */
     public static String requireIsDnsLabel(String string, boolean rfc1035, String message) {
         if (!isDnsLabel(string, rfc1035)) {
             throw new IllegalArgumentException(message);
@@ -112,6 +131,15 @@ public class ResourcesUtil {
         return string;
     }
 
+    /**
+     * Constructs a Kubernetes volume name from the API group, plural resource kind, and resource name.
+     *
+     * @param group the API group (may be empty for core resources)
+     * @param plural the plural form of the resource kind
+     * @param resourceName the name of the resource
+     * @return the constructed volume name, validated as an RFC 1035 DNS label
+     * @throws IllegalArgumentException if the resulting volume name is not a valid DNS label
+     */
     public static String volumeName(String group, String plural, String resourceName) {
         String volumeNamePrefix = group.isEmpty() ? plural : group + "." + plural;
         String volumeName = volumeNamePrefix + "-" + resourceName;
@@ -119,21 +147,46 @@ public class ResourcesUtil {
                 "volume name would not be a DNS label: " + volumeName);
     }
 
+    /**
+     * Determines whether the given local reference refers to a Kubernetes Secret (core API group, kind "Secret" or unspecified).
+     *
+     * @param ref the local reference to check
+     * @return true if the reference refers to a Secret
+     */
     public static boolean isSecret(LocalRef<?> ref) {
         return (ref.getKind() == null || ref.getKind().isEmpty() || "Secret".equals(ref.getKind()))
                 && (ref.getGroup() == null || ref.getGroup().isEmpty());
     }
 
+    /**
+     * Determines whether the given local reference refers to a Strimzi Kafka resource (kafka.strimzi.io group, kind "Kafka" or unspecified).
+     *
+     * @param ref the local reference to check
+     * @return true if the reference refers to a Strimzi Kafka resource
+     */
     public static boolean isStrimziKafka(LocalRef<?> ref) {
         return (ref.getKind() == null || ref.getKind().isEmpty() || "Kafka".equals(ref.getKind()))
                 && (ref.getGroup() == null || ref.getGroup().isEmpty() || "kafka.strimzi.io".equals(ref.getGroup()));
     }
 
+    /**
+     * Determines whether the given local reference refers to a Kubernetes ConfigMap (core API group, kind "ConfigMap" or unspecified).
+     *
+     * @param ref the local reference to check
+     * @return true if the reference refers to a ConfigMap
+     */
     public static boolean isConfigMap(LocalRef<?> ref) {
         return (ref.getKind() == null || ref.getKind().isEmpty() || "ConfigMap".equals(ref.getKind()))
                 && (ref.getGroup() == null || ref.getGroup().isEmpty());
     }
 
+    /**
+     * Creates a new {@link OwnerReference} pointing to the given owner resource.
+     *
+     * @param owner the resource to create an owner reference for
+     * @return a new OwnerReference with the owner's kind, apiVersion, name, and UID
+     * @param <O> the type of the owner resource
+     */
     public static <O extends HasMetadata> OwnerReference newOwnerReferenceTo(O owner) {
         return new OwnerReferenceBuilder()
                 .withKind(owner.getKind())
@@ -143,14 +196,32 @@ public class ResourcesUtil {
                 .build();
     }
 
+    /**
+     * Extracts the kind from the given resource.
+     *
+     * @param resource the resource from which to extract the kind
+     * @return the resource kind
+     */
     public static String kind(HasMetadata resource) {
         return resource.getKind();
     }
 
+    /**
+     * Extracts the name from the given resource's metadata.
+     *
+     * @param resource the resource from which to extract the name
+     * @return the resource name
+     */
     public static String name(HasMetadata resource) {
         return resource.getMetadata().getName();
     }
 
+    /**
+     * Extracts the namespace from the given resource's metadata.
+     *
+     * @param resource the resource from which to extract the namespace
+     * @return the resource namespace
+     */
     public static String namespace(HasMetadata resource) {
         return resource.getMetadata().getNamespace();
     }
@@ -159,7 +230,7 @@ public class ResourcesUtil {
      * Extract generation from a resource's {@code metadata} object.
      *
      * @param resource the object from which to extract the metadata generation.
-     * @return the metadata generation of <code>0</code> if the metadata or the generation itself is null in alignment with @see <a href="https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1623-standardize-conditions#kep-1623-standardize-conditions">KEP 1623</a>.
+     * @return the metadata generation, or {@code 0} if the metadata or the generation itself is null in alignment with <a href="https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1623-standardize-conditions#kep-1623-standardize-conditions">KEP 1623</a>.
      */
     public static long generation(HasMetadata resource) {
         ObjectMeta metadata = resource.getMetadata();
@@ -169,6 +240,12 @@ public class ResourcesUtil {
         return metadata.getGeneration();
     }
 
+    /**
+     * Extracts the UID from the given resource's metadata.
+     *
+     * @param resource the resource from which to extract the UID
+     * @return the resource UID
+     */
     public static String uid(HasMetadata resource) {
         return resource.getMetadata().getUid();
     }
@@ -193,6 +270,13 @@ public class ResourcesUtil {
         return Collectors.toMap(ResourcesUtil::toLocalRef, Function.identity());
     }
 
+    /**
+     * Converts a Kubernetes resource into a {@link LocalRef} containing the resource's kind, group, and name.
+     *
+     * @param ref the resource to convert
+     * @return a local reference representing the given resource
+     * @param <T> the type of the resource
+     */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T extends HasMetadata> LocalRef<T> toLocalRef(T ref) {
         return (LocalRef) new AnyLocalRefBuilder()
@@ -202,6 +286,12 @@ public class ResourcesUtil {
                 .build();
     }
 
+    /**
+     * Extracts the API group from the given resource's apiVersion, returning an empty string for core resources.
+     *
+     * @param resource the resource from which to extract the API group
+     * @return the API group, or an empty string for core API resources (e.g. Secret, ConfigMap)
+     */
     public static String group(HasMetadata resource) {
         // core CustomResource classes like Secret, Deployment etc. have a group of empty string and their apiVersion is the String 'v1'
         if (!resource.getApiVersion().contains("/")) {
@@ -210,6 +300,16 @@ public class ResourcesUtil {
         return resource.getApiVersion().substring(0, resource.getApiVersion().indexOf("/"));
     }
 
+    /**
+     * Returns the {@link ResourceID}s of resources matching the given predicate in the same namespace as the primary resource.
+     *
+     * @param context the event source context providing access to the Kubernetes client
+     * @param primary the resource whose namespace is used for the lookup
+     * @param clazz the class of resources to search for
+     * @param predicate a filter applied to each resource to determine inclusion
+     * @return the set of matching resource IDs
+     * @param <T> the type of the resources being searched
+     */
     public static <T extends HasMetadata> Set<ResourceID> filteredResourceIdsInSameNamespace(EventSourceContext<?> context,
                                                                                              HasMetadata primary,
                                                                                              Class<T> clazz,
@@ -237,6 +337,14 @@ public class ResourcesUtil {
                 .stream();
     }
 
+    /**
+     * Checks whether the given resource is the target of the given local reference by comparing names.
+     *
+     * @param ref the local reference to check
+     * @param resource the resource to test against the reference
+     * @return true if the resource's name matches the reference's name
+     * @param <T> the type of the referent
+     */
     public static <T> boolean isReferent(LocalRef<T> ref, HasMetadata resource) {
         return Objects.equals(ResourcesUtil.name(resource), ref.getName());
     }
@@ -253,15 +361,38 @@ public class ResourcesUtil {
         return Set.of(new ResourceID(ref.getName(), owner.getMetadata().getNamespace()));
     }
 
+    /**
+     * Returns the given namespace if non-null, otherwise falls back to the owner's namespace.
+     *
+     * @param owner the resource providing the fallback namespace
+     * @param namespace the explicit namespace, or null to use the owner's namespace
+     * @return the resolved namespace
+     */
     public static String namespaceFor(HasMetadata owner, String namespace) {
         return Optional.ofNullable(namespace)
                 .orElse(owner.getMetadata().getNamespace());
     }
 
+    /**
+     * Formats a namespace and name into a "namespace/name" string suitable for logging and diagnostics.
+     *
+     * @param namespace the namespace
+     * @param name the resource name
+     * @return the formatted namespaced name
+     */
     public static String namespacedName(String namespace, String name) {
         return namespace + "/" + name;
     }
 
+    /**
+     * Converts a list of local references into a set of {@link ResourceID}s in the owner's namespace.
+     *
+     * @param owner the resource owning the references, used to determine the namespace
+     * @param refs the list of local references to convert
+     * @return a set of ResourceIDs corresponding to the given references
+     * @param <O> the type of the reference owner
+     * @param <R> the type of the referents
+     */
     public static <O extends HasMetadata, R extends HasMetadata> Set<ResourceID> localRefsAsResourceIds(O owner,
                                                                                                         List<? extends LocalRef<R>> refs) {
         return refs.stream()
@@ -271,7 +402,7 @@ public class ResourcesUtil {
 
     /**
      * Finds the (ids of) the resources which reference the given referent
-     * This is the inverse of {@link #localRefAsResourceId(HasMetadata, LocalRef)}}.
+     * This is the inverse of {@link #localRefAsResourceId(HasMetadata, LocalRef)}.
      * @param context The context
      * @param referent The referent
      * @param owner The type of the owner of the reference
@@ -432,6 +563,13 @@ public class ResourcesUtil {
                 .collect(Collectors.toSet());
     }
 
+    /**
+     * Builds a human-readable namespaced slug string for a local reference, such as "secret/my-secret in namespace 'default'".
+     *
+     * @param ref the local reference to describe
+     * @param resource the resource providing the namespace context
+     * @return a namespaced slug string for use in diagnostic messages
+     */
     public static String namespacedSlug(LocalRef<?> ref, HasMetadata resource) {
         return slug(ref) + " in namespace '" + namespace(resource) + "'";
     }
@@ -444,6 +582,12 @@ public class ResourcesUtil {
         return kind + groupString + "/" + name;
     }
 
+    /**
+     * Builds a human-readable slug string for a resource, such as "secret/my-secret" or "kafka.strimzi.io/my-cluster".
+     *
+     * @param ref the resource to describe
+     * @return a slug string combining the lowercase kind, optional group, and name
+     */
     public static String slug(HasMetadata ref) {
         String group = group(ref);
         String name = name(ref);
@@ -510,18 +654,39 @@ public class ResourcesUtil {
                 .anyMatch(Condition::isResolvedRefsFalse);
     }
 
+    /**
+     * Returns a predicate that tests whether a resource's status observedGeneration matches its metadata generation.
+     *
+     * @return a predicate that returns true for resources with fresh (up-to-date) status
+     */
     public static Predicate<HasMetadata> isStatusFresh() {
         return ResourcesUtil::isStatusFresh;
     }
 
+    /**
+     * Returns a predicate that tests whether a resource's status observedGeneration does not match its metadata generation.
+     *
+     * @return a predicate that returns true for resources with stale (not-yet-reconciled) status
+     */
     public static Predicate<HasMetadata> isStatusStale() {
         return isStatusFresh().negate();
     }
 
+    /**
+     * Returns a predicate that tests whether a resource has a current-generation ResolvedRefs=false condition.
+     *
+     * @return a predicate that returns true for resources with an unresolved-references condition matching the current generation
+     */
     public static Predicate<HasMetadata> hasFreshResolvedRefsFalseCondition() {
         return ResourcesUtil::hasFreshResolvedRefsFalseCondition;
     }
 
+    /**
+     * Returns a predicate that tests whether a resource has the specified kind.
+     *
+     * @param kind the expected resource kind
+     * @return a predicate that returns true for resources matching the given kind
+     */
     public static Predicate<HasMetadata> hasKind(String kind) {
         return hasMetadata -> HasMetadata.getKind(hasMetadata.getClass()).equals(kind);
     }
@@ -664,10 +829,31 @@ public class ResourcesUtil {
         }
     }
 
+    /**
+     * Retrieves the Strimzi Kafka secondary resource from the given reconciliation context.
+     *
+     * @param context the reconciliation context to query
+     * @param eventSourceName the event source name used to look up the Kafka resource
+     * @return an Optional containing the Kafka resource if found, or empty otherwise
+     * @param <T> the type of the primary custom resource
+     */
     public static <T extends CustomResource<?, ?>> Optional<Kafka> getKafka(Context<T> context, String eventSourceName) {
         return context.getSecondaryResource(Kafka.class, eventSourceName);
     }
 
+    /**
+     * Validates a {@link StrimziKafkaRef} by checking that the Kafka CRD is installed, the referenced Kafka resource exists,
+     * and the specified listener is present in both the spec and the status.
+     *
+     * @param resource the custom resource containing the reference
+     * @param context the reconciliation context
+     * @param eventSourceName the event source name used to resolve the Kafka resource
+     * @param strimziKafkaRef the Strimzi Kafka reference to validate
+     * @param path the path to the reference within the resource spec, used in condition messages
+     * @param statusFactory used to generate status condition patches on validation failure
+     * @return a result containing either a status condition patch (if invalid) or the resolved Kafka resource
+     * @param <T> the custom resource type
+     */
     public static <T extends CustomResource<?, ?>> ResourceCheckResult<T> checkStrimziKafkaRef(T resource,
                                                                                                Context<T> context,
                                                                                                String eventSourceName,
@@ -699,6 +885,14 @@ public class ResourcesUtil {
         }
     }
 
+    /**
+     * Retrieves the {@link ListenerStatus} for the listener named in the KafkaService's strimziKafkaRef from the Strimzi Kafka resource status.
+     *
+     * @param context the reconciliation context for the KafkaService
+     * @param service the KafkaService whose strimziKafkaRef identifies the listener
+     * @param eventSourceName the event source name used to resolve the Kafka resource
+     * @return an Optional containing the matching ListenerStatus, or empty if the Kafka resource or listener is not found
+     */
     public static Optional<ListenerStatus> retrieveBootstrapServerAddress(Context<KafkaService> context,
                                                                           KafkaService service,
                                                                           String eventSourceName) {
@@ -757,7 +951,11 @@ public class ResourcesUtil {
     }
 
     /**
-     * If `storeType` is null in the KafkaService CR then derive it from the key
+     * Derives the trust store type (PEM, PKCS12, or JKS) from the file extension of the trust anchor's key.
+     *
+     * @param trustAnchorRef the trust anchor reference whose key extension determines the store type
+     * @return the store type string corresponding to the key's file extension
+     * @throws IllegalArgumentException if the key extension is not recognized or the key has no extension
      */
     public static String deriveStoreTypeFromKeySuffix(TrustAnchorRef trustAnchorRef) {
         String ext = getKeyExtension(trustAnchorRef.getKey());
@@ -793,19 +991,38 @@ public class ResourcesUtil {
         return null;
     }
 
+    /**
+     * Determines whether the given trust anchor reference points to a Kubernetes Secret.
+     *
+     * @param trustAnchorRef the trust anchor reference to check
+     * @return true if the trust anchor's underlying ref has kind "Secret"
+     */
     public static boolean isSecret(TrustAnchorRef trustAnchorRef) {
         return "Secret".equals(trustAnchorRef.getRef().getKind());
     }
 
     /**
-     * @return an address that any pod in the same k8s cluster can use to address the service, regardless of which namespace the pod is in
-     * @param serviceName service name
-     * @param namespacedResource resource in the namespace of the Service
+     * Builds a fully-qualified cluster-local DNS address for a Kubernetes Service that is routable from any namespace.
+     *
+     * @param serviceName the name of the Service
+     * @param namespacedResource a resource in the same namespace as the Service, used to determine the namespace
+     * @return a fully-qualified service address in the form "serviceName.namespace.svc.cluster.local"
      */
     public static String crossNamespaceServiceAddress(String serviceName, HasMetadata namespacedResource) {
         return serviceName + "." + namespace(namespacedResource) + ".svc.cluster.local";
     }
 
+    /**
+     * Validates the Strimzi-generated cluster CA trust anchor Secret for the referenced Kafka cluster, checking that
+     * the expected Secret exists and contains the {@value #STRIMZI_CLUSTER_CA_BUNDLE} data key.
+     *
+     * @param resource the KafkaService resource being reconciled
+     * @param context the reconciliation context
+     * @param eventSourceName the event source name used to resolve the cluster CA Secret
+     * @param strimziKafkaRef the Strimzi Kafka reference identifying the cluster
+     * @param statusFactory used to generate status condition patches on validation failure
+     * @return a result containing either a status condition patch (if invalid) or the resolved cluster CA Secret
+     */
     public static ResourceCheckResult<KafkaService> checkStrimziTrustAnchor(KafkaService resource, Context<KafkaService> context,
                                                                             String eventSourceName,
                                                                             StrimziKafkaRef strimziKafkaRef, StatusFactory<KafkaService> statusFactory) {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/SecureConfigInterpolator.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/SecureConfigInterpolator.java
@@ -45,6 +45,7 @@ public class SecureConfigInterpolator {
 
     private static final InterpolatedValue NULL_INTERPOLATED_VALUE = new InterpolatedValue(null, List.of());
 
+    /** Default interpolator configured with secret and configmap providers mounted under {@code /opt/kroxylicious/secure}. */
     public static final SecureConfigInterpolator DEFAULT_INTERPOLATOR = new SecureConfigInterpolator("/opt/kroxylicious/secure", Map.<String, SecureConfigProvider> of(
             "secret", MountedResourceConfigProvider.SECRET_PROVIDER,
             "configmap", MountedResourceConfigProvider.CONFIGMAP_PROVIDER));
@@ -52,11 +53,23 @@ public class SecureConfigInterpolator {
     private final Map<String, SecureConfigProvider> providers;
     private final Path mountPathBase;
 
+    /**
+     * Constructs an interpolator with the given base mount path and config providers.
+     *
+     * @param mountPathBase the base filesystem path under which provider volumes are mounted
+     * @param providers a map of provider names to their implementations
+     */
     public SecureConfigInterpolator(String mountPathBase, Map<String, SecureConfigProvider> providers) {
         this.providers = providers;
         this.mountPathBase = Path.of(mountPathBase);
     }
 
+    /**
+     * Interpolates all provider placeholders in the given config template, resolving them to container file paths.
+     *
+     * @param configTemplate the configuration template object (may contain nested maps, lists, and strings with placeholders)
+     * @return the interpolation result containing the resolved config, required volumes, and volume mounts
+     */
     public InterpolationResult interpolate(Object configTemplate) {
         // use sets so that it doesn't matter is two providers require the same volume or mount (with exactly the same definition)
 
@@ -149,10 +162,18 @@ public class SecureConfigInterpolator {
         return new InterpolatedValue(sb.toString(), containerFileReferences);
     }
 
+    /**
+     * Holds the result of interpolating a config template, including the resolved config and any required Kubernetes volumes and mounts.
+     *
+     * @param config the interpolated configuration object, or null if the input was null
+     * @param volumes the set of Kubernetes volumes required by the interpolated config
+     * @param mounts the set of Kubernetes volume mounts required by the interpolated config
+     */
     public record InterpolationResult(@Nullable Object config,
                                       Set<Volume> volumes,
                                       Set<VolumeMount> mounts) {
 
+        /** Validates that volumes and mounts are non-null. */
         public InterpolationResult {
             Objects.requireNonNull(volumes);
             Objects.requireNonNull(mounts);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/StaleReferentStatusException.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/StaleReferentStatusException.java
@@ -13,6 +13,11 @@ package io.kroxylicious.kubernetes.operator;
  * to reconcile again, this time successfully.
  */
 public class StaleReferentStatusException extends RuntimeException {
+    /**
+     * Constructs a StaleReferentStatusException with a message describing which referent has stale status.
+     *
+     * @param message a description of the stale referent
+     */
     public StaleReferentStatusException(String message) {
         super(message);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/StatusFactory.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/StatusFactory.java
@@ -14,14 +14,30 @@ import io.fabric8.kubernetes.client.CustomResource;
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.common.ConditionBuilder;
 
+/**
+ * Base factory for creating Kubernetes status conditions on custom resources.
+ *
+ * @param <R> the custom resource type this factory creates status patches for
+ */
 public abstract class StatusFactory<R extends CustomResource<?, ?>> {
 
     private final Clock clock;
 
+    /**
+     * Constructs a status factory using the given clock for condition timestamps.
+     *
+     * @param clock the clock to use for generating condition transition times
+     */
     protected StatusFactory(Clock clock) {
         this.clock = clock;
     }
 
+    /**
+     * Creates a new condition builder pre-populated with the current timestamp and observed generation.
+     *
+     * @param observedGenerationSource the resource whose metadata generation is recorded in the condition
+     * @return a pre-populated condition builder
+     */
     public ConditionBuilder newConditionBuilder(HasMetadata observedGenerationSource) {
         var now = clock.instant();
         return new ConditionBuilder()
@@ -29,6 +45,14 @@ public abstract class StatusFactory<R extends CustomResource<?, ?>> {
                 .withObservedGeneration(ResourcesUtil.generation(observedGenerationSource));
     }
 
+    /**
+     * Creates a condition with status TRUE, using the given type and message.
+     *
+     * @param observedGenerationSource the resource whose metadata generation is recorded in the condition
+     * @param type the condition type
+     * @param message a human-readable message describing the condition
+     * @return a new condition with status TRUE
+     */
     public Condition newTrueCondition(HasMetadata observedGenerationSource, Condition.Type type, String message) {
         return newConditionBuilder(observedGenerationSource)
                 .withType(type)
@@ -38,10 +62,26 @@ public abstract class StatusFactory<R extends CustomResource<?, ?>> {
                 .build();
     }
 
+    /**
+     * Creates a condition with status TRUE and an empty message.
+     *
+     * @param observedGenerationSource the resource whose metadata generation is recorded in the condition
+     * @param type the condition type
+     * @return a new condition with status TRUE
+     */
     public Condition newTrueCondition(HasMetadata observedGenerationSource, Condition.Type type) {
         return newTrueCondition(observedGenerationSource, type, "");
     }
 
+    /**
+     * Creates a condition with status FALSE, indicating the condition is not met.
+     *
+     * @param observedGenerationSource the resource whose metadata generation is recorded in the condition
+     * @param type the condition type
+     * @param reason a machine-readable reason for the false status
+     * @param message a human-readable message explaining why the condition is false
+     * @return a new condition with status FALSE
+     */
     public Condition newFalseCondition(
                                        HasMetadata observedGenerationSource,
                                        Condition.Type type,
@@ -55,6 +95,14 @@ public abstract class StatusFactory<R extends CustomResource<?, ?>> {
                 .build();
     }
 
+    /**
+     * Creates a condition with status UNKNOWN, using the exception's class name as the reason and its message as the description.
+     *
+     * @param observedResource the resource whose metadata generation is recorded in the condition
+     * @param type the condition type
+     * @param e the exception that caused the unknown status
+     * @return a new condition with status UNKNOWN
+     */
     public Condition newUnknownCondition(HasMetadata observedResource, Condition.Type type, Exception e) {
         return newConditionBuilder(observedResource)
                 .withType(type)
@@ -64,15 +112,37 @@ public abstract class StatusFactory<R extends CustomResource<?, ?>> {
                 .build();
     }
 
+    /**
+     * Creates a status patch with an unknown condition due to an exception.
+     * @param observedProxy the observed resource
+     * @param type the condition type
+     * @param e the exception that caused the unknown status
+     * @return a resource containing the status patch
+     */
     public abstract R newUnknownConditionStatusPatch(R observedProxy,
                                                      Condition.Type type,
                                                      Exception e);
 
+    /**
+     * Creates a status patch with a false condition.
+     * @param observedProxy the observed resource
+     * @param type the condition type
+     * @param reason the reason the condition is false
+     * @param message a human-readable message
+     * @return a resource containing the status patch
+     */
     public abstract R newFalseConditionStatusPatch(R observedProxy,
                                                    Condition.Type type,
                                                    String reason,
                                                    String message);
 
+    /**
+     * Creates a status patch with a true condition.
+     * @param observedProxy the observed resource
+     * @param type the condition type
+     * @param checksum the referent checksum associated with the condition
+     * @return a resource containing the status patch
+     */
     public abstract R newTrueConditionStatusPatch(R observedProxy,
                                                   Condition.Type type,
                                                   String checksum);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/checkers/AbsentSpecDeprecationChecker.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/checkers/AbsentSpecDeprecationChecker.java
@@ -23,6 +23,13 @@ public class AbsentSpecDeprecationChecker implements DeprecationChecker<KafkaPro
 
     private static final String MESSAGE = "No spec, please add an empty one. Support for spec-less KafkaProxy resources is deprecated and will be removed in a future release.";
 
+    /**
+     * Constructs an AbsentSpecDeprecationChecker.
+     */
+    public AbsentSpecDeprecationChecker() {
+        // explicit ctor needed for javadoc
+    }
+
     public void check(DeprecationCheckContext<KafkaProxySpec, KafkaProxyStatus, KafkaProxy, StatusFactory<KafkaProxy>> context) {
         var proxy = context.resource();
 

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/checkers/DeprecationCheckContext.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/checkers/DeprecationCheckContext.java
@@ -36,6 +36,12 @@ public class DeprecationCheckContext<S, T, R extends CustomResource<S, T>, F ext
     private final F statusFactory;
     private final List<Condition> conditions = new ArrayList<>();
 
+    /**
+     * Constructs a new context for a deprecation check pass.
+     *
+     * @param resource the custom resource to check
+     * @param statusFactory the factory used to create status conditions
+     */
     public DeprecationCheckContext(R resource, F statusFactory) {
         this.resource = Objects.requireNonNull(resource);
         this.statusFactory = Objects.requireNonNull(statusFactory);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/checksum/Crc32ChecksumGenerator.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/checksum/Crc32ChecksumGenerator.java
@@ -16,6 +16,9 @@ import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * A {@link MetadataChecksumGenerator} that computes checksums using CRC-32.
+ */
 @NotThreadSafe
 public class Crc32ChecksumGenerator implements MetadataChecksumGenerator {
 
@@ -23,6 +26,9 @@ public class Crc32ChecksumGenerator implements MetadataChecksumGenerator {
     private final CRC32 checksum;
     private final ByteBuffer byteBuffer;
 
+    /**
+     * Constructs a Crc32ChecksumGenerator.
+     */
     public Crc32ChecksumGenerator() {
         checksum = new CRC32();
         byteBuffer = ByteBuffer.wrap(new byte[Long.BYTES]);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/checksum/MetadataChecksumGenerator.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/checksum/MetadataChecksumGenerator.java
@@ -22,11 +22,22 @@ import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Generates checksums from Kubernetes resource metadata.
+ */
 public interface MetadataChecksumGenerator {
+    /** Logger for this interface. */
     Logger LOGGER = LoggerFactory.getLogger(MetadataChecksumGenerator.class);
+    /** Context key used to store and retrieve a checksum generator. */
     String CHECKSUM_CONTEXT_KEY = "kroxylicious.io/referent-checksum-generator";
+    /** Sentinel value indicating no checksum has been computed. */
     String NO_CHECKSUM_SPECIFIED = "";
 
+    /**
+     * Appends the metadata of the given entity to the checksum.
+     *
+     * @param entity the Kubernetes resource whose metadata is appended
+     */
     default void appendMetadata(HasMetadata entity) {
         LOGGER.atDebug()
                 .addKeyValue(OperatorLoggingKeys.KIND, ResourcesUtil.kind(entity))
@@ -40,12 +51,32 @@ public interface MetadataChecksumGenerator {
         referentChecksum.ifPresent(this::appendString);
     }
 
+    /**
+     * Appends a string value to the checksum.
+     *
+     * @param value the string to append, or {@code null} to skip
+     */
     void appendString(@Nullable String value);
 
+    /**
+     * Appends a long value to the checksum.
+     *
+     * @param value the long value to append
+     */
     void appendLong(Long value);
 
+    /**
+     * Encodes the accumulated checksum as a string.
+     *
+     * @return the encoded checksum, or {@link #NO_CHECKSUM_SPECIFIED} if no data was appended
+     */
     String encode();
 
+    /**
+     * Appends a version specifier from the given object metadata to the checksum.
+     *
+     * @param objectMeta the object metadata whose generation or resource version is appended
+     */
     default void appendVersionSpecifier(ObjectMeta objectMeta) {
         Long generation = objectMeta.getGeneration();
         if (generation != null) {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/checksum/package-info.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/checksum/package-info.java
@@ -5,7 +5,7 @@
  */
 
 /**
- * Classes comprising the operator's logical networking model.
+ * Checksum generation for Kubernetes resource metadata change detection.
  */
 @ReturnValuesAreNonnullByDefault
 @DefaultAnnotationForParameters(NonNull.class)

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/management/UnsupportedHttpMethodFilter.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/management/UnsupportedHttpMethodFilter.java
@@ -19,6 +19,7 @@ import com.sun.net.httpserver.HttpExchange;
  */
 public class UnsupportedHttpMethodFilter extends Filter {
 
+    /** Singleton instance of this filter. */
     public static final Filter INSTANCE = new UnsupportedHttpMethodFilter();
 
     private UnsupportedHttpMethodFilter() {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/ProxyModelBuilder.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/ProxyModelBuilder.java
@@ -32,11 +32,21 @@ public class ProxyModelBuilder {
 
     private final DependencyResolver resolver;
 
+    /**
+     * Creates a ProxyModelBuilder using the given dependency resolver.
+     * @param resolver the resolver used to look up proxy dependencies
+     */
     public ProxyModelBuilder(DependencyResolver resolver) {
         Objects.requireNonNull(resolver);
         this.resolver = resolver;
     }
 
+    /**
+     * Resolves all dependencies of the given KafkaProxy and computes the logical proxy model including networking and valid clusters.
+     * @param primary the KafkaProxy custom resource being reconciled
+     * @param context the reconciler context providing access to secondary resources
+     * @return the computed proxy model
+     */
     public ProxyModel build(KafkaProxy primary, Context<KafkaProxy> context) {
         ProxyResolutionResult resolutionResult = resolver.resolveProxyRefs(primary, context);
         if (!resolutionResult.allReferentsHaveFreshStatus()) {
@@ -59,6 +69,10 @@ public class ProxyModelBuilder {
         return new ProxyModel(resolutionResult, ingressModel, clustersWithValidIngresses);
     }
 
+    /**
+     * Creates a ProxyModelBuilder with the default dependency resolver.
+     * @return a new ProxyModelBuilder instance
+     */
     public static ProxyModelBuilder contextBuilder() {
         return new ProxyModelBuilder(DependencyResolver.create());
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/RouteHostDetails.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/RouteHostDetails.java
@@ -58,9 +58,12 @@ public record RouteHostDetails(
      * for the Gateway of the VirtualKafkaCluster.
      */
     public enum RouteFor {
+        /** Indicates the route is for the bootstrap address of the cluster. */
         BOOTSTRAP,
+        /** Indicates the route is for a specific broker node address. */
         NODE;
 
+        /** Label key used on Route resources to indicate whether a route targets bootstrap or a node. */
         public static final String LABEL_KEY = "kroxylicious.io/route-for";
 
         @Override
@@ -81,10 +84,13 @@ public record RouteHostDetails(
 
     /**
      * Tries to find the first {@link RouteHostDetails} that matches the provided details and return its {@link RouteHostDetails#hostWithoutSubdomain()}.
-     * <p>
-     * See {@link RouteHostDetails} for explanation of parameters.
      *
-     * @return An {@link Optional} containing the {@link RouteHostDetails#hostWithoutSubdomain()} if found, otherwise {@link Optional#empty()}.
+     * @param routeHostDetailsList the list of route host details to search
+     * @param routeNamespace the namespace of the route to match
+     * @param clusterName the cluster name to match
+     * @param ingressName the ingress name to match
+     * @param routeFor the route type to match (bootstrap or node)
+     * @return an {@link Optional} containing the {@link RouteHostDetails#hostWithoutSubdomain()} if found, otherwise {@link Optional#empty()}
      */
     public static Optional<String> findFirstRouteHostWithoutSubdomainFromList(List<RouteHostDetails> routeHostDetailsList, String routeNamespace, String clusterName,
                                                                               String ingressName, RouteHostDetails.RouteFor routeFor) {
@@ -101,6 +107,8 @@ public record RouteHostDetails(
 
     /**
      * Fetches {@link Route} secondary resources and maps them to a {@link RouteHostDetails} list.
+     * @param context the reconciler context containing the secondary Route resources
+     * @return the list of route host details extracted from the secondary Route resources
      */
     public static List<RouteHostDetails> fetchRouteHostDetailsList(Context<KafkaProxy> context) {
         return context.getSecondaryResources(Route.class)

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/ClusterIngressNetworkingModel.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/ClusterIngressNetworkingModel.java
@@ -30,7 +30,7 @@ import io.kroxylicious.proxy.config.NodeIdentificationStrategyFactory;
  * Backend plumbing will include:
  * <ul>
  *     <li>container ports exposed on the Proxy Pod</li>
- *     <li>gateway configuration in the Proxy Config/li>
+ *     <li>gateway configuration in the Proxy Config</li>
  * </ul>
  */
 public interface ClusterIngressNetworkingModel {
@@ -53,6 +53,10 @@ public interface ClusterIngressNetworkingModel {
      */
     Stream<ServiceBuilder> services();
 
+    /**
+     * OpenShift Routes to be created for this model.
+     * @return a stream of RouteBuilders
+     */
     Stream<RouteBuilder> routes();
 
     /**
@@ -70,11 +74,13 @@ public interface ClusterIngressNetworkingModel {
     NodeIdentificationStrategyFactory nodeIdentificationStrategy();
 
     /**
-     * The downstream TLS to be injected into the Proxy Config for this model, if available
+     * The downstream TLS to be injected into the Proxy Config for this model, if available.
+     * @return an optional containing the TLS configuration, or empty if not available
      */
     Optional<Tls> downstreamTls();
 
     /**
+     * Whether this cluster ingress requires a shared SNI port in the proxy container.
      * @return true if this cluster ingress requires a shared SNI port in the proxy container to be provided
      */
     default boolean requiresSharedSniContainerPort() {
@@ -89,6 +95,7 @@ public interface ClusterIngressNetworkingModel {
         return Optional.empty();
     }
 
+    /** Annotation key prefix reserved for operator-managed annotations. */
     String RESERVED_ANNOTATION_PREFIX = "kroxylicious.io/";
 
     /**

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/IngressConflictException.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/IngressConflictException.java
@@ -12,13 +12,23 @@ package io.kroxylicious.kubernetes.operator.model.networking;
  */
 public class IngressConflictException extends RuntimeException {
 
+    /** The name of the conflicting ingress resource. */
     private final String ingressName;
 
+    /**
+     * Creates a new IngressConflictException.
+     * @param ingressName the name of the conflicting ingress
+     * @param message the detail message
+     */
     public IngressConflictException(String ingressName, String message) {
         super(message);
         this.ingressName = ingressName;
     }
 
+    /**
+     * Returns the name of the conflicting ingress.
+     * @return the ingress name
+     */
     public String getIngressName() {
         return ingressName;
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/LoadBalancerClusterIngressNetworkingModel.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/LoadBalancerClusterIngressNetworkingModel.java
@@ -25,6 +25,15 @@ import io.kroxylicious.proxy.service.HostPort;
 
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
 
+/**
+ * Networking model for a cluster ingress using a shared LoadBalancer with SNI routing.
+ *
+ * @param cluster the virtual Kafka cluster
+ * @param ingress the ingress resource
+ * @param loadBalancer the load balancer specification
+ * @param tls the TLS configuration
+ * @param sharedSniPort the shared SNI port on the proxy container
+ */
 public record LoadBalancerClusterIngressNetworkingModel(VirtualKafkaCluster cluster,
                                                         KafkaProxyIngress ingress,
                                                         LoadBalancer loadBalancer,
@@ -32,6 +41,9 @@ public record LoadBalancerClusterIngressNetworkingModel(VirtualKafkaCluster clus
                                                         int sharedSniPort)
         implements ClusterIngressNetworkingModel, SharedLoadBalancerServiceRequirements {
 
+    /**
+     * Validates that all required fields are non-null.
+     */
     public LoadBalancerClusterIngressNetworkingModel {
         Objects.requireNonNull(cluster);
         Objects.requireNonNull(ingress);
@@ -83,6 +95,10 @@ public record LoadBalancerClusterIngressNetworkingModel(VirtualKafkaCluster clus
         return new Annotations.ClusterIngressBootstrapServers(name(cluster), name(ingress), bootstrapServers());
     }
 
+    /**
+     * Returns the bootstrap servers address for this cluster ingress.
+     * @return the bootstrap servers connection string
+     */
     public String bootstrapServers() {
         return HostPort.asString(loadBalancer.getBootstrapAddress(), DEFAULT_CLIENT_FACING_LOADBALANCER_PORT).replace("$(virtualClusterName)", name(cluster));
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/NetworkPlanningException.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/NetworkPlanningException.java
@@ -6,8 +6,15 @@
 
 package io.kroxylicious.kubernetes.operator.model.networking;
 
+/**
+ * Thrown when the networking planner encounters an invalid or unsupported ingress configuration.
+ */
 public class NetworkPlanningException extends RuntimeException {
 
+    /**
+     * Creates a new NetworkPlanningException.
+     * @param message the detail message
+     */
     public NetworkPlanningException(String message) {
         super(message);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/NetworkingPlanner.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/NetworkingPlanner.java
@@ -62,9 +62,9 @@ public class NetworkingPlanner {
      * be used by the proxy container. We want this to be as stable as possible, so we will allocate ports
      * to potentially unacceptable virtual clusters if we can.
      *
-     * @param primary primary being reconciled
-     * @param proxyResolutionResult
-     * @param routeHostDetails
+     * @param primary the KafkaProxy being reconciled
+     * @param proxyResolutionResult the resolved dependencies of the proxy
+     * @param routeHostDetails the route host details for OpenShift route ingresses
      * @return non-null ProxyIngressModel
      */
     public static ProxyNetworkingModel planNetworking(KafkaProxy primary,

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/ProxyNetworkingModel.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/ProxyNetworkingModel.java
@@ -38,6 +38,11 @@ import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
  */
 public record ProxyNetworkingModel(List<ClusterNetworkingModel> clusterNetworkingModels) {
 
+    /**
+     * Finds the networking model for a given cluster, if one exists.
+     * @param cluster the virtual Kafka cluster to look up
+     * @return an optional containing the cluster's networking model, or empty if not found
+     */
     public Optional<ClusterNetworkingModel> clusterIngressModel(VirtualKafkaCluster cluster) {
         return clusterNetworkingModels.stream()
                 .filter(c -> name(c.cluster).equals(name(cluster)))
@@ -45,20 +50,32 @@ public record ProxyNetworkingModel(List<ClusterNetworkingModel> clusterNetworkin
     }
 
     /**
-     *
+     * The networking model for a single VirtualKafkaCluster, including all its ingresses.
      * @param cluster cluster
      * @param clusterIngressNetworkingModelResults the ingress model results, one per ingress in the VKC spec.ingresses in the same order
      */
     public record ClusterNetworkingModel(VirtualKafkaCluster cluster, List<ClusterIngressNetworkingModelResult> clusterIngressNetworkingModelResults) {
 
+        /**
+         * Builds all Kubernetes Services required by the ingresses of this cluster.
+         * @return a stream of Services
+         */
         public Stream<Service> services() {
             return clusterIngressNetworkingModelResults.stream().flatMap(it -> it.clusterIngressNetworkingModel().services()).map(ServiceBuilder::build);
         }
 
+        /**
+         * Builds all OpenShift Routes required by the ingresses of this cluster.
+         * @return a stream of Routes
+         */
         public Stream<Route> routes() {
             return clusterIngressNetworkingModelResults.stream().flatMap(it -> it.clusterIngressNetworkingModel().routes()).map(RouteBuilder::build);
         }
 
+        /**
+         * Collects all conflict exceptions encountered when modelling the cluster's ingresses.
+         * @return the set of ingress conflict exceptions
+         */
         public Set<IngressConflictException> ingressExceptions() {
             return clusterIngressNetworkingModelResults.stream()
                     .filter(it -> it.exception != null)
@@ -74,11 +91,19 @@ public record ProxyNetworkingModel(List<ClusterNetworkingModel> clusterNetworkin
             clusterIngressNetworkingModelResults.forEach(result -> result.proxyContainerPorts().forEach(portConsumer));
         }
 
+        /**
+         * Determines whether any ingress in this cluster requires a shared SNI container port.
+         * @return true if at least one ingress requires a shared SNI container port
+         */
         public boolean anyIngressRequiresSharedSniPort() {
             return clusterIngressNetworkingModelResults.stream()
                     .anyMatch(ingressModelResult -> ingressModelResult.clusterIngressNetworkingModel().requiresSharedSniContainerPort());
         }
 
+        /**
+         * Collects all client-facing ports required on the shared SNI LoadBalancer Service across all ingresses.
+         * @return a stream of port numbers required for the shared SNI LoadBalancer
+         */
         public Stream<Integer> requiredSniLoadbalancerPorts() {
             return clusterIngressNetworkingModelResults.stream()
                     .flatMap(ingressModelResult -> ingressModelResult.clusterIngressNetworkingModel().sharedLoadBalancerServiceRequirements().stream())
@@ -93,6 +118,10 @@ public record ProxyNetworkingModel(List<ClusterNetworkingModel> clusterNetworkin
      */
     public record ClusterIngressNetworkingModelResult(ClusterIngressNetworkingModel clusterIngressNetworkingModel, @Nullable IngressConflictException exception) {
 
+        /**
+         * Returns the container ports that this ingress model requires on the proxy container.
+         * @return a stream of container ports for identifying upstream nodes
+         */
         public Stream<ContainerPort> proxyContainerPorts() {
             return clusterIngressNetworkingModel.identifyingProxyContainerPorts();
         }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/RouteClusterIngressNetworkingModel.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/RouteClusterIngressNetworkingModel.java
@@ -38,6 +38,18 @@ import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.namespace;
 import static java.lang.Math.toIntExact;
 
+/**
+ * Networking model for a cluster ingress using OpenShift Routes with SNI-based node identification.
+ *
+ * @param proxy the KafkaProxy that owns this model
+ * @param cluster the virtual Kafka cluster
+ * @param ingress the ingress resource
+ * @param openShiftRoute the OpenShift route specification from the ingress
+ * @param nodeIdRanges the node ID ranges describing the upstream Kafka nodes
+ * @param tls the TLS configuration for downstream connections
+ * @param sharedSniPort the shared SNI port on the proxy container
+ * @param routeHostDetails the resolved route host details used for domain substitution
+ */
 public record RouteClusterIngressNetworkingModel(KafkaProxy proxy,
                                                  VirtualKafkaCluster cluster,
                                                  KafkaProxyIngress ingress,
@@ -48,6 +60,9 @@ public record RouteClusterIngressNetworkingModel(KafkaProxy proxy,
                                                  List<RouteHostDetails> routeHostDetails)
         implements ClusterIngressNetworkingModel {
 
+    /**
+     * Validates that all required fields are non-null and nodeIdRanges is non-empty.
+     */
     public RouteClusterIngressNetworkingModel {
         Objects.requireNonNull(proxy);
         Objects.requireNonNull(cluster);
@@ -138,6 +153,11 @@ public record RouteClusterIngressNetworkingModel(KafkaProxy proxy,
         return Stream.empty();
     }
 
+    /**
+     * Looks up the resolved domain (host without subdomain) for the given route type from the route host details.
+     * @param routeFor the route type to look up (bootstrap or node)
+     * @return an optional containing the domain if resolved, or empty if not yet available
+     */
     public Optional<String> getDomain(RouteHostDetails.RouteFor routeFor) {
         return RouteHostDetails.findFirstRouteHostWithoutSubdomainFromList(routeHostDetails, namespace(cluster), name(cluster), name(ingress), routeFor);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/SharedLoadBalancerServiceRequirements.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/SharedLoadBalancerServiceRequirements.java
@@ -19,12 +19,14 @@ import io.kroxylicious.kubernetes.operator.Annotations;
 public interface SharedLoadBalancerServiceRequirements {
 
     /**
+     * Returns the client-facing ports required on the shared SNI LoadBalancer Service.
      * @return the client facing ports that should be exposed on the shared SNI LoadBalancer Service, mapping
      * to the shared SNI port on the proxy.
      */
     Stream<Integer> requiredClientFacingPorts();
 
     /**
+     * Returns the bootstrap servers to include in the shared LoadBalancer Service annotations.
      * @return the bootstrapServers that should be included in the shared SNI LoadBalancer Service metadata
      */
     Annotations.ClusterIngressBootstrapServers bootstrapServersToAnnotate();

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/TcpClusterIPClusterIngressNetworkingModel.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/TcpClusterIPClusterIngressNetworkingModel.java
@@ -40,6 +40,16 @@ import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.namespace;
 import static java.lang.Math.toIntExact;
 
+/**
+ * Networking model for a cluster ingress using per-node TCP ClusterIP Services with port-based node identification.
+ *
+ * @param proxy the KafkaProxy that owns this model
+ * @param cluster the virtual Kafka cluster
+ * @param ingress the ingress resource
+ * @param nodeIdRanges the node ID ranges describing the upstream Kafka nodes
+ * @param firstIdentifyingPort the first port in the allocated port range
+ * @param lastIdentifyingPort the last port in the allocated port range
+ */
 public record TcpClusterIPClusterIngressNetworkingModel(KafkaProxy proxy,
                                                         VirtualKafkaCluster cluster,
                                                         KafkaProxyIngress ingress,
@@ -48,6 +58,9 @@ public record TcpClusterIPClusterIngressNetworkingModel(KafkaProxy proxy,
                                                         int lastIdentifyingPort)
         implements ClusterIngressNetworkingModel {
 
+    /**
+     * Validates that the proxy, cluster, ingress, and nodeIdRanges are non-null, nodeIdRanges is non-empty, and the port range matches the required number of identifying ports.
+     */
     public TcpClusterIPClusterIngressNetworkingModel {
         Objects.requireNonNull(proxy);
         Objects.requireNonNull(cluster);
@@ -64,6 +77,12 @@ public record TcpClusterIPClusterIngressNetworkingModel(KafkaProxy proxy,
         }
     }
 
+    /**
+     * Computes the bootstrap service name from the cluster and ingress names.
+     * @param cluster the virtual Kafka cluster
+     * @param ingressName the name of the ingress
+     * @return the bootstrap service name in the form {@code <clusterName>-<ingressName>-bootstrap}
+     */
     public static String bootstrapServiceName(VirtualKafkaCluster cluster, String ingressName) {
         Objects.requireNonNull(cluster);
         Objects.requireNonNull(ingressName);
@@ -155,12 +174,21 @@ public record TcpClusterIPClusterIngressNetworkingModel(KafkaProxy proxy,
         return new HostPort(crossNamespaceBootstrapServiceAddress(), firstIdentifyingPort()).toString();
     }
 
+    /**
+     * Calculates the number of identifying ports required for the given node ID ranges (one per node plus one for bootstrap).
+     * @param nodeIdRanges the node ID ranges
+     * @return the total number of identifying ports required
+     */
     public static int numIdentifyingPortsRequired(List<NodeIdRanges> nodeIdRanges) {
         // one per broker plus the bootstrap
         return nodeCount(nodeIdRanges) + 1;
     }
 
-    // note: we use CRD validation to enforce end >= start at the apiserver level
+    /**
+     * Counts the total number of nodes across all node ID ranges (CRD validation enforces end &gt;= start).
+     * @param nodeIdRanges the node ID ranges
+     * @return the total node count
+     */
     public static int nodeCount(List<NodeIdRanges> nodeIdRanges) {
         Objects.requireNonNull(nodeIdRanges);
         if (nodeIdRanges.isEmpty()) {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/TlsClusterIPClusterIngressNetworkingModel.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/TlsClusterIPClusterIngressNetworkingModel.java
@@ -37,6 +37,15 @@ import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.namespace;
 import static java.lang.Math.toIntExact;
 
+/**
+ * Networking model for TLS-terminated ClusterIP ingress using SNI-based routing.
+ * @param proxy the owning KafkaProxy resource
+ * @param cluster the virtual Kafka cluster
+ * @param ingress the ingress resource
+ * @param nodeIdRanges the node ID ranges for the cluster
+ * @param tls the TLS configuration
+ * @param sharedSniPort the shared SNI port number
+ */
 public record TlsClusterIPClusterIngressNetworkingModel(KafkaProxy proxy,
                                                         VirtualKafkaCluster cluster,
                                                         KafkaProxyIngress ingress,
@@ -45,8 +54,10 @@ public record TlsClusterIPClusterIngressNetworkingModel(KafkaProxy proxy,
                                                         int sharedSniPort)
         implements ClusterIngressNetworkingModel {
 
+    /** Port used for client-facing TLS connections. */
     public static final int CLIENT_FACING_PORT = 9292;
 
+    /** Validates that required parameters are non-null and nodeIdRanges is non-empty. */
     public TlsClusterIPClusterIngressNetworkingModel {
         Objects.requireNonNull(proxy);
         Objects.requireNonNull(cluster);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/package-info.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/package-info.java
@@ -4,6 +4,9 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+/**
+ * Classes comprising the operator's proxy model.
+ */
 @ReturnValuesAreNonnullByDefault
 @DefaultAnnotationForParameters(NonNull.class)
 @DefaultAnnotation(NonNull.class)

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconciler.java
@@ -66,6 +66,13 @@ public class KafkaProtocolFilterReconciler implements
     private final SecureConfigInterpolator secureConfigInterpolator;
     private final SharedInformerManager sharedInformerManager;
 
+    /**
+     * Constructs a reconciler for KafkaProtocolFilter resources.
+     *
+     * @param clock the clock used for condition timestamps
+     * @param secureConfigInterpolator the interpolator for resolving secure config template expressions
+     * @param sharedInformerManager the manager providing shared informers for Secret and ConfigMap resources
+     */
     public KafkaProtocolFilterReconciler(Clock clock, SecureConfigInterpolator secureConfigInterpolator, SharedInformerManager sharedInformerManager) {
         this.statusFactory = new KafkaProtocolFilterStatusFactory(Objects.requireNonNull(clock));
         this.secureConfigInterpolator = Objects.requireNonNull(secureConfigInterpolator);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterStatusFactory.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterStatusFactory.java
@@ -20,8 +20,16 @@ import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.StatusFactory;
 import io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator;
 
+/**
+ * Factory for building status patches for {@link KafkaProtocolFilter} resources.
+ */
 public class KafkaProtocolFilterStatusFactory extends StatusFactory<KafkaProtocolFilter> {
 
+    /**
+     * Constructs a status factory for KafkaProtocolFilter resources.
+     *
+     * @param clock the clock used for condition timestamps
+     */
     public KafkaProtocolFilterStatusFactory(Clock clock) {
         super(clock);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ClusterRouteDependentResource.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ClusterRouteDependentResource.java
@@ -30,6 +30,9 @@ public class ClusterRouteDependentResource
         extends CRUDKubernetesDependentResource<Route, KafkaProxy>
         implements BulkDependentResource<Route, KafkaProxy, String> {
 
+    /**
+     * Constructs the dependent resource for managing OpenShift Routes.
+     */
     public ClusterRouteDependentResource() {
         super(Route.class);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ClusterServiceDependentResource.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ClusterServiceDependentResource.java
@@ -46,6 +46,9 @@ public class ClusterServiceDependentResource
         extends CRUDKubernetesDependentResource<Service, KafkaProxy>
         implements BulkDependentResource<Service, KafkaProxy, String> {
 
+    /**
+     * Constructs the dependent resource for managing Kubernetes Services.
+     */
     public ClusterServiceDependentResource() {
         super(Service.class);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ConfigurationFragment.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ConfigurationFragment.java
@@ -61,6 +61,13 @@ public record ConfigurationFragment<F>(F fragment, Set<Volume> volumes, Set<Volu
         return new ConfigurationFragment<>(mapper.apply(fragment), volumes, mounts);
     }
 
+    /**
+     * Apply the given mapping function to the fragment, merging the resulting volumes and mounts with this instance's.
+     *
+     * @param mapper the mapping function that returns a new configuration fragment
+     * @return a new fragment with merged volumes and mounts
+     * @param <G> the type of the new fragment
+     */
     public <G> ConfigurationFragment<G> flatMap(Function<F, ConfigurationFragment<G>> mapper) {
         ConfigurationFragment<G> apply = mapper.apply(fragment);
         return new ConfigurationFragment<>(apply.fragment(),
@@ -68,6 +75,13 @@ public record ConfigurationFragment<F>(F fragment, Set<Volume> volumes, Set<Volu
                 Stream.concat(mounts.stream(), apply.mounts.stream()).collect(Collectors.toSet()));
     }
 
+    /**
+     * Reduce a list of fragments into a single fragment containing all fragment values, with merged volumes and mounts.
+     *
+     * @param fragments the list of fragments to reduce
+     * @return a single fragment containing all fragment values as a list
+     * @param <F> the type of the individual fragments
+     */
     public static <F> ConfigurationFragment<List<F>> reduce(List<ConfigurationFragment<F>> fragments) {
         var list = fragments.stream().map(ConfigurationFragment::fragment).toList();
         return new ConfigurationFragment<>(list,

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyContext.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyContext.java
@@ -25,11 +25,11 @@ import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
-public record KafkaProxyContext(StatusFactory<VirtualKafkaCluster> virtualKafkaClusterStatusFactory,
-                                ProxyModel model,
-                                Optional<Configuration> configuration,
-                                List<Volume> volumes,
-                                List<VolumeMount> mounts) {
+record KafkaProxyContext(StatusFactory<VirtualKafkaCluster> virtualKafkaClusterStatusFactory,
+                         ProxyModel model,
+                         Optional<Configuration> configuration,
+                         List<Volume> volumes,
+                         List<VolumeMount> mounts) {
 
     @VisibleForTesting
     static final String KEY_CTX = KafkaProxyContext.class.getName();

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconciler.java
@@ -142,14 +142,14 @@ public class KafkaProxyReconciler implements
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyReconciler.class);
 
-    public static final String CONFIG_STATE_DEP = "config-state";
-    public static final String CONFIG_DEP = "config";
-    public static final String DEPLOYMENT_DEP = "deployment";
-    public static final String CLUSTERS_DEP = "clusters";
+    static final String CONFIG_STATE_DEP = "config-state";
+    static final String CONFIG_DEP = "config";
+    static final String DEPLOYMENT_DEP = "deployment";
+    static final String CLUSTERS_DEP = "clusters";
     private static final String SECRET_PLURAL = "secrets";
     private static final String CONFIGMAP_PLURAL = "configmaps";
-    public static final String ROUTES_DEP = "routes";
-    public static final Path MOUNTS_BASE_DIR = Path.of("/opt/kroxylicious/");
+    static final String ROUTES_DEP = "routes";
+    private static final Path MOUNTS_BASE_DIR = Path.of("/opt/kroxylicious/");
     private static final Path TARGET_CLUSTER_MOUNTS_BASE = MOUNTS_BASE_DIR.resolve("target-cluster");
     private static final Path CLIENT_CERTS_BASE_DIR = TARGET_CLUSTER_MOUNTS_BASE.resolve("client-certs");
     private static final Path CLIENT_TRUSTED_CERTS_BASE_DIR = TARGET_CLUSTER_MOUNTS_BASE.resolve("trusted-certs");

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconciler.java
@@ -105,6 +105,9 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.namespace;
 
+/**
+ * Reconciles KafkaProxy custom resources by generating proxy configuration, managing deployments, and updating status conditions.
+ */
 // @formatter:off
 @Workflow(dependents = {
         @Dependent(
@@ -164,12 +167,24 @@ public class KafkaProxyReconciler implements
     private final SecureConfigInterpolator secureConfigInterpolator;
     private final KafkaProxyStatusFactory statusFactory;
 
+    /**
+     * Constructs a reconciler for KafkaProxy resources.
+     *
+     * @param clock the clock used for condition timestamps
+     * @param secureConfigInterpolator the interpolator for resolving secure config template expressions
+     */
     public KafkaProxyReconciler(Clock clock, SecureConfigInterpolator secureConfigInterpolator) {
         this.statusFactory = new KafkaProxyStatusFactory(Objects.requireNonNull(clock));
         this.clock = clock;
         this.secureConfigInterpolator = secureConfigInterpolator;
     }
 
+    /**
+     * Creates a new status factory for KafkaProxy resources.
+     *
+     * @param clock the clock used for condition timestamps
+     * @return a new status factory instance
+     */
     public static StatusFactory<KafkaProxy> newStatusFactory(Clock clock) {
         return new KafkaProxyStatusFactory(clock);
     }
@@ -308,6 +323,12 @@ public class KafkaProxyReconciler implements
                 (virtualCluster, gateways) -> virtualCluster);
     }
 
+    /**
+     * Builds a virtual cluster gateway configuration fragment from the given networking model.
+     *
+     * @param gateway the cluster ingress networking model to build the gateway from
+     * @return a configuration fragment containing the virtual cluster gateway
+     */
     public static ConfigurationFragment<VirtualClusterGateway> buildVirtualClusterGateway(ClusterIngressNetworkingModel gateway) {
 
         var tlsConfigFragment = gateway.downstreamTls()
@@ -488,7 +509,7 @@ public class KafkaProxyReconciler implements
     }
 
     /**
-     * The happy path, where all the dependent resources expressed a desired
+     * The happy path, where all the dependent resources expressed a desired state.
      */
     @Override
     public UpdateControl<KafkaProxy> reconcile(KafkaProxy primary,

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyConfigDependentResource.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyConfigDependentResource.java
@@ -28,9 +28,12 @@ import static io.kroxylicious.kubernetes.operator.ResourcesUtil.namespace;
  */
 @KubernetesDependent(useSSA = BooleanWithUndefined.TRUE)
 public class ProxyConfigDependentResource extends CRUDKubernetesDependentResource<ConfigMap, KafkaProxy> {
+    /** Suffix appended to the KafkaProxy name to form the ConfigMap name. */
     public static final String PROXY_CONFIG_CONFIG_MAP_SUFFIX = "-proxy-config";
 
+    /** The key within the ConfigMap data used to store the proxy configuration YAML. */
     public static final String CONFIG_YAML_KEY = "proxy-config.yaml";
+    /** Condition reason used when the proxy configuration is invalid. */
     public static final String REASON_INVALID = "Invalid";
 
     /**

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyConfigReconcilePrecondition.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyConfigReconcilePrecondition.java
@@ -18,6 +18,13 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
  */
 public class ProxyConfigReconcilePrecondition implements Condition<ConfigMap, KafkaProxy> {
 
+    /**
+     * Constructs the precondition for proxy config reconciliation.
+     */
+    public ProxyConfigReconcilePrecondition() {
+        // explicit ctor needed for javadoc.
+    }
+
     @Override
     public boolean isMet(DependentResource<ConfigMap, KafkaProxy> dependentResource,
                          KafkaProxy primary,

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyConfigStateDependentResource.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyConfigStateDependentResource.java
@@ -38,8 +38,10 @@ import static io.kroxylicious.kubernetes.operator.ResourcesUtil.namespace;
 public class ProxyConfigStateDependentResource
         extends CRUDKubernetesDependentResource<ConfigMap, KafkaProxy> {
 
+    /** Suffix appended to the proxy name to form the config-state {@code ConfigMap} name. */
     public static final String CONFIG_STATE_CONFIG_MAP_SUFFIX = "-config-state";
 
+    /** Creates a new dependent resource for managing the proxy config-state {@code ConfigMap}. */
     public ProxyConfigStateDependentResource() {
         super(ConfigMap.class);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyDeploymentDependentResource.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyDeploymentDependentResource.java
@@ -62,16 +62,22 @@ public class ProxyDeploymentDependentResource
         extends CRUDKubernetesDependentResource<Deployment, KafkaProxy> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxyDeploymentDependentResource.class);
+    /** Name of the Kubernetes volume used to mount the proxy configuration into the container. */
     public static final String CONFIG_VOLUME = "config-volume";
+    /** Absolute path within the proxy container where the configuration file is mounted. */
     public static final String CONFIG_PATH_IN_CONTAINER = "/opt/kroxylicious/config/" + ProxyConfigDependentResource.CONFIG_YAML_KEY;
     private static final int MANAGEMENT_PORT = 9190;
     private static final String MANAGEMENT_PORT_NAME = "management";
+    /** Starting port number used when allocating per-broker proxy ports. */
     public static final int PROXY_PORT_START = 9292;
+    /** Port number used for the shared SNI listener that multiplexes TLS connections by hostname. */
     public static final int SHARED_SNI_PORT = 9291;
 
     private final String kroxyliciousImage = getOperandImage();
+    /** Environment variable name that, when set, overrides the default Kroxylicious operand container image. */
     public static final String KROXYLICIOUS_IMAGE_ENV_VAR = "KROXYLICIOUS_IMAGE";
 
+    /** Creates a new dependent resource for managing the proxy {@code Deployment}. */
     public ProxyDeploymentDependentResource() {
         super(Deployment.class);
     }
@@ -164,6 +170,12 @@ public class ProxyDeploymentDependentResource
         return podLabels(primary);
     }
 
+    /**
+     * Returns the labels applied to pods created by the proxy deployment.
+     *
+     * @param primary the {@code KafkaProxy} resource that owns the deployment
+     * @return a map of label key-value pairs for the proxy pods
+     */
     public static Map<String, String> podLabels(KafkaProxy primary) {
         return standardLabels(primary);
     }
@@ -284,6 +296,12 @@ public class ProxyDeploymentDependentResource
                 .orElse(null);
     }
 
+    /**
+     * Determines the Kroxylicious container image to use, preferring the {@link #KROXYLICIOUS_IMAGE_ENV_VAR}
+     * environment variable and falling back to a classpath properties file.
+     *
+     * @return the fully qualified container image reference for the Kroxylicious operand
+     */
     @VisibleForTesting
     public static String getOperandImage() {
         var envImage = System.getenv().get(KROXYLICIOUS_IMAGE_ENV_VAR);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/VirtualKafkaClusterSecondaryToKafkaProxyPrimaryMapper.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/VirtualKafkaClusterSecondaryToKafkaProxyPrimaryMapper.java
@@ -21,11 +21,18 @@ import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.findAllKnownPrimariesInNamespace;
 
+/**
+ * Maps VirtualKafkaCluster secondary resource events to their associated KafkaProxy primary resources for reconciliation.
+ */
 public class VirtualKafkaClusterSecondaryToKafkaProxyPrimaryMapper implements SecondaryToPrimaryMapper<VirtualKafkaCluster> {
     private static final Logger LOGGER = LoggerFactory.getLogger(VirtualKafkaClusterSecondaryToKafkaProxyPrimaryMapper.class);
 
     private final EventSourceContext<KafkaProxy> context;
 
+    /**
+     * Constructs the mapper with the given event source context.
+     * @param context the event source context for accessing known KafkaProxy primaries
+     */
     public VirtualKafkaClusterSecondaryToKafkaProxyPrimaryMapper(EventSourceContext<KafkaProxy> context) {
         this.context = context;
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/IsOpenshiftRouteSupportedActivationCondition.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/IsOpenshiftRouteSupportedActivationCondition.java
@@ -18,6 +18,14 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
  */
 public class IsOpenshiftRouteSupportedActivationCondition
         implements Condition<Route, KafkaProxy> {
+
+    /**
+     * Constructs the activation condition for OpenShift Route support.
+     */
+    public IsOpenshiftRouteSupportedActivationCondition() {
+        // explicit ctor needed for javadoc.
+    }
+
     @Override
     public boolean isMet(
                          DependentResource<Route, KafkaProxy> dependentResource,

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconciler.java
@@ -54,13 +54,25 @@ public class KafkaProxyIngressReconciler implements
         Reconciler<KafkaProxyIngress> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyIngressReconciler.class);
+    /** Event source name for the KafkaProxy informer. */
     public static final String PROXY_EVENT_SOURCE_NAME = "proxy";
     private final KafkaProxyIngressStatusFactory statusFactory;
 
+    /**
+     * Constructs a reconciler for KafkaProxyIngress resources.
+     *
+     * @param clock the clock used for condition timestamps
+     */
     public KafkaProxyIngressReconciler(Clock clock) {
         this.statusFactory = new KafkaProxyIngressStatusFactory(Objects.requireNonNull(clock));
     }
 
+    /**
+     * Creates a new status factory for KafkaProxyIngress resources.
+     *
+     * @param clock the clock used for condition timestamps
+     * @return a new status factory instance
+     */
     public static StatusFactory<KafkaProxyIngress> newStatusFactory(Clock clock) {
         return new KafkaProxyIngressStatusFactory(clock);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceReconciler.java
@@ -64,10 +64,15 @@ public final class KafkaServiceReconciler implements
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaServiceReconciler.class);
 
+    /** Event source name for TLS certificate Secret informer. */
     public static final String SECRETS_EVENT_SOURCE_NAME = "secrets";
+    /** Event source name for trust anchor ConfigMap informer. */
     public static final String CONFIG_MAPS_TRUST_ANCHOR_REF_EVENT_SOURCE_NAME = "configmapsTrustAnchorRef";
+    /** Event source name for Strimzi CA certificate Secret informer. */
     public static final String SECRETS_STRIMZI_TRUST_ANCHOR_REF_EVENT_SOURCE_NAME = "secretsStrimziTrustAnchorRef";
+    /** Event source name for trust anchor Secret informer. */
     public static final String SECRETS_TRUST_ANCHOR_REF_EVENT_SOURCE_NAME = "secretsTrustAnchorRef";
+    /** Event source name for Strimzi Kafka resource informer. */
     public static final String STRIMZI_KAFKA_EVENT_SOURCE_NAME = "kafkas";
 
     private static final String SPEC_REF = "spec.strimziKafkaRef";
@@ -77,11 +82,23 @@ public final class KafkaServiceReconciler implements
     private final KafkaServiceStatusFactory statusFactory;
     private final SharedInformerManager sharedInformerManager;
 
+    /**
+     * Constructs a reconciler for KafkaService resources.
+     *
+     * @param clock the clock used for condition timestamps
+     * @param sharedInformerManager the manager providing shared informers for Secret, ConfigMap, and Kafka resources
+     */
     public KafkaServiceReconciler(Clock clock, SharedInformerManager sharedInformerManager) {
         this.statusFactory = new KafkaServiceStatusFactory(clock);
         this.sharedInformerManager = sharedInformerManager;
     }
 
+    /**
+     * Creates a new status factory for KafkaService resources.
+     *
+     * @param clock the clock used for condition timestamps
+     * @return a new status factory instance
+     */
     public static StatusFactory<KafkaService> newStatusFactory(Clock clock) {
         return new KafkaServiceStatusFactory(clock);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconciler.java
@@ -97,6 +97,7 @@ public final class VirtualKafkaClusterReconciler implements
     static final String INGRESSES_EVENT_SOURCE_NAME = "ingresses";
     static final String FILTERS_EVENT_SOURCE_NAME = "filters";
     static final String SECRETS_EVENT_SOURCE_NAME = "secrets";
+    /** Event source name for ConfigMap-based trust anchor references. */
     public static final String CONFIG_MAPS_TRUST_ANCHOR_REF_EVENT_SOURCE_NAME = "configmapsTrustAnchorRef";
     static final String SECRET_TRUST_ANCHOR_REF_EVENT_SOURCE_NAME = "secretsTrustAnchorRef";
     static final String KUBERNETES_SERVICES_EVENT_SOURCE_NAME = "kubernetesServices";
@@ -109,12 +110,23 @@ public final class VirtualKafkaClusterReconciler implements
     private final DependencyResolver resolver;
     private final SharedInformerManager sharedInformerManager;
 
+    /**
+     * Constructs the reconciler with the given clock, dependency resolver, and shared informer manager.
+     * @param clock the clock used for status timestamps
+     * @param resolver the dependency resolver for custom resource references
+     * @param sharedInformerManager the shared informer manager for watch coordination
+     */
     public VirtualKafkaClusterReconciler(Clock clock, DependencyResolver resolver, SharedInformerManager sharedInformerManager) {
         this.statusFactory = new VirtualKafkaClusterStatusFactory(clock);
         this.resolver = resolver;
         this.sharedInformerManager = sharedInformerManager;
     }
 
+    /**
+     * Creates a new status factory for VirtualKafkaCluster resources.
+     * @param clock the clock used for status timestamps
+     * @return a new status factory
+     */
     public static StatusFactory<VirtualKafkaCluster> newStatusFactory(Clock clock) {
         return new VirtualKafkaClusterStatusFactory(clock);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ClusterResolutionResult.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ClusterResolutionResult.java
@@ -54,6 +54,7 @@ public record ClusterResolutionResult(VirtualKafkaCluster cluster,
     }
 
     /**
+     * Returns all references from this cluster that could not be resolved.
      * @return a stream of all dangling references
      */
     public Stream<DanglingReference> allDanglingReferences() {
@@ -62,6 +63,7 @@ public record ClusterResolutionResult(VirtualKafkaCluster cluster,
     }
 
     /**
+     * Returns all successfully resolved referents of this cluster, excluding the KafkaProxy to prevent cycles.
      * @return a stream of all resolved referents of this Cluster, note that KafkaProxy is not considered a Referent of VirtualKafkaCluster to prevent cycles
      */
     public Stream<HasMetadata> allResolvedReferents() {
@@ -85,14 +87,29 @@ public record ClusterResolutionResult(VirtualKafkaCluster cluster,
      * @param absentRef the ref that could not be found
      */
     public record DanglingReference(LocalRef<?> referrer, LocalRef<?> absentRef) {
+        /**
+         * Returns a predicate that matches dangling references with the given referrer kind.
+         * @param kind the kind to match
+         * @return a predicate matching on referrer kind
+         */
         public static Predicate<DanglingReference> hasReferrerKind(String kind) {
             return p -> Objects.equals(p.referrer.getKind(), kind);
         }
 
+        /**
+         * Returns a predicate that matches dangling references with the given referent kind.
+         * @param kind the kind to match
+         * @return a predicate matching on referent kind
+         */
         public static Predicate<DanglingReference> hasReferentKind(String kind) {
             return p -> Objects.equals(p.absentRef.getKind(), kind);
         }
 
+        /**
+         * Returns a predicate that matches dangling references with the given referrer.
+         * @param referrer the referrer to match
+         * @return a predicate matching on referrer
+         */
         public static Predicate<DanglingReference> hasReferrer(LocalRef<?> referrer) {
             return p -> p.referrer.equals(referrer);
         }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolver.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolver.java
@@ -47,11 +47,16 @@ import static io.kroxylicious.kubernetes.operator.ResourcesUtil.toLocalRef;
  */
 public class DependencyResolver {
 
+    /** An empty resolution result representing a proxy with no virtual clusters. */
     public static final ProxyResolutionResult EMPTY_RESOLUTION_RESULT = new ProxyResolutionResult(Set.of());
 
     private DependencyResolver() {
     }
 
+    /**
+     * Creates a new DependencyResolver instance.
+     * @return a new DependencyResolver
+     */
     public static DependencyResolver create() {
         return new DependencyResolver();
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ProxyResolutionResult.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ProxyResolutionResult.java
@@ -26,6 +26,11 @@ import static java.util.Comparator.comparing;
 public class ProxyResolutionResult {
     private final Set<ClusterResolutionResult> clusterResolutionResults;
 
+    /**
+     * Constructs a resolution result for a proxy from the per-cluster resolution results.
+     *
+     * @param clusterResolutionResults the set of per-cluster resolution results, must not be null
+     */
     public ProxyResolutionResult(Set<ClusterResolutionResult> clusterResolutionResults) {
         Objects.requireNonNull(clusterResolutionResults);
         this.clusterResolutionResults = clusterResolutionResults;
@@ -62,6 +67,11 @@ public class ProxyResolutionResult {
         return clusterResolutionResults;
     }
 
+    /**
+     * Checks whether all resolved referents and clusters have an up-to-date (fresh) status.
+     *
+     * @return true if every resolved referent and cluster has a fresh status, false otherwise
+     */
     public boolean allReferentsHaveFreshStatus() {
         return clusterResolutionResults.stream().allMatch(
                 clusterResolutionResult -> clusterResolutionResult.allResolvedReferents()
@@ -70,6 +80,11 @@ public class ProxyResolutionResult {
                                 clusterResolutionResult.cluster()));
     }
 
+    /**
+     * Returns all referents and clusters whose status is stale, represented as {@link LocalRef} instances.
+     *
+     * @return a stream of local references to resources with stale status
+     */
     // using wildcards intentionally
     @SuppressWarnings("java:S1452")
     public Stream<LocalRef<?>> allReferentsWithStaleStatus() {
@@ -84,6 +99,11 @@ public class ProxyResolutionResult {
         });
     }
 
+    /**
+     * Returns all per-cluster resolution results, ordered by the cluster's {@code metadata.name}.
+     *
+     * @return a stream of cluster resolution results sorted alphabetically by cluster name
+     */
     public Stream<ClusterResolutionResult> allResolutionResultsInClusterNameOrder() {
         return clusterResolutionResults.stream().sorted(comparing(r -> ResourcesUtil.name(r.cluster())));
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ResolutionResult.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ResolutionResult.java
@@ -21,6 +21,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * @param <T> the referent type
  * @param referrer the referring resource represented as a LocalRef
  * @param reference the reference we attempted to resolve
+ * @param referentNew the resolved referent resource, or null if the reference is dangling
  */
 public record ResolutionResult<T extends HasMetadata>(LocalRef<?> referrer, LocalRef<T> reference, @Nullable T referentNew) {
     /**
@@ -31,14 +32,32 @@ public record ResolutionResult<T extends HasMetadata>(LocalRef<?> referrer, Loca
         return referentNew == null;
     }
 
+    /**
+     * Returns the resolved referent resource, throwing if the reference is dangling.
+     *
+     * @return the resolved referent resource, never null
+     */
     public T referentResource() {
         return maybeReferentResource().orElseThrow(() -> new NullPointerException("Referent resource for " + reference + " is null"));
     }
 
+    /**
+     * Returns the resolved referent resource as an {@link Optional}, empty if the reference is dangling.
+     *
+     * @return an optional containing the referent resource, or empty if unresolved
+     */
     public Optional<T> maybeReferentResource() {
         return Optional.ofNullable(referentNew);
     }
 
+    /**
+     * Creates a successfully resolved result from the referring resource and the found referent.
+     *
+     * @param <T> the type of the referent resource
+     * @param referrer the resource that holds the reference
+     * @param referent the resource that was successfully resolved
+     * @return a new resolution result representing a successful resolution
+     */
     public static <T extends HasMetadata> ResolutionResult<T> resolved(HasMetadata referrer, T referent) {
         return new ResolutionResult<>(ResourcesUtil.toLocalRef(referrer), ResourcesUtil.toLocalRef(referent), referent);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/package-info.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/package-info.java
@@ -5,7 +5,7 @@
  */
 
 /**
- * Classes comprising the operator's configuration model.
+ * Dependency resolution for Kubernetes custom resource references.
  */
 @ReturnValuesAreNonnullByDefault
 @DefaultAnnotationForParameters(NonNull.class)


### PR DESCRIPTION
## Summary

- Reduce visibility of needlessly public classes, fields, and methods that are only used within their own package
- Add javadoc to all remaining public API members across the operator module (~50 files)
- Fix incorrect `package-info.java` descriptions (checksum and resolver packages)
- Fix broken HTML and truncated javadoc in existing documentation
- Remove the `javadoc.failOnWarnings=false` POM override so future warnings break the build

Fixes #4576

## Test plan

- [x] `mvn -pl kroxylicious-kubernetes/kroxylicious-operator javadoc:javadoc` passes with zero warnings
- [x] `mvn -pl kroxylicious-kubernetes/kroxylicious-operator test` — all 783 tests pass
- [ ] CI passes

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)