### PR TITLE
docs(entity-isolation): enhance documentation and remove javadoc warnings

### DIFF
--- a/kroxylicious-filters/kroxylicious-entity-isolation/pom.xml
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/pom.xml
@@ -20,10 +20,6 @@
     <name>Entity isolation filter</name>
     <description>Entity isolation filter</description>
 
-    <properties>
-        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
-    </properties>
-
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/EntityIsolation.java
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/EntityIsolation.java
@@ -97,6 +97,11 @@ public class EntityIsolation implements FilterFactory<EntityIsolation.Config, En
                          @JsonProperty(required = true) @PluginImplName(EntityNameMapperService.class) String mapper,
                          @PluginImplConfig(implNameProperty = "mapper") Object mapperConfig) {
 
+        /**
+         * Validates the configuration, rejecting entity types that are not yet supported.
+         *
+         * @throws IllegalArgumentException if {@code entityTypes} contains an unsupported entity type.
+         */
         public Config {
             Objects.requireNonNull(entityTypes);
             Objects.requireNonNull(mapper);

--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/EntityNameMapper.java
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/EntityNameMapper.java
@@ -60,10 +60,21 @@ public interface EntityNameMapper {
      * Signals that the entity name that would be created by the mapper is somehow invalid.
      */
     class EntityMapperException extends RuntimeException {
+        /**
+         * Creates an entity mapper exception.
+         *
+         * @param message the detail message.
+         */
         public EntityMapperException(String message) {
             super(message);
         }
 
+        /**
+         * Creates an entity mapper exception.
+         *
+         * @param message the detail message.
+         * @param cause the underlying cause.
+         */
         public EntityMapperException(String message, Throwable cause) {
             super(message, cause);
         }

--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/EntityNameMapperService.java
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/EntityNameMapperService.java
@@ -6,6 +6,12 @@
 
 package io.kroxylicious.filter.entityisolation;
 
+/**
+ * A pluggable service responsible for building the {@link EntityNameMapper} used by the
+ * {@link EntityIsolationFilter} to map entity names between the downstream and upstream.
+ *
+ * @param <C> the service configuration type
+ */
 public interface EntityNameMapperService<C> {
 
     /**

--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/MapperContext.java
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/MapperContext.java
@@ -22,6 +22,9 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * @param clientSaslContext client SASL context - will be null if channel has not negotiated SASL.
  */
 public record MapperContext(Subject authenticatedSubject, @Nullable ClientTlsContext clientTlsContext, @Nullable ClientSaslContext clientSaslContext) {
+    /**
+     * Validates the mapper context.
+     */
     public MapperContext {
         Objects.requireNonNull(authenticatedSubject);
     }

--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/PrincipalEntityNameMapperService.java
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/PrincipalEntityNameMapperService.java
@@ -17,9 +17,21 @@ import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * An {@link EntityNameMapperService} that builds a {@link PrincipalEntityNameMapper}, which
+ * isolates entities by prefixing entity names with the name of a principal taken from the
+ * authenticated subject.
+ */
 @Plugin(configType = PrincipalEntityNameMapperService.Config.class)
 public class PrincipalEntityNameMapperService implements EntityNameMapperService<PrincipalEntityNameMapperService.Config> {
     private static final Config DEFAULT_CONFIG = new Config(User.class, "-");
+
+    /**
+     * Creates the principal entity name mapper service.
+     */
+    public PrincipalEntityNameMapperService() {
+        // empty
+    }
 
     @Nullable
     private Config effectiveConfig;


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [X] PR references related GitHub issue(s) so they are closed on merging. Closes: #4571 
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
