### PR TITLE
fix(authorizer-acl): add casts for Eclipse JDT wildcard capture

### DIFF
--- a/kroxylicious-authorizer-providers/kroxylicious-authorizer-acl/src/main/java/io/kroxylicious/authorizer/provider/acl/AclAuthorizerService.java
+++ b/kroxylicious-authorizer-providers/kroxylicious-authorizer-acl/src/main/java/io/kroxylicious/authorizer/provider/acl/AclAuthorizerService.java
@@ -460,9 +460,9 @@ public class AclAuthorizerService implements AuthorizerService<AclAuthorizerConf
                 }
                 else {
                     List<? extends Enum> list = Objects.requireNonNull(opNames).stream()
-                            .map(name -> Enum.valueOf(enumCls, name))
+                            .map(name -> (Enum) Enum.valueOf(enumCls, name))
                             .toList();
-                    this.resourceBuilder = this.operationsBuilder.operations(EnumSet.copyOf(list));
+                    this.resourceBuilder = this.operationsBuilder.operations((Set) EnumSet.copyOf(list));
                 }
             }
 


### PR DESCRIPTION
## Summary

- Eclipse JDT (used by VS Code's Red Hat Java extension) is stricter than javac about wildcard capture conversion in raw generic contexts
- Add explicit casts to raw `Enum` and `Set` types in `AclAuthorizerService.enterResource()` so the code compiles under both javac and Eclipse JDT
- Without this, VS Code users see `Unresolved compilation problems: Type mismatch: cannot convert from Enum to capture#35-of ? extends Enum` at runtime

Related to #4609

## Test plan

- [x] Verified compilation with javac
- [x] Verified compilation with Eclipse JDT compiler (ecj)
- [ ] CI passes

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>