### PR TITLE
build(ci): normalise license plugin excludes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -679,28 +679,23 @@
                                     <exclude>**/goal.txt</exclude>
                                     <exclude>**/.jbang/**</exclude>
                                     <exclude>changelog/**</exclude>
-                                    <exclude>src/main/resources/archetype-resources/**</exclude>
-                                    <!-- Root-level scan: exclude archetype resources and Helm templates.
-                                         These paths are relative to the module that runs license-check.
-                                         Module-relative form above covers the archetype module's own execution;
-                                         root-relative forms below cover the root module's execution, which
-                                         scans the full tree when modules are declared in profiles rather than
-                                         unconditionally (profile-declared modules are not automatically skipped
-                                         by the license plugin). Helm templates cannot carry license headers
-                                         because helm renders them before the {{- comment syntax is processed,
-                                         which produces duplicate headers in rendered output. -->
-                                    <exclude>kroxylicious-filter-archetype/src/main/resources/archetype-resources/**</exclude>
-                                    <exclude>kroxylicious-openmessaging-benchmarks/helm/**</exclude>
-                                    <!-- Need to keep original copyright for Vert.x classes -->
-                                    <exclude>src/main/java/io/kroxylicious/proxy/future/**</exclude>
-                                    <exclude>src/main/java/io/kroxylicious/proxy/internal/future/**</exclude>
-                                    <!-- Exclude third-party CRDs (carry their own license) -->
-                                    <exclude>src/test/resources/strimzi-crds/**</exclude>
-                                    <!-- Exclude test key material -->
-                                    <exclude>src/test/resources/io/kroxylicious/proxy/config/tls/*.key</exclude>
-                                    <exclude>src/test/resources/io/kroxylicious/proxy/config/tls/*.pem</exclude>
-                                    <exclude>src/test/resources/io/kroxylicious/proxy/config/tls/*.crt</exclude>
-                                    <exclude>src/test/resources/io/kroxylicious/proxy/config/tls/*.password</exclude>
+                                    <!-- Use **/ prefix so each pattern works whether the license plugin runs
+                                         at module scope or from the root during a full-tree scan (profile-declared
+                                         modules are not automatically skipped by the license plugin). -->
+                                    <!-- Archetype stub resources are templates and cannot carry a project license header -->
+                                    <exclude>**/src/main/resources/archetype-resources/**</exclude>
+                                    <!-- Helm templates cannot carry license headers: helm renders them and the
+                                         {{- comment syntax produces duplicate headers in the rendered output -->
+                                    <exclude>**/helm/**</exclude>
+                                    <!-- Third-party CRDs carry their own license -->
+                                    <exclude>**/strimzi-crds/**</exclude>
+                                    <!-- Binary and credential formats that cannot carry a license header -->
+                                    <exclude>**/*.key</exclude>
+                                    <exclude>**/*.pem</exclude>
+                                    <exclude>**/*.crt</exclude>
+                                    <exclude>**/*.password</exclude>
+                                    <!-- JSON-based formats that cannot carry a license header -->
+                                    <exclude>**/*.excalidraw</exclude>
                                 </excludes>
                             </licenseSet>
                         </licenseSets>


### PR DESCRIPTION
### Type of change

- Bug fix
- Refactoring

### Description

The root parent's `license:check` goal scans the full file tree when modules are declared in profiles — profile-declared modules are not automatically skipped by the plugin. This became visible after #4505 introduced profile-based module grouping: the `**/strimzi-crds/**` exclude was missing its root-relative form, causing the Sonar build to fail for any PR opened against `main`.

This PR fixes that and takes the opportunity to normalise all excludes to use the `**/` prefix, so each pattern works whether the plugin runs at module scope or from the root during a full-tree scan.

Changes:
- Add `**/strimzi-crds/**` (root-relative form was missing — immediate fix for the Sonar failure)
- Collapse the archetype two-form (module-relative + root-relative) into `**/src/main/resources/archetype-resources/**`
- Normalise helm to `**/helm/**`
- Add `**/*.key`, `**/*.pem`, `**/*.crt`, `**/*.password`, `**/*.excalidraw` for binary and JSON formats that cannot carry a license header (also fixes `[WARNING] Unknown file extension` noise for checked-in key material)
- Remove stale Vert.x future excludes (files deleted in `6bd48ae`)

### Checklist

- [ ] The PR title is in [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Testing: no production code changed; fix is in build configuration
- [ ] Docs: no user-facing change