### PR TITLE
fix(kroxylicious-kms): documentation in KMS-related classes

### DIFF
--- a/kroxylicious-kms/pom.xml
+++ b/kroxylicious-kms/pom.xml
@@ -23,10 +23,6 @@
     <description>An API for interacting with Key Management Systems (KMSes).</description>
     <packaging>jar</packaging>
 
-    <properties>
-        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.kroxylicious</groupId>

--- a/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/DestroyableRawSecretKey.java
+++ b/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/DestroyableRawSecretKey.java
@@ -29,8 +29,17 @@ public final class DestroyableRawSecretKey implements SecretKey {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DestroyableRawSecretKey.class);
 
+    /**
+     * The lower-cased name of the key algorithm.
+     */
     private final String algorithm;
+    /**
+     * Whether {@link #destroy()} has been called.
+     */
     private boolean destroyed = false;
+    /**
+     * The RAW-encoded key material, which is zeroed out when the key is {@linkplain #destroy() destroyed}.
+     */
     private final byte[] key;
 
     private DestroyableRawSecretKey(byte[] bytes, String algorithm) {
@@ -40,6 +49,7 @@ public final class DestroyableRawSecretKey implements SecretKey {
 
     /**
      * Returns the number of bits in this key.
+     * @return The number of bits in this key.
      */
     public int numKeyBits() {
         return key.length * Byte.SIZE;
@@ -121,6 +131,11 @@ public final class DestroyableRawSecretKey implements SecretKey {
         return key.clone();
     }
 
+    /**
+     * Checks that the given key has not been destroyed.
+     * @param key The key to check.
+     * @throws IllegalStateException if the key has been destroyed
+     */
     public static void checkNotDestroyed(SecretKey key) {
         if (key.isDestroyed()) {
             throw new IllegalStateException("Key has been destroyed");

--- a/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/KmsException.java
+++ b/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/KmsException.java
@@ -10,17 +10,33 @@ package io.kroxylicious.kms.service;
  * Represents problems interacting with a Key Management System.
  */
 public class KmsException extends RuntimeException {
+    /**
+     * Creates a new exception with no detail message.
+     */
     public KmsException() {
     }
 
+    /**
+     * Creates a new exception with the given cause.
+     * @param cause The cause.
+     */
     public KmsException(Throwable cause) {
         super(cause);
     }
 
+    /**
+     * Creates a new exception with the given message.
+     * @param message The detail message.
+     */
     public KmsException(String message) {
         super(message);
     }
 
+    /**
+     * Creates a new exception with the given message and cause.
+     * @param message The detail message.
+     * @param cause The cause.
+     */
     public KmsException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/UnknownAliasException.java
+++ b/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/UnknownAliasException.java
@@ -7,10 +7,14 @@
 package io.kroxylicious.kms.service;
 
 /**
- * Thrown when a client tries to resolve a key with an alias which is not know to the KMS.
+ * Thrown when a client tries to resolve a key with an alias which is not known to the KMS.
  */
 public class UnknownAliasException extends KmsException {
 
+    /**
+     * Creates a new exception for the given alias.
+     * @param alias The alias that could not be resolved.
+     */
     public UnknownAliasException(String alias) {
         super(alias);
     }

--- a/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/UnknownKeyException.java
+++ b/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/UnknownKeyException.java
@@ -10,10 +10,17 @@ package io.kroxylicious.kms.service;
  * Thrown when a KMS instance is passed reference to key that it does not manage.
  */
 public class UnknownKeyException extends KmsException {
+    /**
+     * Creates a new exception with no detail message.
+     */
     public UnknownKeyException() {
         super();
     }
 
+    /**
+     * Creates a new exception with the given message.
+     * @param message The detail message.
+     */
     public UnknownKeyException(String message) {
         super(message);
     }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

- Warnings removed: 12

### Additional Context

Before: **12 Javadoc warnings** in the module. Count after: **0**

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [X] PR references related GitHub issue(s) so they are closed on merging. Closes: #4545 
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
