### PR TITLE
fix(routing): nodeForId and virtualNode preserve virtual broker ID

### DIFF
--- a/changelog/unreleased/04465-add-oci-annotations.yml
+++ b/changelog/unreleased/04465-add-oci-annotations.yml
@@ -1,6 +1,3 @@
-# This file is used by logchange tool to generate CHANGELOG.md 🌳 🪓 => 🪵 
-# Visit https://github.com/logchange/logchange and leave a star 🌟 
-# More info about configuration you can find https://github.com/logchange/logchange#yaml-format ⬅️⬅ ️
 title: Adding OCI annotations to the published images
 merge_requests:
   - 4465

--- a/changelog/unreleased/04600-routing-node-id-fix.yml
+++ b/changelog/unreleased/04600-routing-node-id-fix.yml
@@ -1,0 +1,10 @@
+# This file is used by logchange tool to generate CHANGELOG.md 🌳 🪓 => 🪵 
+# Visit https://github.com/logchange/logchange and leave a star 🌟 
+# More info about configuration you can find https://github.com/logchange/logchange#yaml-format ⬅️⬅ ️
+title: "fix(routing): nodeForId and virtualNode preserve virtual broker ID"
+merge_requests:
+  - 4600
+issues:
+  - 4595
+type: fixed
+

--- a/changelog/unreleased/04600-routing-node-id-fix.yml
+++ b/changelog/unreleased/04600-routing-node-id-fix.yml
@@ -1,6 +1,3 @@
-# This file is used by logchange tool to generate CHANGELOG.md 🌳 🪓 => 🪵 
-# Visit https://github.com/logchange/logchange and leave a star 🌟 
-# More info about configuration you can find https://github.com/logchange/logchange#yaml-format ⬅️⬅ ️
 title: "fix(routing): nodeForId and virtualNode preserve virtual broker ID"
 merge_requests:
   - 4600

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingContextContractIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingContextContractIT.java
@@ -411,8 +411,10 @@ class RoutingContextContractIT {
 
     @Test
     void nodeForIdWithBijectiveMappingRoutesToCorrectUpstream() {
-        // Two routes → BijectiveNodeIdMapping: route-a id=0, route-b id=1.
-        // Physical node 0 in route-b = virtual node 1. nodeForId(1) must reach route-b's broker.
+        // With two routes, BijectiveNodeIdMapping assigns virtual IDs across both target clusters.
+        // route-a's physical node 0 becomes virtual node 0; route-b's physical node 0 becomes virtual node 1.
+        // Each target cluster advertises its own physical node 0 in METADATA responses, but the virtual IDs differ.
+        // nodeForId(1) must resolve to route-b's target node (physical 0, virtual 1), not route-a's.
         try (var mockA = MockServer.startOnRandomPort();
                 var mockB = MockServer.startOnRandomPort()) {
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingContextContractIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingContextContractIT.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.message.MetadataRequestData;
 import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseBroker;
 import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
@@ -406,6 +407,150 @@ class RoutingContextContractIT {
             // Then: the router's onRequest was invoked and chose respondWithoutReply
             assertThat(produceHandled).succeedsWithin(Duration.ofSeconds(10));
         }
+    }
+
+    @Test
+    void nodeForIdWithBijectiveMappingRoutesToCorrectUpstream() {
+        // Two routes → BijectiveNodeIdMapping: route-a id=0, route-b id=1.
+        // Physical node 0 in route-b = virtual node 1. nodeForId(1) must reach route-b's broker.
+        try (var mockA = MockServer.startOnRandomPort();
+                var mockB = MockServer.startOnRandomPort()) {
+
+            // Given
+            var mdA = new MetadataResponseData();
+            mdA.brokers().add(new MetadataResponseBroker().setNodeId(0).setHost("localhost").setPort(mockA.port()));
+            mockA.addMockResponseForApiKey(new ResponsePayload(ApiKeys.METADATA, (short) 12, mdA));
+            mockA.addMockResponseForApiKey(new ResponsePayload(ApiKeys.LIST_GROUPS, (short) 3, new ListGroupsResponseData()));
+
+            var mdB = new MetadataResponseData();
+            mdB.brokers().add(new MetadataResponseBroker().setNodeId(0).setHost("localhost").setPort(mockB.port()));
+            mockB.addMockResponseForApiKey(new ResponsePayload(ApiKeys.METADATA, (short) 12, mdB));
+            mockB.addMockResponseForApiKey(new ResponsePayload(ApiKeys.LIST_GROUPS, (short) 3, new ListGroupsResponseData()));
+
+            var metadataHeader = new RequestHeaderData()
+                    .setRequestApiKey(ApiKeys.METADATA.id)
+                    .setRequestApiVersion((short) 12);
+
+            // Internal METADATA to each route populates routerNodeAddresses before nodeForId(1) resolves.
+            ContextCapturingRouterFactory.currentAction
+                    .set((apiKey, apiVersion, header, request, ctx) -> ctx.sendRequest(ctx.anyNode("route-a"), metadataHeader, new MetadataRequestData())
+                            .thenCompose(ignored -> ctx.sendRequest(ctx.anyNode("route-b"), metadataHeader, new MetadataRequestData()))
+                            .thenCompose(ignored -> {
+                                var node = ctx.nodeForId(1);
+                                return ctx.sendRequest(node, header, request)
+                                        .thenCompose(body -> ctx.respondWith(body).completed());
+                            }));
+
+            try (var tester = KroxyliciousTesters.newBuilder(bijectiveConfig(mockA, mockB))
+                    .setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
+                    var client = tester.simpleTestClient()) {
+
+                // When
+                var response = client.getSync(new Request(ApiKeys.LIST_GROUPS, (short) 3, "client", new ListGroupsRequestData()));
+
+                // Then
+                assertThat(response.payload().message()).isInstanceOf(ListGroupsResponseData.class);
+                assertThat(mockB.getReceivedRequests())
+                        .extracting(Request::apiKeys)
+                        .contains(ApiKeys.LIST_GROUPS);
+                assertThat(mockA.getReceivedRequests())
+                        .filteredOn(r -> r.apiKeys() == ApiKeys.LIST_GROUPS)
+                        .isEmpty();
+            }
+        }
+    }
+
+    @Test
+    void virtualNodeWithBijectiveMappingRoutesToCorrectUpstream() {
+        // Two routes → BijectiveNodeIdMapping: route-a id=0 = virtual 0 (port 9193), route-b id=1 = virtual 1 (port 9194).
+        // Bootstrap merges METADATA from both routes so BrokerAddressFilter reconciles both node-port bindings,
+        // preventing EagerMetadataLearner from firing when the test connects to 9193 and 9194.
+        // duplicate() required: brokers returned by bodyB already belong to its ImplicitLinkedHashCollection.
+        try (var mockA = MockServer.startOnRandomPort();
+                var mockB = MockServer.startOnRandomPort()) {
+
+            // Given
+            var mdA = new MetadataResponseData();
+            mdA.brokers().add(new MetadataResponseBroker().setNodeId(0).setHost("localhost").setPort(mockA.port()));
+            mockA.addMockResponseForApiKey(new ResponsePayload(ApiKeys.METADATA, (short) 12, mdA));
+
+            var mdB = new MetadataResponseData();
+            mdB.brokers().add(new MetadataResponseBroker().setNodeId(0).setHost("localhost").setPort(mockB.port()));
+            mockB.addMockResponseForApiKey(new ResponsePayload(ApiKeys.METADATA, (short) 12, mdB));
+
+            var metadataHeader = new RequestHeaderData()
+                    .setRequestApiKey(ApiKeys.METADATA.id)
+                    .setRequestApiVersion((short) 12);
+
+            ContextCapturingRouterFactory.currentAction.set((apiKey, apiVersion, header, request, ctx) -> {
+                var vn = ctx.virtualNode();
+                if (vn.isEmpty()) {
+                    return ctx.sendRequest(ctx.anyNode("route-a"), header, request)
+                            .thenCompose(bodyA -> ctx.sendRequest(ctx.anyNode("route-b"), metadataHeader, new MetadataRequestData())
+                                    .thenCompose(bodyB -> {
+                                        ((MetadataResponseData) bodyB).brokers()
+                                                .forEach(b -> ((MetadataResponseData) bodyA).brokers().add(b.duplicate()));
+                                        return ctx.respondWith(bodyA).completed();
+                                    }));
+                }
+                return ctx.sendRequest(vn.get(), header, request)
+                        .thenCompose(body -> ctx.respondWith(body).completed());
+            });
+
+            try (var tester = KroxyliciousTesters.newBuilder(bijectiveConfig(mockA, mockB))
+                    .setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester()) {
+
+                primeProxyWithBrokerAddresses(tester);
+                mockA.clear();
+                mockB.clear();
+                // Two responses on mockA: guards against both requests landing there if the bug regresses.
+                mockA.addMockResponseForApiKey(new ResponsePayload(ApiKeys.LIST_GROUPS, (short) 3, new ListGroupsResponseData()));
+                mockA.addMockResponseForApiKey(new ResponsePayload(ApiKeys.LIST_GROUPS, (short) 3, new ListGroupsResponseData()));
+                mockB.addMockResponseForApiKey(new ResponsePayload(ApiKeys.LIST_GROUPS, (short) 3, new ListGroupsResponseData()));
+
+                // When
+                try (var nodeZero = tester.simpleTestClient("localhost:9193", false)) {
+                    nodeZero.getSync(new Request(ApiKeys.LIST_GROUPS, (short) 3, "client", new ListGroupsRequestData()));
+                }
+                try (var nodeOne = tester.simpleTestClient("localhost:9194", false)) {
+                    nodeOne.getSync(new Request(ApiKeys.LIST_GROUPS, (short) 3, "client", new ListGroupsRequestData()));
+                }
+
+                // Then
+                assertThat(mockA.getReceivedRequests())
+                        .extracting(Request::apiKeys)
+                        .containsExactly(ApiKeys.LIST_GROUPS);
+                assertThat(mockB.getReceivedRequests())
+                        .extracting(Request::apiKeys)
+                        .containsExactly(ApiKeys.LIST_GROUPS);
+            }
+        }
+    }
+
+    private ConfigurationBuilder bijectiveConfig(MockServer mockA, MockServer mockB) {
+        var clusterA = new ClusterDefinition("cluster-a", "localhost:" + mockA.port(), null);
+        var clusterB = new ClusterDefinition("cluster-b", "localhost:" + mockB.port(), null);
+        var routeA = new RouteDefinition("route-a", 0, List.of(), new RouteTarget("cluster-a", null));
+        var routeB = new RouteDefinition("route-b", 1, List.of(), new RouteTarget("cluster-b", null));
+        var routerDef = new RouterDefinition(ROUTER,
+                ContextCapturingRouterFactory.class.getName(),
+                new ContextCapturingRouterFactory.Config("route-a"),
+                List.of(routeA, routeB));
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, ROUTER))
+                .addToGateways(defaultGatewayBuilder()
+                        .withNewPortIdentifiesNode()
+                        .withBootstrapAddress(HostPort.parse(BOOTSTRAP))
+                        .withNodeIdRanges(new NamedRange("nodes", 0, 1))
+                        .endPortIdentifiesNode()
+                        .build())
+                .build();
+        return baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterA)
+                .addToClusterDefinitions(clusterB)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
     }
 
     private static void primeProxyWithBrokerAddresses(KroxyliciousTester tester) {

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingContextContractIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingContextContractIT.java
@@ -42,6 +42,7 @@ import io.kroxylicious.proxy.config.RouterDefinition;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.internal.config.Feature;
 import io.kroxylicious.proxy.internal.config.Features;
+import io.kroxylicious.proxy.router.RouterContext;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.topology.VirtualNode;
 import io.kroxylicious.testing.integration.Request;
@@ -409,12 +410,22 @@ class RoutingContextContractIT {
         }
     }
 
+    /**
+     * Checks that a Router can send a request to {@link RouterContext#nodeForId(int)}} in a multi-upstream configuration like:
+     * <pre>
+     * mapping: BijectiveNodeIdMapping
+     * routes:
+     *   route-a:
+     *     upstream: { nodeId: 0, port: mockA }
+     *     virtualId: 0
+     *   route-b:
+     *     upstream: { nodeId: 0, port: mockB }
+     *     virtualId: 1
+     * </pre>
+     * With the expectation that the request will be forwarded on to the expected virtual node.
+     */
     @Test
     void nodeForIdWithBijectiveMappingRoutesToCorrectUpstream() {
-        // With two routes, BijectiveNodeIdMapping assigns virtual IDs across both target clusters.
-        // route-a's physical node 0 becomes virtual node 0; route-b's physical node 0 becomes virtual node 1.
-        // Each target cluster advertises its own physical node 0 in METADATA responses, but the virtual IDs differ.
-        // nodeForId(1) must resolve to route-b's target node (physical 0, virtual 1), not route-a's.
         try (var mockA = MockServer.startOnRandomPort();
                 var mockB = MockServer.startOnRandomPort()) {
 
@@ -462,12 +473,22 @@ class RoutingContextContractIT {
         }
     }
 
+    /**
+     * Checks that a Router can send a request to {@link RouterContext#virtualNode()} in a multi-upstream configuration like:
+     * <pre>
+     * mapping: BijectiveNodeIdMapping
+     * routes:
+     *   route-a:
+     *     upstream: { nodeId: 0, port: mockA }
+     *     virtualId: 0
+     *   route-b:
+     *     upstream: { nodeId: 0, port: mockB }
+     *     virtualId: 1
+     * </pre>
+     * With the expectation that the request will be forwarded on to the virtual node associated with the client's connection.
+     */
     @Test
     void virtualNodeWithBijectiveMappingRoutesToCorrectUpstream() {
-        // Two routes → BijectiveNodeIdMapping: route-a id=0 = virtual 0 (port 9193), route-b id=1 = virtual 1 (port 9194).
-        // Bootstrap merges METADATA from both routes so BrokerAddressFilter reconciles both node-port bindings,
-        // preventing EagerMetadataLearner from firing when the test connects to 9193 and 9194.
-        // duplicate() required: brokers returned by bodyB already belong to its ImplicitLinkedHashCollection.
         try (var mockA = MockServer.startOnRandomPort();
                 var mockB = MockServer.startOnRandomPort()) {
 
@@ -501,12 +522,12 @@ class RoutingContextContractIT {
 
             try (var tester = KroxyliciousTesters.newBuilder(bijectiveConfig(mockA, mockB))
                     .setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester()) {
-
+                // Given
+                // Pre-condition: Bootstrap merges METADATA from both routes so BrokerAddressFilter reconciles both node-port bindings.
+                // This prevents EagerMetadataLearner from firing when the test connects to 9193 and 9194.
                 primeProxyWithBrokerAddresses(tester);
                 mockA.clear();
                 mockB.clear();
-                // Two responses on mockA: guards against both requests landing there if the bug regresses.
-                mockA.addMockResponseForApiKey(new ResponsePayload(ApiKeys.LIST_GROUPS, (short) 3, new ListGroupsResponseData()));
                 mockA.addMockResponseForApiKey(new ResponsePayload(ApiKeys.LIST_GROUPS, (short) 3, new ListGroupsResponseData()));
                 mockB.addMockResponseForApiKey(new ResponsePayload(ApiKeys.LIST_GROUPS, (short) 3, new ListGroupsResponseData()));
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterContextImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterContextImpl.java
@@ -53,7 +53,7 @@ class RouterContextImpl implements RouterContext {
             return Optional.empty();
         }
         NodeIdMapping.RouteAndNode ran = handler.nodeIdMapping.fromVirtual(endpointVirtualNodeId);
-        return Optional.of(new VirtualNodeImpl(ran.route(), ran.targetNodeId()));
+        return Optional.of(new VirtualNodeImpl(ran.route(), endpointVirtualNodeId));
     }
 
     /**
@@ -74,7 +74,7 @@ class RouterContextImpl implements RouterContext {
     @Override
     public VirtualNode nodeForId(int virtualNodeId) {
         NodeIdMapping.RouteAndNode ran = handler.nodeIdMapping.fromVirtual(virtualNodeId);
-        return new VirtualNodeImpl(ran.route(), ran.targetNodeId());
+        return new VirtualNodeImpl(ran.route(), virtualNodeId);
     }
 
     @Override

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterContextImplTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterContextImplTest.java
@@ -70,6 +70,15 @@ class RouterContextImplTest {
                 endpointVirtualNodeId);
     }
 
+    private RouterContextImpl createBijectiveContext(Integer endpointVirtualNodeId) {
+        var bijectiveRoutes = Map.of(
+                "route-a", new RouteDescriptor("route-a", 0, new TargetCluster("localhost:9092", Optional.empty()), null, List.of()),
+                "route-b", new RouteDescriptor("route-b", 1, new TargetCluster("localhost:9093", Optional.empty()), null, List.of()));
+        var bijectiveMapping = new BijectiveNodeIdMapping(Map.of("route-a", 0, "route-b", 1), 2);
+        var handler = new RouterDispatchHandler(router, bijectiveRoutes, Map.of(), ccsm, "test-cluster", bijectiveMapping, null);
+        return new RouterContextImpl(clientFrame, handler, "test-session", Subject.anonymous(), endpointVirtualNodeId);
+    }
+
     @Test
     void anyNodeShouldReturnVirtualNodeForKnownRoute() {
         // Given
@@ -134,16 +143,10 @@ class RouterContextImplTest {
 
     @Test
     void nodeForIdPreservesVirtualIdWithBijectiveMapping() {
-        // BijectiveNodeIdMapping: route-b id=1, totalRoutes=2.
-        // fromVirtual(1) → RouteAndNode("route-b", physicalNode=0). VirtualNode must retain virtual ID 1, not 0.
-        var bijectiveRoutes = Map.of(
-                "route-a", new RouteDescriptor("route-a", 0, new TargetCluster("localhost:9092", Optional.empty()), null, List.of()),
-                "route-b", new RouteDescriptor("route-b", 1, new TargetCluster("localhost:9093", Optional.empty()), null, List.of()));
-        var bijectiveMapping = new BijectiveNodeIdMapping(Map.of("route-a", 0, "route-b", 1), 2);
-        var handler = new RouterDispatchHandler(router, bijectiveRoutes, Map.of(), ccsm, "test-cluster", bijectiveMapping, null);
-        var ctx = new RouterContextImpl(clientFrame, handler, "test-session", Subject.anonymous(), null);
+        // Given
+        var ctx = createBijectiveContext(null);
 
-        // When
+        // When: fromVirtual(1) → RouteAndNode("route-b", physicalNode=0); virtual ID must be retained as 1, not 0
         var node = ctx.nodeForId(1);
 
         // Then
@@ -153,19 +156,13 @@ class RouterContextImplTest {
 
     @Test
     void virtualNodePreservesVirtualIdWithBijectiveMapping() {
-        // BijectiveNodeIdMapping: route-b id=1, totalRoutes=2.
-        // fromVirtual(1) → RouteAndNode("route-b", physicalNode=0). VirtualNode must retain virtual ID 1, not 0.
-        var bijectiveRoutes = Map.of(
-                "route-a", new RouteDescriptor("route-a", 0, new TargetCluster("localhost:9092", Optional.empty()), null, List.of()),
-                "route-b", new RouteDescriptor("route-b", 1, new TargetCluster("localhost:9093", Optional.empty()), null, List.of()));
-        var bijectiveMapping = new BijectiveNodeIdMapping(Map.of("route-a", 0, "route-b", 1), 2);
-        var handler = new RouterDispatchHandler(router, bijectiveRoutes, Map.of(), ccsm, "test-cluster", bijectiveMapping, null);
-        var ctx = new RouterContextImpl(clientFrame, handler, "test-session", Subject.anonymous(), 1);
+        // Given: endpoint virtual node ID 1 → route-b, physical node 0
+        var ctx = createBijectiveContext(1);
 
         // When
         var vn = ctx.virtualNode();
 
-        // Then
+        // Then: virtual ID must be retained as 1, not the physical node ID 0
         assertThat(vn).isPresent();
         assertThat(((VirtualNodeImpl) vn.get()).route()).isEqualTo("route-b");
         assertThat(((VirtualNodeImpl) vn.get()).virtualNodeId()).isEqualTo(1);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterContextImplTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterContextImplTest.java
@@ -133,6 +133,45 @@ class RouterContextImplTest {
     }
 
     @Test
+    void nodeForIdPreservesVirtualIdWithBijectiveMapping() {
+        // BijectiveNodeIdMapping: route-b id=1, totalRoutes=2.
+        // fromVirtual(1) → RouteAndNode("route-b", physicalNode=0). VirtualNode must retain virtual ID 1, not 0.
+        var bijectiveRoutes = Map.of(
+                "route-a", new RouteDescriptor("route-a", 0, new TargetCluster("localhost:9092", Optional.empty()), null, List.of()),
+                "route-b", new RouteDescriptor("route-b", 1, new TargetCluster("localhost:9093", Optional.empty()), null, List.of()));
+        var bijectiveMapping = new BijectiveNodeIdMapping(Map.of("route-a", 0, "route-b", 1), 2);
+        var handler = new RouterDispatchHandler(router, bijectiveRoutes, Map.of(), ccsm, "test-cluster", bijectiveMapping, null);
+        var ctx = new RouterContextImpl(clientFrame, handler, "test-session", Subject.anonymous(), null);
+
+        // When
+        var node = ctx.nodeForId(1);
+
+        // Then
+        assertThat(((VirtualNodeImpl) node).route()).isEqualTo("route-b");
+        assertThat(((VirtualNodeImpl) node).virtualNodeId()).isEqualTo(1);
+    }
+
+    @Test
+    void virtualNodePreservesVirtualIdWithBijectiveMapping() {
+        // BijectiveNodeIdMapping: route-b id=1, totalRoutes=2.
+        // fromVirtual(1) → RouteAndNode("route-b", physicalNode=0). VirtualNode must retain virtual ID 1, not 0.
+        var bijectiveRoutes = Map.of(
+                "route-a", new RouteDescriptor("route-a", 0, new TargetCluster("localhost:9092", Optional.empty()), null, List.of()),
+                "route-b", new RouteDescriptor("route-b", 1, new TargetCluster("localhost:9093", Optional.empty()), null, List.of()));
+        var bijectiveMapping = new BijectiveNodeIdMapping(Map.of("route-a", 0, "route-b", 1), 2);
+        var handler = new RouterDispatchHandler(router, bijectiveRoutes, Map.of(), ccsm, "test-cluster", bijectiveMapping, null);
+        var ctx = new RouterContextImpl(clientFrame, handler, "test-session", Subject.anonymous(), 1);
+
+        // When
+        var vn = ctx.virtualNode();
+
+        // Then
+        assertThat(vn).isPresent();
+        assertThat(((VirtualNodeImpl) vn.get()).route()).isEqualTo("route-b");
+        assertThat(((VirtualNodeImpl) vn.get()).virtualNodeId()).isEqualTo(1);
+    }
+
+    @Test
     void respondWithBodyShouldBuildRespondWithResult() {
         // Given
         var ctx = createContext();


### PR DESCRIPTION
## Problem

`RouterContextImpl.nodeForId()` and `virtualNode()` stored the physical broker ID (`RouteAndNode.targetNodeId()`) in `VirtualNodeImpl` instead of the original virtual ID. With `BijectiveNodeIdMapping` (used whenever there are two or more routes), physical and virtual IDs diverge, so `forwardToNode()` resolved the wrong upstream address and routed requests to the wrong cluster.

For example, with two routes and `nodeForId(1)`: `fromVirtual(1)` returns `RouteAndNode("route-b", physicalNode=0)`. Storing `0` as the virtual node ID caused the address resolver to find cluster A's broker rather than cluster B's.

## Fix

Both methods now pass the original virtual ID to `VirtualNodeImpl` rather than `ran.targetNodeId()`. The route is still derived from the mapping; only the ID stored for subsequent address resolution changes.

## Test plan

- Two new unit tests in `RouterContextImplTest` use `BijectiveNodeIdMapping` directly to assert that `nodeForId(1)` and `virtualNode()` both return virtual ID `1`, not physical ID `0`.
- New IT `nodeForIdWithBijectiveMappingRoutesToCorrectUpstream` in `RoutingContextContractIT` primes both routes' node addresses then calls `nodeForId(1)`, asserting the request reaches cluster B (not cluster A).

Fixes: #4595