### PR TITLE
docs(kroxylicious-kms-provider-hashicorp-vault-test-support)  enchange documentation and remove warnings

### DIFF
--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/pom.xml
@@ -21,10 +21,6 @@
     <name>HashiCorp Vault KMS test support</name>
     <description>Test support code for modules testing the HashiCorp Vault KMS</description>
 
-    <properties>
-        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
-    </properties>
-
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/AbstractVaultTestKmsFacade.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/AbstractVaultTestKmsFacade.java
@@ -43,6 +43,13 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import static java.net.URLEncoder.encode;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+/**
+ * Abstract base for {@link TestKmsFacade} implementations backed by a HashiCorp Vault instance.
+ * Prepares Vault for use by the tests (enabling the Transit engine and creating a least-privilege
+ * token for the KMS) and provides a {@link TestKekManager} that manages KEKs using the Vault
+ * Transit engine REST API, leaving subclasses responsible for the lifecycle of, and connection
+ * details for, the underlying Vault instance.
+ */
 public abstract class AbstractVaultTestKmsFacade implements TestKmsFacade<Config, String, VaultEdek> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractVaultTestKmsFacade.class);
@@ -55,13 +62,25 @@ public abstract class AbstractVaultTestKmsFacade implements TestKmsFacade<Config
     private @Nullable String kmsVaultToken;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final HttpClient vaultClient = HttpClient.newHttpClient();
+    /**
+     * The root token used to authenticate with the Vault instance.
+     */
     public static final String VAULT_ROOT_TOKEN = "rootToken";
 
+    /**
+     * Creates the facade.
+     */
     protected AbstractVaultTestKmsFacade() {
     }
 
+    /**
+     * Starts the underlying Vault instance.
+     */
     protected abstract void startVault();
 
+    /**
+     * Stops the underlying Vault instance.
+     */
     protected abstract void stopVault();
 
     @Override
@@ -114,6 +133,9 @@ public abstract class AbstractVaultTestKmsFacade implements TestKmsFacade<Config
         }
     }
 
+    /**
+     * Enables the Vault Transit engine at the {@code transit} mount path, if it is not already enabled.
+     */
     protected void enableTransit() {
         String expectedMountPath = "transit";
         if (!sendRequestExpectingOk(createVaultGet(getVaultUrl().resolve("/v1/sys/mounts/" + expectedMountPath + "/")))) {
@@ -128,6 +150,12 @@ public abstract class AbstractVaultTestKmsFacade implements TestKmsFacade<Config
         }
     }
 
+    /**
+     * Creates a Vault policy.
+     *
+     * @param policyName name of the policy.
+     * @param policyStream stream containing the policy document, in HCL format.
+     */
     protected void createPolicy(String policyName, InputStream policyStream) {
         Objects.requireNonNull(policyName);
         Objects.requireNonNull(policyStream);
@@ -137,6 +165,14 @@ public abstract class AbstractVaultTestKmsFacade implements TestKmsFacade<Config
         sendRequestExpectingNoContentResponse(request);
     }
 
+    /**
+     * Creates a Vault orphan token.
+     *
+     * @param description display name for the token.
+     * @param noDefaultPolicy if true, the {@code default} policy will not be attached to the token.
+     * @param policies names of the policies to attach to the token.
+     * @return the client token.
+     */
     protected String createOrphanToken(String description, boolean noDefaultPolicy, Set<String> policies) {
         var token = new CreateTokenRequest(description, noDefaultPolicy, policies);
         String body = encodeJson(token);
@@ -145,6 +181,10 @@ public abstract class AbstractVaultTestKmsFacade implements TestKmsFacade<Config
         return sendRequestForKey("dummy", request, VAULT_RESPONSE_CREATE_TOKEN_RESPONSE_TYPEREF).auth().clientToken();
     }
 
+    /**
+     * Gets the endpoint URL of the Vault instance.
+     * @return the endpoint URL.
+     */
     protected abstract URI getVaultUrl();
 
     @Override
@@ -162,6 +202,10 @@ public abstract class AbstractVaultTestKmsFacade implements TestKmsFacade<Config
         stopVault();
     }
 
+    /**
+     * Gets the URL of the Transit engine of the Vault instance.
+     * @return the Transit engine URL.
+     */
     protected final URI getVaultTransitEngineUrl() {
         return getVaultUrl().resolve("v1/transit/");
     }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/AbstractVaultTestKmsFacadeFactory.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/AbstractVaultTestKmsFacadeFactory.java
@@ -10,7 +10,17 @@ import io.kroxylicious.kms.provider.hashicorp.vault.VaultEdek;
 import io.kroxylicious.kms.provider.hashicorp.vault.config.Config;
 import io.kroxylicious.testing.kms.TestKmsFacadeFactory;
 
+/**
+ * Abstract factory for {@link AbstractVaultTestKmsFacade}s.
+ */
 public abstract class AbstractVaultTestKmsFacadeFactory implements TestKmsFacadeFactory<Config, String, VaultEdek> {
+    /**
+     * Creates the factory.
+     */
+    protected AbstractVaultTestKmsFacadeFactory() {
+        // Intentionally empty
+    }
+
     @Override
     public abstract AbstractVaultTestKmsFacade build();
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/VaultTestKmsFacade.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/VaultTestKmsFacade.java
@@ -14,6 +14,10 @@ import org.testcontainers.vault.VaultContainer;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * A {@link io.kroxylicious.testing.kms.TestKmsFacade} backed by a HashiCorp Vault instance
+ * provided by a <a href="https://hub.docker.com/r/hashicorp/vault">Vault</a> container.
+ */
 public class VaultTestKmsFacade extends AbstractVaultTestKmsFacade {
     private static final String IMAGE = "hashicorp/vault:2.0.3@sha256:a296a888b118615dc01d5f1a6846e6d4a7277946caaed5b447008fff5fe06b54";
     private static final DockerImageName HASHICORP_VAULT = DockerImageName.parse(IMAGE)
@@ -21,6 +25,13 @@ public class VaultTestKmsFacade extends AbstractVaultTestKmsFacade {
 
     @SuppressWarnings("rawtypes")
     private @Nullable VaultContainer vaultContainer;
+
+    /**
+     * Creates the facade.
+     */
+    public VaultTestKmsFacade() {
+        // Intentionally empty
+    }
 
     @Override
     public boolean isAvailable() {

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/VaultTestKmsFacadeFactory.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/VaultTestKmsFacadeFactory.java
@@ -15,6 +15,13 @@ import io.kroxylicious.testing.kms.TestKmsFacadeFactory;
  */
 public class VaultTestKmsFacadeFactory extends AbstractVaultTestKmsFacadeFactory implements TestKmsFacadeFactory<Config, String, VaultEdek> {
     /**
+     * Creates the factory.
+     */
+    public VaultTestKmsFacadeFactory() {
+        // Intentionally empty
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/model/CreatePolicyRequest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/model/CreatePolicyRequest.java
@@ -12,8 +12,20 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
+/**
+ * A request to create a Vault policy.
+ *
+ * @param policy the policy document, in HCL format.
+ * @see <a href="https://developer.hashicorp.com/vault/api-docs/system/policy#create-update-policy">Vault API Create/Update Policy</a>
+ */
 public record CreatePolicyRequest(String policy) {
 
+    /**
+     * Creates a CreatePolicyRequest from an input stream.
+     *
+     * @param is stream containing the policy document, in HCL format.
+     * @return the CreatePolicyRequest.
+     */
     public static CreatePolicyRequest fromInputStream(InputStream is) {
         Objects.requireNonNull(is);
         try {

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/model/CreateTokenRequest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/model/CreateTokenRequest.java
@@ -10,4 +10,12 @@ import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * A request to create a Vault token.
+ *
+ * @param displayName display name for the token.
+ * @param noDefaultPolicy if true, the {@code default} policy will not be attached to the token.
+ * @param policies names of the policies to attach to the token.
+ * @see <a href="https://developer.hashicorp.com/vault/api-docs/auth/token#create-token">Vault API Create Token</a>
+ */
 public record CreateTokenRequest(@JsonProperty("display_name") String displayName, @JsonProperty("no_default_policy") boolean noDefaultPolicy, Set<String> policies) {}

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/model/CreateTokenResponse.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/model/CreateTokenResponse.java
@@ -11,15 +11,36 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * The response from a request to create a Vault token.
+ *
+ * @param auth authentication information, including the created token.
+ * @see <a href="https://developer.hashicorp.com/vault/api-docs/auth/token#create-token">Vault API Create Token</a>
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record CreateTokenResponse(Auth auth) {
 
+    /**
+     * Creates a CreateTokenResponse.
+     *
+     * @param auth authentication information, including the created token.
+     */
     public CreateTokenResponse {
         Objects.requireNonNull(auth);
     }
 
+    /**
+     * Authentication information associated with a created token.
+     *
+     * @param clientToken the client token.
+     */
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record Auth(@JsonProperty("client_token") String clientToken) {
+        /**
+         * Creates an Auth.
+         *
+         * @param clientToken the client token.
+         */
         public Auth {
             Objects.requireNonNull(clientToken);
         }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/model/EnableEngineRequest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/model/EnableEngineRequest.java
@@ -6,4 +6,10 @@
 
 package io.kroxylicious.testing.kms.vault.model;
 
+/**
+ * A request to enable a Vault secrets engine.
+ *
+ * @param type type of the secrets engine to enable (e.g. {@code transit}).
+ * @see <a href="https://developer.hashicorp.com/vault/api-docs/system/mounts#enable-secrets-engine">Vault API Enable Secrets Engine</a>
+ */
 public record EnableEngineRequest(String type) {}

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/model/UpdateKeyConfigRequest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/model/UpdateKeyConfigRequest.java
@@ -8,4 +8,10 @@ package io.kroxylicious.testing.kms.vault.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * A request to update the configuration of a Transit engine key.
+ *
+ * @param deletionAllowed if true, the key is allowed to be deleted.
+ * @see <a href="https://developer.hashicorp.com/vault/api-docs/secret/transit#update-key-configuration">Vault API Update Key Configuration</a>
+ */
 public record UpdateKeyConfigRequest(@JsonProperty("deletion_allowed") boolean deletionAllowed) {}

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/model/package-info.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/model/package-info.java
@@ -4,6 +4,9 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+/**
+ * Model classes for the subset of the HashiCorp Vault REST API used to prepare Vault for tests.
+ */
 @ReturnValuesAreNonnullByDefault
 @DefaultAnnotationForParameters(NonNull.class)
 @DefaultAnnotation(NonNull.class)

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/package-info.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/package-info.java
@@ -4,6 +4,10 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+/**
+ * Test support for the HashiCorp Vault KMS provider, providing {@link io.kroxylicious.testing.kms.TestKmsFacade}
+ * implementations backed by a HashiCorp Vault container.
+ */
 @ReturnValuesAreNonnullByDefault
 @DefaultAnnotationForParameters(NonNull.class)
 @DefaultAnnotation(NonNull.class)


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [X] PR references related GitHub issue(s) so they are closed on merging. Closes: #4564 
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
