### PR TITLE
docs: add SASL Termination to Client Authentication guide

### DIFF
--- a/.claude/rules/documentation-requirements.md
+++ b/.claude/rules/documentation-requirements.md
@@ -80,6 +80,7 @@ Each filter guide must cover:
 - Use US (global) English
 - Follow IBM documentation style guide
 - Be comprehensive
+- Avoid contractions. For example instead of "Here's", use "Here is"
 
 ## Compiling the documentation
 

--- a/kroxylicious-app/pom.xml
+++ b/kroxylicious-app/pom.xml
@@ -402,6 +402,11 @@
                 </dependency>
                 <dependency>
                     <groupId>io.kroxylicious</groupId>
+                    <artifactId>kroxylicious-sasl-termination</artifactId>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.kroxylicious</groupId>
                     <artifactId>kroxylicious-authorization</artifactId>
                     <scope>runtime</scope>
                 </dependency>

--- a/kroxylicious-docs/docs/_assemblies/assembly-configuring-authentication-sasl-termination.adoc
+++ b/kroxylicious-docs/docs/_assemblies/assembly-configuring-authentication-sasl-termination.adoc
@@ -1,0 +1,44 @@
+////
+  // Copyright Kroxylicious Authors.
+  //
+  // Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+////
+
+:_mod-docs-content-type: ASSEMBLY
+
+[id='assembly-configuring-authentication-sasl-termination-{context}']
+= Configuring SASL Termination
+
+[role="_abstract"]
+To enable SASL Termination, configure a `SaslTermination` filter in the proxy's filter chain.
+This filter handles the SASL authentication exchange at the proxy without forwarding it to the broker.
+The proxy validates the client's credentials directly and constructs an authenticated subject on success.
+
+.Prerequisites
+
+* An instance of Kroxylicious.
+ifdef::OpenShiftOnly[]
+For information on deploying Kroxylicious, see the {OperatorGuide}.
+endif::OpenShiftOnly[]
+ifndef::OpenShiftOnly[]
+For information on deploying Kroxylicious, see the {ProxyGuide} or {OperatorGuide}.
+endif::OpenShiftOnly[]
+* For the `OAUTHBEARER` mechanism, a reachable JWKS endpoint that publishes the public keys used to verify JWT signatures.
+
+.Procedure
+
+. Configure a `SaslTermination` type filter.
+ifdef::include-platform-bare-metal[]
+* In a standalone proxy deployment. See <<con-example-proxy-config-{context}>>
+endif::[]
+ifdef::include-platform-kubernetes[]
+* In a Kubernetes deployment using a `KafkaProtocolFilter` resource. See <<con-example-kafkaprotocolfilter-resource-{context}>>
+endif::[]
+
+ifdef::include-platform-bare-metal[]
+include::../_modules/sasl-termination/con-example-proxy-config.adoc[leveloffset=+1]
+endif::[]
+
+ifdef::include-platform-kubernetes[]
+include::../_modules/sasl-termination/con-example-kafkaprotocolfilter-resource.adoc[leveloffset=+1]
+endif::[]

--- a/kroxylicious-docs/docs/_modules/authentication/con-authentication-logging.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/con-authentication-logging.adoc
@@ -79,6 +79,60 @@ The full stack trace is included only at `DEBUG` level.
 The full stack trace is included only at `DEBUG` level.
 |===
 
+== SASL Termination filter logs
+
+The `SaslTermination` filter emits log messages for authentication events and security-relevant conditions.
+
+.SASL Termination filter log messages
+|===
+|Level |Message |Structured fields |When emitted
+
+|WARN
+|`Reauthentication rejected: mechanism change not permitted`
+|`sessionId`, `virtualCluster`, `mechanism`, `previousMechanism`
+|A client attempts to reauthenticate using a different SASL mechanism than the one used for the original authentication.
+The connection is closed.
+
+|WARN
+|`Reauthentication rejected: authorization ID changed`
+|`sessionId`, `virtualCluster`, `reauthentication`, `previousAuthorizationId`, `newAuthorizationId`
+|A client reauthenticates successfully but the authorization ID differs from the original authentication.
+The connection is closed.
+
+|WARN
+|`Rejecting oversized SASL authenticate payload`
+|`sessionId`, `virtualCluster`, `mechanism`, `payloadSize`, `maxPayloadSize`
+|A client sends a SASL authenticate request that exceeds the configured maximum payload size.
+The connection is closed.
+
+|WARN
+|`Token expired during authentication`
+|`sessionId`, `virtualCluster`, `mechanism`
+|A JWT token's expiry has already passed by the time authentication completes (for example, due to the fixed auth delay).
+The connection is closed.
+
+|WARN
+|`Rejecting request from unauthenticated client`
+|`sessionId`, `virtualCluster`, `reason`, `requestType`
+|A client sends a non-SASL request either without having authenticated or after the session has expired.
+The `reason` field indicates whether the client was never authenticated or the session expired.
+The connection is closed.
+
+|WARN
+|`Authentication took longer than fixedAuthDelay`
+|`sessionId`, `virtualCluster`, `mechanism`, `elapsed`, `fixedAuthDelay`
+|The actual authentication work took longer than the configured fixed auth delay, reducing the effectiveness of timing side-channel mitigation.
+Consider increasing `fixedAuthDelay`.
+
+|ERROR
+|`Authentication error`
+|`sessionId`, `virtualCluster`, `mechanism`, `origin`
+|An unexpected internal error occurred during authentication (for example, a failure in the subject builder or the mechanism state machine).
+The full stack trace is always included.
+|===
+
+For detailed authentication flow troubleshooting, enable `DEBUG` logging on `io.kroxylicious.filter.sasl.termination`.
+
 == OAuthBearer Validation filter logs
 
 The `OauthBearerValidation` filter emits log messages at `DEBUG` level for authentication events.

--- a/kroxylicious-docs/docs/_modules/authentication/con-authentication-metrics.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/con-authentication-metrics.adoc
@@ -29,7 +29,30 @@ This allows operators to monitor authentication activity across all virtual clus
 
 NOTE: This metric is emitted by the proxy runtime, not by individual filters.
 It is incremented whenever a filter calls `clientSaslAuthenticationSuccess` or `clientSaslAuthenticationFailure` on the filter context.
+Both the `SaslInspection` and `SaslTermination` filters trigger this metric.
 In SASL Passthrough mode (the default, with no SASL filter configured), no filter announces authentication outcomes, so this metric is not incremented.
+
+== SASL Termination metrics
+
+The `SaslTermination` filter emits additional metrics specific to the termination process.
+
+.SASL Termination metrics
+|===
+|Metric name |Type |Labels |Description
+
+|`kroxylicious_filter_sasl_termination_auth_duration_seconds`
+|Timer
+|`mechanism`, `virtual_cluster`
+|Records the authentication latency, exclusive of the configured fixed timing delay.
+ This measures the real work performed during authentication: credential store lookup, token validation, and signature verification.
+ Recorded on both successful and failed authentication attempts.
+
+|`kroxylicious_filter_sasl_termination_session_expired_total`
+|Counter
+|`mechanism`, `virtual_cluster`
+|Incremented by one every time a client's session expires without the client reauthenticating in time.
+ When this counter increments, the client's next request is rejected and the connection is closed.
+|===
 
 == Operational use
 
@@ -53,5 +76,14 @@ Alert if clients authenticate using a mechanism you do not expect, which may ind
 
 Correlate with connection metrics::
 Compare `kroxylicious_client_auth_total{outcome="success"}` with `kroxylicious_client_to_proxy_connections_total` to understand what proportion of connections successfully authenticate.
+
+Tune the fixed authentication delay::
+Use `kroxylicious_filter_sasl_termination_auth_duration_seconds` to understand how long authentication actually takes.
+If the p99 latency approaches or exceeds the configured `fixedAuthDelay`, the filter logs a warning and the timing side-channel mitigation is less effective.
+Consider increasing `fixedAuthDelay` to maintain a margin above the observed authentication latency.
+
+Alert on session expiry::
+A rising `kroxylicious_filter_sasl_termination_session_expired_total` indicates that clients are not reauthenticating before their sessions expire.
+This may indicate misconfigured clients, network issues preventing reauthentication, or a `maxTimeBeforeReauth` value that is too short for the workload.
 
 For the full list of proxy metrics, see the monitoring section of the {ProxyGuide}.

--- a/kroxylicious-docs/docs/_modules/authentication/con-choosing-authentication-approach.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/con-choosing-authentication-approach.adoc
@@ -43,8 +43,8 @@ Use SASL Passthrough Inspection when:
 Consider the following:
 
 * The broker still decides whether authentication succeeds.
-  An unauthenticated attacker that can reach the proxy still has proxied access to the broker.
-  If your threat model requires preventing unauthenticated traffic from reaching the broker, consider OAuthBearer Validation or mTLS instead.
+  An unauthenticated attacker that can reach the proxy still has proxied access to the broker — the proxy forwards their application requests without restriction.
+  If your threat model requires that only authenticated clients' requests are forwarded to the broker, consider OAuthBearer Validation, SASL Termination, or mTLS instead.
 * The proxy observes the SASL exchange and holds the authorization ID in memory.
   For mechanisms that transmit credentials in plain text (such as PLAIN), this means plain-text passwords briefly exist in the proxy's memory.
   The PLAIN mechanism is disabled by default for this reason.
@@ -54,8 +54,25 @@ Consider the following:
 Use OAuthBearer Validation when:
 
 * Your Kafka clients authenticate using OAuth 2.0 bearer tokens (the `OAUTHBEARER` SASL mechanism).
-* You want the proxy to reject clients with invalid or expired tokens before they reach the broker.
+* You want the proxy to reject clients with invalid or expired tokens before their application requests are forwarded to the broker.
 * You want to reduce load on the broker from repeated invalid authentication attempts.
+
+This mode requires a reachable JWKS endpoint that provides the public keys used to verify JWT signatures.
+
+== SASL Termination
+
+Use SASL Termination when:
+
+* You want the proxy to be the sole authority for client authentication, fully decoupling it from the broker.
+* You need to ensure that only authenticated clients' application requests are forwarded to the broker.
+* Your Kafka clients authenticate using OAuth 2.0 bearer tokens (the `OAUTHBEARER` SASL mechanism), which is the only mechanism currently supported.
+
+Consider the following:
+
+* The proxy validates credentials directly and does not forward SASL exchanges to the broker.
+  The broker does not need to be configured for SASL authentication at all, or it can use a different authentication mechanism for other clients.
+* Delegation Token APIs (`CreateDelegationToken`, `RenewDelegationToken`, `ExpireDelegationToken`, `DescribeDelegationToken`) are not available to clients when SASL is terminated at the proxy, because these APIs depend on a broker-side SASL session.
+* Unlike SASL Passthrough Inspection, SASL Termination enforces authentication at the proxy: clients that fail authentication are rejected before their application requests are forwarded to the broker.
 
 This mode requires a reachable JWKS endpoint that provides the public keys used to verify JWT signatures.
 
@@ -96,4 +113,10 @@ This can be useful when you want transport-level identity as a baseline and appl
 |Yes (token validation)
 |Yes (`OauthBearerValidation` filter)
 |JWKS endpoint
+
+|SASL Termination
+|Yes (from SASL exchange)
+|Yes (proxy validates directly)
+|Yes (`SaslTermination` filter)
+|JWKS endpoint (for OAUTHBEARER)
 |===

--- a/kroxylicious-docs/docs/_modules/authentication/con-sasl-authentication-modes.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/con-sasl-authentication-modes.adoc
@@ -79,6 +79,7 @@ This mode is implemented by the `SaslTermination` filter.
 It fully decouples client authentication from broker authentication, which can be useful when the proxy and broker use different credential stores or when you want to ensure that only authenticated clients' application requests are forwarded to the broker.
 
 The `SaslTermination` filter currently supports the `OAUTHBEARER` SASL mechanism.
+If a client attempts to use a mechanism that is not configured, the proxy rejects the handshake with an unsupported mechanism error and closes the connection.
 For `OAUTHBEARER`, the filter validates JWT tokens against a JSON Web Key Set (JWKS) retrieved from a configurable endpoint, checking the token signature, audience, issuer, and expiry.
 
 The filter supports session expiry and reauthentication (https://cwiki.apache.org/confluence/display/KAFKA/KIP-368%3A+Allow+SASL+Connections+to+Periodically+Re-Authenticate[KIP-368]).

--- a/kroxylicious-docs/docs/_modules/authentication/con-sasl-authentication-modes.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/con-sasl-authentication-modes.adoc
@@ -63,18 +63,29 @@ OAuthBearer Validation is a specialized mode in which the proxy validates a clie
 If the token is invalid, the proxy short-circuits the exchange and returns an error to the client without contacting the broker.
 
 This mode is implemented by the `OauthBearerValidation` filter.
-It reduces load on the broker by rejecting clients with invalid or expired tokens at the proxy, and it prevents unauthenticated traffic from reaching the broker.
+It reduces load on the broker by rejecting clients with invalid or expired tokens at the proxy before their application requests are forwarded.
 
 The filter validates tokens against a JSON Web Key Set (JWKS) retrieved from a configurable endpoint.
 It supports configurable token validation including expected audience, expected issuer, and custom claim names.
 
 To limit the impact of repeated authentication failures, the filter applies exponential backoff to clients that present invalid tokens.
 
-// == SASL Termination (future)
-//
-// NOTE: SASL Termination is not yet available as a production feature.
-//
-// In SASL Termination mode, the proxy handles the SASL authentication exchange itself, without forwarding `SaslAuthenticate` requests to the broker.
-// The proxy validates the client's credentials directly and constructs an authenticated subject on success.
-//
-// This mode fully decouples client authentication from broker authentication, which can be useful when the proxy and broker use different credential stores.
+== SASL Termination
+
+In SASL Termination mode, the proxy handles the SASL authentication exchange itself, without forwarding `SaslAuthenticate` requests to the broker.
+The proxy validates the client's credentials directly and constructs an authenticated subject on success.
+
+This mode is implemented by the `SaslTermination` filter.
+It fully decouples client authentication from broker authentication, which can be useful when the proxy and broker use different credential stores or when you want to ensure that only authenticated clients' application requests are forwarded to the broker.
+
+The `SaslTermination` filter currently supports the `OAUTHBEARER` SASL mechanism.
+For `OAUTHBEARER`, the filter validates JWT tokens against a JSON Web Key Set (JWKS) retrieved from a configurable endpoint, checking the token signature, audience, issuer, and expiry.
+
+The filter supports session expiry and reauthentication (https://cwiki.apache.org/confluence/display/KAFKA/KIP-368%3A+Allow+SASL+Connections+to+Periodically+Re-Authenticate[KIP-368]).
+When a token's expiry is reached, the client must reauthenticate or the connection is closed.
+
+Because SASL is terminated at the proxy, certain Kafka APIs that depend on a broker-side SASL session are not available.
+The filter removes the Delegation Token APIs (`CreateDelegationToken`, `RenewDelegationToken`, `ExpireDelegationToken`, `DescribeDelegationToken`) from the `ApiVersions` response and rejects any requests for these APIs.
+
+To mitigate timing side-channel attacks (such as username enumeration), the filter applies a configurable fixed delay to each authentication round.
+This ensures that authentication responses take a consistent amount of time regardless of the reason for success or failure.

--- a/kroxylicious-docs/docs/_modules/authentication/con-subjects-and-subject-builders.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/con-subjects-and-subject-builders.adoc
@@ -39,7 +39,7 @@ SASL subject builder::
 Builds a subject from information obtained during a successful SASL authentication exchange, such as the SASL authorization ID.
 +
 The SASL subject builder is configured on the SASL filter (for example, the `SaslInspection` filter).
-See xref:con-configuring-sasl-subject-builder-auth-sasl-inspection[] for configuration details.
+See xref:con-configuring-sasl-subject-builder-{context}[] for configuration details.
 
 Both subject builders use a pluggable architecture.
 The default implementations extract principals from certificate fields or SASL authorization IDs using configurable mapping rules.

--- a/kroxylicious-docs/docs/_modules/authentication/ref-authentication-glossary.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/ref-authentication-glossary.adoc
@@ -21,5 +21,5 @@ Principal:: A named identifier that represents one aspect of an authenticated cl
 SASL:: Simple Authentication and Security Layer is an https://datatracker.ietf.org/doc/html/rfc4422[IETF framework] for handling authentication.
 SASL Passthrough:: A mode in which the proxy forwards SASL authentication exchanges between client and broker without inspecting or modifying them. This is the default behavior.
 SASL Passthrough Inspection:: A mode in which the proxy observes SASL authentication exchanges to infer the client's identity without altering the exchange. The broker remains the authority for authentication decisions.
-//SASL Termination:: A mode in which the proxy handles SASL authentication itself, without forwarding to the broker. Not yet available as a production feature.
+SASL Termination:: A mode in which the proxy handles SASL authentication itself, without forwarding to the broker. The proxy validates credentials directly and constructs an authenticated subject on success.
 Subject:: The authenticated identity of a client, composed of one or more principals. Used by filters to make identity-aware decisions.

--- a/kroxylicious-docs/docs/_modules/sasl-termination/con-example-kafkaprotocolfilter-resource.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/con-example-kafkaprotocolfilter-resource.adoc
@@ -16,7 +16,7 @@
 [role="_abstract"]
 If your instance of Kroxylicious runs on Kubernetes, you must use a `KafkaProtocolFilter` resource to contain the filter configuration.
 
-Here's a complete example of a `KafkaProtocolFilter` resource configured for SASL Termination:
+Here is a complete example of a `KafkaProtocolFilter` resource configured for SASL Termination:
 
 [source,yaml]
 ----

--- a/kroxylicious-docs/docs/_modules/sasl-termination/con-example-kafkaprotocolfilter-resource.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/con-example-kafkaprotocolfilter-resource.adoc
@@ -53,4 +53,4 @@ If omitted, a default subject builder creates a principal with name matching the
 
 For `OAUTHBEARER` mechanism configuration, see the bare-metal configuration example for a full description of the mechanism-specific fields (`jwksEndpointUrl`, `expectedAudience`, `expectedIssuer`, and others).
 
-Refer to the {OperatorGuide} for more information about configuration on Kubernetes.
+For more information about configuration on Kubernetes, see the {OperatorGuide}.

--- a/kroxylicious-docs/docs/_modules/sasl-termination/con-example-kafkaprotocolfilter-resource.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/con-example-kafkaprotocolfilter-resource.adoc
@@ -1,0 +1,56 @@
+////
+  // Copyright Kroxylicious Authors.
+  //
+  // Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+////
+
+:_mod-docs-content-type: CONCEPT
+
+// file included in the following:
+//
+// assembly-configuring-authentication-sasl-termination.adoc
+
+[id='con-example-kafkaprotocolfilter-resource-{context}']
+= Example `KafkaProtocolFilter` resource
+
+[role="_abstract"]
+If your instance of Kroxylicious runs on Kubernetes, you must use a `KafkaProtocolFilter` resource to contain the filter configuration.
+
+Here's a complete example of a `KafkaProtocolFilter` resource configured for SASL Termination:
+
+[source,yaml]
+----
+kind: KafkaProtocolFilter
+metadata:
+  name: my-sasl-termination-filter
+spec:
+  type: SaslTermination
+  configTemplate:
+    mechanisms:
+      - mechanism: OAUTHBEARER
+        jwksEndpointUrl: https://idp.example.com/.well-known/jwks.json
+        expectedAudience: kafka
+        expectedIssuer: https://idp.example.com
+    maxTimeBeforeReauth: 1h
+    fixedAuthDelay: 200ms
+    subjectBuilder: <class name>
+    subjectBuilderConfig: <object providing configuration for the subject builder>
+----
+where:
+
+* `mechanisms` (required) configures the list of SASL mechanisms that the filter supports.
+Each entry specifies a `mechanism` name and mechanism-specific configuration.
+Currently, only `OAUTHBEARER` is supported.
+* `maxTimeBeforeReauth` specifies the maximum session lifetime before the client must reauthenticate (https://cwiki.apache.org/confluence/display/KAFKA/KIP-368%3A+Allow+SASL+Connections+to+Periodically+Re-Authenticate[KIP-368]).
+The effective session expiry is the earlier of this value and the token's own expiry.
+If omitted, session expiry is governed solely by the token's expiry claim.
+* `fixedAuthDelay` specifies the fixed delay applied to each authentication round to mitigate timing side-channel attacks.
+Defaults to 200 milliseconds if omitted.
+Set to `0s` to disable.
+* `subjectBuilder` is the name of a plugin class implementing `io.kroxylicious.proxy.authentication.SaslSubjectBuilderService`.
+If omitted, a default subject builder creates a principal with name matching the SASL authorization ID.
+* `subjectBuilderConfig` provides subject builder configuration.
+
+For `OAUTHBEARER` mechanism configuration, see the bare-metal configuration example for a full description of the mechanism-specific fields (`jwksEndpointUrl`, `expectedAudience`, `expectedIssuer`, and others).
+
+Refer to the {OperatorGuide} for more information about configuration on Kubernetes.

--- a/kroxylicious-docs/docs/_modules/sasl-termination/con-example-proxy-config.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/con-example-proxy-config.adoc
@@ -1,0 +1,69 @@
+////
+  // Copyright Kroxylicious Authors.
+  //
+  // Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+////
+
+:_mod-docs-content-type: CONCEPT
+
+// file included in the following:
+//
+// assembly-configuring-authentication-sasl-termination.adoc
+
+[id='con-example-proxy-config-{context}']
+= Example proxy configuration file
+
+[role="_abstract"]
+If your instance of the Kroxylicious Proxy runs directly on an operating system, provide the filter configuration in the `filterDefinitions` list of your proxy configuration.
+
+Here's a complete example of a `filterDefinitions` entry configured for SASL Termination:
+
+[source, yaml]
+----
+filterDefinitions:
+  - name: my-sasl-termination-filter
+    type: SaslTermination
+    config:
+      mechanisms:
+        - mechanism: OAUTHBEARER
+          jwksEndpointUrl: https://idp.example.com/.well-known/jwks.json
+          expectedAudience: kafka
+          expectedIssuer: https://idp.example.com
+      maxTimeBeforeReauth: 1h
+      fixedAuthDelay: 200ms
+      subjectBuilder: <class name>
+      subjectBuilderConfig: <object providing configuration for the subject builder>
+----
+where:
+
+* `mechanisms` (required) configures the list of SASL mechanisms that the filter supports.
+Each entry specifies a `mechanism` name and mechanism-specific configuration.
+Currently, only `OAUTHBEARER` is supported.
+* `maxTimeBeforeReauth` specifies the maximum session lifetime before the client must reauthenticate (https://cwiki.apache.org/confluence/display/KAFKA/KIP-368%3A+Allow+SASL+Connections+to+Periodically+Re-Authenticate[KIP-368]).
+The effective session expiry is the earlier of this value and the token's own expiry.
+If omitted, session expiry is governed solely by the token's expiry claim.
+* `fixedAuthDelay` specifies the fixed delay applied to each authentication round to mitigate timing side-channel attacks.
+Defaults to 200 milliseconds if omitted.
+Set to `0s` to disable.
+* `subjectBuilder` is the name of a plugin class implementing `io.kroxylicious.proxy.authentication.SaslSubjectBuilderService`.
+If omitted, a default subject builder creates a principal with name matching the SASL authorization ID.
+* `subjectBuilderConfig` provides subject builder configuration.
+
+== OAUTHBEARER mechanism configuration
+
+The `OAUTHBEARER` mechanism validates JWT bearer tokens against a JWKS endpoint.
+
+* `jwksEndpointUrl` (required) specifies the OAuth/OIDC provider endpoint from which the JSON Web Key Set (JWKS) is retrieved.
+* `expectedAudience` (required) specifies the expected audience claim value used to verify the JWT.
+Use a comma-separated list for multiple valid audiences.
+* `expectedIssuer` (required) specifies the expected issuer claim value used to verify the JWT.
+
+The following properties are optional:
+
+* `scopeClaimName` specifies an alternative claim name for the scope in the JWT payload.
+* `subClaimName` specifies an alternative claim name for the subject in the JWT payload.
+* `jwksEndpointRefresh` specifies the interval between refreshes of the JWKS cache used to verify JWT signatures.
+* `jwksEndpointRetryBackoff` specifies the initial delay between attempts to retrieve the JWKS from the external authentication provider.
+* `jwksEndpointRetryBackoffMax` specifies the maximum delay between JWKS retrieval attempts.
+
+Refer to the {ProxyGuide} for more information about configuring the proxy.

--- a/kroxylicious-docs/docs/_modules/sasl-termination/con-example-proxy-config.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/con-example-proxy-config.adoc
@@ -16,7 +16,7 @@
 [role="_abstract"]
 If your instance of the Kroxylicious Proxy runs directly on an operating system, provide the filter configuration in the `filterDefinitions` list of your proxy configuration.
 
-Here's a complete example of a `filterDefinitions` entry configured for SASL Termination:
+Here is a complete example of a `filterDefinitions` entry configured for SASL Termination:
 
 [source, yaml]
 ----
@@ -66,4 +66,4 @@ The following properties are optional:
 * `jwksEndpointRetryBackoff` specifies the initial delay between attempts to retrieve the JWKS from the external authentication provider.
 * `jwksEndpointRetryBackoffMax` specifies the maximum delay between JWKS retrieval attempts.
 
-Refer to the {ProxyGuide} for more information about configuring the proxy.
+For more information about configuring proxy, see the {ProxyGuide}. "

--- a/kroxylicious-docs/docs/_modules/sasl-termination/con-example-proxy-config.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/con-example-proxy-config.adoc
@@ -66,4 +66,4 @@ The following properties are optional:
 * `jwksEndpointRetryBackoff` specifies the initial delay between attempts to retrieve the JWKS from the external authentication provider.
 * `jwksEndpointRetryBackoffMax` specifies the maximum delay between JWKS retrieval attempts.
 
-For more information about configuring proxy, see the {ProxyGuide}. "
+For more information about configuring proxy, see the {ProxyGuide}.

--- a/kroxylicious-docs/docs/authentication-guide/index.adoc
+++ b/kroxylicious-docs/docs/authentication-guide/index.adoc
@@ -44,9 +44,13 @@ include::_modules/authentication/con-configuring-sasl-passthrough.adoc[leveloffs
 ifdef::context[:parent-context: {context}]
 :context: auth-sasl-inspection
 include::_assemblies/assembly-configuring-authentication-sasl-inspection.adoc[leveloffset=+1]
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]
 
-// configuring the SASL subject builder
-include::_modules/sasl-inspection/con-configuring-sasl-subject-builder.adoc[leveloffset=+1]
+// configuring SASL termination
+ifdef::context[:parent-context: {context}]
+:context: auth-sasl-termination
+include::_assemblies/assembly-configuring-authentication-sasl-termination.adoc[leveloffset=+1]
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
 
@@ -56,6 +60,9 @@ ifdef::context[:parent-context: {context}]
 include::_assemblies/assembly-configuring-authentication-oauthbearer.adoc[leveloffset=+1]
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
+
+// configuring the SASL subject builder (applies to both SASL inspection and SASL termination)
+include::_modules/sasl-inspection/con-configuring-sasl-subject-builder.adoc[leveloffset=+1]
 
 // authentication metrics
 include::_modules/authentication/con-{guide}-metrics.adoc[leveloffset=+1]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Document the SaslTermination filter covering OAUTHBEARER mechanism configuration (bare-metal and Kubernetes), decision guidance, metrics (auth_duration_seconds, session_expired_total), and WARN/ERROR-level logging. Restructure the SASL subject builder include so it is shared by both inspection and termination sections.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

### Additional Context

Relates to: https://github.com/kroxylicious/kroxylicious/issues/4521

