### PR TITLE
feat(kroxylicious-simple-transform): enhance documentation and remove  javadoc warnings in transformation classes

### DIFF
--- a/kroxylicious-filters/kroxylicious-simple-transform/pom.xml
+++ b/kroxylicious-filters/kroxylicious-simple-transform/pom.xml
@@ -22,10 +22,6 @@
     <name>Simple filters</name>
     <description>Several simple filters that exist for test purposes.</description>
 
-    <properties>
-        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
-    </properties>
-
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/ByteBufferTransformation.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/ByteBufferTransformation.java
@@ -12,5 +12,12 @@ import java.nio.ByteBuffer;
  */
 @FunctionalInterface
 public interface ByteBufferTransformation {
+
+    /**
+     * Transforms the given buffer.
+     * @param topicName The name of the topic to which the record being transformed belongs.
+     * @param original The buffer to transform.
+     * @return The transformed buffer.
+     */
     ByteBuffer transform(String topicName, ByteBuffer original);
 }

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/ByteBufferTransformationFactory.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/ByteBufferTransformationFactory.java
@@ -8,6 +8,10 @@ package io.kroxylicious.filter.simpletransform;
 
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 
+/**
+ * A pluggable factory for {@link ByteBufferTransformation} instances.
+ * @param <C> The type of the configuration object.
+ */
 public interface ByteBufferTransformationFactory<C> {
 
     /**
@@ -17,6 +21,12 @@ public interface ByteBufferTransformationFactory<C> {
      */
     void validateConfiguration(C config) throws PluginConfigurationException;
 
+    /**
+     * Checks that the given configuration is non-null.
+     * @param config The configuration to check.
+     * @return The given configuration.
+     * @throws PluginConfigurationException If the given configuration is null.
+     */
     default C requireConfig(C config) {
         if (config == null) {
             throw new PluginConfigurationException(this.getClass().getSimpleName() + " requires configuration, but config object is null");
@@ -24,6 +34,11 @@ public interface ByteBufferTransformationFactory<C> {
         return config;
     }
 
+    /**
+     * Creates a transformation from the given configuration.
+     * @param configuration The configuration.
+     * @return The transformation.
+     */
     ByteBufferTransformation createTransformation(C configuration);
 
 }

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/FetchResponseTransformation.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/FetchResponseTransformation.java
@@ -30,6 +30,13 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 @DeprecatedPluginName(oldName = "io.kroxylicious.proxy.filter.simpletransform.FetchResponseTransformation", since = "0.19.0")
 public class FetchResponseTransformation implements FilterFactory<Config, Config> {
 
+    /**
+     * Creates a new factory.
+     */
+    public FetchResponseTransformation() {
+        // empty
+    }
+
     @Override
     public Config initialize(FilterFactoryContext context, @Nullable Config config) {
         return Plugins.requireConfig(this, config);
@@ -44,6 +51,11 @@ public class FetchResponseTransformation implements FilterFactory<Config, Config
         return new FetchResponseTransformationFilter(factory.createTransformation(configuration.transformationConfig()));
     }
 
+    /**
+     * The configuration for the {@link FetchResponseTransformation} filter factory.
+     * @param transformation The name of the {@link ByteBufferTransformationFactory} plugin implementation to use.
+     * @param transformationConfig The configuration for the transformation.
+     */
     public record Config(@JsonProperty(required = true) @PluginImplName(ByteBufferTransformationFactory.class) String transformation,
                          @PluginImplConfig(implNameProperty = "transformation") Object transformationConfig) {
 

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/ProduceRequestTransformation.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/ProduceRequestTransformation.java
@@ -29,9 +29,22 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 @DeprecatedPluginName(oldName = "io.kroxylicious.proxy.filter.simpletransform.ProduceRequestTransformation", since = "0.19.0")
 public class ProduceRequestTransformation
         implements FilterFactory<Config, Config> {
+
+    /**
+     * The configuration for the {@link ProduceRequestTransformation} filter factory.
+     * @param transformation The name of the {@link ByteBufferTransformationFactory} plugin implementation to use.
+     * @param transformationConfig The configuration for the transformation.
+     */
     public record Config(
                          @PluginImplName(ByteBufferTransformationFactory.class) @JsonProperty(required = true) String transformation,
                          @PluginImplConfig(implNameProperty = "transformation") Object transformationConfig) {}
+
+    /**
+     * Creates a new factory.
+     */
+    public ProduceRequestTransformation() {
+        // empty
+    }
 
     @Override
     @SuppressWarnings({ "rawtypes", "unchecked", "java:S2638" })

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/Replacing.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/Replacing.java
@@ -24,14 +24,40 @@ import io.kroxylicious.proxy.plugin.DeprecatedPluginName;
 import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 
+/**
+ * A {@link ByteBufferTransformationFactory} for a transformation which replaces
+ * matches of a regular expression with a fixed replacement value.
+ */
 @Plugin(configType = Replacing.Config.class)
 @DeprecatedPluginName(oldName = "io.kroxylicious.proxy.filter.simpletransform.Replacing", since = "0.19.0")
 public class Replacing implements ByteBufferTransformationFactory<Replacing.Config> {
+
+    /**
+     * Creates a new factory.
+     */
+    public Replacing() {
+        // empty
+    }
+
+    /**
+     * The configuration for the {@link Replacing} transformation.
+     * @param charset The name of the charset used to decode and re-encode the buffer. Defaults to UTF-8.
+     * @param targetPattern The regular expression whose matches are replaced.
+     * @param replacementValue The replacement value. Mutually exclusive with {@code pathToReplacementValue}.
+     * @param pathToReplacementValue The path of a file containing the replacement value. Mutually exclusive with {@code replacementValue}.
+     */
     public record Config(
                          @JsonProperty String charset,
                          @JsonProperty(required = true) String targetPattern,
                          @JsonProperty String replacementValue,
                          @JsonProperty Path pathToReplacementValue) {
+        /**
+         * Creates a new configuration.
+         * @param charset The name of the charset used to decode and re-encode the buffer. Defaults to UTF-8 when null.
+         * @param targetPattern The regular expression whose matches are replaced.
+         * @param replacementValue The replacement value. Mutually exclusive with {@code pathToReplacementValue}.
+         * @param pathToReplacementValue The path of a file containing the replacement value. Mutually exclusive with {@code replacementValue}.
+         */
         public Config(@JsonProperty String charset, @JsonProperty(required = true) String targetPattern, @JsonProperty String replacementValue,
                       @JsonProperty Path pathToReplacementValue) {
             this.charset = Optional.ofNullable(charset).orElse(StandardCharsets.UTF_8.name());
@@ -66,6 +92,9 @@ public class Replacing implements ByteBufferTransformationFactory<Replacing.Conf
         return new Transformation(configuration);
     }
 
+    /**
+     * A {@link ByteBufferTransformation} which replaces matches of a regular expression with a replacement value.
+     */
     public static class Transformation implements ByteBufferTransformation {
 
         private final Charset charset;

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/UpperCasing.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/UpperCasing.java
@@ -15,9 +15,25 @@ import io.kroxylicious.proxy.plugin.DeprecatedPluginName;
 import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 
+/**
+ * A {@link ByteBufferTransformationFactory} for a transformation which converts
+ * the buffer, decoded using a configured charset, to upper case.
+ */
 @Plugin(configType = UpperCasing.Config.class)
 @DeprecatedPluginName(oldName = "io.kroxylicious.proxy.filter.simpletransform.UpperCasing", since = "0.19.0")
 public class UpperCasing implements ByteBufferTransformationFactory<UpperCasing.Config> {
+
+    /**
+     * Creates a new factory.
+     */
+    public UpperCasing() {
+        // empty
+    }
+
+    /**
+     * The configuration for the {@link UpperCasing} transformation.
+     * @param charset The name of the charset used to decode and re-encode the buffer.
+     */
     public record Config(String charset) {}
 
     @Override

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/package-info.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/package-info.java
@@ -4,6 +4,10 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+/**
+ * Simple filters which transform the keys and values of produce requests and fetch responses,
+ * using a pluggable {@link io.kroxylicious.filter.simpletransform.ByteBufferTransformation}.
+ */
 @ReturnValuesAreNonnullByDefault
 @DefaultAnnotationForParameters(NonNull.class)
 @DefaultAnnotation(NonNull.class)


### PR DESCRIPTION

### Type of change

_Select the type of your PR_
- Documentation

### Description

Eliminated 19 Warnings

### Additional Context

_Why are you making this pull request?_

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging. Closes: #4556 
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
