### PR TITLE
docs(dev-guide): document SNAPSHOT artifact consumption

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -122,6 +122,10 @@ mvn org.commonjava.maven.plugins:directory-maven-plugin:highest-basedir@resolve-
 Every push to `main` and `release/*` branches publishes SNAPSHOT artifacts to the [Central Portal snapshot repository](https://central.sonatype.com/repository/maven-snapshots/).
 This lets you test against unreleased changes without building Kroxylicious from source.
 
+> **Warning:** SNAPSHOT artifacts carry no compatibility guarantees.
+> Unreleased APIs may change or be removed between snapshots without notice.
+> Do not use SNAPSHOTs in production.
+
 To pull SNAPSHOT Kroxylicious dependencies into a Maven project, add the snapshot repository to your `pom.xml`:
 
 ```xml

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -96,6 +96,50 @@ Run the following to add missing license headers e.g. when adding new source fil
 mvn org.commonjava.maven.plugins:directory-maven-plugin:highest-basedir@resolve-rootdir license:format
 ```
 
+### Using SNAPSHOT Artifacts
+
+Every push to `main` and `release/*` branches publishes SNAPSHOT artifacts to the [Central Portal snapshot repository](https://central.sonatype.com/repository/maven-snapshots/).
+This lets you test against unreleased changes without building Kroxylicious from source.
+
+To pull SNAPSHOT Kroxylicious dependencies into a Maven project, add the snapshot repository to your `pom.xml`:
+
+```xml
+<repositories>
+  <repository>
+    <id>central-snapshots</id>
+    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    <snapshots>
+      <enabled>true</enabled>
+    </snapshots>
+  </repository>
+</repositories>
+```
+
+For Gradle (Kotlin DSL):
+
+```kotlin
+repositories {
+    maven {
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+        mavenContent {
+            snapshotsOnly()
+        }
+    }
+}
+```
+
+Then depend on the SNAPSHOT version of any Kroxylicious artifact, for example:
+
+```xml
+<dependency>
+  <groupId>io.kroxylicious</groupId>
+  <artifactId>kroxylicious-api</artifactId>
+  <version><!-- e.g. 0.24.0-SNAPSHOT --></version>
+</dependency>
+```
+
+The current SNAPSHOT version is the `version` field in the root `pom.xml` of this repository.
+
 ### Formatting the Code
 No one likes to argue about code formatting in pull requests, as project we take the stance that if we can't automate the formatting we are not going to argue about it either. Having said that we don't want a mishmash of conflicting styles! So we attack this from multiple angles.
 

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -117,6 +117,50 @@ Run the following to add missing license headers e.g. when adding new source fil
 mvn org.commonjava.maven.plugins:directory-maven-plugin:highest-basedir@resolve-rootdir license:format
 ```
 
+### Using SNAPSHOT Artifacts
+
+Every push to `main` and `release/*` branches publishes SNAPSHOT artifacts to the [Central Portal snapshot repository](https://central.sonatype.com/repository/maven-snapshots/).
+This lets you test against unreleased changes without building Kroxylicious from source.
+
+To pull SNAPSHOT Kroxylicious dependencies into a Maven project, add the snapshot repository to your `pom.xml`:
+
+```xml
+<repositories>
+  <repository>
+    <id>central-snapshots</id>
+    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    <snapshots>
+      <enabled>true</enabled>
+    </snapshots>
+  </repository>
+</repositories>
+```
+
+For Gradle (Kotlin DSL):
+
+```kotlin
+repositories {
+    maven {
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+        mavenContent {
+            snapshotsOnly()
+        }
+    }
+}
+```
+
+Then depend on the SNAPSHOT version of any Kroxylicious artifact, for example:
+
+```xml
+<dependency>
+  <groupId>io.kroxylicious</groupId>
+  <artifactId>kroxylicious-api</artifactId>
+  <version><!-- e.g. 0.24.0-SNAPSHOT --></version>
+</dependency>
+```
+
+The current SNAPSHOT version is the `version` field in the root `pom.xml` of this repository.
+
 ### Formatting the Code
 No one likes to argue about code formatting in pull requests, as project we take the stance that if we can't automate the formatting we are not going to argue about it either. Having said that we don't want a mishmash of conflicting styles! So we attack this from multiple angles.
 


### PR DESCRIPTION
PR #4132 introduced automatic SNAPSHOT publishing to the Central Portal snapshot repository, but left documenting it for a follow-up. Developers building filters against unreleased Kroxylicious changes had no documented path other than building from source.

Adds a "Using SNAPSHOT Artifacts" subsection to DEV_GUIDE.md with Maven and Gradle configuration snippets for consuming SNAPSHOT artifacts.

Closes #4137

### Checklist
- [x] New tests written (where applicable). _N/A — documentation only._
- [x] If making a user-facing change, documentation is provided. _This PR is the documentation._
- [x] Existing unit/integration/system tests passing. _N/A._
- [x] Any Sonarcloud warnings are addressed. _N/A._
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [x] For user facing changes, update CHANGELOG.md. _N/A — dev tooling doc, not a product change._