### PR TITLE
test(runtime): cover multi-facet changes in a single hot reload

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/HotReloadIT.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
@@ -26,19 +27,29 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.it.net.IntegrationTestInetAddressResolverProvider;
+import io.kroxylicious.it.testplugins.router.InvocationCountingRouterFactory;
 import io.kroxylicious.proxy.KafkaProxy;
+import io.kroxylicious.proxy.config.ClusterDefinition;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
+import io.kroxylicious.proxy.config.RouteDefinition;
+import io.kroxylicious.proxy.config.RouteTarget;
+import io.kroxylicious.proxy.config.RouterDefinition;
 import io.kroxylicious.proxy.config.VirtualCluster;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
+import io.kroxylicious.proxy.internal.config.Feature;
+import io.kroxylicious.proxy.internal.config.Features;
 import io.kroxylicious.proxy.reload.ReconfigureError;
 import io.kroxylicious.proxy.service.HostPort;
+import io.kroxylicious.testing.integration.config.NamedFilterDefinitionBuilder;
 import io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils;
 import io.kroxylicious.testing.integration.tester.KroxyliciousTester;
 import io.kroxylicious.testing.integration.tester.KroxyliciousTesters;
@@ -71,6 +82,10 @@ class HotReloadIT extends BaseIT {
     private static final String VC_BASELINE_NAME = "vc-baseline";
     private static final String VC_OUTGOING_NAME = "vc-outgoing";
     private static final String VC_INCOMING_NAME = "vc-incoming";
+    private static final String MULTI_FACET_VC_NAME = "vc-multi-facet";
+    private static final String MULTI_FACET_CLUSTER_NAME = "multi-facet-cluster";
+    private static final String MULTI_FACET_ROUTER_NAME = "multi-facet-router";
+    private static final String MULTI_FACET_FILTER_NAME = "route-counter";
 
     private static final String SNI_BASE_DOMAIN = IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName(".hotreload");
     private static final String VC_BASELINE_BOOTSTRAP = "bootstrap-baseline" + SNI_BASE_DOMAIN + ":0";
@@ -83,6 +98,7 @@ class HotReloadIT extends BaseIT {
     private static final Duration RECONFIGURE_TIMEOUT = Duration.ofSeconds(15);
     private static final Duration PRODUCE_CONSUME_TIMEOUT = Duration.ofSeconds(15);
     private static final Duration REJECTION_TIMEOUT = Duration.ofSeconds(5);
+    private static final Features ROUTING_ENABLED = Features.builder().enable(Feature.ROUTING).build();
 
     /**
      * Identifies a non-baseline VC slot used by the tests. {@link #buildConfig} takes a
@@ -101,6 +117,68 @@ class HotReloadIT extends BaseIT {
             this.name = name;
             this.bootstrap = bootstrap;
             this.brokerPattern = brokerPattern;
+        }
+    }
+
+    @AfterEach
+    void resetInvocationCounts() {
+        InvocationCountingRouterFactory.assertAllClosedAndResetCounts();
+        InvocationCountingFilterFactory.assertAllClosedAndResetCounts();
+    }
+
+    @Test
+    void shouldApplyChangesAcrossDetectorsInSingleReload(@BrokerCluster KafkaCluster cluster) throws Exception {
+        // Given
+        UUID oldRouterId = UUID.randomUUID();
+        UUID newRouterId = UUID.randomUUID();
+        UUID oldFilterId = UUID.randomUUID();
+        UUID newFilterId = UUID.randomUUID();
+
+        var clusterDefinition = new ClusterDefinition(MULTI_FACET_CLUSTER_NAME, cluster.getBootstrapServers(), null);
+        var oldVirtualCluster = multiFacetVirtualCluster(0);
+        var startingBuilder = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDefinition)
+                .addToFilterDefinitions(invocationCounterDefinition(oldFilterId))
+                .addToRouterDefinitions(multiFacetRouterDefinition(oldRouterId, "old-route"))
+                .addToVirtualClusters(oldVirtualCluster);
+
+        try (KroxyliciousTester tester = KroxyliciousTesters.newBuilder(startingBuilder)
+                .setFeatures(ROUTING_ENABLED)
+                .createDefaultKroxyliciousTester()) {
+            String topic = tester.createTopic(MULTI_FACET_VC_NAME);
+            int port = boundPort(tester, MULTI_FACET_VC_NAME);
+            var newVirtualCluster = new VirtualClusterBuilder(multiFacetVirtualCluster(port)).withLogNetwork(true).build();
+            var afterConfig = KroxyliciousConfigUtils.baseConfigurationBuilder()
+                    .addToClusterDefinitions(clusterDefinition)
+                    .addToFilterDefinitions(invocationCounterDefinition(newFilterId))
+                    .addToRouterDefinitions(multiFacetRouterDefinition(newRouterId, "new-route"))
+                    .addToVirtualClusters(newVirtualCluster)
+                    .build();
+
+            // When
+            var reconfigureResult = tester.reconfigure(afterConfig);
+
+            // Then
+            assertThat(reconfigureResult)
+                    .succeedsWithin(RECONFIGURE_TIMEOUT)
+                    .satisfies(result -> assertThat(result.hasErrors())
+                            .as("one reload changing a virtual cluster, router, route, and referenced filter should succeed")
+                            .isFalse());
+
+            assertThat(InvocationCountingRouterFactory.closeCountFor(oldRouterId))
+                    .as("the old router should be closed exactly once")
+                    .isEqualTo(1);
+            assertThat(InvocationCountingRouterFactory.initializationCountFor(newRouterId))
+                    .as("the replacement router should be initialized exactly once")
+                    .isEqualTo(1);
+            assertThat(InvocationCountingFilterFactory.closeCountFor(oldFilterId))
+                    .as("the old route filter should be closed exactly once")
+                    .isEqualTo(1);
+            assertThat(InvocationCountingFilterFactory.initializationCountFor(newFilterId))
+                    .as("the replacement route filter should be initialized exactly once")
+                    .isEqualTo(1);
+
+            assertProduceConsumeRoundTrip(tester, MULTI_FACET_VC_NAME, topic, "after-multi-facet-reconfigure");
         }
     }
 
@@ -619,6 +697,27 @@ class HotReloadIT extends BaseIT {
             builder.addToVirtualClusters(vc);
         }
         return builder;
+    }
+
+    private static VirtualCluster multiFacetVirtualCluster(int port) {
+        return new VirtualClusterBuilder()
+                .withName(MULTI_FACET_VC_NAME)
+                .withTarget(new RouteTarget(null, MULTI_FACET_ROUTER_NAME))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(new HostPort("localhost", port)).build())
+                .build();
+    }
+
+    private static RouterDefinition multiFacetRouterDefinition(UUID configId, String routeName) {
+        var route = new RouteDefinition(routeName, 0, List.of(MULTI_FACET_FILTER_NAME),
+                new RouteTarget(MULTI_FACET_CLUSTER_NAME, null));
+        var config = new InvocationCountingRouterFactory.Config(configId, routeName);
+        return new RouterDefinition(MULTI_FACET_ROUTER_NAME, InvocationCountingRouterFactory.class.getName(), config, List.of(route));
+    }
+
+    private static NamedFilterDefinition invocationCounterDefinition(UUID configId) {
+        return new NamedFilterDefinitionBuilder(MULTI_FACET_FILTER_NAME, InvocationCountingFilterFactory.class.getSimpleName())
+                .withConfig("configInstanceId", configId)
+                .build();
     }
 
     private static VirtualCluster portVc(KafkaCluster cluster, String name) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ChangeDetectorPipelineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/ChangeDetectorPipelineTest.java
@@ -10,9 +10,13 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
+import io.kroxylicious.proxy.config.ClusterDefinition;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.PortIdentifiesNodeIdentificationStrategy;
+import io.kroxylicious.proxy.config.RouteDefinition;
+import io.kroxylicious.proxy.config.RouteTarget;
+import io.kroxylicious.proxy.config.RouterDefinition;
 import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.config.VirtualCluster;
 import io.kroxylicious.proxy.config.VirtualClusterGateway;
@@ -24,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Cross-detector integration tests for the change-detection pipeline. Each individual
- * detector is unit-tested in its own file; this class verifies that running both detectors
+ * detector is unit-tested in its own file; this class verifies that running the detectors
  * over the same configuration and merging their results produces a well-formed
  * {@link ChangeResult} — specifically, that the pairwise-disjointness invariant
  * enforced by {@link ChangeResult#merge(ChangeResult)} holds across realistic scenarios
@@ -34,6 +38,7 @@ class ChangeDetectorPipelineTest {
 
     private final VirtualClusterChangeDetector vccDetector = new VirtualClusterChangeDetector();
     private final FilterChangeDetector filterDetector = new FilterChangeDetector();
+    private final RoutingGraphChangeDetector routingDetector = new RoutingGraphChangeDetector();
 
     @Test
     void clusterWithBothGatewayAndFilterChangeAppearsOnceInModify() {
@@ -216,6 +221,40 @@ class ChangeDetectorPipelineTest {
 
         var merged = vccResult.merge(filterResult);
         assertThat(merged.clustersToModify()).containsExactlyInAnyOrder("gateway-changed", "filter-changed");
+        assertThat(merged.clustersToAdd()).isEmpty();
+        assertThat(merged.clustersToRemove()).isEmpty();
+    }
+
+    @Test
+    void clusterChangedAcrossAllDetectorsAppearsOnceInModify() {
+        // Given
+        var oldFilter = new NamedFilterDefinition("filter-a", "io.kroxylicious.test.FakeFilter", "config-v1");
+        var newFilter = new NamedFilterDefinition("filter-a", "io.kroxylicious.test.FakeFilter", "config-v2");
+        var clusterDefinition = new ClusterDefinition("upstream", "kafka:9092", null);
+        var route = new RouteDefinition("route-a", 0, List.of("filter-a"), new RouteTarget("upstream", null));
+        var oldRouter = new RouterDefinition("router-a", "io.kroxylicious.test.FakeRouter", "config-v1", List.of(route));
+        var newRouter = new RouterDefinition("router-a", "io.kroxylicious.test.FakeRouter", "config-v2", List.of(route));
+        var oldVc = new VirtualCluster("cluster", null, new RouteTarget(null, "router-a"),
+                List.of(gateway("default", 9192)), false, false, List.of(), null, null, null);
+        var newVc = new VirtualCluster("cluster", null, new RouteTarget(null, "router-a"),
+                List.of(gateway("default", 9192)), true, false, List.of(), null, null, null);
+        var oldConfig = new Configuration(null, List.of(clusterDefinition), List.of(oldFilter), null, List.of(oldRouter),
+                List.of(oldVc), null, false, Optional.empty(), null, null);
+        var newConfig = new Configuration(null, List.of(clusterDefinition), List.of(newFilter), null, List.of(newRouter),
+                List.of(newVc), null, false, Optional.empty(), null, null);
+        var context = new ConfigurationChangeContext(oldConfig, newConfig);
+
+        // When
+        var vccResult = vccDetector.detect(context);
+        var filterResult = filterDetector.detect(context);
+        var routingResult = routingDetector.detect(context);
+        var merged = vccResult.merge(filterResult).merge(routingResult);
+
+        // Then
+        assertThat(vccResult.clustersToModify()).containsExactly("cluster");
+        assertThat(filterResult.clustersToModify()).containsExactly("cluster");
+        assertThat(routingResult.clustersToModify()).containsExactly("cluster");
+        assertThat(merged.clustersToModify()).containsExactly("cluster");
         assertThat(merged.clustersToAdd()).isEmpty();
         assertThat(merged.clustersToRemove()).isEmpty();
     }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds regression coverage for #4251:

- verifies all three detectors report the same modified virtual cluster and merge into one modification; and
- verifies one multi-facet reload replaces router and filter components once and serves Kafka traffic afterward.

Test-only; no production behavior changes.

### Additional Context

Closes #4251.

### Validation

- `ChangeDetectorPipelineTest`: 7 passed.
- `HotReloadIT#shouldApplyChangesAcrossDetectorsInSingleReload`: passed.
- `mvn clean verify`: passed.

### Checklist

- [x] New tests written (where applicable).
- [x] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. (Not applicable: test-only change.)
- [x] Existing relevant unit and integration tests passing (`mvn clean verify`); system tests are not applicable to this test-only change.
- [x] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment). (Pending PR CI.)
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [x] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format. (Not applicable: test-only change.)
