### PR TITLE
fix: remove javadoc warnings suppression and enhance exception handllng in AuthorizerException

### DIFF
--- a/kroxylicious-authorizer-api/pom.xml
+++ b/kroxylicious-authorizer-api/pom.xml
@@ -21,10 +21,6 @@
     <artifactId>kroxylicious-authorizer-api</artifactId>
     <name>Authorizer Plugin API</name>
 
-    <properties>
-        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.kroxylicious</groupId>

--- a/kroxylicious-authorizer-api/src/main/java/io/kroxylicious/authorizer/service/Action.java
+++ b/kroxylicious-authorizer-api/src/main/java/io/kroxylicious/authorizer/service/Action.java
@@ -17,11 +17,21 @@ public record Action(
                      ResourceType<?> operation,
                      String resourceName) {
 
+    /**
+     * Creates an action.
+     * @param operation The operation (and the resource type)
+     * @param resourceName The resource name
+     * @throws NullPointerException if the {@code operation} or {@code resourceName} is null
+     */
     public Action {
         Objects.requireNonNull(operation);
         Objects.requireNonNull(resourceName);
     }
 
+    /**
+     * The class of the {@linkplain #operation() operation}, which identifies the type of resource being acted upon.
+     * @return The class of the operation.
+     */
     @SuppressWarnings({ "rawtypes", "unchecked", "java:S1452" })
     public Class<? extends ResourceType<?>> resourceTypeClass() {
         return (Class) operation.getClass();

--- a/kroxylicious-authorizer-api/src/main/java/io/kroxylicious/authorizer/service/AuthorizerException.java
+++ b/kroxylicious-authorizer-api/src/main/java/io/kroxylicious/authorizer/service/AuthorizerException.java
@@ -10,10 +10,19 @@ package io.kroxylicious.authorizer.service;
  * An exception to be thrown if an {@link Authorizer} cannot be built, or is not able to make a decision.
  */
 public class AuthorizerException extends RuntimeException {
+    /**
+     * Creates an exception with the given detail message.
+     * @param message The detail message
+     */
     public AuthorizerException(String message) {
         super(message);
     }
 
+    /**
+     * Creates an exception with the given detail message and cause.
+     * @param message The detail message
+     * @param cause The cause
+     */
     public AuthorizerException(String message, Throwable cause) {
         super(message, cause);
     }


### PR DESCRIPTION


### Type of change

_Select the type of your PR_

- Documentation

### Description

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [X] PR references related GitHub issue(s) so they are closed on merging. Closes: #4540 
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
