### PR TITLE
build(kroxylicious-kafka-message-generator): fork Kafka MessageGenerator at 4.3.0

### DIFF
--- a/kroxylicious-kafka-message-generator/README.md
+++ b/kroxylicious-kafka-message-generator/README.md
@@ -1,0 +1,33 @@
+# kroxylicious-kafka-message-generator
+
+A fork of the Apache Kafka `MessageGenerator` tool, used to generate `*Data` classes from the
+Kafka protocol JSON IDL specs. These generated classes will form part of the stable public API
+surface of Kroxylicious (see [proposal 116](https://github.com/kroxylicious/kroxylicious-design/blob/main/proposals/116-kafka-api-migration.md)).
+
+## Origin
+
+Forked from the [Apache Kafka](https://github.com/apache/kafka) repository at:
+
+- **Tag:** `4.3.0`
+- **Commit:** `a9ce3221537b8653448750697915607dc7936cf3`
+- **Source path:** `generator/src/main/java/org/apache/kafka/message/`
+
+The source files retain their original Apache Software Foundation copyright headers and are
+redistributed under the Apache 2.0 licence, the same licence as the original.
+
+## What changed from upstream
+
+- Package renamed from `org.apache.kafka.message` to `io.kroxylicious.kafka.message`
+- The `checker/` sub-package (schema evolution tooling with a JGit dependency) was not copied;
+  it is not required for code generation
+
+All other changes from this point forward are deliberate Kroxylicious modifications.
+
+## Updating from upstream
+
+When absorbing a new Kafka release:
+
+1. Review the diff in `generator/src/main/java/org/apache/kafka/message/` between the old
+   and new Kafka tags
+2. Cherry-pick relevant changes into this module
+3. Update the **Tag** and **Commit** recorded above

--- a/kroxylicious-kafka-message-generator/etc/asf-license.txt
+++ b/kroxylicious-kafka-message-generator/etc/asf-license.txt
@@ -1,0 +1,14 @@
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/kroxylicious-kafka-message-generator/pom.xml
+++ b/kroxylicious-kafka-message-generator/pom.xml
@@ -57,6 +57,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <!-- All source in this module is forked from Apache Kafka and carries ASF
+                         copyright headers, not Kroxylicious headers. Skip the header check. -->
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>

--- a/kroxylicious-kafka-message-generator/pom.xml
+++ b/kroxylicious-kafka-message-generator/pom.xml
@@ -61,8 +61,16 @@
                 <artifactId>license-maven-plugin</artifactId>
                 <configuration>
                     <!-- All source in this module is forked from Apache Kafka and carries ASF
-                         copyright headers, not Kroxylicious headers. Skip the header check. -->
-                    <skip>true</skip>
+                         copyright headers. Override the project-wide Kroxylicious header with
+                         the ASF header. Update this when modifications are made to the source. -->
+                    <licenseSets>
+                        <licenseSet>
+                            <header>${project.basedir}/etc/asf-license.txt</header>
+                            <excludes>
+                                <exclude>pom.xml</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
                 </configuration>
             </plugin>
             <plugin>

--- a/kroxylicious-kafka-message-generator/pom.xml
+++ b/kroxylicious-kafka-message-generator/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kroxylicious</groupId>
+        <artifactId>kroxylicious-parent</artifactId>
+        <version>0.24.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kroxylicious-kafka-message-generator</artifactId>
+    <name>Kafka Message Generator</name>
+    <description>Fork of the Apache Kafka MessageGenerator tool, used to generate *Data classes
+        from the Kafka protocol JSON IDL specs. Source files retain their original ASF copyright
+        headers and are redistributed under the Apache 2.0 licence.</description>
+
+    <properties>
+        <!-- All source in this module is forked from Apache Kafka and retains ASF copyright
+             headers. Checkstyle and ErrorProne are suppressed; a separate task will
+             bring the files into conformance with Kroxylicious conventions. -->
+        <errorprone.skip>true</errorprone.skip>
+        <checkstyle.skip>true</checkstyle.skip>
+        <spotbugs.skip>true</spotbugs.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.argparse4j</groupId>
+            <artifactId>argparse4j</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- Forked ASF source lacks Javadoc on many members; suppress doclint. -->
+                    <doclint>none</doclint>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- Forked ASF source does not conform to Kroxylicious ErrorProne rules.
+                         Clear the annotation processor paths so ErrorProne does not run. -->
+                    <annotationProcessorPaths combine.self="override"/>
+                    <compilerArgs combine.self="override"/>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kroxylicious-kafka-message-generator/pom.xml
+++ b/kroxylicious-kafka-message-generator/pom.xml
@@ -59,10 +59,13 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <configuration>
+                <configuration combine.self="override">
                     <!-- All source in this module is forked from Apache Kafka and carries ASF
                          copyright headers. Override the project-wide Kroxylicious header with
-                         the ASF header. Update this when modifications are made to the source. -->
+                         the ASF header. combine.self="override" prevents the parent's Kroxylicious
+                         licenseSet from merging in at module scope.
+                         Update this when modifications are made to the source. -->
+                    <strictCheck>true</strictCheck>
                     <licenseSets>
                         <licenseSet>
                             <header>${project.basedir}/etc/asf-license.txt</header>

--- a/kroxylicious-kafka-message-generator/pom.xml
+++ b/kroxylicious-kafka-message-generator/pom.xml
@@ -52,6 +52,11 @@
             <groupId>net.sourceforge.argparse4j</groupId>
             <artifactId>argparse4j</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ApiMessageTypeGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ApiMessageTypeGenerator.java
@@ -1,0 +1,455 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+public final class ApiMessageTypeGenerator implements TypeClassGenerator {
+    private final HeaderGenerator headerGenerator;
+    private final CodeBuffer buffer;
+    private final TreeMap<Short, ApiData> apis;
+    private final EnumMap<RequestListenerType, List<ApiData>> apisByListener = new EnumMap<>(RequestListenerType.class);
+
+    private static final class ApiData {
+        short apiKey;
+        MessageSpec requestSpec;
+        MessageSpec responseSpec;
+
+        ApiData(short apiKey) {
+            this.apiKey = apiKey;
+        }
+
+        String name() {
+            if (requestSpec != null) {
+                return MessageGenerator.stripSuffix(requestSpec.name(),
+                        MessageGenerator.REQUEST_SUFFIX);
+            }
+            else if (responseSpec != null) {
+                return MessageGenerator.stripSuffix(responseSpec.name(),
+                        MessageGenerator.RESPONSE_SUFFIX);
+            }
+            else {
+                throw new RuntimeException("Neither requestSpec nor responseSpec is defined " +
+                        "for API key " + apiKey);
+            }
+        }
+
+        String requestSchema() {
+            if (requestSpec == null) {
+                return "null";
+            }
+            else if (!requestSpec.hasValidVersion()) {
+                return "new Schema[0]";
+            }
+            else {
+                return String.format("%sData.SCHEMAS", requestSpec.name());
+            }
+        }
+
+        String responseSchema() {
+            if (responseSpec == null) {
+                return "null";
+            }
+            else if (!requestSpec.hasValidVersion()) {
+                return "new Schema[0]";
+            }
+            else {
+                return String.format("%sData.SCHEMAS", responseSpec.name());
+            }
+        }
+    }
+
+    public ApiMessageTypeGenerator(String packageName) {
+        this.headerGenerator = new HeaderGenerator(packageName);
+        this.apis = new TreeMap<>();
+        this.buffer = new CodeBuffer();
+    }
+
+    @Override
+    public String outputName() {
+        return MessageGenerator.API_MESSAGE_TYPE_JAVA;
+    }
+
+    @Override
+    public void registerMessageType(MessageSpec spec) {
+        switch (spec.type()) {
+            case REQUEST: {
+                short apiKey = spec.apiKey().get();
+                ApiData data = apis.get(apiKey);
+                if (!apis.containsKey(apiKey)) {
+                    data = new ApiData(apiKey);
+                    apis.put(apiKey, data);
+                }
+                if (data.requestSpec != null) {
+                    throw new RuntimeException("Found more than one request with " +
+                            "API key " + spec.apiKey().get());
+                }
+                data.requestSpec = spec;
+
+                if (spec.listeners() != null) {
+                    for (RequestListenerType listener : spec.listeners()) {
+                        apisByListener.putIfAbsent(listener, new ArrayList<>());
+                        apisByListener.get(listener).add(data);
+                    }
+                }
+                break;
+            }
+            case RESPONSE: {
+                short apiKey = spec.apiKey().get();
+                ApiData data = apis.get(apiKey);
+                if (!apis.containsKey(apiKey)) {
+                    data = new ApiData(apiKey);
+                    apis.put(apiKey, data);
+                }
+                if (data.responseSpec != null) {
+                    throw new RuntimeException("Found more than one response with " +
+                            "API key " + spec.apiKey().get());
+                }
+                data.responseSpec = spec;
+                break;
+            }
+            default:
+                // do nothing
+                break;
+        }
+    }
+
+    @Override
+    public void generateAndWrite(BufferedWriter writer) throws IOException {
+        generate();
+        write(writer);
+    }
+
+    private void generate() {
+        buffer.printf("public enum ApiMessageType {%n");
+        buffer.incrementIndent();
+        generateEnumValues();
+        buffer.printf("%n");
+        generateInstanceVariables();
+        buffer.printf("%n");
+        generateEnumConstructor();
+        buffer.printf("%n");
+        generateFromApiKey();
+        buffer.printf("%n");
+        generateNewApiMessageMethod("request");
+        buffer.printf("%n");
+        generateNewApiMessageMethod("response");
+        buffer.printf("%n");
+        generateAccessor("lowestSupportedVersion", "short");
+        buffer.printf("%n");
+        generateHighestSupportedVersion();
+        buffer.printf("%n");
+        generateAccessor("lowestDeprecatedVersion", "short");
+        buffer.printf("%n");
+        generateAccessor("highestDeprecatedVersion", "short");
+        buffer.printf("%n");
+        generateAccessor("listeners", "EnumSet<ListenerType>");
+        buffer.printf("%n");
+        generateAccessor("latestVersionUnstable", "boolean");
+        buffer.printf("%n");
+        generateAccessor("apiKey", "short");
+        buffer.printf("%n");
+        generateAccessor("requestSchemas", "Schema[]");
+        buffer.printf("%n");
+        generateAccessor("responseSchemas", "Schema[]");
+        buffer.printf("%n");
+        generateToString();
+        buffer.printf("%n");
+        generateHeaderVersion("request");
+        buffer.printf("%n");
+        generateHeaderVersion("response");
+        buffer.printf("%n");
+        generateListenerTypesEnum();
+        buffer.printf("%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        headerGenerator.generate();
+    }
+
+    private String generateListenerTypeEnumSet(Collection<String> values) {
+        if (values.isEmpty()) {
+            return "EnumSet.noneOf(ListenerType.class)";
+        }
+        StringBuilder bldr = new StringBuilder("EnumSet.of(");
+        Iterator<String> iter = values.iterator();
+        while (iter.hasNext()) {
+            bldr.append("ListenerType.");
+            bldr.append(iter.next());
+            if (iter.hasNext()) {
+                bldr.append(", ");
+            }
+        }
+        bldr.append(")");
+        return bldr.toString();
+    }
+
+    private void generateEnumValues() {
+        int numProcessed = 0;
+        for (Map.Entry<Short, ApiData> entry : apis.entrySet()) {
+            ApiData apiData = entry.getValue();
+            String name = apiData.name();
+            numProcessed++;
+
+            final Collection<String> listeners;
+            if (apiData.requestSpec.listeners() == null) {
+                listeners = List.of();
+            }
+            else {
+                listeners = apiData.requestSpec.listeners().stream()
+                        .map(RequestListenerType::name)
+                        .collect(Collectors.toList());
+            }
+
+            buffer.printf("%s(\"%s\", (short) %d, %s, %s, (short) %d, (short) %d, (short) %d, (short) %d, %s, %s)%s%n",
+                    MessageGenerator.toSnakeCase(name).toUpperCase(Locale.ROOT),
+                    MessageGenerator.capitalizeFirst(name),
+                    entry.getKey(),
+                    apiData.requestSchema(),
+                    apiData.responseSchema(),
+                    apiData.requestSpec.struct().versions().lowest(),
+                    apiData.requestSpec.struct().versions().highest(),
+                    apiData.requestSpec.struct().deprecatedVersions().lowest(),
+                    apiData.requestSpec.struct().deprecatedVersions().highest(),
+                    generateListenerTypeEnumSet(listeners),
+                    apiData.requestSpec.latestVersionUnstable(),
+                    (numProcessed == apis.size()) ? ";" : ",");
+        }
+    }
+
+    private void generateInstanceVariables() {
+        buffer.printf("public final String name;%n");
+        buffer.printf("private final short apiKey;%n");
+        buffer.printf("private final Schema[] requestSchemas;%n");
+        buffer.printf("private final Schema[] responseSchemas;%n");
+        buffer.printf("private final short lowestSupportedVersion;%n");
+        buffer.printf("private final short highestSupportedVersion;%n");
+        buffer.printf("private final short lowestDeprecatedVersion;%n");
+        buffer.printf("private final short highestDeprecatedVersion;%n");
+        buffer.printf("private final EnumSet<ListenerType> listeners;%n");
+        buffer.printf("private final boolean latestVersionUnstable;%n");
+        headerGenerator.addImport(MessageGenerator.SCHEMA_CLASS);
+        headerGenerator.addImport(MessageGenerator.ENUM_SET_CLASS);
+    }
+
+    private void generateEnumConstructor() {
+        buffer.printf("ApiMessageType(String name, short apiKey, " +
+                "Schema[] requestSchemas, Schema[] responseSchemas, " +
+                "short lowestSupportedVersion, short highestSupportedVersion, " +
+                "short lowestDeprecatedVersion, short highestDeprecatedVersion, " +
+                "EnumSet<ListenerType> listeners, boolean latestVersionUnstable) {%n");
+        buffer.incrementIndent();
+        buffer.printf("this.name = name;%n");
+        buffer.printf("this.apiKey = apiKey;%n");
+        buffer.printf("this.requestSchemas = requestSchemas;%n");
+        buffer.printf("this.responseSchemas = responseSchemas;%n");
+        buffer.printf("this.lowestSupportedVersion = lowestSupportedVersion;%n");
+        buffer.printf("this.highestSupportedVersion = highestSupportedVersion;%n");
+        buffer.printf("this.lowestDeprecatedVersion = lowestDeprecatedVersion;%n");
+        buffer.printf("this.highestDeprecatedVersion = highestDeprecatedVersion;%n");
+        buffer.printf("this.listeners = listeners;%n");
+        buffer.printf("this.latestVersionUnstable = latestVersionUnstable;%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateFromApiKey() {
+        buffer.printf("public static ApiMessageType fromApiKey(short apiKey) {%n");
+        buffer.incrementIndent();
+        buffer.printf("switch (apiKey) {%n");
+        buffer.incrementIndent();
+        for (Map.Entry<Short, ApiData> entry : apis.entrySet()) {
+            ApiData apiData = entry.getValue();
+            String name = apiData.name();
+            buffer.printf("case %d:%n", entry.getKey());
+            buffer.incrementIndent();
+            buffer.printf("return %s;%n", MessageGenerator.toSnakeCase(name).toUpperCase(Locale.ROOT));
+            buffer.decrementIndent();
+        }
+        buffer.printf("default:%n");
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+        buffer.printf("throw new UnsupportedVersionException(\"Unsupported API key \"" +
+                " + apiKey);%n");
+        buffer.decrementIndent();
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateNewApiMessageMethod(String type) {
+        headerGenerator.addImport(MessageGenerator.API_MESSAGE_CLASS);
+        buffer.printf("public ApiMessage new%s() {%n",
+                MessageGenerator.capitalizeFirst(type));
+        buffer.incrementIndent();
+        buffer.printf("switch (apiKey) {%n");
+        buffer.incrementIndent();
+        for (Map.Entry<Short, ApiData> entry : apis.entrySet()) {
+            MessageSpec spec = messageSpec(type, entry.getKey(), entry.getValue());
+            if (spec.hasValidVersion()) {
+                buffer.printf("case %d:%n", entry.getKey());
+                buffer.incrementIndent();
+                buffer.printf("return new %s%sData();%n",
+                        entry.getValue().name(),
+                        MessageGenerator.capitalizeFirst(type));
+                buffer.decrementIndent();
+            }
+        }
+        buffer.printf("default:%n");
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+        buffer.printf("throw new UnsupportedVersionException(\"Unsupported %s API key \"" +
+                " + apiKey);%n", type);
+        buffer.decrementIndent();
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateAccessor(String name, String type) {
+        buffer.printf("public %s %s() {%n", type, name);
+        buffer.incrementIndent();
+        buffer.printf("return this.%s;%n", name);
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateToString() {
+        buffer.printf("@Override%n");
+        buffer.printf("public String toString() {%n");
+        buffer.incrementIndent();
+        buffer.printf("return this.name();%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateHeaderVersion(String type) {
+        buffer.printf("public short %sHeaderVersion(short _version) {%n", type);
+        buffer.incrementIndent();
+        buffer.printf("switch (apiKey) {%n");
+        buffer.incrementIndent();
+        for (Map.Entry<Short, ApiData> entry : apis.entrySet()) {
+            short apiKey = entry.getKey();
+            ApiData apiData = entry.getValue();
+            String name = apiData.name();
+
+            MessageSpec spec = messageSpec(type, apiKey, entry.getValue());
+            if (!spec.hasValidVersion())
+                continue;
+
+            buffer.printf("case %d: // %s%n", apiKey, MessageGenerator.capitalizeFirst(name));
+            buffer.incrementIndent();
+            if (type.equals("response") && apiKey == 18) {
+                buffer.printf("// ApiVersionsResponse always includes a v0 header.%n");
+                buffer.printf("// See KIP-511 for details.%n");
+                buffer.printf("return (short) 0;%n");
+                buffer.decrementIndent();
+                continue;
+            }
+            VersionConditional.forVersions(spec.flexibleVersions(),
+                    spec.validVersions()).ifMember(__ -> {
+                        if (type.equals("request")) {
+                            buffer.printf("return (short) 2;%n");
+                        }
+                        else {
+                            buffer.printf("return (short) 1;%n");
+                        }
+                    }).ifNotMember(__ -> {
+                        if (type.equals("request")) {
+                            buffer.printf("return (short) 1;%n");
+                        }
+                        else {
+                            buffer.printf("return (short) 0;%n");
+                        }
+                    }).generate(buffer);
+            buffer.decrementIndent();
+        }
+        buffer.printf("default:%n");
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+        buffer.printf("throw new UnsupportedVersionException(\"Unsupported API key \"" +
+                " + apiKey);%n");
+        buffer.decrementIndent();
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private static MessageSpec messageSpec(String type, short apiKey, ApiData apiData) {
+        MessageSpec spec;
+        if (type.equals("request")) {
+            spec = apiData.requestSpec;
+        }
+        else if (type.equals("response")) {
+            spec = apiData.responseSpec;
+        }
+        else {
+            throw new RuntimeException("Invalid type " + type);
+        }
+        if (spec == null)
+            throw new RuntimeException("failed to find " + type + " for API key " + apiKey);
+        return spec;
+    }
+
+    private void generateListenerTypesEnum() {
+        buffer.printf("public enum ListenerType {%n");
+        buffer.incrementIndent();
+        Iterator<RequestListenerType> listenerIter = Arrays.stream(RequestListenerType.values()).iterator();
+        while (listenerIter.hasNext()) {
+            RequestListenerType scope = listenerIter.next();
+            buffer.printf("%s%s%n", scope.name(), listenerIter.hasNext() ? "," : ";");
+        }
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateHighestSupportedVersion() {
+        buffer.printf("public short highestSupportedVersion(boolean enableUnstableLastVersion) {%n");
+        buffer.incrementIndent();
+        buffer.printf("if (!this.latestVersionUnstable || enableUnstableLastVersion) {%n");
+        buffer.incrementIndent();
+        buffer.printf("return this.highestSupportedVersion;%n");
+        buffer.decrementIndent();
+        buffer.printf("} else {%n");
+        buffer.incrementIndent();
+        buffer.printf("// A negative value means that the API has no enabled versions.%n");
+        buffer.printf("return (short) (this.highestSupportedVersion - 1);%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void write(BufferedWriter writer) throws IOException {
+        headerGenerator.buffer().write(writer);
+        buffer.write(writer);
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ClauseGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ClauseGenerator.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+/**
+ * Generates a clause.
+ */
+public interface ClauseGenerator {
+    void generate(Versions versions);
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/CodeBuffer.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/CodeBuffer.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+
+public class CodeBuffer {
+    private final ArrayList<String> lines;
+    private int indent;
+
+    public CodeBuffer() {
+        this.lines = new ArrayList<>();
+        this.indent = 0;
+    }
+
+    public void incrementIndent() {
+        indent++;
+    }
+
+    public void decrementIndent() {
+        indent--;
+        if (indent < 0) {
+            throw new RuntimeException("Indent < 0");
+        }
+    }
+
+    public void printf(String format, Object... args) {
+        lines.add(String.format(indentSpaces() + format, args));
+    }
+
+    public void write(Writer writer) throws IOException {
+        for (String line : lines) {
+            writer.write(line);
+        }
+    }
+
+    public void write(CodeBuffer other) {
+        for (String line : lines) {
+            other.lines.add(other.indentSpaces() + line);
+        }
+    }
+
+    private String indentSpaces() {
+        return "    ".repeat(Math.max(0, indent));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof CodeBuffer)) {
+            return false;
+        }
+        CodeBuffer o = (CodeBuffer) other;
+        return lines.equals(o.lines);
+    }
+
+    @Override
+    public int hashCode() {
+        return lines.hashCode();
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/CoordinatorRecordJsonConvertersGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/CoordinatorRecordJsonConvertersGenerator.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kroxylicious.kafka.message;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class CoordinatorRecordJsonConvertersGenerator implements TypeClassGenerator {
+    private final HeaderGenerator headerGenerator;
+    private final CodeBuffer buffer;
+    private final TreeMap<Short, CoordinatorRecord> records;
+
+    private static final class CoordinatorRecord {
+        final short id;
+        MessageSpec key;
+        MessageSpec value;
+
+        CoordinatorRecord(short id) {
+            this.id = id;
+        }
+    }
+
+    public CoordinatorRecordJsonConvertersGenerator(String packageName) {
+        this.headerGenerator = new HeaderGenerator(packageName);
+        this.records = new TreeMap<>();
+        this.buffer = new CodeBuffer();
+    }
+
+    @Override
+    public String outputName() {
+        return MessageGenerator.COORDINATOR_RECORD_JSON_CONVERTERS_JAVA;
+    }
+
+    @Override
+    public void registerMessageType(MessageSpec spec) {
+        switch (spec.type()) {
+            case COORDINATOR_KEY: {
+                short id = spec.apiKey().get();
+                CoordinatorRecord record = records.computeIfAbsent(id, __ -> new CoordinatorRecord(id));
+                if (record.key != null) {
+                    throw new RuntimeException("Duplicate coordinator record key for type " +
+                            id + ". Original claimant: " + record.key.name() + ". New " +
+                            "claimant: " + spec.name());
+                }
+                record.key = spec;
+                break;
+            }
+
+            case COORDINATOR_VALUE: {
+                short id = spec.apiKey().get();
+                CoordinatorRecord record = records.computeIfAbsent(id, __ -> new CoordinatorRecord(id));
+                if (record.value != null) {
+                    throw new RuntimeException("Duplicate coordinator record value for type " +
+                            id + ". Original claimant: " + record.key.name() + ". New " +
+                            "claimant: " + spec.name());
+                }
+                record.value = spec;
+                break;
+            }
+
+            default:
+                // Ignore
+        }
+    }
+
+    @Override
+    public void generateAndWrite(BufferedWriter writer) throws IOException {
+        buffer.printf("public class CoordinatorRecordJsonConverters {%n");
+        buffer.incrementIndent();
+        generateWriteKeyJson();
+        buffer.printf("%n");
+        generateWriteValueJson();
+        buffer.printf("%n");
+        generateReadKeyFromJson();
+        buffer.printf("%n");
+        generateReadValueFromJson();
+        buffer.printf("%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        headerGenerator.generate();
+
+        headerGenerator.buffer().write(writer);
+        buffer.write(writer);
+    }
+
+    private void generateWriteKeyJson() {
+        headerGenerator.addImport(MessageGenerator.JSON_NODE_CLASS);
+        headerGenerator.addImport(MessageGenerator.API_MESSAGE_CLASS);
+
+        buffer.printf("public static JsonNode writeRecordKeyAsJson(ApiMessage key) {%n");
+        buffer.incrementIndent();
+        buffer.printf("switch (key.apiKey()) {%n");
+        buffer.incrementIndent();
+        for (Map.Entry<Short, CoordinatorRecord> entry : records.entrySet()) {
+            String apiMessageClassName = MessageGenerator.capitalizeFirst(entry.getValue().key.name());
+            buffer.printf("case %d:%n", entry.getKey());
+            buffer.incrementIndent();
+            buffer.printf("return %sJsonConverter.write((%s) key, (short) 0);%n", apiMessageClassName, apiMessageClassName);
+            buffer.decrementIndent();
+        }
+        buffer.printf("default:%n");
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+        buffer.printf("throw new UnsupportedVersionException(\"Unknown record id \"" +
+                " + key.apiKey());%n");
+        buffer.decrementIndent();
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateWriteValueJson() {
+        headerGenerator.addImport(MessageGenerator.JSON_NODE_CLASS);
+        headerGenerator.addImport(MessageGenerator.API_MESSAGE_CLASS);
+
+        buffer.printf("public static JsonNode writeRecordValueAsJson(ApiMessage value, short version) {%n");
+        buffer.incrementIndent();
+        buffer.printf("switch (value.apiKey()) {%n");
+        buffer.incrementIndent();
+        for (Map.Entry<Short, CoordinatorRecord> entry : records.entrySet()) {
+            String apiMessageClassName = MessageGenerator.capitalizeFirst(entry.getValue().value.name());
+            buffer.printf("case %d:%n", entry.getKey());
+            buffer.incrementIndent();
+            buffer.printf("return %sJsonConverter.write((%s) value, version);%n", apiMessageClassName, apiMessageClassName);
+            buffer.decrementIndent();
+        }
+        buffer.printf("default:%n");
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+        buffer.printf("throw new UnsupportedVersionException(\"Unknown record id \"" +
+                " + value.apiKey());%n");
+        buffer.decrementIndent();
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateReadKeyFromJson() {
+        headerGenerator.addImport(MessageGenerator.JSON_NODE_CLASS);
+        headerGenerator.addImport(MessageGenerator.API_MESSAGE_CLASS);
+
+        buffer.printf("public static ApiMessage readRecordKeyFromJson(JsonNode json, short apiKey) {%n");
+        buffer.incrementIndent();
+        buffer.printf("switch (apiKey) {%n");
+        buffer.incrementIndent();
+        for (Map.Entry<Short, CoordinatorRecord> entry : records.entrySet()) {
+            String apiMessageClassName = MessageGenerator.capitalizeFirst(entry.getValue().key.name());
+            buffer.printf("case %d:%n", entry.getKey());
+            buffer.incrementIndent();
+            buffer.printf("return %sJsonConverter.read(json, (short) 0);%n", apiMessageClassName);
+            buffer.decrementIndent();
+        }
+        buffer.printf("default:%n");
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+        buffer.printf("throw new UnsupportedVersionException(\"Unknown record id \"" +
+                " + apiKey);%n");
+        buffer.decrementIndent();
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateReadValueFromJson() {
+        headerGenerator.addImport(MessageGenerator.JSON_NODE_CLASS);
+        headerGenerator.addImport(MessageGenerator.API_MESSAGE_CLASS);
+
+        buffer.printf("public static ApiMessage readRecordValueFromJson(JsonNode json, short apiKey, short version) {%n");
+        buffer.incrementIndent();
+        buffer.printf("switch (apiKey) {%n");
+        buffer.incrementIndent();
+        for (Map.Entry<Short, CoordinatorRecord> entry : records.entrySet()) {
+            String apiMessageClassName = MessageGenerator.capitalizeFirst(entry.getValue().value.name());
+            buffer.printf("case %d:%n", entry.getKey());
+            buffer.incrementIndent();
+            buffer.printf("return %sJsonConverter.read(json, version);%n", apiMessageClassName);
+            buffer.decrementIndent();
+        }
+        buffer.printf("default:%n");
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+        buffer.printf("throw new UnsupportedVersionException(\"Unknown record id \"" +
+                " + apiKey);%n");
+        buffer.decrementIndent();
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/CoordinatorRecordTypeGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/CoordinatorRecordTypeGenerator.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kroxylicious.kafka.message;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class CoordinatorRecordTypeGenerator implements TypeClassGenerator {
+    private final HeaderGenerator headerGenerator;
+    private final CodeBuffer buffer;
+    private final TreeMap<Short, CoordinatorRecord> records;
+
+    private static final class CoordinatorRecord {
+        final short id;
+        MessageSpec key;
+        MessageSpec value;
+
+        CoordinatorRecord(short id) {
+            this.id = id;
+        }
+    }
+
+    public CoordinatorRecordTypeGenerator(String packageName) {
+        this.headerGenerator = new HeaderGenerator(packageName);
+        this.records = new TreeMap<>();
+        this.buffer = new CodeBuffer();
+    }
+
+    @Override
+    public String outputName() {
+        return MessageGenerator.COORDINATOR_RECORD_TYPE_JAVA;
+    }
+
+    @Override
+    public void registerMessageType(MessageSpec spec) {
+        switch (spec.type()) {
+            case COORDINATOR_KEY: {
+                short id = spec.apiKey().get();
+                CoordinatorRecord record = records.computeIfAbsent(id, __ -> new CoordinatorRecord(id));
+                if (record.key != null) {
+                    throw new RuntimeException("Duplicate coordinator record key for type " +
+                            id + ". Original claimant: " + record.key.name() + ". New " +
+                            "claimant: " + spec.name());
+                }
+                record.key = spec;
+                break;
+            }
+
+            case COORDINATOR_VALUE: {
+                short id = spec.apiKey().get();
+                CoordinatorRecord record = records.computeIfAbsent(id, __ -> new CoordinatorRecord(id));
+                if (record.value != null) {
+                    throw new RuntimeException("Duplicate coordinator record value for type " +
+                            id + ". Original claimant: " + record.key.name() + ". New " +
+                            "claimant: " + spec.name());
+                }
+                record.value = spec;
+                break;
+            }
+
+            default:
+                // Ignore
+        }
+    }
+
+    @Override
+    public void generateAndWrite(BufferedWriter writer) throws IOException {
+        generate();
+        write(writer);
+    }
+
+    private void generate() {
+        buffer.printf("public enum CoordinatorRecordType {%n");
+        buffer.incrementIndent();
+        generateEnumValues();
+        buffer.printf("%n");
+        generateInstanceVariables();
+        buffer.printf("%n");
+        generateEnumConstructor();
+        buffer.printf("%n");
+        generateFromApiKey();
+        buffer.printf("%n");
+        generateNewRecordKey();
+        buffer.printf("%n");
+        generateNewRecordValue();
+        buffer.printf("%n");
+        generateAccessor("id", "short");
+        buffer.printf("%n");
+        generateAccessor("lowestSupportedVersion", "short");
+        buffer.printf("%n");
+        generateAccessor("highestSupportedVersion", "short");
+        buffer.printf("%n");
+        generateToString();
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        headerGenerator.generate();
+    }
+
+    private String cleanName(String name) {
+        return name
+                .replace("Key", "")
+                .replace("Value", "");
+    }
+
+    private void generateEnumValues() {
+        int numProcessed = 0;
+        for (Map.Entry<Short, CoordinatorRecord> entry : records.entrySet()) {
+            MessageSpec key = entry.getValue().key;
+            if (key == null) {
+                throw new RuntimeException("Coordinator record " + entry.getKey() + " has no key.");
+            }
+            MessageSpec value = entry.getValue().value;
+            if (value == null) {
+                throw new RuntimeException("Coordinator record " + entry.getKey() + " has no value.");
+            }
+            String name = cleanName(key.name());
+            numProcessed++;
+            buffer.printf("%s(\"%s\", (short) %d, (short) %d, (short) %d)%s%n",
+                    MessageGenerator.toSnakeCase(name).toUpperCase(Locale.ROOT),
+                    MessageGenerator.capitalizeFirst(name),
+                    entry.getKey(),
+                    value.validVersions().lowest(),
+                    value.validVersions().highest(),
+                    (numProcessed == records.size()) ? ";" : ",");
+        }
+    }
+
+    private void generateInstanceVariables() {
+        buffer.printf("private final String name;%n");
+        buffer.printf("private final short id;%n");
+        buffer.printf("private final short lowestSupportedVersion;%n");
+        buffer.printf("private final short highestSupportedVersion;%n");
+    }
+
+    private void generateEnumConstructor() {
+        buffer.printf("CoordinatorRecordType(String name, short id, short lowestSupportedVersion, short highestSupportedVersion) {%n");
+        buffer.incrementIndent();
+        buffer.printf("this.name = name;%n");
+        buffer.printf("this.id = id;%n");
+        buffer.printf("this.lowestSupportedVersion = lowestSupportedVersion;%n");
+        buffer.printf("this.highestSupportedVersion = highestSupportedVersion;%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateFromApiKey() {
+        buffer.printf("public static CoordinatorRecordType fromId(short id) {%n");
+        buffer.incrementIndent();
+        buffer.printf("switch (id) {%n");
+        buffer.incrementIndent();
+        for (Map.Entry<Short, CoordinatorRecord> entry : records.entrySet()) {
+            buffer.printf("case %d:%n", entry.getKey());
+            buffer.incrementIndent();
+            buffer.printf("return %s;%n", MessageGenerator.toSnakeCase(cleanName(entry.getValue().key.name())).toUpperCase(Locale.ROOT));
+            buffer.decrementIndent();
+        }
+        buffer.printf("default:%n");
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+        buffer.printf("throw new UnsupportedVersionException(\"Unknown record id \"" +
+                " + id);%n");
+        buffer.decrementIndent();
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateNewRecordKey() {
+        headerGenerator.addImport(MessageGenerator.API_MESSAGE_CLASS);
+        buffer.printf("public ApiMessage newRecordKey() {%n");
+        buffer.incrementIndent();
+        buffer.printf("switch (id) {%n");
+        buffer.incrementIndent();
+        for (Map.Entry<Short, CoordinatorRecord> entry : records.entrySet()) {
+            buffer.printf("case %d:%n", entry.getKey());
+            buffer.incrementIndent();
+            buffer.printf("return new %s();%n",
+                    MessageGenerator.capitalizeFirst(entry.getValue().key.name()));
+            buffer.decrementIndent();
+        }
+        buffer.printf("default:%n");
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+        buffer.printf("throw new UnsupportedVersionException(\"Unknown record id \"" +
+                " + id);%n");
+        buffer.decrementIndent();
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateNewRecordValue() {
+        headerGenerator.addImport(MessageGenerator.API_MESSAGE_CLASS);
+        buffer.printf("public ApiMessage newRecordValue() {%n");
+        buffer.incrementIndent();
+        buffer.printf("switch (id) {%n");
+        buffer.incrementIndent();
+        for (Map.Entry<Short, CoordinatorRecord> entry : records.entrySet()) {
+            buffer.printf("case %d:%n", entry.getKey());
+            buffer.incrementIndent();
+            buffer.printf("return new %s();%n",
+                    MessageGenerator.capitalizeFirst(entry.getValue().value.name()));
+            buffer.decrementIndent();
+        }
+        buffer.printf("default:%n");
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+        buffer.printf("throw new UnsupportedVersionException(\"Unknown record id \"" +
+                " + id);%n");
+        buffer.decrementIndent();
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateAccessor(String name, String type) {
+        buffer.printf("public %s %s() {%n", type, name);
+        buffer.incrementIndent();
+        buffer.printf("return this.%s;%n", name);
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateToString() {
+        buffer.printf("@Override%n");
+        buffer.printf("public String toString() {%n");
+        buffer.incrementIndent();
+        buffer.printf("return this.name();%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void write(BufferedWriter writer) throws IOException {
+        headerGenerator.buffer().write(writer);
+        buffer.write(writer);
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/EntityType.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/EntityType.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum EntityType {
+    @JsonProperty("unknown")
+    UNKNOWN(null),
+
+    @JsonProperty("transactionalId")
+    TRANSACTIONAL_ID(FieldType.StringFieldType.INSTANCE),
+
+    @JsonProperty("producerId")
+    PRODUCER_ID(FieldType.Int64FieldType.INSTANCE),
+
+    @JsonProperty("groupId")
+    GROUP_ID(FieldType.StringFieldType.INSTANCE),
+
+    @JsonProperty("topicName")
+    TOPIC_NAME(FieldType.StringFieldType.INSTANCE),
+
+    @JsonProperty("brokerId")
+    BROKER_ID(FieldType.Int32FieldType.INSTANCE);
+
+    private final FieldType baseType;
+
+    EntityType(FieldType baseType) {
+        this.baseType = baseType;
+    }
+
+    public void verifyTypeMatches(String fieldName, FieldType type) {
+        if (this == UNKNOWN) {
+            return;
+        }
+        if (type instanceof FieldType.ArrayType) {
+            FieldType.ArrayType arrayType = (FieldType.ArrayType) type;
+            verifyTypeMatches(fieldName, arrayType.elementType());
+        }
+        else {
+            if (!type.toString().equals(baseType.toString())) {
+                throw new RuntimeException("Field " + fieldName + " has entity type " +
+                        name() + ", but field type " + type + ", which does " +
+                        "not match.");
+            }
+        }
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/FieldSpec.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/FieldSpec.java
@@ -1,0 +1,733 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public final class FieldSpec {
+    private static final Pattern VALID_FIELD_NAMES = Pattern.compile("[A-Za-z]([A-Za-z0-9]*)");
+
+    private final String name;
+
+    private final Versions versions;
+
+    private final List<FieldSpec> fields;
+
+    private final FieldType type;
+
+    private final boolean mapKey;
+
+    private final Versions nullableVersions;
+
+    private final String fieldDefault;
+
+    private final boolean ignorable;
+
+    private final EntityType entityType;
+
+    private final String about;
+
+    private final Versions taggedVersions;
+
+    private final Optional<Versions> flexibleVersions;
+
+    private final Optional<Integer> tag;
+
+    private final boolean zeroCopy;
+
+    @JsonCreator
+    public FieldSpec(@JsonProperty("name") String name,
+                     @JsonProperty("versions") String versions,
+                     @JsonProperty("fields") List<FieldSpec> fields,
+                     @JsonProperty("type") String type,
+                     @JsonProperty("mapKey") boolean mapKey,
+                     @JsonProperty("nullableVersions") String nullableVersions,
+                     @JsonProperty("default") String fieldDefault,
+                     @JsonProperty("ignorable") boolean ignorable,
+                     @JsonProperty("entityType") EntityType entityType,
+                     @JsonProperty("about") String about,
+                     @JsonProperty("taggedVersions") String taggedVersions,
+                     @JsonProperty("flexibleVersions") String flexibleVersions,
+                     @JsonProperty("tag") Integer tag,
+                     @JsonProperty("zeroCopy") boolean zeroCopy) {
+        this.name = Objects.requireNonNull(name);
+        if (!VALID_FIELD_NAMES.matcher(this.name).matches()) {
+            throw new RuntimeException("Invalid field name " + this.name);
+        }
+        this.taggedVersions = Versions.parse(taggedVersions, Versions.NONE);
+        // If versions is not set, but taggedVersions is, default to taggedVersions.
+        this.versions = Versions.parse(versions, this.taggedVersions.empty() ? null : this.taggedVersions);
+        if (this.versions == null) {
+            throw new RuntimeException("You must specify the version of the " +
+                    name + " structure.");
+        }
+        this.fields = fields == null ? List.of() : List.copyOf(fields);
+        this.type = FieldType.parse(Objects.requireNonNull(type));
+        this.mapKey = mapKey;
+        this.nullableVersions = Versions.parse(nullableVersions, Versions.NONE);
+        if (!this.nullableVersions.empty()) {
+            if (!this.type.canBeNullable()) {
+                throw new RuntimeException("Type " + this.type + " cannot be nullable.");
+            }
+        }
+        this.fieldDefault = fieldDefault == null ? "" : fieldDefault;
+        this.ignorable = ignorable;
+        this.entityType = (entityType == null) ? EntityType.UNKNOWN : entityType;
+        this.entityType.verifyTypeMatches(name, this.type);
+
+        this.about = about == null ? "" : about;
+        if (!this.fields().isEmpty()) {
+            if (!this.type.isArray() && !this.type.isStruct()) {
+                throw new RuntimeException("Non-array or Struct field " + name + " cannot have fields");
+            }
+            // Check struct invariants
+            if (this.type.isStruct() || this.type.isStructArray()) {
+                new StructSpec(name,
+                        versions,
+                        Versions.NONE_STRING, // version deprecations not supported at field level
+                        fields);
+            }
+        }
+
+        if (flexibleVersions == null || flexibleVersions.isEmpty()) {
+            this.flexibleVersions = Optional.empty();
+        }
+        else {
+            this.flexibleVersions = Optional.of(Versions.parse(flexibleVersions, null));
+            if (!(this.type.isString() || this.type.isBytes())) {
+                // For now, only allow flexibleVersions overrides for the string and bytes
+                // types. Overrides are only needed to keep compatibility with some old formats,
+                // so there isn't any need to support them for all types.
+                throw new RuntimeException("Invalid flexibleVersions override for " + name +
+                        ".  Only fields of type string or bytes can specify a flexibleVersions " +
+                        "override.");
+            }
+        }
+        this.tag = Optional.ofNullable(tag);
+        if (this.tag.isPresent() && mapKey) {
+            throw new RuntimeException("Tagged fields cannot be used as keys.");
+        }
+        checkTagInvariants();
+
+        this.zeroCopy = zeroCopy;
+        if (this.zeroCopy && !this.type.isBytes()) {
+            throw new RuntimeException("Invalid zeroCopy value for " + name +
+                    ". Only fields of type bytes can use zeroCopy flag.");
+        }
+    }
+
+    private void checkTagInvariants() {
+        if (this.tag.isPresent()) {
+            if (this.tag.get() < 0) {
+                throw new RuntimeException("Field " + name + " specifies a tag of " + this.tag.get() +
+                        ".  Tags cannot be negative.");
+            }
+            if (this.taggedVersions.empty()) {
+                throw new RuntimeException("Field " + name + " specifies a tag of " + this.tag.get() +
+                        ", but has no tagged versions.  If a tag is specified, taggedVersions must " +
+                        "be specified as well.");
+            }
+            Versions nullableTaggedVersions = this.nullableVersions.intersect(this.taggedVersions);
+            if (!(nullableTaggedVersions.empty() || nullableTaggedVersions.equals(this.taggedVersions))) {
+                throw new RuntimeException("Field " + name + " specifies nullableVersions " +
+                        this.nullableVersions + " and taggedVersions " + this.taggedVersions + ".  " +
+                        "Either all tagged versions must be nullable, or none must be.");
+            }
+            if (this.taggedVersions.highest() < Short.MAX_VALUE) {
+                throw new RuntimeException("Field " + name + " specifies taggedVersions " +
+                        this.taggedVersions + ", which is not open-ended.  taggedVersions must " +
+                        "be either none, or an open-ended range (that ends with a plus sign).");
+            }
+            if (!this.taggedVersions.intersect(this.versions).equals(this.taggedVersions)) {
+                throw new RuntimeException("Field " + name + " specifies taggedVersions " +
+                        this.taggedVersions + ", and versions " + this.versions + ".  " +
+                        "taggedVersions must be a subset of versions.");
+            }
+        }
+        else if (!this.taggedVersions.empty()) {
+            throw new RuntimeException("Field " + name + " does not specify a tag, " +
+                    "but specifies tagged versions of " + this.taggedVersions + ".  " +
+                    "Please specify a tag, or remove the taggedVersions.");
+        }
+    }
+
+    @JsonProperty("name")
+    public String name() {
+        return name;
+    }
+
+    String capitalizedCamelCaseName() {
+        return MessageGenerator.capitalizeFirst(name);
+    }
+
+    String camelCaseName() {
+        return MessageGenerator.lowerCaseFirst(name);
+    }
+
+    String snakeCaseName() {
+        return MessageGenerator.toSnakeCase(name);
+    }
+
+    public Versions versions() {
+        return versions;
+    }
+
+    @JsonProperty("versions")
+    public String versionsString() {
+        return versions.toString();
+    }
+
+    @JsonProperty("fields")
+    public List<FieldSpec> fields() {
+        return fields;
+    }
+
+    @JsonProperty("type")
+    public String typeString() {
+        return type.toString();
+    }
+
+    public FieldType type() {
+        return type;
+    }
+
+    @JsonProperty("mapKey")
+    public boolean mapKey() {
+        return mapKey;
+    }
+
+    public Versions nullableVersions() {
+        return nullableVersions;
+    }
+
+    @JsonProperty("nullableVersions")
+    public String nullableVersionsString() {
+        return nullableVersions.toString();
+    }
+
+    @JsonProperty("default")
+    public String defaultString() {
+        return fieldDefault;
+    }
+
+    @JsonProperty("ignorable")
+    public boolean ignorable() {
+        return ignorable;
+    }
+
+    @JsonProperty("entityType")
+    public EntityType entityType() {
+        return entityType;
+    }
+
+    @JsonProperty("about")
+    public String about() {
+        return about;
+    }
+
+    @JsonProperty("taggedVersions")
+    public String taggedVersionsString() {
+        return taggedVersions.toString();
+    }
+
+    public Versions taggedVersions() {
+        return taggedVersions;
+    }
+
+    @JsonProperty("flexibleVersions")
+    public String flexibleVersionsString() {
+        return flexibleVersions.map(Versions::toString).orElse(null);
+    }
+
+    public Optional<Versions> flexibleVersions() {
+        return flexibleVersions;
+    }
+
+    @JsonProperty("tag")
+    public Integer tagInteger() {
+        return tag.orElse(null);
+    }
+
+    public Optional<Integer> tag() {
+        return tag;
+    }
+
+    @JsonProperty("zeroCopy")
+    public boolean zeroCopy() {
+        return zeroCopy;
+    }
+
+    /**
+     * Get a string representation of the field default.
+     *
+     * @param headerGenerator   The header generator in case we need to add imports.
+     * @param structRegistry    The struct registry in case we need to look up structs.
+     *
+     * @return                  A string that can be used for the field default in the
+     *                          generated code.
+     */
+    String fieldDefault(HeaderGenerator headerGenerator,
+                        StructRegistry structRegistry) {
+        if (type instanceof FieldType.BoolFieldType) {
+            if (fieldDefault.isEmpty()) {
+                return "false";
+            }
+            else if (fieldDefault.equalsIgnoreCase("true")) {
+                return "true";
+            }
+            else if (fieldDefault.equalsIgnoreCase("false")) {
+                return "false";
+            }
+            else {
+                throw new RuntimeException("Invalid default for boolean field " +
+                        name + ": " + fieldDefault);
+            }
+        }
+        else if ((type instanceof FieldType.Int8FieldType) ||
+                (type instanceof FieldType.Int16FieldType) ||
+                (type instanceof FieldType.Uint16FieldType) ||
+                (type instanceof FieldType.Uint32FieldType) ||
+                (type instanceof FieldType.Int32FieldType) ||
+                (type instanceof FieldType.Int64FieldType)) {
+            int base = 10;
+            String defaultString = fieldDefault;
+            if (defaultString.startsWith("0x")) {
+                base = 16;
+                defaultString = defaultString.substring(2);
+            }
+            if (type instanceof FieldType.Int8FieldType) {
+                if (defaultString.isEmpty()) {
+                    return "(byte) 0";
+                }
+                else {
+                    try {
+                        Byte.valueOf(defaultString, base);
+                    }
+                    catch (NumberFormatException e) {
+                        throw new RuntimeException("Invalid default for int8 field " +
+                                name + ": " + defaultString, e);
+                    }
+                    return "(byte) " + fieldDefault;
+                }
+            }
+            else if (type instanceof FieldType.Int16FieldType) {
+                if (defaultString.isEmpty()) {
+                    return "(short) 0";
+                }
+                else {
+                    try {
+                        Short.valueOf(defaultString, base);
+                    }
+                    catch (NumberFormatException e) {
+                        throw new RuntimeException("Invalid default for int16 field " +
+                                name + ": " + defaultString, e);
+                    }
+                    return "(short) " + fieldDefault;
+                }
+            }
+            else if (type instanceof FieldType.Uint16FieldType) {
+                if (defaultString.isEmpty()) {
+                    return "0";
+                }
+                else {
+                    try {
+                        int value = Integer.valueOf(defaultString, base);
+                        if (value < 0 || value > MessageGenerator.UNSIGNED_SHORT_MAX) {
+                            throw new RuntimeException("Invalid default for uint16 field " +
+                                    name + ": out of range.");
+                        }
+                    }
+                    catch (NumberFormatException e) {
+                        throw new RuntimeException("Invalid default for uint16 field " +
+                                name + ": " + defaultString, e);
+                    }
+                    return fieldDefault;
+                }
+            }
+            else if (type instanceof FieldType.Uint32FieldType) {
+                if (defaultString.isEmpty()) {
+                    return "0";
+                }
+                else {
+                    try {
+                        long value = Long.valueOf(defaultString, base);
+                        if (value < 0 || value > MessageGenerator.UNSIGNED_INT_MAX) {
+                            throw new RuntimeException("Invalid default for uint32 field " +
+                                    name + ": out of range.");
+                        }
+                    }
+                    catch (NumberFormatException e) {
+                        throw new RuntimeException("Invalid default for uint32 field " +
+                                name + ": " + defaultString, e);
+                    }
+                    return fieldDefault;
+                }
+            }
+            else if (type instanceof FieldType.Int32FieldType) {
+                if (defaultString.isEmpty()) {
+                    return "0";
+                }
+                else {
+                    try {
+                        Integer.valueOf(defaultString, base);
+                    }
+                    catch (NumberFormatException e) {
+                        throw new RuntimeException("Invalid default for int32 field " +
+                                name + ": " + defaultString, e);
+                    }
+                    return fieldDefault;
+                }
+            }
+            else if (type instanceof FieldType.Int64FieldType) {
+                if (defaultString.isEmpty()) {
+                    return "0L";
+                }
+                else {
+                    try {
+                        Long.valueOf(defaultString, base);
+                    }
+                    catch (NumberFormatException e) {
+                        throw new RuntimeException("Invalid default for int64 field " +
+                                name + ": " + defaultString, e);
+                    }
+                    return fieldDefault + "L";
+                }
+            }
+            else {
+                throw new RuntimeException("Unsupported field type " + type);
+            }
+        }
+        else if (type instanceof FieldType.UUIDFieldType) {
+            headerGenerator.addImport(MessageGenerator.UUID_CLASS);
+            if (fieldDefault.isEmpty()) {
+                return "Uuid.ZERO_UUID";
+            }
+            else {
+                try {
+                    ByteBuffer uuidBytes = ByteBuffer.wrap(Base64.getUrlDecoder().decode(fieldDefault));
+                    uuidBytes.getLong();
+                    uuidBytes.getLong();
+                }
+                catch (IllegalArgumentException e) {
+                    throw new RuntimeException("Invalid default for uuid field " +
+                            name + ": " + fieldDefault, e);
+                }
+                headerGenerator.addImport(MessageGenerator.UUID_CLASS);
+                return "Uuid.fromString(\"" + fieldDefault + "\")";
+            }
+        }
+        else if (type instanceof FieldType.Float64FieldType) {
+            if (fieldDefault.isEmpty()) {
+                return "0.0";
+            }
+            else {
+                try {
+                    Double.parseDouble(fieldDefault);
+                }
+                catch (NumberFormatException e) {
+                    throw new RuntimeException("Invalid default for float64 field " +
+                            name + ": " + fieldDefault, e);
+                }
+                return "Double.parseDouble(\"" + fieldDefault + "\")";
+            }
+        }
+        else if (type instanceof FieldType.StringFieldType) {
+            if (fieldDefault.equals("null")) {
+                validateNullDefault();
+                return "null";
+            }
+            else {
+                return "\"" + fieldDefault + "\"";
+            }
+        }
+        else if (type.isBytes()) {
+            if (fieldDefault.equals("null")) {
+                validateNullDefault();
+                return "null";
+            }
+            else if (!fieldDefault.isEmpty()) {
+                throw new RuntimeException("Invalid default for bytes field " +
+                        name + ".  The only valid default for a bytes field " +
+                        "is empty or null.");
+            }
+            if (zeroCopy) {
+                headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+                return "ByteUtils.EMPTY_BUF";
+            }
+            else {
+                headerGenerator.addImport(MessageGenerator.BYTES_CLASS);
+                return "Bytes.EMPTY";
+            }
+        }
+        else if (type.isRecords()) {
+            return "null";
+        }
+        else if (type.isStruct()) {
+            if (fieldDefault.equals("null")) {
+                validateNullDefault();
+                return "null";
+            }
+            else if (!fieldDefault.isEmpty()) {
+                throw new RuntimeException("Invalid default for struct field " +
+                        name + ".  The only valid default for a struct field " +
+                        "is the empty struct or null.");
+            }
+            return "new " + type + "()";
+        }
+        else if (type.isArray()) {
+            if (fieldDefault.equals("null")) {
+                validateNullDefault();
+                return "null";
+            }
+            else if (!fieldDefault.isEmpty()) {
+                throw new RuntimeException("Invalid default for array field " +
+                        name + ".  The only valid default for an array field " +
+                        "is the empty array or null.");
+            }
+            return String.format("new %s(0)",
+                    concreteJavaType(headerGenerator, structRegistry));
+        }
+        else {
+            throw new RuntimeException("Unsupported field type " + type);
+        }
+    }
+
+    private void validateNullDefault() {
+        if (!(nullableVersions().contains(versions))) {
+            throw new RuntimeException("null cannot be the default for field " +
+                    name + ", because not all versions of this field are " +
+                    "nullable.");
+        }
+    }
+
+    /**
+     * Get the abstract Java type of the field-- for example, List.
+     *
+     * @param headerGenerator   The header generator in case we need to add imports.
+     * @param structRegistry    The struct registry in case we need to look up structs.
+     *
+     * @return                  The abstract java type name.
+     */
+    String fieldAbstractJavaType(HeaderGenerator headerGenerator,
+                                 StructRegistry structRegistry) {
+        if (type instanceof FieldType.BoolFieldType) {
+            return "boolean";
+        }
+        else if (type instanceof FieldType.Int8FieldType) {
+            return "byte";
+        }
+        else if (type instanceof FieldType.Int16FieldType) {
+            return "short";
+        }
+        else if (type instanceof FieldType.Uint16FieldType) {
+            return "int";
+        }
+        else if (type instanceof FieldType.Uint32FieldType) {
+            return "long";
+        }
+        else if (type instanceof FieldType.Int32FieldType) {
+            return "int";
+        }
+        else if (type instanceof FieldType.Int64FieldType) {
+            return "long";
+        }
+        else if (type instanceof FieldType.UUIDFieldType) {
+            headerGenerator.addImport(MessageGenerator.UUID_CLASS);
+            return "Uuid";
+        }
+        else if (type instanceof FieldType.Float64FieldType) {
+            return "double";
+        }
+        else if (type.isString()) {
+            return "String";
+        }
+        else if (type.isBytes()) {
+            if (zeroCopy) {
+                headerGenerator.addImport(MessageGenerator.BYTE_BUFFER_CLASS);
+                return "ByteBuffer";
+            }
+            else {
+                return "byte[]";
+            }
+        }
+        else if (type instanceof FieldType.RecordsFieldType) {
+            headerGenerator.addImport(MessageGenerator.BASE_RECORDS_CLASS);
+            return "BaseRecords";
+        }
+        else if (type.isStruct()) {
+            return MessageGenerator.capitalizeFirst(typeString());
+        }
+        else if (type.isArray()) {
+            FieldType.ArrayType arrayType = (FieldType.ArrayType) type;
+            if (structRegistry.isStructArrayWithKeys(this)) {
+                headerGenerator.addImport(MessageGenerator.IMPLICIT_LINKED_HASH_MULTI_COLLECTION_CLASS);
+                return collectionType(arrayType.elementType().toString());
+            }
+            else {
+                headerGenerator.addImport(MessageGenerator.LIST_CLASS);
+                return String.format("List<%s>",
+                        arrayType.elementType().getBoxedJavaType(headerGenerator));
+            }
+        }
+        else {
+            throw new RuntimeException("Unknown field type " + type);
+        }
+    }
+
+    /**
+     * Get the concrete Java type of the field-- for example, ArrayList.
+     *
+     * @param headerGenerator   The header generator in case we need to add imports.
+     * @param structRegistry    The struct registry in case we need to look up structs.
+     *
+     * @return                  The abstract java type name.
+     */
+    String concreteJavaType(HeaderGenerator headerGenerator,
+                            StructRegistry structRegistry) {
+        if (type.isArray()) {
+            FieldType.ArrayType arrayType = (FieldType.ArrayType) type;
+            if (structRegistry.isStructArrayWithKeys(this)) {
+                return collectionType(arrayType.elementType().toString());
+            }
+            else {
+                headerGenerator.addImport(MessageGenerator.ARRAYLIST_CLASS);
+                return String.format("ArrayList<%s>",
+                        arrayType.elementType().getBoxedJavaType(headerGenerator));
+            }
+        }
+        else {
+            return fieldAbstractJavaType(headerGenerator, structRegistry);
+        }
+    }
+
+    static String collectionType(String baseType) {
+        return baseType + "Collection";
+    }
+
+    /**
+     * Generate an if statement that checks if this field has a non-default value.
+     *
+     * @param headerGenerator   The header generator in case we need to add imports.
+     * @param structRegistry    The struct registry in case we need to look up structs.
+     * @param buffer            The code buffer to write to.
+     * @param fieldPrefix       The prefix to prepend before references to this field.
+     * @param nullableVersions  The nullable versions to use for this field.  This is
+     *                          mainly to let us choose to ignore the possibility of
+     *                          nulls sometimes (like when dealing with array entries
+     *                          that cannot be null).
+     */
+    void generateNonDefaultValueCheck(HeaderGenerator headerGenerator,
+                                      StructRegistry structRegistry,
+                                      CodeBuffer buffer,
+                                      String fieldPrefix,
+                                      Versions nullableVersions) {
+        String fieldDefault = fieldDefault(headerGenerator, structRegistry);
+        if (type().isArray()) {
+            if (fieldDefault.equals("null")) {
+                buffer.printf("if (%s%s != null) {%n", fieldPrefix, camelCaseName());
+            }
+            else if (nullableVersions.empty()) {
+                buffer.printf("if (!%s%s.isEmpty()) {%n", fieldPrefix, camelCaseName());
+            }
+            else {
+                buffer.printf("if (%s%s == null || !%s%s.isEmpty()) {%n",
+                        fieldPrefix, camelCaseName(), fieldPrefix, camelCaseName());
+            }
+        }
+        else if (type().isBytes()) {
+            if (fieldDefault.equals("null")) {
+                buffer.printf("if (%s%s != null) {%n", fieldPrefix, camelCaseName());
+            }
+            else if (nullableVersions.empty()) {
+                if (zeroCopy()) {
+                    buffer.printf("if (%s%s.hasRemaining()) {%n",
+                            fieldPrefix, camelCaseName());
+                }
+                else {
+                    buffer.printf("if (%s%s.length != 0) {%n",
+                            fieldPrefix, camelCaseName());
+                }
+            }
+            else {
+                if (zeroCopy()) {
+                    buffer.printf("if (%s%s == null || %s%s.remaining() > 0) {%n",
+                            fieldPrefix, camelCaseName(), fieldPrefix, camelCaseName());
+                }
+                else {
+                    buffer.printf("if (%s%s == null || %s%s.length != 0) {%n",
+                            fieldPrefix, camelCaseName(), fieldPrefix, camelCaseName());
+                }
+            }
+        }
+        else if (type().isString() || type().isStruct() || type() instanceof FieldType.UUIDFieldType) {
+            if (fieldDefault.equals("null")) {
+                buffer.printf("if (%s%s != null) {%n", fieldPrefix, camelCaseName());
+            }
+            else if (nullableVersions.empty()) {
+                buffer.printf("if (!%s%s.equals(%s)) {%n",
+                        fieldPrefix, camelCaseName(), fieldDefault);
+            }
+            else {
+                buffer.printf("if (%s%s == null || !%s%s.equals(%s)) {%n",
+                        fieldPrefix, camelCaseName(), fieldPrefix, camelCaseName(),
+                        fieldDefault);
+            }
+        }
+        else if (type() instanceof FieldType.BoolFieldType) {
+            buffer.printf("if (%s%s%s) {%n",
+                    fieldDefault.equals("true") ? "!" : "",
+                    fieldPrefix, camelCaseName());
+        }
+        else {
+            buffer.printf("if (%s%s != %s) {%n",
+                    fieldPrefix, camelCaseName(), fieldDefault);
+        }
+    }
+
+    /**
+     * Generate an if statement that checks if this field is non-default and also
+     * non-ignorable.
+     *
+     * @param headerGenerator   The header generator in case we need to add imports.
+     * @param structRegistry    The struct registry in case we need to look up structs.
+     * @param fieldPrefix       The prefix to prepend before references to this field.
+     * @param buffer            The code buffer to write to.
+     */
+    void generateNonIgnorableFieldCheck(HeaderGenerator headerGenerator,
+                                        StructRegistry structRegistry,
+                                        String fieldPrefix,
+                                        CodeBuffer buffer) {
+        generateNonDefaultValueCheck(headerGenerator, structRegistry,
+                buffer, fieldPrefix, nullableVersions());
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+        buffer.printf("throw new UnsupportedVersionException(" +
+                "\"Attempted to write a non-default %s at version \" + _version);%n",
+                camelCaseName());
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/FieldType.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/FieldType.java
@@ -1,0 +1,516 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.util.Optional;
+
+public interface FieldType {
+    String ARRAY_PREFIX = "[]";
+
+    final class BoolFieldType implements FieldType {
+        static final BoolFieldType INSTANCE = new BoolFieldType();
+        private static final String NAME = "bool";
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return "Boolean";
+        }
+
+        @Override
+        public Optional<Integer> fixedLength() {
+            return Optional.of(1);
+        }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
+    }
+
+    final class Int8FieldType implements FieldType {
+        static final Int8FieldType INSTANCE = new Int8FieldType();
+        private static final String NAME = "int8";
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return "Byte";
+        }
+
+        @Override
+        public Optional<Integer> fixedLength() {
+            return Optional.of(1);
+        }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
+    }
+
+    final class Int16FieldType implements FieldType {
+        static final Int16FieldType INSTANCE = new Int16FieldType();
+        private static final String NAME = "int16";
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return "Short";
+        }
+
+        @Override
+        public Optional<Integer> fixedLength() {
+            return Optional.of(2);
+        }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
+    }
+
+    final class Uint16FieldType implements FieldType {
+        static final Uint16FieldType INSTANCE = new Uint16FieldType();
+        private static final String NAME = "uint16";
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return "Integer";
+        }
+
+        @Override
+        public Optional<Integer> fixedLength() {
+            return Optional.of(2);
+        }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
+    }
+
+    final class Int32FieldType implements FieldType {
+        static final Int32FieldType INSTANCE = new Int32FieldType();
+        private static final String NAME = "int32";
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return "Integer";
+        }
+
+        @Override
+        public Optional<Integer> fixedLength() {
+            return Optional.of(4);
+        }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
+    }
+
+    final class Uint32FieldType implements FieldType {
+        static final Uint32FieldType INSTANCE = new Uint32FieldType();
+        private static final String NAME = "uint32";
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return "Long";
+        }
+
+        @Override
+        public Optional<Integer> fixedLength() {
+            return Optional.of(4);
+        }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
+    }
+
+    final class Int64FieldType implements FieldType {
+        static final Int64FieldType INSTANCE = new Int64FieldType();
+        private static final String NAME = "int64";
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return "Long";
+        }
+
+        @Override
+        public Optional<Integer> fixedLength() {
+            return Optional.of(8);
+        }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
+    }
+
+    final class UUIDFieldType implements FieldType {
+        static final UUIDFieldType INSTANCE = new UUIDFieldType();
+        private static final String NAME = "uuid";
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            headerGenerator.addImport(MessageGenerator.UUID_CLASS);
+            return "Uuid";
+        }
+
+        @Override
+        public Optional<Integer> fixedLength() {
+            return Optional.of(16);
+        }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
+    }
+
+    final class Float64FieldType implements FieldType {
+        static final Float64FieldType INSTANCE = new Float64FieldType();
+        private static final String NAME = "float64";
+
+        @Override
+        public Optional<Integer> fixedLength() {
+            return Optional.of(8);
+        }
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return "Double";
+        }
+
+        @Override
+        public boolean isFloat() {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
+    }
+
+    final class StringFieldType implements FieldType {
+        static final StringFieldType INSTANCE = new StringFieldType();
+        private static final String NAME = "string";
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return "String";
+        }
+
+        @Override
+        public boolean serializationIsDifferentInFlexibleVersions() {
+            return true;
+        }
+
+        @Override
+        public boolean isString() {
+            return true;
+        }
+
+        @Override
+        public boolean canBeNullable() {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
+    }
+
+    final class BytesFieldType implements FieldType {
+        static final BytesFieldType INSTANCE = new BytesFieldType();
+        private static final String NAME = "bytes";
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            headerGenerator.addImport(MessageGenerator.BYTE_BUFFER_CLASS);
+            return "ByteBuffer";
+        }
+
+        @Override
+        public boolean serializationIsDifferentInFlexibleVersions() {
+            return true;
+        }
+
+        @Override
+        public boolean isBytes() {
+            return true;
+        }
+
+        @Override
+        public boolean canBeNullable() {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
+    }
+
+    final class RecordsFieldType implements FieldType {
+        static final RecordsFieldType INSTANCE = new RecordsFieldType();
+        private static final String NAME = "records";
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            headerGenerator.addImport(MessageGenerator.BASE_RECORDS_CLASS);
+            return "BaseRecords";
+        }
+
+        @Override
+        public boolean serializationIsDifferentInFlexibleVersions() {
+            return true;
+        }
+
+        @Override
+        public boolean isRecords() {
+            return true;
+        }
+
+        @Override
+        public boolean canBeNullable() {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
+    }
+
+    final class StructType implements FieldType {
+        private final String type;
+
+        StructType(String type) {
+            this.type = type;
+        }
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return type;
+        }
+
+        @Override
+        public boolean serializationIsDifferentInFlexibleVersions() {
+            return true;
+        }
+
+        @Override
+        public boolean isStruct() {
+            return true;
+        }
+
+        @Override
+        public boolean canBeNullable() {
+            return true;
+        }
+
+        public String typeName() {
+            return type;
+        }
+
+        @Override
+        public String toString() {
+            return type;
+        }
+    }
+
+    final class ArrayType implements FieldType {
+        private final FieldType elementType;
+
+        ArrayType(FieldType elementType) {
+            this.elementType = elementType;
+        }
+
+        @Override
+        public boolean serializationIsDifferentInFlexibleVersions() {
+            return true;
+        }
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isArray() {
+            return true;
+        }
+
+        @Override
+        public boolean isStructArray() {
+            return elementType.isStruct();
+        }
+
+        @Override
+        public boolean canBeNullable() {
+            return true;
+        }
+
+        public FieldType elementType() {
+            return elementType;
+        }
+
+        public String elementName() {
+            return elementType.toString();
+        }
+
+        @Override
+        public String toString() {
+            return "[]" + elementType.toString();
+        }
+    }
+
+    static FieldType parse(String string) {
+        string = string.trim();
+        switch (string) {
+            case BoolFieldType.NAME:
+                return BoolFieldType.INSTANCE;
+            case Int8FieldType.NAME:
+                return Int8FieldType.INSTANCE;
+            case Int16FieldType.NAME:
+                return Int16FieldType.INSTANCE;
+            case Uint16FieldType.NAME:
+                return Uint16FieldType.INSTANCE;
+            case Uint32FieldType.NAME:
+                return Uint32FieldType.INSTANCE;
+            case Int32FieldType.NAME:
+                return Int32FieldType.INSTANCE;
+            case Int64FieldType.NAME:
+                return Int64FieldType.INSTANCE;
+            case UUIDFieldType.NAME:
+                return UUIDFieldType.INSTANCE;
+            case Float64FieldType.NAME:
+                return Float64FieldType.INSTANCE;
+            case StringFieldType.NAME:
+                return StringFieldType.INSTANCE;
+            case BytesFieldType.NAME:
+                return BytesFieldType.INSTANCE;
+            case RecordsFieldType.NAME:
+                return RecordsFieldType.INSTANCE;
+            default:
+                if (string.startsWith(ARRAY_PREFIX)) {
+                    String elementTypeString = string.substring(ARRAY_PREFIX.length());
+                    if (elementTypeString.isEmpty()) {
+                        throw new RuntimeException("Can't parse array type " + string +
+                                ".  No element type found.");
+                    }
+                    FieldType elementType = parse(elementTypeString);
+                    if (elementType.isArray()) {
+                        throw new RuntimeException("Can't have an array of arrays.  " +
+                                "Use an array of structs containing an array instead.");
+                    }
+                    return new ArrayType(elementType);
+                }
+                else if (MessageGenerator.firstIsCapitalized(string)) {
+                    return new StructType(string);
+                }
+                else {
+                    throw new RuntimeException("Can't parse type " + string);
+                }
+        }
+    }
+
+    String getBoxedJavaType(HeaderGenerator headerGenerator);
+
+    /**
+     * Returns true if this is an array type.
+     */
+    default boolean isArray() {
+        return false;
+    }
+
+    /**
+     * Returns true if this is an array of structures.
+     */
+    default boolean isStructArray() {
+        return false;
+    }
+
+    /**
+     * Returns true if the serialization of this type is different in flexible versions.
+     */
+    default boolean serializationIsDifferentInFlexibleVersions() {
+        return false;
+    }
+
+    /**
+     * Returns true if this is a string type.
+     */
+    default boolean isString() {
+        return false;
+    }
+
+    /**
+     * Returns true if this is a bytes type.
+     */
+    default boolean isBytes() {
+        return false;
+    }
+
+    /**
+     * Returns true if this is a records type
+     */
+    default boolean isRecords() {
+        return false;
+    }
+
+    /**
+     * Returns true if this is a floating point type.
+     */
+    default boolean isFloat() {
+        return false;
+    }
+
+    /**
+     * Returns true if this is a struct type.
+     */
+    default boolean isStruct() {
+        return false;
+    }
+
+    /**
+     * Returns true if this field type is compatible with nullability.
+     */
+    default boolean canBeNullable() {
+        return false;
+    }
+
+    /**
+     * Gets the fixed length of the field, or Empty if the field is variable-length.
+     */
+    default Optional<Integer> fixedLength() {
+        return Optional.empty();
+    }
+
+    default boolean isVariableLength() {
+        return fixedLength().isEmpty();
+    }
+
+    /**
+     * Convert the field type to a JSON string.
+     */
+    String toString();
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/HeaderGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/HeaderGenerator.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.util.Objects;
+import java.util.TreeSet;
+
+/**
+ * The Kafka header generator.
+ */
+public final class HeaderGenerator {
+    private static final String[] HEADER = new String[]{
+            "/*",
+            " * Licensed to the Apache Software Foundation (ASF) under one or more",
+            " * contributor license agreements. See the NOTICE file distributed with",
+            " * this work for additional information regarding copyright ownership.",
+            " * The ASF licenses this file to You under the Apache License, Version 2.0",
+            " * (the \"License\"); you may not use this file except in compliance with",
+            " * the License. You may obtain a copy of the License at",
+            " *",
+            " *    http://www.apache.org/licenses/LICENSE-2.0",
+            " *",
+            " * Unless required by applicable law or agreed to in writing, software",
+            " * distributed under the License is distributed on an \"AS IS\" BASIS,",
+            " * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+            " * See the License for the specific language governing permissions and",
+            " * limitations under the License.",
+            " */",
+            "",
+            "// THIS CODE IS AUTOMATICALLY GENERATED.  DO NOT EDIT.",
+            ""
+    };
+
+    private final CodeBuffer buffer;
+
+    private final TreeSet<String> imports;
+    private final String packageName;
+
+    private final TreeSet<String> staticImports;
+
+    public HeaderGenerator(String packageName) {
+        this.buffer = new CodeBuffer();
+        this.imports = new TreeSet<>();
+        this.packageName = packageName;
+        this.staticImports = new TreeSet<>();
+    }
+
+    public void addImport(String newImport) {
+        this.imports.add(newImport);
+    }
+
+    public void addStaticImport(String newImport) {
+        this.staticImports.add(newImport);
+    }
+
+    public void generate() {
+        Objects.requireNonNull(packageName);
+        for (String header : HEADER) {
+            buffer.printf("%s%n", header);
+        }
+        buffer.printf("package %s;%n", packageName);
+        buffer.printf("%n");
+        for (String newImport : imports) {
+            buffer.printf("import %s;%n", newImport);
+        }
+        buffer.printf("%n");
+        if (!staticImports.isEmpty()) {
+            for (String newImport : staticImports) {
+                buffer.printf("import static %s;%n", newImport);
+            }
+            buffer.printf("%n");
+        }
+    }
+
+    public CodeBuffer buffer() {
+        return buffer;
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/IsNullConditional.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/IsNullConditional.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+/**
+ * For versions of a field that are nullable, IsNullCondition creates a null check.
+ */
+public final class IsNullConditional {
+    interface ConditionalGenerator {
+        String generate(String name, boolean negated);
+    }
+
+    private static class PrimitiveConditionalGenerator implements ConditionalGenerator {
+        static final PrimitiveConditionalGenerator INSTANCE = new PrimitiveConditionalGenerator();
+
+        @Override
+        public String generate(String name, boolean negated) {
+            if (negated) {
+                return String.format("%s != null", name);
+            }
+            else {
+                return String.format("%s == null", name);
+            }
+        }
+    }
+
+    static IsNullConditional forName(String name) {
+        return new IsNullConditional(name);
+    }
+
+    static IsNullConditional forField(FieldSpec field) {
+        IsNullConditional cond = new IsNullConditional(field.camelCaseName());
+        cond.nullableVersions(field.nullableVersions());
+        return cond;
+    }
+
+    private final String name;
+    private Versions nullableVersions = Versions.ALL;
+    private Versions possibleVersions = Versions.ALL;
+    private Runnable ifNull = null;
+    private Runnable ifShouldNotBeNull = null;
+    private boolean alwaysEmitBlockScope = false;
+    private ConditionalGenerator conditionalGenerator = PrimitiveConditionalGenerator.INSTANCE;
+
+    private IsNullConditional(String name) {
+        this.name = name;
+    }
+
+    IsNullConditional nullableVersions(Versions nullableVersions) {
+        this.nullableVersions = nullableVersions;
+        return this;
+    }
+
+    IsNullConditional possibleVersions(Versions possibleVersions) {
+        this.possibleVersions = possibleVersions;
+        return this;
+    }
+
+    IsNullConditional ifNull(Runnable ifNull) {
+        this.ifNull = ifNull;
+        return this;
+    }
+
+    IsNullConditional ifShouldNotBeNull(Runnable ifShouldNotBeNull) {
+        this.ifShouldNotBeNull = ifShouldNotBeNull;
+        return this;
+    }
+
+    IsNullConditional alwaysEmitBlockScope(boolean alwaysEmitBlockScope) {
+        this.alwaysEmitBlockScope = alwaysEmitBlockScope;
+        return this;
+    }
+
+    IsNullConditional conditionalGenerator(ConditionalGenerator conditionalGenerator) {
+        this.conditionalGenerator = conditionalGenerator;
+        return this;
+    }
+
+    void generate(CodeBuffer buffer) {
+        if (nullableVersions.intersect(possibleVersions).empty()) {
+            if (ifShouldNotBeNull != null) {
+                if (alwaysEmitBlockScope) {
+                    buffer.printf("{%n");
+                    buffer.incrementIndent();
+                }
+                ifShouldNotBeNull.run();
+                if (alwaysEmitBlockScope) {
+                    buffer.decrementIndent();
+                    buffer.printf("}%n");
+                }
+            }
+        }
+        else {
+            if (ifNull != null) {
+                buffer.printf("if (%s) {%n", conditionalGenerator.generate(name, false));
+                buffer.incrementIndent();
+                ifNull.run();
+                buffer.decrementIndent();
+                if (ifShouldNotBeNull != null) {
+                    buffer.printf("} else {%n");
+                    buffer.incrementIndent();
+                    ifShouldNotBeNull.run();
+                    buffer.decrementIndent();
+                }
+                buffer.printf("}%n");
+            }
+            else if (ifShouldNotBeNull != null) {
+                buffer.printf("if (%s) {%n", conditionalGenerator.generate(name, true));
+                buffer.incrementIndent();
+                ifShouldNotBeNull.run();
+                buffer.decrementIndent();
+                buffer.printf("}%n");
+            }
+        }
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/JsonConverterGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/JsonConverterGenerator.java
@@ -1,0 +1,435 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.io.BufferedWriter;
+import java.util.Iterator;
+
+/**
+ * Generates Kafka MessageData classes.
+ */
+public final class JsonConverterGenerator implements MessageClassGenerator {
+    private static final String SUFFIX = "JsonConverter";
+    private final String packageName;
+    private final StructRegistry structRegistry;
+    private final HeaderGenerator headerGenerator;
+    private final CodeBuffer buffer;
+
+    JsonConverterGenerator(String packageName) {
+        this.packageName = packageName;
+        this.structRegistry = new StructRegistry();
+        this.headerGenerator = new HeaderGenerator(packageName);
+        this.buffer = new CodeBuffer();
+    }
+
+    @Override
+    public String outputName(MessageSpec spec) {
+        return spec.dataClassName() + SUFFIX;
+    }
+
+    @Override
+    public void generateAndWrite(MessageSpec message, BufferedWriter writer)
+            throws Exception {
+        structRegistry.register(message);
+        headerGenerator.addStaticImport(String.format("%s.%s.*",
+                packageName, message.dataClassName()));
+        buffer.printf("public class %s {%n",
+                MessageGenerator.capitalizeFirst(outputName(message)));
+        buffer.incrementIndent();
+        generateConverters(message.dataClassName(), message.struct(),
+                message.validVersions());
+        for (Iterator<StructRegistry.StructInfo> iter = structRegistry.structs(); iter.hasNext();) {
+            StructRegistry.StructInfo info = iter.next();
+            buffer.printf("%n");
+            buffer.printf("public static class %s {%n",
+                    MessageGenerator.capitalizeFirst(info.spec().name() + SUFFIX));
+            buffer.incrementIndent();
+            generateConverters(MessageGenerator.capitalizeFirst(info.spec().name()),
+                    info.spec(), info.parentVersions());
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        headerGenerator.generate();
+        headerGenerator.buffer().write(writer);
+        buffer.write(writer);
+    }
+
+    private void generateConverters(String name,
+                                    StructSpec spec,
+                                    Versions parentVersions) {
+        generateRead(name, spec, parentVersions);
+        generateWrite(name, spec, parentVersions);
+        generateOverloadWrite(name);
+    }
+
+    private void generateRead(String className,
+                              StructSpec struct,
+                              Versions parentVersions) {
+        headerGenerator.addImport(MessageGenerator.JSON_NODE_CLASS);
+        buffer.printf("public static %s read(JsonNode _node, short _version) {%n",
+                className);
+        buffer.incrementIndent();
+        buffer.printf("%s _object = new %s();%n", className, className);
+        VersionConditional.forVersions(struct.versions(), parentVersions).allowMembershipCheckAlwaysFalse(false).ifNotMember(__ -> {
+            headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+            buffer.printf("throw new UnsupportedVersionException(\"Can't read " +
+                    "version \" + _version + \" of %s\");%n", className);
+        }).generate(buffer);
+        Versions curVersions = parentVersions.intersect(struct.versions());
+        for (FieldSpec field : struct.fields()) {
+            String sourceVariable = String.format("_%sNode", field.camelCaseName());
+            buffer.printf("JsonNode %s = _node.get(\"%s\");%n",
+                    sourceVariable,
+                    field.camelCaseName());
+            buffer.printf("if (%s == null) {%n", sourceVariable);
+            buffer.incrementIndent();
+            Versions mandatoryVersions = field.versions().subtract(field.taggedVersions());
+            VersionConditional.forVersions(mandatoryVersions, curVersions).ifMember(__ -> buffer.printf("throw new RuntimeException(\"%s: unable to locate " +
+                    "field '%s', which is mandatory in version \" + _version);%n",
+                    className, field.camelCaseName())).ifNotMember(__ -> buffer.printf("_object.%s = %s;%n", field.camelCaseName(),
+                            field.fieldDefault(headerGenerator, structRegistry)))
+                    .generate(buffer);
+            buffer.decrementIndent();
+            buffer.printf("} else {%n");
+            buffer.incrementIndent();
+            VersionConditional.forVersions(struct.versions(), curVersions).ifMember(presentVersions -> generateTargetFromJson(new Target(field,
+                    sourceVariable,
+                    className,
+                    input -> String.format("_object.%s = %s", field.camelCaseName(), input)),
+                    curVersions)).ifNotMember(__ -> buffer.printf(
+                            "throw new RuntimeException(\"%s: field '%s' is not " +
+                                    "supported in version \" + _version);%n",
+                            className, field.camelCaseName()))
+                    .generate(buffer);
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+        buffer.printf("return _object;%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateTargetFromJson(Target target, Versions curVersions) {
+        if (target.field().type() instanceof FieldType.BoolFieldType) {
+            buffer.printf("if (!%s.isBoolean()) {%n", target.sourceVariable());
+            buffer.incrementIndent();
+            buffer.printf("throw new RuntimeException(\"%s expected Boolean type, " +
+                    "but got \" + _node.getNodeType());%n", target.humanReadableName());
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    target.sourceVariable() + ".asBoolean()"));
+        }
+        else if (target.field().type() instanceof FieldType.Int8FieldType) {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("MessageUtil.jsonNodeToByte(%s, \"%s\")",
+                            target.sourceVariable(), target.humanReadableName())));
+        }
+        else if (target.field().type() instanceof FieldType.Int16FieldType) {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("MessageUtil.jsonNodeToShort(%s, \"%s\")",
+                            target.sourceVariable(), target.humanReadableName())));
+        }
+        else if (target.field().type() instanceof FieldType.Uint16FieldType) {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("MessageUtil.jsonNodeToUnsignedShort(%s, \"%s\")",
+                            target.sourceVariable(), target.humanReadableName())));
+        }
+        else if (target.field().type() instanceof FieldType.Uint32FieldType) {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("MessageUtil.jsonNodeToUnsignedInt(%s, \"%s\")",
+                            target.sourceVariable(), target.humanReadableName())));
+        }
+        else if (target.field().type() instanceof FieldType.Int32FieldType) {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("MessageUtil.jsonNodeToInt(%s, \"%s\")",
+                            target.sourceVariable(), target.humanReadableName())));
+        }
+        else if (target.field().type() instanceof FieldType.Int64FieldType) {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("MessageUtil.jsonNodeToLong(%s, \"%s\")",
+                            target.sourceVariable(), target.humanReadableName())));
+        }
+        else if (target.field().type() instanceof FieldType.UUIDFieldType) {
+            buffer.printf("if (!%s.isTextual()) {%n", target.sourceVariable());
+            buffer.incrementIndent();
+            buffer.printf("throw new RuntimeException(\"%s expected a JSON string " +
+                    "type, but got \" + _node.getNodeType());%n", target.humanReadableName());
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+            headerGenerator.addImport(MessageGenerator.UUID_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(String.format(
+                    "Uuid.fromString(%s.asText())", target.sourceVariable())));
+        }
+        else if (target.field().type() instanceof FieldType.Float64FieldType) {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("MessageUtil.jsonNodeToDouble(%s, \"%s\")",
+                            target.sourceVariable(), target.humanReadableName())));
+        }
+        else {
+            // Handle the variable length types. All of them are potentially
+            // nullable, so handle that here.
+            IsNullConditional.forName(target.sourceVariable()).nullableVersions(target.field().nullableVersions()).possibleVersions(curVersions)
+                    .conditionalGenerator((name, negated) -> String.format("%s%s.isNull()", negated ? "!" : "", name))
+                    .ifNull(() -> buffer.printf("%s;%n", target.assignmentStatement("null")))
+                    .ifShouldNotBeNull(() -> generateVariableLengthTargetFromJson(target, curVersions)).generate(buffer);
+        }
+    }
+
+    private void generateVariableLengthTargetFromJson(Target target, Versions curVersions) {
+        if (target.field().type().isString()) {
+            buffer.printf("if (!%s.isTextual()) {%n", target.sourceVariable());
+            buffer.incrementIndent();
+            buffer.printf("throw new RuntimeException(\"%s expected a string " +
+                    "type, but got \" + _node.getNodeType());%n", target.humanReadableName());
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("%s.asText()", target.sourceVariable())));
+        }
+        else if (target.field().type().isBytes()) {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            if (target.field().zeroCopy()) {
+                headerGenerator.addImport(MessageGenerator.BYTE_BUFFER_CLASS);
+                buffer.printf("%s;%n", target.assignmentStatement(
+                        String.format("ByteBuffer.wrap(MessageUtil.jsonNodeToBinary(%s, \"%s\"))",
+                                target.sourceVariable(), target.humanReadableName())));
+            }
+            else {
+                buffer.printf("%s;%n", target.assignmentStatement(
+                        String.format("MessageUtil.jsonNodeToBinary(%s, \"%s\")",
+                                target.sourceVariable(), target.humanReadableName())));
+            }
+        }
+        else if (target.field().type().isRecords()) {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            headerGenerator.addImport(MessageGenerator.BYTE_BUFFER_CLASS);
+            headerGenerator.addImport(MessageGenerator.MEMORY_RECORDS_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("MemoryRecords.readableRecords(ByteBuffer.wrap(MessageUtil.jsonNodeToBinary(%s, \"%s\")))",
+                            target.sourceVariable(), target.humanReadableName())));
+        }
+        else if (target.field().type().isArray()) {
+            buffer.printf("if (!%s.isArray()) {%n", target.sourceVariable());
+            buffer.incrementIndent();
+            buffer.printf("throw new RuntimeException(\"%s expected a JSON " +
+                    "array, but got \" + _node.getNodeType());%n", target.humanReadableName());
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+            String type = target.field().concreteJavaType(headerGenerator, structRegistry);
+            buffer.printf("%s _collection = new %s(%s.size());%n", type, type, target.sourceVariable());
+            buffer.printf("%s;%n", target.assignmentStatement("_collection"));
+            headerGenerator.addImport(MessageGenerator.JSON_NODE_CLASS);
+            buffer.printf("for (JsonNode _element : %s) {%n", target.sourceVariable());
+            buffer.incrementIndent();
+            generateTargetFromJson(target.arrayElementTarget(
+                    input -> String.format("_collection.add(%s)", input)),
+                    curVersions);
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+        else if (target.field().type().isStruct()) {
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("%s%s.read(%s, _version)",
+                            target.field().type(), SUFFIX, target.sourceVariable())));
+        }
+        else {
+            throw new RuntimeException("Unexpected type " + target.field().type());
+        }
+    }
+
+    private void generateOverloadWrite(String className) {
+        buffer.printf("public static JsonNode write(%s _object, short _version) {%n",
+                className);
+        buffer.incrementIndent();
+        buffer.printf("return write(_object, _version, true);%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateWrite(String className,
+                               StructSpec struct,
+                               Versions parentVersions) {
+        headerGenerator.addImport(MessageGenerator.JSON_NODE_CLASS);
+        buffer.printf("public static JsonNode write(%s _object, short _version, boolean _serializeRecords) {%n",
+                className);
+        buffer.incrementIndent();
+        VersionConditional.forVersions(struct.versions(), parentVersions).allowMembershipCheckAlwaysFalse(false).ifNotMember(__ -> {
+            headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+            buffer.printf("throw new UnsupportedVersionException(\"Can't write " +
+                    "version \" + _version + \" of %s\");%n", className);
+        }).generate(buffer);
+        Versions curVersions = parentVersions.intersect(struct.versions());
+        headerGenerator.addImport(MessageGenerator.OBJECT_NODE_CLASS);
+        headerGenerator.addImport(MessageGenerator.JSON_NODE_FACTORY_CLASS);
+        buffer.printf("ObjectNode _node = new ObjectNode(JsonNodeFactory.instance);%n");
+        for (FieldSpec field : struct.fields()) {
+            Target target = new Target(field,
+                    String.format("_object.%s", field.camelCaseName()),
+                    field.camelCaseName(),
+                    input -> String.format("_node.set(\"%s\", %s)", field.camelCaseName(), input));
+            VersionConditional cond = VersionConditional.forVersions(field.versions(), curVersions)
+                    .ifMember(presentVersions -> VersionConditional.forVersions(field.taggedVersions(), presentVersions).ifMember(presentAndTaggedVersions -> {
+                        field.generateNonDefaultValueCheck(headerGenerator,
+                                structRegistry, buffer, "_object.", field.nullableVersions());
+                        buffer.incrementIndent();
+                        if (field.defaultString().equals("null")) {
+                            // If the default was null, and we already checked that this field was not
+                            // the default, we can omit further null checks.
+                            generateTargetToJson(target.nonNullableCopy(), presentAndTaggedVersions);
+                        }
+                        else {
+                            generateTargetToJson(target, presentAndTaggedVersions);
+                        }
+                        buffer.decrementIndent();
+                        buffer.printf("}%n");
+                    }).ifNotMember(presentAndNotTaggedVersions -> generateTargetToJson(target, presentAndNotTaggedVersions)).generate(buffer));
+            if (!field.ignorable()) {
+                cond.ifNotMember(__ -> field.generateNonIgnorableFieldCheck(headerGenerator,
+                        structRegistry, "_object.", buffer));
+            }
+            cond.generate(buffer);
+        }
+        buffer.printf("return _node;%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateTargetToJson(Target target, Versions versions) {
+        if (target.field().type() instanceof FieldType.BoolFieldType) {
+            headerGenerator.addImport(MessageGenerator.BOOLEAN_NODE_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("BooleanNode.valueOf(%s)", target.sourceVariable())));
+        }
+        else if ((target.field().type() instanceof FieldType.Int8FieldType) ||
+                (target.field().type() instanceof FieldType.Int16FieldType)) {
+            headerGenerator.addImport(MessageGenerator.SHORT_NODE_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("new ShortNode(%s)", target.sourceVariable())));
+        }
+        else if ((target.field().type() instanceof FieldType.Int32FieldType) ||
+                (target.field().type() instanceof FieldType.Uint16FieldType)) {
+            headerGenerator.addImport(MessageGenerator.INT_NODE_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("new IntNode(%s)", target.sourceVariable())));
+        }
+        else if (target.field().type() instanceof FieldType.Int64FieldType ||
+                (target.field().type() instanceof FieldType.Uint32FieldType)) {
+            headerGenerator.addImport(MessageGenerator.LONG_NODE_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("new LongNode(%s)", target.sourceVariable())));
+        }
+        else if (target.field().type() instanceof FieldType.UUIDFieldType) {
+            headerGenerator.addImport(MessageGenerator.TEXT_NODE_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("new TextNode(%s.toString())", target.sourceVariable())));
+        }
+        else if (target.field().type() instanceof FieldType.Float64FieldType) {
+            headerGenerator.addImport(MessageGenerator.DOUBLE_NODE_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("new DoubleNode(%s)", target.sourceVariable())));
+        }
+        else {
+            // Handle the variable length types. All of them are potentially
+            // nullable, so handle that here.
+            IsNullConditional.forName(target.sourceVariable()).nullableVersions(target.field().nullableVersions()).possibleVersions(versions)
+                    .conditionalGenerator((name, negated) -> String.format("%s %s= null", name, negated ? "!" : "=")).ifNull(() -> {
+                        headerGenerator.addImport(MessageGenerator.NULL_NODE_CLASS);
+                        buffer.printf("%s;%n", target.assignmentStatement("NullNode.instance"));
+                    }).ifShouldNotBeNull(() -> generateVariableLengthTargetToJson(target, versions)).generate(buffer);
+        }
+    }
+
+    private void generateVariableLengthTargetToJson(Target target, Versions versions) {
+        if (target.field().type().isString()) {
+            headerGenerator.addImport(MessageGenerator.TEXT_NODE_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("new TextNode(%s)", target.sourceVariable())));
+        }
+        else if (target.field().type().isBytes()) {
+            headerGenerator.addImport(MessageGenerator.BINARY_NODE_CLASS);
+            if (target.field().zeroCopy()) {
+                headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+                buffer.printf("%s;%n", target.assignmentStatement(
+                        String.format("new BinaryNode(MessageUtil.byteBufferToArray(%s))",
+                                target.sourceVariable())));
+            }
+            else {
+                headerGenerator.addImport(MessageGenerator.ARRAYS_CLASS);
+                buffer.printf("%s;%n", target.assignmentStatement(
+                        String.format("new BinaryNode(Arrays.copyOf(%s, %s.length))",
+                                target.sourceVariable(), target.sourceVariable())));
+            }
+        }
+        else if (target.field().type().isRecords()) {
+            headerGenerator.addImport(MessageGenerator.BINARY_NODE_CLASS);
+            headerGenerator.addImport(MessageGenerator.INT_NODE_CLASS);
+            // KIP-673: When logging requests/responses, we do not serialize the record, instead we
+            // output its sizeInBytes, because outputting the bytes is not very useful and can be
+            // quite expensive. Otherwise, we will serialize the record.
+            buffer.printf("if (_serializeRecords) {%n");
+            buffer.incrementIndent();
+            buffer.printf("%s;%n", target.assignmentStatement("new BinaryNode(new byte[]{})"));
+            buffer.decrementIndent();
+            buffer.printf("} else {%n");
+            buffer.incrementIndent();
+            buffer.printf("_node.set(\"%sSizeInBytes\", new IntNode(%s.sizeInBytes()));%n",
+                    target.field().camelCaseName(),
+                    target.sourceVariable());
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+        else if (target.field().type().isArray()) {
+            headerGenerator.addImport(MessageGenerator.ARRAY_NODE_CLASS);
+            headerGenerator.addImport(MessageGenerator.JSON_NODE_FACTORY_CLASS);
+            FieldType.ArrayType arrayType = (FieldType.ArrayType) target.field().type();
+            FieldType elementType = arrayType.elementType();
+            String arrayInstanceName = String.format("_%sArray",
+                    target.field().camelCaseName());
+            buffer.printf("ArrayNode %s = new ArrayNode(JsonNodeFactory.instance);%n",
+                    arrayInstanceName);
+            buffer.printf("for (%s _element : %s) {%n",
+                    elementType.getBoxedJavaType(headerGenerator), target.sourceVariable());
+            buffer.incrementIndent();
+            generateTargetToJson(target.arrayElementTarget(
+                    input -> String.format("%s.add(%s)", arrayInstanceName, input)),
+                    versions);
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+            buffer.printf("%s;%n", target.assignmentStatement(arrayInstanceName));
+        }
+        else if (target.field().type().isStruct()) {
+            buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("%sJsonConverter.write(%s, _version, _serializeRecords)",
+                            target.field().type(), target.sourceVariable())));
+        }
+        else {
+            throw new RuntimeException("unknown type " + target.field().type());
+        }
+    }
+
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/MessageClassGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/MessageClassGenerator.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.io.BufferedWriter;
+
+public interface MessageClassGenerator {
+    /**
+     * The short name of the converter class we are generating.  For example,
+     * FetchRequestDataJsonConverter.java.
+     */
+    String outputName(MessageSpec spec);
+
+    /**
+     * Generate the converter, and then write it out.
+     *
+     * @param spec      The message to generate a converter for.
+     * @param writer    The writer to write out the state to.
+     */
+    void generateAndWrite(MessageSpec spec, BufferedWriter writer) throws Exception;
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/MessageDataGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/MessageDataGenerator.java
@@ -1,0 +1,1666 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.io.BufferedWriter;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/**
+ * Generates Kafka MessageData classes.
+ */
+public final class MessageDataGenerator implements MessageClassGenerator {
+    private final StructRegistry structRegistry;
+    private final HeaderGenerator headerGenerator;
+    private final SchemaGenerator schemaGenerator;
+    private final CodeBuffer buffer;
+    private Versions messageFlexibleVersions;
+
+    MessageDataGenerator(String packageName) {
+        this.structRegistry = new StructRegistry();
+        this.headerGenerator = new HeaderGenerator(packageName);
+        this.schemaGenerator = new SchemaGenerator(headerGenerator, structRegistry);
+        this.buffer = new CodeBuffer();
+    }
+
+    @Override
+    public String outputName(MessageSpec spec) {
+        return spec.dataClassName();
+    }
+
+    @Override
+    public void generateAndWrite(MessageSpec message, BufferedWriter writer) throws Exception {
+        generate(message);
+        write(writer);
+    }
+
+    void generate(MessageSpec message) throws Exception {
+        if (message.struct().versions().contains(Short.MAX_VALUE)) {
+            throw new RuntimeException("Message " + message.name() + " does " +
+                    "not specify a maximum version.");
+        }
+        structRegistry.register(message);
+        schemaGenerator.generateSchemas(message);
+        messageFlexibleVersions = message.flexibleVersions();
+        generateClass(Optional.of(message),
+                message.dataClassName(),
+                message.struct(),
+                message.struct().versions());
+        headerGenerator.generate();
+    }
+
+    void write(BufferedWriter writer) throws Exception {
+        headerGenerator.buffer().write(writer);
+        buffer.write(writer);
+    }
+
+    private void generateClass(Optional<MessageSpec> topLevelMessageSpec,
+                               String className,
+                               StructSpec struct,
+                               Versions parentVersions)
+            throws Exception {
+        buffer.printf("%n");
+        boolean isTopLevel = topLevelMessageSpec.isPresent();
+        boolean isSetElement = struct.hasKeys(); // Check if the class is inside a set.
+        if (isTopLevel && isSetElement) {
+            throw new RuntimeException("Cannot set mapKey on top level fields.");
+        }
+        generateClassHeader(className, isTopLevel, isSetElement);
+        buffer.incrementIndent();
+        generateFieldDeclarations(struct, isSetElement);
+        buffer.printf("%n");
+        schemaGenerator.writeSchema(className, buffer);
+        generateClassConstructors(className, struct, isSetElement);
+        buffer.printf("%n");
+        if (isTopLevel) {
+            generateShortAccessor("apiKey", topLevelMessageSpec.get().apiKey().orElse((short) -1));
+        }
+        buffer.printf("%n");
+        generateShortAccessor("lowestSupportedVersion", parentVersions.lowest());
+        buffer.printf("%n");
+        generateShortAccessor("highestSupportedVersion", parentVersions.highest());
+        buffer.printf("%n");
+        generateClassReader(className, struct, parentVersions);
+        buffer.printf("%n");
+        generateClassWriter(className, struct, parentVersions);
+        buffer.printf("%n");
+        generateClassMessageSize(className, struct, parentVersions);
+        if (isSetElement) {
+            buffer.printf("%n");
+            generateClassEquals(className, struct, true);
+        }
+        buffer.printf("%n");
+        generateClassEquals(className, struct, false);
+        buffer.printf("%n");
+        generateClassHashCode(struct, isSetElement);
+        buffer.printf("%n");
+        generateClassDuplicate(className, struct);
+        buffer.printf("%n");
+        generateClassToString(className, struct);
+        generateFieldAccessors(struct, isSetElement);
+        buffer.printf("%n");
+        generateUnknownTaggedFieldsAccessor();
+        generateFieldMutators(struct, className, isSetElement);
+
+        if (!isTopLevel) {
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+        generateSubclasses(className, struct, parentVersions, isSetElement);
+        if (isTopLevel) {
+            for (Iterator<StructSpec> iter = structRegistry.commonStructs(); iter.hasNext();) {
+                StructSpec commonStruct = iter.next();
+                generateClass(Optional.empty(),
+                        commonStruct.name(),
+                        commonStruct,
+                        commonStruct.versions());
+            }
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+    }
+
+    private void generateClassHeader(String className, boolean isTopLevel,
+                                     boolean isSetElement) {
+        Set<String> implementedInterfaces = new HashSet<>();
+        if (isTopLevel) {
+            implementedInterfaces.add("ApiMessage");
+            headerGenerator.addImport(MessageGenerator.API_MESSAGE_CLASS);
+        }
+        else {
+            implementedInterfaces.add("Message");
+            headerGenerator.addImport(MessageGenerator.MESSAGE_CLASS);
+        }
+        if (isSetElement) {
+            headerGenerator.addImport(MessageGenerator.IMPLICIT_LINKED_HASH_MULTI_COLLECTION_CLASS);
+            implementedInterfaces.add("ImplicitLinkedHashMultiCollection.Element");
+        }
+        Set<String> classModifiers = new LinkedHashSet<>();
+        classModifiers.add("public");
+        if (!isTopLevel) {
+            classModifiers.add("static");
+        }
+        buffer.printf("%s class %s implements %s {%n",
+                String.join(" ", classModifiers),
+                className,
+                String.join(", ", implementedInterfaces));
+    }
+
+    private void generateSubclasses(String className, StructSpec struct,
+                                    Versions parentVersions, boolean isSetElement)
+            throws Exception {
+        for (FieldSpec field : struct.fields()) {
+            if (field.type().isStructArray()) {
+                FieldType.ArrayType arrayType = (FieldType.ArrayType) field.type();
+                if (!structRegistry.commonStructNames().contains(arrayType.elementName())) {
+                    generateClass(Optional.empty(),
+                            arrayType.elementType().toString(),
+                            structRegistry.findStruct(field),
+                            parentVersions.intersect(struct.versions()));
+                }
+            }
+            else if (field.type().isStruct()) {
+                if (!structRegistry.commonStructNames().contains(field.typeString())) {
+                    generateClass(Optional.empty(),
+                            field.typeString(),
+                            structRegistry.findStruct(field),
+                            parentVersions.intersect(struct.versions()));
+                }
+            }
+        }
+        if (isSetElement) {
+            generateHashSet(className, struct);
+        }
+    }
+
+    private void generateHashSet(String className, StructSpec struct) {
+        buffer.printf("%n");
+        headerGenerator.addImport(MessageGenerator.IMPLICIT_LINKED_HASH_MULTI_COLLECTION_CLASS);
+        buffer.printf("public static class %s extends ImplicitLinkedHashMultiCollection<%s> {%n",
+                FieldSpec.collectionType(className), className);
+        buffer.incrementIndent();
+        generateHashSetZeroArgConstructor(className);
+        buffer.printf("%n");
+        generateHashSetSizeArgConstructor(className);
+        buffer.printf("%n");
+        generateHashSetIteratorConstructor(className);
+        buffer.printf("%n");
+        generateHashSetFindMethod(className, struct);
+        buffer.printf("%n");
+        generateHashSetFindAllMethod(className, struct);
+        buffer.printf("%n");
+        generateCollectionDuplicateMethod(className);
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateHashSetZeroArgConstructor(String className) {
+        buffer.printf("public %s() {%n", FieldSpec.collectionType(className));
+        buffer.incrementIndent();
+        buffer.printf("super();%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateHashSetSizeArgConstructor(String className) {
+        buffer.printf("public %s(int expectedNumElements) {%n",
+                FieldSpec.collectionType(className));
+        buffer.incrementIndent();
+        buffer.printf("super(expectedNumElements);%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateHashSetIteratorConstructor(String className) {
+        headerGenerator.addImport(MessageGenerator.ITERATOR_CLASS);
+        buffer.printf("public %s(Iterator<%s> iterator) {%n",
+                FieldSpec.collectionType(className), className);
+        buffer.incrementIndent();
+        buffer.printf("super(iterator);%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateHashSetFindMethod(String className, StructSpec struct) {
+        headerGenerator.addImport(MessageGenerator.LIST_CLASS);
+        buffer.printf("public %s find(%s) {%n", className,
+                commaSeparatedHashSetFieldAndTypes(struct));
+        buffer.incrementIndent();
+        generateKeyElement(className, struct);
+        headerGenerator.addImport(MessageGenerator.IMPLICIT_LINKED_HASH_MULTI_COLLECTION_CLASS);
+        buffer.printf("return find(_key);%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateHashSetFindAllMethod(String className, StructSpec struct) {
+        headerGenerator.addImport(MessageGenerator.LIST_CLASS);
+        buffer.printf("public List<%s> findAll(%s) {%n", className,
+                commaSeparatedHashSetFieldAndTypes(struct));
+        buffer.incrementIndent();
+        generateKeyElement(className, struct);
+        headerGenerator.addImport(MessageGenerator.IMPLICIT_LINKED_HASH_MULTI_COLLECTION_CLASS);
+        buffer.printf("return findAll(_key);%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateKeyElement(String className, StructSpec struct) {
+        buffer.printf("%s _key = new %s();%n", className, className);
+        for (FieldSpec field : struct.fields()) {
+            if (field.mapKey()) {
+                buffer.printf("_key.set%s(%s);%n",
+                        field.capitalizedCamelCaseName(),
+                        field.camelCaseName());
+            }
+        }
+    }
+
+    private String commaSeparatedHashSetFieldAndTypes(StructSpec struct) {
+        return struct.fields().stream().filter(FieldSpec::mapKey).map(f -> String.format("%s %s",
+                f.concreteJavaType(headerGenerator, structRegistry), f.camelCaseName())).collect(Collectors.joining(", "));
+    }
+
+    private void generateCollectionDuplicateMethod(String className) {
+        headerGenerator.addImport(MessageGenerator.LIST_CLASS);
+        buffer.printf("public %s duplicate() {%n", FieldSpec.collectionType(className));
+        buffer.incrementIndent();
+        buffer.printf("%s _duplicate = new %s(size());%n",
+                FieldSpec.collectionType(className), FieldSpec.collectionType(className));
+        buffer.printf("for (%s _element : this) {%n", className);
+        buffer.incrementIndent();
+        buffer.printf("_duplicate.add(_element.duplicate());%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.printf("return _duplicate;%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateFieldDeclarations(StructSpec struct, boolean isSetElement) {
+        for (FieldSpec field : struct.fields()) {
+            generateFieldDeclaration(field);
+        }
+        headerGenerator.addImport(MessageGenerator.LIST_CLASS);
+        headerGenerator.addImport(MessageGenerator.RAW_TAGGED_FIELD_CLASS);
+        buffer.printf("private List<RawTaggedField> _unknownTaggedFields;%n");
+        if (isSetElement) {
+            buffer.printf("private int next;%n");
+            buffer.printf("private int prev;%n");
+        }
+    }
+
+    private void generateFieldDeclaration(FieldSpec field) {
+        buffer.printf("%s %s;%n",
+                field.fieldAbstractJavaType(headerGenerator, structRegistry),
+                field.camelCaseName());
+    }
+
+    private void generateFieldAccessors(StructSpec struct, boolean isSetElement) {
+        for (FieldSpec field : struct.fields()) {
+            generateFieldAccessor(field);
+        }
+        if (isSetElement) {
+            buffer.printf("%n");
+            buffer.printf("@Override%n");
+            generateAccessor("int", "next", "next");
+
+            buffer.printf("%n");
+            buffer.printf("@Override%n");
+            generateAccessor("int", "prev", "prev");
+        }
+    }
+
+    private void generateUnknownTaggedFieldsAccessor() {
+        buffer.printf("@Override%n");
+        headerGenerator.addImport(MessageGenerator.LIST_CLASS);
+        headerGenerator.addImport(MessageGenerator.RAW_TAGGED_FIELD_CLASS);
+        buffer.printf("public List<RawTaggedField> unknownTaggedFields() {%n");
+        buffer.incrementIndent();
+        // Optimize _unknownTaggedFields by not creating a new list object
+        // unless we need it.
+        buffer.printf("if (_unknownTaggedFields == null) {%n");
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.ARRAYLIST_CLASS);
+        buffer.printf("_unknownTaggedFields = new ArrayList<>(0);%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.printf("return _unknownTaggedFields;%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+
+    }
+
+    private void generateFieldMutators(StructSpec struct, String className,
+                                       boolean isSetElement) {
+        for (FieldSpec field : struct.fields()) {
+            generateFieldMutator(className, field);
+        }
+        if (isSetElement) {
+            buffer.printf("%n");
+            buffer.printf("@Override%n");
+            generateSetter("int", "setNext", "next");
+
+            buffer.printf("%n");
+            buffer.printf("@Override%n");
+            generateSetter("int", "setPrev", "prev");
+        }
+    }
+
+    private void generateClassConstructors(String className, StructSpec struct, boolean isSetElement) {
+        headerGenerator.addImport(MessageGenerator.READABLE_CLASS);
+        buffer.printf("public %s(Readable _readable, short _version) {%n", className);
+        buffer.incrementIndent();
+        buffer.printf("read(_readable, _version);%n");
+        generateConstructorEpilogue(isSetElement);
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.printf("%n");
+
+        buffer.printf("public %s() {%n", className);
+        buffer.incrementIndent();
+        for (FieldSpec field : struct.fields()) {
+            buffer.printf("this.%s = %s;%n",
+                    field.camelCaseName(),
+                    field.fieldDefault(headerGenerator, structRegistry));
+        }
+        generateConstructorEpilogue(isSetElement);
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateConstructorEpilogue(boolean isSetElement) {
+        if (isSetElement) {
+            headerGenerator.addImport(MessageGenerator.IMPLICIT_LINKED_HASH_COLLECTION_CLASS);
+            buffer.printf("this.prev = ImplicitLinkedHashCollection.INVALID_INDEX;%n");
+            buffer.printf("this.next = ImplicitLinkedHashCollection.INVALID_INDEX;%n");
+        }
+    }
+
+    private void generateShortAccessor(String name, short val) {
+        buffer.printf("@Override%n");
+        buffer.printf("public short %s() {%n", name);
+        buffer.incrementIndent();
+        buffer.printf("return %d;%n", val);
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateClassReader(String className, StructSpec struct,
+                                     Versions parentVersions) {
+        headerGenerator.addImport(MessageGenerator.READABLE_CLASS);
+        buffer.printf("@Override%n");
+        buffer.printf("public final void read(Readable _readable, short _version) {%n");
+        buffer.incrementIndent();
+        VersionConditional.forVersions(parentVersions, struct.versions()).allowMembershipCheckAlwaysFalse(false).ifNotMember(__ -> {
+            headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+            buffer.printf("throw new UnsupportedVersionException(\"Can't read " +
+                    "version \" + _version + \" of %s\");%n", className);
+        }).generate(buffer);
+        Versions curVersions = parentVersions.intersect(struct.versions());
+        for (FieldSpec field : struct.fields()) {
+            Versions fieldFlexibleVersions = fieldFlexibleVersions(field);
+            if (!field.taggedVersions().intersect(fieldFlexibleVersions).equals(field.taggedVersions())) {
+                throw new RuntimeException("Field " + field.name() + " specifies tagged " +
+                        "versions " + field.taggedVersions() + " that are not a subset of the " +
+                        "flexible versions " + fieldFlexibleVersions);
+            }
+            Versions mandatoryVersions = field.versions().subtract(field.taggedVersions());
+            VersionConditional.forVersions(mandatoryVersions, curVersions).alwaysEmitBlockScope(field.type().isVariableLength()).ifNotMember(__ -> {
+                // If the field is not present, or is tagged, set it to its default here.
+                buffer.printf("this.%s = %s;%n", field.camelCaseName(),
+                        field.fieldDefault(headerGenerator, structRegistry));
+            }).ifMember(presentAndUntaggedVersions -> {
+                if (field.type().isVariableLength() && !field.type().isStruct()) {
+                    ClauseGenerator callGenerateVariableLengthReader = versions -> generateVariableLengthReader(fieldFlexibleVersions(field),
+                            field.camelCaseName(),
+                            field.type(),
+                            versions,
+                            field.nullableVersions(),
+                            String.format("this.%s = ", field.camelCaseName()),
+                            String.format(";%n"),
+                            structRegistry.isStructArrayWithKeys(field),
+                            field.zeroCopy());
+                    // For arrays where the field type needs to be serialized differently in flexible
+                    // versions, lift the flexible version check outside of the array.
+                    // This may mean generating two separate 'for' loops-- one for flexible
+                    // versions, and one for regular versions.
+                    if (field.type().isArray() &&
+                            ((FieldType.ArrayType) field.type()).elementType().serializationIsDifferentInFlexibleVersions()) {
+                        VersionConditional.forVersions(fieldFlexibleVersions(field),
+                                presentAndUntaggedVersions).ifMember(callGenerateVariableLengthReader).ifNotMember(callGenerateVariableLengthReader).generate(buffer);
+                    }
+                    else {
+                        callGenerateVariableLengthReader.generate(presentAndUntaggedVersions);
+                    }
+                }
+                else if (field.type().isStruct()) {
+                    generateStructReader(field, presentAndUntaggedVersions, false);
+                }
+                else {
+                    buffer.printf("this.%s = %s;%n", field.camelCaseName(),
+                            primitiveReadExpression(field.type()));
+                }
+            }).generate(buffer);
+        }
+        buffer.printf("this._unknownTaggedFields = null;%n");
+        VersionConditional.forVersions(messageFlexibleVersions, curVersions).ifMember(curFlexibleVersions -> {
+            buffer.printf("int _numTaggedFields = _readable.readUnsignedVarint();%n");
+            buffer.printf("for (int _i = 0; _i < _numTaggedFields; _i++) {%n");
+            buffer.incrementIndent();
+            buffer.printf("int _tag = _readable.readUnsignedVarint();%n");
+            buffer.printf("int _size = _readable.readUnsignedVarint();%n");
+            buffer.printf("switch (_tag) {%n");
+            buffer.incrementIndent();
+            for (FieldSpec field : struct.fields()) {
+                Versions validTaggedVersions = field.versions().intersect(field.taggedVersions());
+                if (!validTaggedVersions.empty()) {
+                    if (field.tag().isEmpty()) {
+                        throw new RuntimeException("Field " + field.name() + " has tagged versions, but no tag.");
+                    }
+                    buffer.printf("case %d: {%n", field.tag().get());
+                    buffer.incrementIndent();
+                    VersionConditional.forVersions(validTaggedVersions, curFlexibleVersions).ifMember(presentAndTaggedVersions -> {
+                        if (field.type().isVariableLength() && !field.type().isStruct()) {
+                            // All tagged fields are serialized using the new-style
+                            // flexible versions serialization.
+                            generateVariableLengthReader(fieldFlexibleVersions(field),
+                                    field.camelCaseName(),
+                                    field.type(),
+                                    presentAndTaggedVersions,
+                                    field.nullableVersions(),
+                                    String.format("this.%s = ", field.camelCaseName()),
+                                    String.format(";%n"),
+                                    structRegistry.isStructArrayWithKeys(field),
+                                    field.zeroCopy());
+                        }
+                        else if (field.type().isStruct()) {
+                            generateStructReader(field, presentAndTaggedVersions, true);
+                        }
+                        else {
+                            buffer.printf("this.%s = %s;%n", field.camelCaseName(),
+                                    primitiveReadExpression(field.type()));
+                        }
+                        buffer.printf("break;%n");
+                    }).ifNotMember(__ -> buffer.printf("throw new RuntimeException(\"Tag %d is not " +
+                            "valid for version \" + _version);%n", field.tag().get())).generate(buffer);
+                    buffer.decrementIndent();
+                    buffer.printf("}%n");
+                }
+            }
+            buffer.printf("default:%n");
+            buffer.incrementIndent();
+            buffer.printf("this._unknownTaggedFields = _readable.readUnknownTaggedField(this._unknownTaggedFields, _tag, _size);%n");
+            buffer.printf("break;%n");
+            buffer.decrementIndent();
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }).generate(buffer);
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateStructReader(
+                                      FieldSpec field,
+                                      Versions supportedVersions,
+                                      boolean tagged) {
+        VersionConditional.forVersions(field.nullableVersions(), supportedVersions).ifMember(__ -> {
+            if (tagged) {
+                buffer.printf("if (_readable.readUnsignedVarint() <= 0) {%n");
+            }
+            else {
+                buffer.printf("if (_readable.readByte() < 0) {%n");
+            }
+            buffer.incrementIndent();
+            buffer.printf("this.%s = null;%n", field.camelCaseName());
+            buffer.decrementIndent();
+            buffer.printf("} else {%n");
+            buffer.incrementIndent();
+            buffer.printf("this.%s = %s;%n", field.camelCaseName(),
+                    primitiveReadExpression(field.type()));
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }).ifNotMember(__ -> buffer.printf("this.%s = %s;%n", field.camelCaseName(),
+                primitiveReadExpression(field.type()))).generate(buffer);
+    }
+
+    private String primitiveReadExpression(FieldType type) {
+        if (type instanceof FieldType.BoolFieldType) {
+            return "_readable.readByte() != 0";
+        }
+        else if (type instanceof FieldType.Int8FieldType) {
+            return "_readable.readByte()";
+        }
+        else if (type instanceof FieldType.Int16FieldType) {
+            return "_readable.readShort()";
+        }
+        else if (type instanceof FieldType.Uint16FieldType) {
+            return "_readable.readUnsignedShort()";
+        }
+        else if (type instanceof FieldType.Uint32FieldType) {
+            return "_readable.readUnsignedInt()";
+        }
+        else if (type instanceof FieldType.Int32FieldType) {
+            return "_readable.readInt()";
+        }
+        else if (type instanceof FieldType.Int64FieldType) {
+            return "_readable.readLong()";
+        }
+        else if (type instanceof FieldType.UUIDFieldType) {
+            return "_readable.readUuid()";
+        }
+        else if (type instanceof FieldType.Float64FieldType) {
+            return "_readable.readDouble()";
+        }
+        else if (type.isStruct()) {
+            return String.format("new %s(_readable, _version)", type);
+        }
+        else {
+            throw new RuntimeException("Unsupported field type " + type);
+        }
+    }
+
+    private void generateVariableLengthReader(Versions fieldFlexibleVersions,
+                                              String name,
+                                              FieldType type,
+                                              Versions possibleVersions,
+                                              Versions nullableVersions,
+                                              String assignmentPrefix,
+                                              String assignmentSuffix,
+                                              boolean isStructArrayWithKeys,
+                                              boolean zeroCopy) {
+        String lengthVar = type.isArray() ? "arrayLength" : "length";
+        buffer.printf("int %s;%n", lengthVar);
+        VersionConditional.forVersions(fieldFlexibleVersions, possibleVersions).ifMember(__ -> buffer.printf("%s = _readable.readUnsignedVarint() - 1;%n", lengthVar))
+                .ifNotMember(__ -> {
+                    if (type.isString()) {
+                        buffer.printf("%s = _readable.readShort();%n", lengthVar);
+                    }
+                    else if (type.isBytes() || type.isArray() || type.isRecords()) {
+                        buffer.printf("%s = _readable.readInt();%n", lengthVar);
+                    }
+                    else {
+                        throw new RuntimeException("Can't handle variable length type " + type);
+                    }
+                }).generate(buffer);
+        buffer.printf("if (%s < 0) {%n", lengthVar);
+        buffer.incrementIndent();
+        VersionConditional.forVersions(nullableVersions, possibleVersions).ifNotMember(__ -> buffer.printf("throw new RuntimeException(\"non-nullable field %s " +
+                "was serialized as null\");%n", name)).ifMember(__ -> buffer.printf("%snull%s", assignmentPrefix, assignmentSuffix)).generate(buffer);
+        buffer.decrementIndent();
+        if (type.isString()) {
+            buffer.printf("} else if (%s > 0x7fff) {%n", lengthVar);
+            buffer.incrementIndent();
+            buffer.printf("throw new RuntimeException(\"string field %s " +
+                    "had invalid length \" + %s);%n", name, lengthVar);
+            buffer.decrementIndent();
+        }
+        buffer.printf("} else {%n");
+        buffer.incrementIndent();
+        if (type.isString()) {
+            buffer.printf("%s_readable.readString(%s)%s",
+                    assignmentPrefix, lengthVar, assignmentSuffix);
+        }
+        else if (type.isBytes()) {
+            if (zeroCopy) {
+                buffer.printf("%s_readable.readByteBuffer(%s)%s",
+                        assignmentPrefix, lengthVar, assignmentSuffix);
+            }
+            else {
+                buffer.printf("byte[] newBytes = _readable.readArray(%s);%n", lengthVar);
+                buffer.printf("%snewBytes%s", assignmentPrefix, assignmentSuffix);
+            }
+        }
+        else if (type.isRecords()) {
+            buffer.printf("%s_readable.readRecords(%s)%s",
+                    assignmentPrefix, lengthVar, assignmentSuffix);
+        }
+        else if (type.isArray()) {
+            FieldType.ArrayType arrayType = (FieldType.ArrayType) type;
+            buffer.printf("if (%s > _readable.remaining()) {%n", lengthVar);
+            buffer.incrementIndent();
+            buffer.printf("throw new RuntimeException(\"Tried to allocate a collection of size \" + %s + \", but " +
+                    "there are only \" + _readable.remaining() + \" bytes remaining.\");%n", lengthVar);
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+            if (isStructArrayWithKeys) {
+                headerGenerator.addImport(MessageGenerator.IMPLICIT_LINKED_HASH_MULTI_COLLECTION_CLASS);
+                buffer.printf("%s newCollection = new %s(%s);%n",
+                        FieldSpec.collectionType(arrayType.elementType().toString()),
+                        FieldSpec.collectionType(arrayType.elementType().toString()), lengthVar);
+            }
+            else {
+                headerGenerator.addImport(MessageGenerator.ARRAYLIST_CLASS);
+                String boxedArrayType = arrayType.elementType().getBoxedJavaType(headerGenerator);
+                buffer.printf("ArrayList<%s> newCollection = new ArrayList<>(%s);%n", boxedArrayType, lengthVar);
+            }
+            buffer.printf("for (int i = 0; i < %s; i++) {%n", lengthVar);
+            buffer.incrementIndent();
+            if (arrayType.elementType().isArray()) {
+                throw new RuntimeException("Nested arrays are not supported.  " +
+                        "Use an array of structures containing another array.");
+            }
+            else if (arrayType.elementType().isBytes() || arrayType.elementType().isString()) {
+                generateVariableLengthReader(fieldFlexibleVersions,
+                        name + " element",
+                        arrayType.elementType(),
+                        possibleVersions,
+                        Versions.NONE,
+                        "newCollection.add(",
+                        String.format(");%n"),
+                        false,
+                        false);
+            }
+            else {
+                buffer.printf("newCollection.add(%s);%n",
+                        primitiveReadExpression(arrayType.elementType()));
+            }
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+            buffer.printf("%snewCollection%s", assignmentPrefix, assignmentSuffix);
+        }
+        else {
+            throw new RuntimeException("Can't handle variable length type " + type);
+        }
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateClassWriter(String className, StructSpec struct,
+                                     Versions parentVersions) {
+        headerGenerator.addImport(MessageGenerator.WRITABLE_CLASS);
+        headerGenerator.addImport(MessageGenerator.OBJECT_SERIALIZATION_CACHE_CLASS);
+        buffer.printf("@Override%n");
+        buffer.printf("public void write(Writable _writable, ObjectSerializationCache _cache, short _version) {%n");
+        buffer.incrementIndent();
+        VersionConditional.forVersions(struct.versions(), parentVersions).allowMembershipCheckAlwaysFalse(false).ifNotMember(__ -> {
+            headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+            buffer.printf("throw new UnsupportedVersionException(\"Can't write " +
+                    "version \" + _version + \" of %s\");%n", className);
+        }).generate(buffer);
+        buffer.printf("int _numTaggedFields = 0;%n");
+        Versions curVersions = parentVersions.intersect(struct.versions());
+        TreeMap<Integer, FieldSpec> taggedFields = new TreeMap<>();
+        for (FieldSpec field : struct.fields()) {
+            VersionConditional cond = VersionConditional.forVersions(field.versions(), curVersions)
+                    .ifMember(presentVersions -> VersionConditional.forVersions(field.taggedVersions(), presentVersions).ifNotMember(presentAndUntaggedVersions -> {
+                        if (field.type().isVariableLength() && !field.type().isStruct()) {
+                            ClauseGenerator callGenerateVariableLengthWriter = versions -> generateVariableLengthWriter(fieldFlexibleVersions(field),
+                                    field.camelCaseName(),
+                                    field.type(),
+                                    versions,
+                                    field.nullableVersions(),
+                                    field.zeroCopy());
+                            // For arrays where the field type needs to be serialized differently in flexible
+                            // versions, lift the flexible version check outside of the array.
+                            // This may mean generating two separate 'for' loops-- one for flexible
+                            // versions, and one for regular versions.
+                            if (field.type().isArray() &&
+                                    ((FieldType.ArrayType) field.type()).elementType().serializationIsDifferentInFlexibleVersions()) {
+                                VersionConditional.forVersions(fieldFlexibleVersions(field),
+                                        presentAndUntaggedVersions).ifMember(callGenerateVariableLengthWriter).ifNotMember(callGenerateVariableLengthWriter)
+                                        .generate(buffer);
+                            }
+                            else {
+                                callGenerateVariableLengthWriter.generate(presentAndUntaggedVersions);
+                            }
+                        }
+                        else if (field.type().isStruct()) {
+                            IsNullConditional.forName(field.camelCaseName()).possibleVersions(presentAndUntaggedVersions).nullableVersions(field.nullableVersions())
+                                    .ifNull(() -> VersionConditional.forVersions(field.nullableVersions(), presentAndUntaggedVersions)
+                                            .ifMember(__ -> buffer.printf("_writable.writeByte((byte) -1);%n"))
+                                            .ifNotMember(__ -> buffer.printf("throw new NullPointerException();%n")).generate(buffer))
+                                    .ifShouldNotBeNull(() -> {
+                                        VersionConditional.forVersions(field.nullableVersions(), presentAndUntaggedVersions)
+                                                .ifMember(__ -> buffer.printf("_writable.writeByte((byte) 1);%n")).generate(buffer);
+                                        buffer.printf("%s;%n",
+                                                primitiveWriteExpression(field.type(), field.camelCaseName()));
+                                    }).generate(buffer);
+                        }
+                        else {
+                            buffer.printf("%s;%n",
+                                    primitiveWriteExpression(field.type(), field.camelCaseName()));
+                        }
+                    }).ifMember(__ -> {
+                        field.generateNonDefaultValueCheck(headerGenerator,
+                                structRegistry, buffer, "this.", field.nullableVersions());
+                        buffer.incrementIndent();
+                        buffer.printf("_numTaggedFields++;%n");
+                        buffer.decrementIndent();
+                        buffer.printf("}%n");
+                        if (taggedFields.put(field.tag().get(), field) != null) {
+                            throw new RuntimeException("Field " + field.name() + " has tag " +
+                                    field.tag() + ", but another field already used that tag.");
+                        }
+                    }).generate(buffer));
+            if (!field.ignorable()) {
+                cond.ifNotMember(__ -> field.generateNonIgnorableFieldCheck(headerGenerator,
+                        structRegistry, "this.", buffer));
+            }
+            cond.generate(buffer);
+        }
+        headerGenerator.addImport(MessageGenerator.RAW_TAGGED_FIELD_WRITER_CLASS);
+        buffer.printf("RawTaggedFieldWriter _rawWriter = RawTaggedFieldWriter.forFields(_unknownTaggedFields);%n");
+        buffer.printf("_numTaggedFields += _rawWriter.numFields();%n");
+        VersionConditional.forVersions(messageFlexibleVersions, curVersions).ifNotMember(__ -> generateCheckForUnsupportedNumTaggedFields("_numTaggedFields > 0"))
+                .ifMember(flexibleVersions -> {
+                    buffer.printf("_writable.writeUnsignedVarint(_numTaggedFields);%n");
+                    int prevTag = -1;
+                    for (FieldSpec field : taggedFields.values()) {
+                        if (prevTag + 1 != field.tag().get()) {
+                            buffer.printf("_rawWriter.writeRawTags(_writable, %d);%n", field.tag().get());
+                        }
+                        VersionConditional.forVersions(field.taggedVersions().intersect(field.versions()), flexibleVersions).allowMembershipCheckAlwaysFalse(false)
+                                .ifMember(presentAndTaggedVersions -> {
+                                    IsNullConditional cond = IsNullConditional.forName(field.camelCaseName()).nullableVersions(field.nullableVersions())
+                                            .possibleVersions(presentAndTaggedVersions).alwaysEmitBlockScope(true).ifShouldNotBeNull(() -> {
+                                                if (!field.defaultString().equals("null")) {
+                                                    field.generateNonDefaultValueCheck(headerGenerator,
+                                                            structRegistry, buffer, "this.", Versions.NONE);
+                                                    buffer.incrementIndent();
+                                                }
+                                                buffer.printf("_writable.writeUnsignedVarint(%d);%n", field.tag().get());
+                                                if (field.type().isString()) {
+                                                    buffer.printf("byte[] _stringBytes = _cache.getSerializedValue(this.%s);%n",
+                                                            field.camelCaseName());
+                                                    headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+                                                    buffer.printf("_writable.writeUnsignedVarint(_stringBytes.length + " +
+                                                            "ByteUtils.sizeOfUnsignedVarint(_stringBytes.length + 1));%n");
+                                                    buffer.printf("_writable.writeUnsignedVarint(_stringBytes.length + 1);%n");
+                                                    buffer.printf("_writable.writeByteArray(_stringBytes);%n");
+                                                }
+                                                else if (field.type().isBytes()) {
+                                                    headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+                                                    buffer.printf("_writable.writeUnsignedVarint(this.%s.length + " +
+                                                            "ByteUtils.sizeOfUnsignedVarint(this.%s.length + 1));%n",
+                                                            field.camelCaseName(), field.camelCaseName());
+                                                    buffer.printf("_writable.writeUnsignedVarint(this.%s.length + 1);%n",
+                                                            field.camelCaseName());
+                                                    buffer.printf("_writable.writeByteArray(this.%s);%n",
+                                                            field.camelCaseName());
+                                                }
+                                                else if (field.type().isArray()) {
+                                                    headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+                                                    buffer.printf("_writable.writeUnsignedVarint(_cache.getArraySizeInBytes(this.%s));%n",
+                                                            field.camelCaseName());
+                                                    generateVariableLengthWriter(fieldFlexibleVersions(field),
+                                                            field.camelCaseName(),
+                                                            field.type(),
+                                                            presentAndTaggedVersions,
+                                                            Versions.NONE,
+                                                            field.zeroCopy());
+                                                }
+                                                else if (field.type().isStruct()) {
+                                                    VersionConditional.forVersions(field.nullableVersions(), presentAndTaggedVersions).ifMember(___ -> {
+                                                        buffer.printf("_writable.writeUnsignedVarint(this.%s.size(_cache, _version) + 1);%n",
+                                                                field.camelCaseName());
+                                                        buffer.printf("_writable.writeUnsignedVarint(1);%n");
+                                                    }).ifNotMember(___ -> buffer.printf("_writable.writeUnsignedVarint(this.%s.size(_cache, _version));%n",
+                                                            field.camelCaseName())).generate(buffer);
+                                                    buffer.printf("%s;%n",
+                                                            primitiveWriteExpression(field.type(), field.camelCaseName()));
+                                                }
+                                                else if (field.type().isRecords()) {
+                                                    throw new RuntimeException("Unsupported attempt to declare field `" +
+                                                            field.name() + "` with `records` type as a tagged field.");
+                                                }
+                                                else {
+                                                    buffer.printf("_writable.writeUnsignedVarint(%d);%n",
+                                                            field.type().fixedLength().get());
+                                                    buffer.printf("%s;%n",
+                                                            primitiveWriteExpression(field.type(), field.camelCaseName()));
+                                                }
+                                                if (!field.defaultString().equals("null")) {
+                                                    buffer.decrementIndent();
+                                                    buffer.printf("}%n");
+                                                }
+                                            });
+                                    if (!field.defaultString().equals("null")) {
+                                        cond.ifNull(() -> {
+                                            buffer.printf("_writable.writeUnsignedVarint(%d);%n", field.tag().get());
+                                            buffer.printf("_writable.writeUnsignedVarint(1);%n");
+                                            buffer.printf("_writable.writeUnsignedVarint(0);%n");
+                                        });
+                                    }
+                                    cond.generate(buffer);
+                                }).generate(buffer);
+                        prevTag = field.tag().get();
+                    }
+                    if (prevTag < Integer.MAX_VALUE) {
+                        buffer.printf("_rawWriter.writeRawTags(_writable, Integer.MAX_VALUE);%n");
+                    }
+                }).generate(buffer);
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateCheckForUnsupportedNumTaggedFields(String conditional) {
+        buffer.printf("if (%s) {%n", conditional);
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+        buffer.printf("throw new UnsupportedVersionException(\"Tagged fields were set, " +
+                "but version \" + _version + \" of this message does not support them.\");%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private String primitiveWriteExpression(FieldType type, String name) {
+        if (type instanceof FieldType.BoolFieldType) {
+            return String.format("_writable.writeByte(%s ? (byte) 1 : (byte) 0)", name);
+        }
+        else if (type instanceof FieldType.Int8FieldType) {
+            return String.format("_writable.writeByte(%s)", name);
+        }
+        else if (type instanceof FieldType.Int16FieldType) {
+            return String.format("_writable.writeShort(%s)", name);
+        }
+        else if (type instanceof FieldType.Uint16FieldType) {
+            return String.format("_writable.writeUnsignedShort(%s)", name);
+        }
+        else if (type instanceof FieldType.Uint32FieldType) {
+            return String.format("_writable.writeUnsignedInt(%s)", name);
+        }
+        else if (type instanceof FieldType.Int32FieldType) {
+            return String.format("_writable.writeInt(%s)", name);
+        }
+        else if (type instanceof FieldType.Int64FieldType) {
+            return String.format("_writable.writeLong(%s)", name);
+        }
+        else if (type instanceof FieldType.UUIDFieldType) {
+            return String.format("_writable.writeUuid(%s)", name);
+        }
+        else if (type instanceof FieldType.Float64FieldType) {
+            return String.format("_writable.writeDouble(%s)", name);
+        }
+        else if (type instanceof FieldType.StructType) {
+            return String.format("%s.write(_writable, _cache, _version)", name);
+        }
+        else {
+            throw new RuntimeException("Unsupported field type " + type);
+        }
+    }
+
+    private void generateVariableLengthWriter(Versions fieldFlexibleVersions,
+                                              String name,
+                                              FieldType type,
+                                              Versions possibleVersions,
+                                              Versions nullableVersions,
+                                              boolean zeroCopy) {
+        IsNullConditional.forName(name).possibleVersions(possibleVersions).nullableVersions(nullableVersions).alwaysEmitBlockScope(type.isString())
+                .ifNull(() -> VersionConditional.forVersions(nullableVersions, possibleVersions).ifMember(presentVersions -> VersionConditional
+                        .forVersions(fieldFlexibleVersions, presentVersions).ifMember(___ -> buffer.printf("_writable.writeUnsignedVarint(0);%n")).ifNotMember(___ -> {
+                            if (type.isString()) {
+                                buffer.printf("_writable.writeShort((short) -1);%n");
+                            }
+                            else {
+                                buffer.printf("_writable.writeInt(-1);%n");
+                            }
+                        }).generate(buffer)).ifNotMember(__ -> buffer.printf("throw new NullPointerException();%n")).generate(buffer))
+                .ifShouldNotBeNull(() -> {
+                    final String lengthExpression;
+                    if (type.isString()) {
+                        buffer.printf("byte[] _stringBytes = _cache.getSerializedValue(%s);%n",
+                                name);
+                        lengthExpression = "_stringBytes.length";
+                    }
+                    else if (type.isBytes()) {
+                        if (zeroCopy) {
+                            lengthExpression = String.format("%s.remaining()", name);
+                        }
+                        else {
+                            lengthExpression = String.format("%s.length", name);
+                        }
+                    }
+                    else if (type.isRecords()) {
+                        lengthExpression = String.format("%s.sizeInBytes()", name);
+                    }
+                    else if (type.isArray()) {
+                        lengthExpression = String.format("%s.size()", name);
+                    }
+                    else {
+                        throw new RuntimeException("Unhandled type " + type);
+                    }
+                    // Check whether we're dealing with a flexible version or not. In a flexible
+                    // version, the length is serialized differently.
+                    //
+                    // Note: for arrays, each branch of the if contains the loop for writing out
+                    // the elements. This allows us to lift the version check out of the loop.
+                    // This is helpful for things like arrays of strings, where each element
+                    // will be serialized differently based on whether the version is flexible.
+                    VersionConditional.forVersions(fieldFlexibleVersions, possibleVersions)
+                            .ifMember(ifMemberVersions -> buffer.printf("_writable.writeUnsignedVarint(%s + 1);%n", lengthExpression))
+                            .ifNotMember(ifNotMemberVersions -> {
+                                if (type.isString()) {
+                                    buffer.printf("_writable.writeShort((short) %s);%n", lengthExpression);
+                                }
+                                else {
+                                    buffer.printf("_writable.writeInt(%s);%n", lengthExpression);
+                                }
+                            }).generate(buffer);
+                    if (type.isString()) {
+                        buffer.printf("_writable.writeByteArray(_stringBytes);%n");
+                    }
+                    else if (type.isBytes()) {
+                        if (zeroCopy) {
+                            buffer.printf("_writable.writeByteBuffer(%s);%n", name);
+                        }
+                        else {
+                            buffer.printf("_writable.writeByteArray(%s);%n", name);
+                        }
+                    }
+                    else if (type.isRecords()) {
+                        buffer.printf("_writable.writeRecords(%s);%n", name);
+                    }
+                    else if (type.isArray()) {
+                        FieldType.ArrayType arrayType = (FieldType.ArrayType) type;
+                        FieldType elementType = arrayType.elementType();
+                        String elementName = String.format("%sElement", name);
+                        buffer.printf("for (%s %s : %s) {%n",
+                                elementType.getBoxedJavaType(headerGenerator),
+                                elementName,
+                                name);
+                        buffer.incrementIndent();
+                        if (elementType.isArray()) {
+                            throw new RuntimeException("Nested arrays are not supported.  " +
+                                    "Use an array of structures containing another array.");
+                        }
+                        else if (elementType.isBytes() || elementType.isString()) {
+                            generateVariableLengthWriter(fieldFlexibleVersions,
+                                    elementName,
+                                    elementType,
+                                    possibleVersions,
+                                    Versions.NONE,
+                                    false);
+                        }
+                        else {
+                            buffer.printf("%s;%n", primitiveWriteExpression(elementType, elementName));
+                        }
+                        buffer.decrementIndent();
+                        buffer.printf("}%n");
+                    }
+                }).generate(buffer);
+    }
+
+    private void generateClassMessageSize(
+                                          String className,
+                                          StructSpec struct,
+                                          Versions parentVersions) {
+        headerGenerator.addImport(MessageGenerator.OBJECT_SERIALIZATION_CACHE_CLASS);
+        headerGenerator.addImport(MessageGenerator.MESSAGE_SIZE_ACCUMULATOR_CLASS);
+        buffer.printf("@Override%n");
+        buffer.printf("public void addSize(MessageSizeAccumulator _size, ObjectSerializationCache _cache, short _version) {%n");
+        buffer.incrementIndent();
+        buffer.printf("int _numTaggedFields = 0;%n");
+        VersionConditional.forVersions(parentVersions, struct.versions()).allowMembershipCheckAlwaysFalse(false).ifNotMember(__ -> {
+            headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+            buffer.printf("throw new UnsupportedVersionException(\"Can't size " +
+                    "version \" + _version + \" of %s\");%n", className);
+        }).generate(buffer);
+        Versions curVersions = parentVersions.intersect(struct.versions());
+        for (FieldSpec field : struct.fields()) {
+            VersionConditional.forVersions(field.versions(), curVersions)
+                    .ifMember(presentVersions -> VersionConditional.forVersions(field.taggedVersions(), presentVersions)
+                            .ifMember(presentAndTaggedVersions -> generateFieldSize(field, presentAndTaggedVersions, true))
+                            .ifNotMember(presentAndUntaggedVersions -> generateFieldSize(field, presentAndUntaggedVersions, false)).generate(buffer))
+                    .generate(buffer);
+        }
+        buffer.printf("if (_unknownTaggedFields != null) {%n");
+        buffer.incrementIndent();
+        buffer.printf("_numTaggedFields += _unknownTaggedFields.size();%n");
+        buffer.printf("for (RawTaggedField _field : _unknownTaggedFields) {%n");
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+        buffer.printf("_size.addBytes(ByteUtils.sizeOfUnsignedVarint(_field.tag()));%n");
+        buffer.printf("_size.addBytes(ByteUtils.sizeOfUnsignedVarint(_field.size()));%n");
+        buffer.printf("_size.addBytes(_field.size());%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        VersionConditional.forVersions(messageFlexibleVersions, curVersions).ifNotMember(__ -> generateCheckForUnsupportedNumTaggedFields("_numTaggedFields > 0"))
+                .ifMember(__ -> {
+                    headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+                    buffer.printf("_size.addBytes(ByteUtils.sizeOfUnsignedVarint(_numTaggedFields));%n");
+                }).generate(buffer);
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    /**
+     * Generate the size calculator for a variable-length array element.
+     * Array elements cannot be null.
+     */
+    private void generateVariableLengthArrayElementSize(Versions flexibleVersions,
+                                                        String fieldName,
+                                                        FieldType type,
+                                                        Versions versions) {
+        if (type instanceof FieldType.StringFieldType) {
+            generateStringToBytes(fieldName);
+            VersionConditional.forVersions(flexibleVersions, versions).ifNotMember(__ -> buffer.printf("_size.addBytes(_stringBytes.length + 2);%n")).ifMember(__ -> {
+                headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+                buffer.printf("_size.addBytes(_stringBytes.length + " +
+                        "ByteUtils.sizeOfUnsignedVarint(_stringBytes.length + 1));%n");
+            }).generate(buffer);
+        }
+        else if (type instanceof FieldType.BytesFieldType) {
+            buffer.printf("_size.addBytes(%s.length);%n", fieldName);
+            VersionConditional.forVersions(flexibleVersions, versions).ifNotMember(__ -> buffer.printf("_size.addBytes(4);%n")).ifMember(__ -> {
+                headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+                buffer.printf("_size.addBytes(" +
+                        "ByteUtils.sizeOfUnsignedVarint(%s.length + 1));%n",
+                        fieldName);
+            }).generate(buffer);
+        }
+        else if (type instanceof FieldType.StructType) {
+            buffer.printf("%s.addSize(_size, _cache, _version);%n", fieldName);
+        }
+        else {
+            throw new RuntimeException("Unsupported type " + type);
+        }
+    }
+
+    private void generateFieldSize(FieldSpec field,
+                                   Versions possibleVersions,
+                                   boolean tagged) {
+        if (field.type().fixedLength().isPresent()) {
+            generateFixedLengthFieldSize(field, tagged);
+        }
+        else {
+            generateVariableLengthFieldSize(field, possibleVersions, tagged);
+        }
+    }
+
+    private void generateFixedLengthFieldSize(FieldSpec field,
+                                              boolean tagged) {
+        if (tagged) {
+            // Check to see that the field is not set to the default value.
+            // If it is, then we don't need to serialize it.
+            field.generateNonDefaultValueCheck(headerGenerator, structRegistry, buffer,
+                    "this.", field.nullableVersions());
+            buffer.incrementIndent();
+            buffer.printf("_numTaggedFields++;%n");
+            buffer.printf("_size.addBytes(%d);%n",
+                    MessageGenerator.sizeOfUnsignedVarint(field.tag().get()));
+            // Account for the tagged field prefix length.
+            buffer.printf("_size.addBytes(%d);%n",
+                    MessageGenerator.sizeOfUnsignedVarint(field.type().fixedLength().get()));
+            buffer.printf("_size.addBytes(%d);%n", field.type().fixedLength().get());
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+        else {
+            buffer.printf("_size.addBytes(%d);%n", field.type().fixedLength().get());
+        }
+    }
+
+    private void generateVariableLengthFieldSize(FieldSpec field,
+                                                 Versions possibleVersions,
+                                                 boolean tagged) {
+        IsNullConditional.forField(field).alwaysEmitBlockScope(true).possibleVersions(possibleVersions).nullableVersions(field.nullableVersions()).ifNull(() -> {
+            if (!tagged || !field.defaultString().equals("null")) {
+                VersionConditional.forVersions(fieldFlexibleVersions(field), possibleVersions).ifMember(__ -> {
+                    if (tagged) {
+                        buffer.printf("_numTaggedFields++;%n");
+                        buffer.printf("_size.addBytes(%d);%n",
+                                MessageGenerator.sizeOfUnsignedVarint(field.tag().get()));
+                        buffer.printf("_size.addBytes(%d);%n", MessageGenerator.sizeOfUnsignedVarint(
+                                MessageGenerator.sizeOfUnsignedVarint(0)));
+                    }
+                    buffer.printf("_size.addBytes(%d);%n", MessageGenerator.sizeOfUnsignedVarint(0));
+                }).ifNotMember(__ -> {
+                    if (tagged) {
+                        throw new RuntimeException("Tagged field " + field.name() +
+                                " should not be present in non-flexible versions.");
+                    }
+                    if (field.type().isString()) {
+                        buffer.printf("_size.addBytes(2);%n");
+                    }
+                    else if (field.type().isStruct()) {
+                        buffer.printf("_size.addBytes(1);%n");
+                    }
+                    else {
+                        buffer.printf("_size.addBytes(4);%n");
+                    }
+                }).generate(buffer);
+            }
+        }).ifShouldNotBeNull(() -> {
+            if (tagged) {
+                if (!field.defaultString().equals("null")) {
+                    field.generateNonDefaultValueCheck(headerGenerator,
+                            structRegistry, buffer, "this.", Versions.NONE);
+                    buffer.incrementIndent();
+                }
+                buffer.printf("_numTaggedFields++;%n");
+                buffer.printf("_size.addBytes(%d);%n",
+                        MessageGenerator.sizeOfUnsignedVarint(field.tag().get()));
+            }
+            if (field.type().isString()) {
+                generateStringToBytes(field.camelCaseName());
+                VersionConditional.forVersions(fieldFlexibleVersions(field), possibleVersions).ifMember(__ -> {
+                    headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+                    if (tagged) {
+                        buffer.printf("int _stringPrefixSize = " +
+                                "ByteUtils.sizeOfUnsignedVarint(_stringBytes.length + 1);%n");
+                        buffer.printf("_size.addBytes(_stringBytes.length + _stringPrefixSize + " +
+                                "ByteUtils.sizeOfUnsignedVarint(_stringPrefixSize + _stringBytes.length));%n");
+
+                    }
+                    else {
+                        buffer.printf("_size.addBytes(_stringBytes.length + " +
+                                "ByteUtils.sizeOfUnsignedVarint(_stringBytes.length + 1));%n");
+                    }
+                }).ifNotMember(__ -> {
+                    if (tagged) {
+                        throw new RuntimeException("Tagged field " + field.name() +
+                                " should not be present in non-flexible versions.");
+                    }
+                    buffer.printf("_size.addBytes(_stringBytes.length + 2);%n");
+                }).generate(buffer);
+            }
+            else if (field.type().isArray()) {
+                if (tagged) {
+                    buffer.printf("int _sizeBeforeArray = _size.totalSize();%n");
+                }
+                VersionConditional.forVersions(fieldFlexibleVersions(field), possibleVersions).ifMember(__ -> {
+                    headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+                    buffer.printf("_size.addBytes(ByteUtils.sizeOfUnsignedVarint(%s.size() + 1));%n",
+                            field.camelCaseName());
+                }).ifNotMember(__ -> buffer.printf("_size.addBytes(4);%n")).generate(buffer);
+                FieldType.ArrayType arrayType = (FieldType.ArrayType) field.type();
+                FieldType elementType = arrayType.elementType();
+                if (elementType.fixedLength().isPresent()) {
+                    buffer.printf("_size.addBytes(%s.size() * %d);%n",
+                            field.camelCaseName(),
+                            elementType.fixedLength().get());
+                }
+                else if (elementType instanceof FieldType.ArrayType) {
+                    throw new RuntimeException("Arrays of arrays are not supported " +
+                            "(use a struct).");
+                }
+                else {
+                    buffer.printf("for (%s %sElement : %s) {%n",
+                            elementType.getBoxedJavaType(headerGenerator),
+                            field.camelCaseName(), field.camelCaseName());
+                    buffer.incrementIndent();
+                    generateVariableLengthArrayElementSize(fieldFlexibleVersions(field),
+                            String.format("%sElement", field.camelCaseName()),
+                            elementType,
+                            possibleVersions);
+                    buffer.decrementIndent();
+                    buffer.printf("}%n");
+                }
+                if (tagged) {
+                    headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+                    buffer.printf("int _arraySize = _size.totalSize() - _sizeBeforeArray;%n");
+                    buffer.printf("_cache.setArraySizeInBytes(%s, _arraySize);%n",
+                            field.camelCaseName());
+                    buffer.printf("_size.addBytes(ByteUtils.sizeOfUnsignedVarint(_arraySize));%n");
+                }
+            }
+            else if (field.type().isBytes()) {
+                if (tagged) {
+                    buffer.printf("int _sizeBeforeBytes = _size.totalSize();%n");
+                }
+                if (field.zeroCopy()) {
+                    buffer.printf("_size.addZeroCopyBytes(%s.remaining());%n", field.camelCaseName());
+                }
+                else {
+                    buffer.printf("_size.addBytes(%s.length);%n", field.camelCaseName());
+                }
+                VersionConditional.forVersions(fieldFlexibleVersions(field), possibleVersions).ifMember(__ -> {
+                    headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+                    if (field.zeroCopy()) {
+                        buffer.printf("_size.addBytes(" +
+                                "ByteUtils.sizeOfUnsignedVarint(%s.remaining() + 1));%n", field.camelCaseName());
+                    }
+                    else {
+                        buffer.printf("_size.addBytes(ByteUtils.sizeOfUnsignedVarint(%s.length + 1));%n",
+                                field.camelCaseName());
+                    }
+                }).ifNotMember(__ -> buffer.printf("_size.addBytes(4);%n")).generate(buffer);
+                if (tagged) {
+                    headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+                    buffer.printf("int _bytesSize = _size.totalSize() - _sizeBeforeBytes;%n");
+                    buffer.printf("_size.addBytes(ByteUtils.sizeOfUnsignedVarint(_bytesSize));%n");
+                }
+            }
+            else if (field.type().isRecords()) {
+                buffer.printf("_size.addZeroCopyBytes(%s.sizeInBytes());%n", field.camelCaseName());
+                VersionConditional.forVersions(fieldFlexibleVersions(field), possibleVersions).ifMember(__ -> {
+                    headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+                    buffer.printf("_size.addBytes(" +
+                            "ByteUtils.sizeOfUnsignedVarint(%s.sizeInBytes() + 1));%n", field.camelCaseName());
+                }).ifNotMember(__ -> buffer.printf("_size.addBytes(4);%n")).generate(buffer);
+            }
+            else if (field.type().isStruct()) {
+                if (tagged) {
+                    buffer.printf("int _sizeBeforeStruct = _size.totalSize();%n", field.camelCaseName());
+                    // Add a byte if the field is nullable.
+                    VersionConditional.forVersions(field.nullableVersions(), possibleVersions).ifMember(__ -> buffer.printf("_size.addBytes(1);%n")).generate(buffer);
+                    buffer.printf("this.%s.addSize(_size, _cache, _version);%n", field.camelCaseName());
+                    buffer.printf("int _structSize = _size.totalSize() - _sizeBeforeStruct;%n", field.camelCaseName());
+                    buffer.printf("_size.addBytes(ByteUtils.sizeOfUnsignedVarint(_structSize));%n");
+                }
+                else {
+                    // Add a byte if the field is nullable.
+                    VersionConditional.forVersions(field.nullableVersions(), possibleVersions).ifMember(__ -> buffer.printf("_size.addBytes(1);%n")).generate(buffer);
+                    buffer.printf("this.%s.addSize(_size, _cache, _version);%n", field.camelCaseName());
+                }
+            }
+            else {
+                throw new RuntimeException("unhandled type " + field.type());
+            }
+            if (tagged && !field.defaultString().equals("null")) {
+                buffer.decrementIndent();
+                buffer.printf("}%n");
+            }
+        }).generate(buffer);
+    }
+
+    private void generateStringToBytes(String name) {
+        headerGenerator.addImport(MessageGenerator.STANDARD_CHARSETS);
+        buffer.printf("byte[] _stringBytes = %s.getBytes(StandardCharsets.UTF_8);%n", name);
+        buffer.printf("if (_stringBytes.length > 0x7fff) {%n");
+        buffer.incrementIndent();
+        buffer.printf("throw new RuntimeException(\"'%s' field is too long to " +
+                "be serialized\");%n", name);
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.printf("_cache.cacheSerializedValue(%s, _stringBytes);%n", name);
+    }
+
+    private void generateClassEquals(String className, StructSpec struct,
+                                     boolean elementKeysAreEqual) {
+        buffer.printf("@Override%n");
+        buffer.printf("public boolean %s(Object obj) {%n",
+                elementKeysAreEqual ? "elementKeysAreEqual" : "equals");
+        buffer.incrementIndent();
+        buffer.printf("if (!(obj instanceof %s)) return false;%n", className);
+        buffer.printf("%s other = (%s) obj;%n", className, className);
+        if (!struct.fields().isEmpty()) {
+            for (FieldSpec field : struct.fields()) {
+                if (!elementKeysAreEqual || field.mapKey()) {
+                    generateFieldEquals(field);
+                }
+            }
+        }
+        if (elementKeysAreEqual) {
+            buffer.printf("return true;%n");
+        }
+        else {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            buffer.printf("return MessageUtil.compareRawTaggedFields(_unknownTaggedFields, " +
+                    "other._unknownTaggedFields);%n");
+        }
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateFieldEquals(FieldSpec field) {
+        if (field.type() instanceof FieldType.UUIDFieldType) {
+            buffer.printf("if (!this.%s.equals(other.%s)) return false;%n",
+                    field.camelCaseName(), field.camelCaseName());
+        }
+        else if (field.type().isString() || field.type().isArray() || field.type().isStruct()) {
+            buffer.printf("if (this.%s == null) {%n", field.camelCaseName());
+            buffer.incrementIndent();
+            buffer.printf("if (other.%s != null) return false;%n", field.camelCaseName());
+            buffer.decrementIndent();
+            buffer.printf("} else {%n");
+            buffer.incrementIndent();
+            buffer.printf("if (!this.%s.equals(other.%s)) return false;%n",
+                    field.camelCaseName(), field.camelCaseName());
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+        else if (field.type().isBytes()) {
+            if (field.zeroCopy()) {
+                headerGenerator.addImport(MessageGenerator.OBJECTS_CLASS);
+                buffer.printf("if (!Objects.equals(this.%s, other.%s)) return false;%n",
+                        field.camelCaseName(), field.camelCaseName());
+            }
+            else {
+                // Arrays#equals handles nulls.
+                headerGenerator.addImport(MessageGenerator.ARRAYS_CLASS);
+                buffer.printf("if (!Arrays.equals(this.%s, other.%s)) return false;%n",
+                        field.camelCaseName(), field.camelCaseName());
+            }
+        }
+        else if (field.type().isRecords()) {
+            headerGenerator.addImport(MessageGenerator.OBJECTS_CLASS);
+            buffer.printf("if (!Objects.equals(this.%s, other.%s)) return false;%n",
+                    field.camelCaseName(), field.camelCaseName());
+        }
+        else {
+            buffer.printf("if (%s != other.%s) return false;%n",
+                    field.camelCaseName(), field.camelCaseName());
+        }
+    }
+
+    private void generateClassHashCode(StructSpec struct, boolean onlyMapKeys) {
+        buffer.printf("@Override%n");
+        buffer.printf("public int hashCode() {%n");
+        buffer.incrementIndent();
+        buffer.printf("int hashCode = 0;%n");
+        for (FieldSpec field : struct.fields()) {
+            if ((!onlyMapKeys) || field.mapKey()) {
+                generateFieldHashCode(field);
+            }
+        }
+        buffer.printf("return hashCode;%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateFieldHashCode(FieldSpec field) {
+        if (field.type() instanceof FieldType.BoolFieldType) {
+            buffer.printf("hashCode = 31 * hashCode + (%s ? 1231 : 1237);%n",
+                    field.camelCaseName());
+        }
+        else if ((field.type() instanceof FieldType.Int8FieldType) ||
+                (field.type() instanceof FieldType.Int16FieldType) ||
+                (field.type() instanceof FieldType.Uint16FieldType) ||
+                (field.type() instanceof FieldType.Int32FieldType)) {
+            buffer.printf("hashCode = 31 * hashCode + %s;%n",
+                    field.camelCaseName());
+        }
+        else if (field.type() instanceof FieldType.Int64FieldType ||
+                (field.type() instanceof FieldType.Uint32FieldType)) {
+            buffer.printf("hashCode = 31 * hashCode + ((int) (%s >> 32) ^ (int) %s);%n",
+                    field.camelCaseName(), field.camelCaseName());
+        }
+        else if (field.type() instanceof FieldType.UUIDFieldType) {
+            buffer.printf("hashCode = 31 * hashCode + %s.hashCode();%n",
+                    field.camelCaseName());
+        }
+        else if (field.type() instanceof FieldType.Float64FieldType) {
+            buffer.printf("hashCode = 31 * hashCode + Double.hashCode(%s);%n",
+                    field.camelCaseName(), field.camelCaseName());
+        }
+        else if (field.type().isBytes()) {
+            if (field.zeroCopy()) {
+                headerGenerator.addImport(MessageGenerator.OBJECTS_CLASS);
+                buffer.printf("hashCode = 31 * hashCode + Objects.hashCode(%s);%n",
+                        field.camelCaseName());
+            }
+            else {
+                headerGenerator.addImport(MessageGenerator.ARRAYS_CLASS);
+                buffer.printf("hashCode = 31 * hashCode + Arrays.hashCode(%s);%n",
+                        field.camelCaseName());
+            }
+        }
+        else if (field.type().isRecords()) {
+            headerGenerator.addImport(MessageGenerator.OBJECTS_CLASS);
+            buffer.printf("hashCode = 31 * hashCode + Objects.hashCode(%s);%n",
+                    field.camelCaseName());
+        }
+        else if (field.type().isStruct()
+                || field.type().isArray()
+                || field.type().isString()) {
+            buffer.printf("hashCode = 31 * hashCode + (%s == null ? 0 : %s.hashCode());%n",
+                    field.camelCaseName(), field.camelCaseName());
+        }
+        else {
+            throw new RuntimeException("Unsupported field type " + field.type());
+        }
+    }
+
+    private void generateClassDuplicate(String className, StructSpec struct) {
+        buffer.printf("@Override%n");
+        buffer.printf("public %s duplicate() {%n", className);
+        buffer.incrementIndent();
+        buffer.printf("%s _duplicate = new %s();%n", className, className);
+        for (FieldSpec field : struct.fields()) {
+            generateFieldDuplicate(new Target(field,
+                    field.camelCaseName(),
+                    field.camelCaseName(),
+                    input -> String.format("_duplicate.%s = %s", field.camelCaseName(), input)));
+        }
+        buffer.printf("return _duplicate;%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateFieldDuplicate(Target target) {
+        FieldSpec field = target.field();
+        if ((field.type() instanceof FieldType.BoolFieldType) ||
+                (field.type() instanceof FieldType.Int8FieldType) ||
+                (field.type() instanceof FieldType.Int16FieldType) ||
+                (field.type() instanceof FieldType.Uint16FieldType) ||
+                (field.type() instanceof FieldType.Uint32FieldType) ||
+                (field.type() instanceof FieldType.Int32FieldType) ||
+                (field.type() instanceof FieldType.Int64FieldType) ||
+                (field.type() instanceof FieldType.Float64FieldType) ||
+                (field.type() instanceof FieldType.UUIDFieldType)) {
+            buffer.printf("%s;%n", target.assignmentStatement(target.sourceVariable()));
+        }
+        else {
+            IsNullConditional cond = IsNullConditional.forName(target.sourceVariable()).nullableVersions(target.field().nullableVersions())
+                    .ifNull(() -> buffer.printf("%s;%n", target.assignmentStatement("null")));
+            if (field.type().isBytes()) {
+                if (field.zeroCopy()) {
+                    cond.ifShouldNotBeNull(() -> buffer.printf("%s;%n", target.assignmentStatement(
+                            String.format("%s.duplicate()", target.sourceVariable()))));
+                }
+                else {
+                    cond.ifShouldNotBeNull(() -> {
+                        headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+                        buffer.printf("%s;%n", target.assignmentStatement(
+                                String.format("MessageUtil.duplicate(%s)",
+                                        target.sourceVariable())));
+                    });
+                }
+            }
+            else if (field.type().isRecords()) {
+                cond.ifShouldNotBeNull(() -> {
+                    headerGenerator.addImport(MessageGenerator.MEMORY_RECORDS_CLASS);
+                    buffer.printf("%s;%n", target.assignmentStatement(
+                            String.format("MemoryRecords.readableRecords(((MemoryRecords) %s).buffer().duplicate())",
+                                    target.sourceVariable())));
+                });
+            }
+            else if (field.type().isStruct()) {
+                cond.ifShouldNotBeNull(() -> buffer.printf("%s;%n", target.assignmentStatement(
+                        String.format("%s.duplicate()", target.sourceVariable()))));
+            }
+            else if (field.type().isString()) {
+                // Strings are immutable, so we don't need to duplicate them.
+                cond.ifShouldNotBeNull(() -> buffer.printf("%s;%n", target.assignmentStatement(
+                        target.sourceVariable())));
+            }
+            else if (field.type().isArray()) {
+                cond.ifShouldNotBeNull(() -> {
+                    String newArrayName = String.format("new%s", field.capitalizedCamelCaseName());
+                    String type = field.concreteJavaType(headerGenerator, structRegistry);
+                    buffer.printf("%s %s = new %s(%s.size());%n",
+                            type, newArrayName, type, target.sourceVariable());
+                    FieldType.ArrayType arrayType = (FieldType.ArrayType) field.type();
+                    buffer.printf("for (%s _element : %s) {%n",
+                            arrayType.elementType().getBoxedJavaType(headerGenerator),
+                            target.sourceVariable());
+                    buffer.incrementIndent();
+                    generateFieldDuplicate(target.arrayElementTarget(input -> String.format("%s.add(%s)", newArrayName, input)));
+                    buffer.decrementIndent();
+                    buffer.printf("}%n");
+                    buffer.printf("%s;%n", target.assignmentStatement(
+                            String.format("new%s", field.capitalizedCamelCaseName())));
+                });
+            }
+            else {
+                throw new RuntimeException("Unhandled field type " + field.type());
+            }
+            cond.generate(buffer);
+        }
+    }
+
+    private void generateClassToString(String className, StructSpec struct) {
+        buffer.printf("@Override%n");
+        buffer.printf("public String toString() {%n");
+        buffer.incrementIndent();
+        buffer.printf("return \"%s(\"%n", className);
+        buffer.incrementIndent();
+        String prefix = "";
+        for (FieldSpec field : struct.fields()) {
+            generateFieldToString(prefix, field);
+            prefix = ", ";
+        }
+        buffer.printf("+ \")\";%n");
+        buffer.decrementIndent();
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateFieldToString(String prefix, FieldSpec field) {
+        if (field.type() instanceof FieldType.BoolFieldType) {
+            buffer.printf("+ \"%s%s=\" + (%s ? \"true\" : \"false\")%n", prefix, field.camelCaseName(), field.camelCaseName());
+        }
+        else if ((field.type() instanceof FieldType.Int8FieldType) ||
+                (field.type() instanceof FieldType.Int16FieldType) ||
+                (field.type() instanceof FieldType.Uint16FieldType) ||
+                (field.type() instanceof FieldType.Uint32FieldType) ||
+                (field.type() instanceof FieldType.Int32FieldType) ||
+                (field.type() instanceof FieldType.Int64FieldType) ||
+                (field.type() instanceof FieldType.Float64FieldType)) {
+            buffer.printf("+ \"%s%s=\" + %s%n",
+                    prefix, field.camelCaseName(), field.camelCaseName());
+        }
+        else if (field.type().isString()) {
+            buffer.printf("+ \"%s%s=\" + ((%s == null) ? \"null\" : \"'\" + %s.toString() + \"'\")%n",
+                    prefix, field.camelCaseName(), field.camelCaseName(), field.camelCaseName());
+        }
+        else if (field.type().isBytes()) {
+            if (field.zeroCopy()) {
+                buffer.printf("+ \"%s%s=\" + %s%n",
+                        prefix, field.camelCaseName(), field.camelCaseName());
+            }
+            else {
+                headerGenerator.addImport(MessageGenerator.ARRAYS_CLASS);
+                buffer.printf("+ \"%s%s=\" + Arrays.toString(%s)%n",
+                        prefix, field.camelCaseName(), field.camelCaseName());
+            }
+        }
+        else if (field.type().isRecords()) {
+            buffer.printf("+ \"%s%s=\" + %s%n",
+                    prefix, field.camelCaseName(), field.camelCaseName());
+        }
+        else if (field.type() instanceof FieldType.UUIDFieldType) {
+            buffer.printf("+ \"%s%s=\" + %s.toString()%n",
+                    prefix, field.camelCaseName(), field.camelCaseName());
+        }
+        else if (field.type().isStruct()) {
+            if (field.nullableVersions().empty()) {
+                buffer.printf("+ \"%s%s=\" + %s.toString()%n",
+                        prefix, field.camelCaseName(), field.camelCaseName());
+            }
+            else {
+                buffer.printf("+ \"%s%s=\" + ((%s == null) ? \"null\" : %s.toString())%n",
+                        prefix, field.camelCaseName(), field.camelCaseName(), field.camelCaseName());
+            }
+        }
+        else if (field.type().isArray()) {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            if (field.nullableVersions().empty()) {
+                buffer.printf("+ \"%s%s=\" + MessageUtil.deepToString(%s.iterator())%n",
+                        prefix, field.camelCaseName(), field.camelCaseName());
+            }
+            else {
+                buffer.printf("+ \"%s%s=\" + ((%s == null) ? \"null\" : " +
+                        "MessageUtil.deepToString(%s.iterator()))%n",
+                        prefix, field.camelCaseName(), field.camelCaseName(), field.camelCaseName());
+            }
+        }
+        else {
+            throw new RuntimeException("Unsupported field type " + field.type());
+        }
+    }
+
+    private void generateFieldAccessor(FieldSpec field) {
+        buffer.printf("%n");
+        generateAccessor(field.fieldAbstractJavaType(headerGenerator, structRegistry),
+                field.camelCaseName(),
+                field.camelCaseName());
+    }
+
+    private void generateAccessor(String javaType, String functionName, String memberName) {
+        buffer.printf("public %s %s() {%n", javaType, functionName);
+        buffer.incrementIndent();
+        buffer.printf("return this.%s;%n", memberName);
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateFieldMutator(String className, FieldSpec field) {
+        buffer.printf("%n");
+        buffer.printf("public %s set%s(%s v) {%n",
+                className,
+                field.capitalizedCamelCaseName(),
+                field.fieldAbstractJavaType(headerGenerator, structRegistry));
+        buffer.incrementIndent();
+        if (field.type() instanceof FieldType.Uint16FieldType) {
+            buffer.printf("if (v < 0 || v > %d) {%n", MessageGenerator.UNSIGNED_SHORT_MAX);
+            buffer.incrementIndent();
+            buffer.printf("throw new RuntimeException(\"Invalid value \" + v + " +
+                    "\" for unsigned short field.\");%n");
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+        if (field.type() instanceof FieldType.Uint32FieldType) {
+            buffer.printf("if (v < 0 || v > %dL) {%n", MessageGenerator.UNSIGNED_INT_MAX);
+            buffer.incrementIndent();
+            buffer.printf("throw new RuntimeException(\"Invalid value \" + v + " +
+                    "\" for unsigned int field.\");%n");
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+        buffer.printf("this.%s = v;%n", field.camelCaseName());
+        buffer.printf("return this;%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateSetter(String javaType, String functionName, String memberName) {
+        buffer.printf("public void %s(%s v) {%n", functionName, javaType);
+        buffer.incrementIndent();
+        buffer.printf("this.%s = v;%n", memberName);
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private Versions fieldFlexibleVersions(FieldSpec field) {
+        if (field.flexibleVersions().isPresent()) {
+            if (!messageFlexibleVersions.intersect(field.flexibleVersions().get()).equals(field.flexibleVersions().get())) {
+                throw new RuntimeException("The flexible versions for field " +
+                        field.name() + " are " + field.flexibleVersions().get() +
+                        ", which are not a subset of the flexible versions for the " +
+                        "message as a whole, which are " + messageFlexibleVersions);
+            }
+            return field.flexibleVersions().get();
+        }
+        else {
+            return messageFlexibleVersions;
+        }
+    }
+
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/MessageGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/MessageGenerator.java
@@ -1,0 +1,409 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+
+import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.Namespace;
+
+import static net.sourceforge.argparse4j.impl.Arguments.store;
+
+/**
+ * The Kafka message generator.
+ */
+public final class MessageGenerator {
+    static final String JSON_SUFFIX = ".json";
+
+    static final String JSON_GLOB = "*" + JSON_SUFFIX;
+
+    static final String JAVA_SUFFIX = ".java";
+
+    static final String API_MESSAGE_TYPE_JAVA = "ApiMessageType.java";
+
+    static final String API_SCOPE_JAVA = "ApiScope.java";
+
+    static final String COORDINATOR_RECORD_TYPE_JAVA = "CoordinatorRecordType.java";
+
+    static final String COORDINATOR_RECORD_JSON_CONVERTERS_JAVA = "CoordinatorRecordJsonConverters.java";
+
+    static final String METADATA_RECORD_TYPE_JAVA = "MetadataRecordType.java";
+
+    static final String METADATA_JSON_CONVERTERS_JAVA = "MetadataJsonConverters.java";
+
+    static final String API_MESSAGE_CLASS = "org.apache.kafka.common.protocol.ApiMessage";
+
+    static final String MESSAGE_CLASS = "org.apache.kafka.common.protocol.Message";
+
+    static final String MESSAGE_UTIL_CLASS = "org.apache.kafka.common.protocol.MessageUtil";
+
+    static final String READABLE_CLASS = "org.apache.kafka.common.protocol.Readable";
+
+    static final String WRITABLE_CLASS = "org.apache.kafka.common.protocol.Writable";
+
+    static final String ARRAYS_CLASS = "java.util.Arrays";
+
+    static final String OBJECTS_CLASS = "java.util.Objects";
+
+    static final String LIST_CLASS = "java.util.List";
+
+    static final String ARRAYLIST_CLASS = "java.util.ArrayList";
+
+    static final String IMPLICIT_LINKED_HASH_COLLECTION_CLASS = "org.apache.kafka.common.utils.ImplicitLinkedHashCollection";
+
+    static final String IMPLICIT_LINKED_HASH_MULTI_COLLECTION_CLASS = "org.apache.kafka.common.utils.ImplicitLinkedHashMultiCollection";
+
+    static final String UNSUPPORTED_VERSION_EXCEPTION_CLASS = "org.apache.kafka.common.errors.UnsupportedVersionException";
+
+    static final String ITERATOR_CLASS = "java.util.Iterator";
+
+    static final String ENUM_SET_CLASS = "java.util.EnumSet";
+
+    static final String TYPE_CLASS = "org.apache.kafka.common.protocol.types.Type";
+
+    static final String FIELD_CLASS = "org.apache.kafka.common.protocol.types.Field";
+
+    static final String SCHEMA_CLASS = "org.apache.kafka.common.protocol.types.Schema";
+
+    static final String NULLABLE_SCHEMA_CLASS = "org.apache.kafka.common.protocol.types.NullableSchema";
+
+    static final String ARRAYOF_CLASS = "org.apache.kafka.common.protocol.types.ArrayOf";
+
+    static final String COMPACT_ARRAYOF_CLASS = "org.apache.kafka.common.protocol.types.CompactArrayOf";
+
+    static final String BYTES_CLASS = "org.apache.kafka.common.utils.Bytes";
+
+    static final String UUID_CLASS = "org.apache.kafka.common.Uuid";
+
+    static final String BASE_RECORDS_CLASS = "org.apache.kafka.common.record.internal.BaseRecords";
+
+    static final String MEMORY_RECORDS_CLASS = "org.apache.kafka.common.record.internal.MemoryRecords";
+
+    static final String REQUEST_SUFFIX = "Request";
+
+    static final String RESPONSE_SUFFIX = "Response";
+
+    static final String BYTE_UTILS_CLASS = "org.apache.kafka.common.utils.ByteUtils";
+
+    static final String STANDARD_CHARSETS = "java.nio.charset.StandardCharsets";
+
+    static final String TAGGED_FIELDS_SECTION_CLASS = "org.apache.kafka.common.protocol.types.Field.TaggedFieldsSection";
+
+    static final String OBJECT_SERIALIZATION_CACHE_CLASS = "org.apache.kafka.common.protocol.ObjectSerializationCache";
+
+    static final String MESSAGE_SIZE_ACCUMULATOR_CLASS = "org.apache.kafka.common.protocol.MessageSizeAccumulator";
+
+    static final String RAW_TAGGED_FIELD_CLASS = "org.apache.kafka.common.protocol.types.RawTaggedField";
+
+    static final String RAW_TAGGED_FIELD_WRITER_CLASS = "org.apache.kafka.common.protocol.types.RawTaggedFieldWriter";
+
+    static final String TREE_MAP_CLASS = "java.util.TreeMap";
+
+    static final String BYTE_BUFFER_CLASS = "java.nio.ByteBuffer";
+
+    static final String NAVIGABLE_MAP_CLASS = "java.util.NavigableMap";
+
+    static final String MAP_ENTRY_CLASS = "java.util.Map.Entry";
+
+    static final String JSON_NODE_CLASS = "com.fasterxml.jackson.databind.JsonNode";
+
+    static final String OBJECT_NODE_CLASS = "com.fasterxml.jackson.databind.node.ObjectNode";
+
+    static final String JSON_NODE_FACTORY_CLASS = "com.fasterxml.jackson.databind.node.JsonNodeFactory";
+
+    static final String BOOLEAN_NODE_CLASS = "com.fasterxml.jackson.databind.node.BooleanNode";
+
+    static final String SHORT_NODE_CLASS = "com.fasterxml.jackson.databind.node.ShortNode";
+
+    static final String INT_NODE_CLASS = "com.fasterxml.jackson.databind.node.IntNode";
+
+    static final String LONG_NODE_CLASS = "com.fasterxml.jackson.databind.node.LongNode";
+
+    static final String TEXT_NODE_CLASS = "com.fasterxml.jackson.databind.node.TextNode";
+
+    static final String BINARY_NODE_CLASS = "com.fasterxml.jackson.databind.node.BinaryNode";
+
+    static final String NULL_NODE_CLASS = "com.fasterxml.jackson.databind.node.NullNode";
+
+    static final String ARRAY_NODE_CLASS = "com.fasterxml.jackson.databind.node.ArrayNode";
+
+    static final String DOUBLE_NODE_CLASS = "com.fasterxml.jackson.databind.node.DoubleNode";
+
+    static final long UNSIGNED_INT_MAX = 4294967295L;
+
+    static final int UNSIGNED_SHORT_MAX = 65535;
+
+    /**
+     * The Jackson serializer we use for JSON objects.
+     */
+    public static final ObjectMapper JSON_SERDE;
+
+    static {
+        JSON_SERDE = new ObjectMapper();
+        JSON_SERDE.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        JSON_SERDE.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        JSON_SERDE.configure(DeserializationFeature.FAIL_ON_TRAILING_TOKENS, true);
+        JSON_SERDE.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+        JSON_SERDE.setDefaultPropertyInclusion(JsonInclude.Include.NON_EMPTY);
+        JSON_SERDE.registerModule(new Jdk8Module());
+    }
+
+    private static List<TypeClassGenerator> createTypeClassGenerators(String packageName,
+                                                                      List<String> types) {
+        if (types == null)
+            return List.of();
+        List<TypeClassGenerator> generators = new ArrayList<>();
+        for (String type : types) {
+            switch (type) {
+                case "ApiMessageTypeGenerator":
+                    generators.add(new ApiMessageTypeGenerator(packageName));
+                    break;
+                case "MetadataRecordTypeGenerator":
+                    generators.add(new MetadataRecordTypeGenerator(packageName));
+                    break;
+                case "MetadataJsonConvertersGenerator":
+                    generators.add(new MetadataJsonConvertersGenerator(packageName));
+                    break;
+                case "CoordinatorRecordTypeGenerator":
+                    generators.add(new CoordinatorRecordTypeGenerator(packageName));
+                    break;
+                case "CoordinatorRecordJsonConvertersGenerator":
+                    generators.add(new CoordinatorRecordJsonConvertersGenerator(packageName));
+                    break;
+                default:
+                    throw new RuntimeException("Unknown type class generator type '" + type + "'");
+            }
+        }
+        return generators;
+    }
+
+    private static List<MessageClassGenerator> createMessageClassGenerators(String packageName,
+                                                                            List<String> types) {
+        if (types == null)
+            return List.of();
+        List<MessageClassGenerator> generators = new ArrayList<>();
+        for (String type : types) {
+            switch (type) {
+                case "MessageDataGenerator":
+                    generators.add(new MessageDataGenerator(packageName));
+                    break;
+                case "JsonConverterGenerator":
+                    generators.add(new JsonConverterGenerator(packageName));
+                    break;
+                default:
+                    throw new RuntimeException("Unknown message class generator type '" + type + "'");
+            }
+        }
+        return generators;
+    }
+
+    public static void processDirectories(String packageName,
+                                          String outputDir,
+                                          String inputDir,
+                                          List<String> typeClassGeneratorTypes,
+                                          List<String> messageClassGeneratorTypes)
+            throws Exception {
+        Files.createDirectories(Paths.get(outputDir));
+        int numProcessed = 0;
+
+        List<TypeClassGenerator> typeClassGenerators = createTypeClassGenerators(packageName, typeClassGeneratorTypes);
+        Set<String> outputFileNames = new HashSet<>();
+        try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(Paths.get(inputDir), JSON_GLOB)) {
+            for (Path inputPath : directoryStream) {
+                try {
+                    MessageSpec spec = JSON_SERDE.readValue(inputPath.toFile(), MessageSpec.class);
+                    outputFileNames.addAll(
+                            generateAndWriteMessageClasses(spec, packageName, outputDir, messageClassGeneratorTypes));
+                    numProcessed++;
+                    typeClassGenerators.forEach(generator -> generator.registerMessageType(spec));
+                }
+                catch (Exception e) {
+                    throw new RuntimeException("Exception while processing " + inputPath.toString(), e);
+                }
+            }
+        }
+        for (TypeClassGenerator typeClassGenerator : typeClassGenerators) {
+            outputFileNames.add(typeClassGenerator.outputName());
+            generateAndWriteTypeClasses(outputDir, typeClassGenerator);
+        }
+
+        try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(Paths.get(outputDir))) {
+            for (Path outputPath : directoryStream) {
+                Path fileName = outputPath.getFileName();
+                if (fileName != null) {
+                    if (!outputFileNames.contains(fileName.toString())) {
+                        Files.delete(outputPath);
+                    }
+                }
+            }
+        }
+        System.out.printf("MessageGenerator: processed %d Kafka message JSON file(s).%n", numProcessed);
+    }
+
+    /**
+     * Generate and write message classes.
+     * @return output file names.
+     */
+    static Set<String> generateAndWriteMessageClasses(MessageSpec spec,
+                                                      String packageName,
+                                                      String outputDir,
+                                                      List<String> messageClassGeneratorTypes)
+            throws Exception {
+        var outputFileNames = new HashSet<String>();
+        // Only generate `Data` classes for apis that have valid version(s)
+        if (spec.hasValidVersion()) {
+            List<MessageClassGenerator> generators = createMessageClassGenerators(packageName, messageClassGeneratorTypes);
+            for (MessageClassGenerator generator : generators) {
+                String name = generator.outputName(spec) + JAVA_SUFFIX;
+                outputFileNames.add(name);
+                Path outputPath = Paths.get(outputDir, name);
+                try (BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+                    generator.generateAndWrite(spec, writer);
+                }
+            }
+        }
+        return outputFileNames;
+    }
+
+    static void generateAndWriteTypeClasses(String outputDir, TypeClassGenerator typeClassGenerator) throws IOException {
+        Path factoryOutputPath = Paths.get(outputDir, typeClassGenerator.outputName());
+        try (BufferedWriter writer = Files.newBufferedWriter(factoryOutputPath, StandardCharsets.UTF_8)) {
+            typeClassGenerator.generateAndWrite(writer);
+        }
+    }
+
+    public static String capitalizeFirst(String string) {
+        if (string.isEmpty()) {
+            return string;
+        }
+        return string.substring(0, 1).toUpperCase(Locale.ENGLISH) +
+                string.substring(1);
+    }
+
+    static String lowerCaseFirst(String string) {
+        if (string.isEmpty()) {
+            return string;
+        }
+        return string.substring(0, 1).toLowerCase(Locale.ENGLISH) +
+                string.substring(1);
+    }
+
+    static boolean firstIsCapitalized(String string) {
+        if (string.isEmpty()) {
+            return false;
+        }
+        return Character.isUpperCase(string.charAt(0));
+    }
+
+    static String toSnakeCase(String string) {
+        StringBuilder bld = new StringBuilder();
+        boolean prevWasCapitalized = true;
+        for (int i = 0; i < string.length(); i++) {
+            char c = string.charAt(i);
+            if (Character.isUpperCase(c)) {
+                if (!prevWasCapitalized) {
+                    bld.append('_');
+                }
+                bld.append(Character.toLowerCase(c));
+                prevWasCapitalized = true;
+            }
+            else {
+                bld.append(c);
+                prevWasCapitalized = false;
+            }
+        }
+        return bld.toString();
+    }
+
+    static String stripSuffix(String str, String suffix) {
+        if (str.endsWith(suffix)) {
+            return str.substring(0, str.length() - suffix.length());
+        }
+        else {
+            throw new RuntimeException("String " + str + " does not end with the " +
+                    "expected suffix " + suffix);
+        }
+    }
+
+    /**
+     * Return the number of bytes needed to encode an integer in unsigned variable-length format.
+     */
+    static int sizeOfUnsignedVarint(int value) {
+        int bytes = 1;
+        while ((value & 0xffffff80) != 0L) {
+            bytes += 1;
+            value >>>= 7;
+        }
+        return bytes;
+    }
+
+    public static void main(String[] args) throws Exception {
+        ArgumentParser parser = ArgumentParsers
+                .newArgumentParser("message-generator")
+                .defaultHelp(true)
+                .description("The Kafka message generator");
+        parser.addArgument("--package", "-p")
+                .action(store())
+                .required(true)
+                .metavar("PACKAGE")
+                .help("The java package to use in generated files.");
+        parser.addArgument("--output", "-o")
+                .action(store())
+                .required(true)
+                .metavar("OUTPUT")
+                .help("The output directory to create.");
+        parser.addArgument("--input", "-i")
+                .action(store())
+                .required(true)
+                .metavar("INPUT")
+                .help("The input directory to use.");
+        parser.addArgument("--typeclass-generators", "-t")
+                .nargs("+")
+                .action(store())
+                .metavar("TYPECLASS_GENERATORS")
+                .help("The type class generators to use, if any.");
+        parser.addArgument("--message-class-generators", "-m")
+                .nargs("+")
+                .action(store())
+                .metavar("MESSAGE_CLASS_GENERATORS")
+                .help("The message class generators to use.");
+        Namespace res = parser.parseArgsOrFail(args);
+        processDirectories(res.getString("package"), res.getString("output"),
+                res.getString("input"), res.getList("typeclass_generators"),
+                res.getList("message_class_generators"));
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/MessageSpec.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/MessageSpec.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public final class MessageSpec {
+    private final StructSpec struct;
+
+    private final Optional<Short> apiKey;
+
+    private final MessageSpecType type;
+
+    private final List<StructSpec> commonStructs;
+
+    private final Versions flexibleVersions;
+
+    private final List<RequestListenerType> listeners;
+
+    private final boolean latestVersionUnstable;
+
+    @JsonCreator
+    @SuppressWarnings({ "NPathComplexity", "CyclomaticComplexity" })
+    public MessageSpec(@JsonProperty("name") String name,
+                       @JsonProperty("validVersions") String validVersions,
+                       @JsonProperty("deprecatedVersions") String deprecatedVersions,
+                       @JsonProperty("fields") List<FieldSpec> fields,
+                       @JsonProperty("apiKey") Short apiKey,
+                       @JsonProperty("type") MessageSpecType type,
+                       @JsonProperty("commonStructs") List<StructSpec> commonStructs,
+                       @JsonProperty("flexibleVersions") String flexibleVersions,
+                       @JsonProperty("listeners") List<RequestListenerType> listeners,
+                       @JsonProperty("latestVersionUnstable") boolean latestVersionUnstable) {
+        this.struct = new StructSpec(name, validVersions, deprecatedVersions, fields);
+        this.apiKey = apiKey == null ? Optional.empty() : Optional.of(apiKey);
+        this.type = Objects.requireNonNull(type);
+        this.commonStructs = commonStructs == null ? List.of() : List.copyOf(commonStructs);
+        // If the struct has no valid versions (the typical use case is to completely remove support for
+        // an existing protocol api while ensuring the api key id is not reused), we configure the spec
+        // to effectively be empty
+        if (struct.versions().empty()) {
+            this.flexibleVersions = Versions.NONE;
+            this.listeners = List.of();
+            this.latestVersionUnstable = false;
+        }
+        else {
+            if (flexibleVersions == null) {
+                throw new RuntimeException("You must specify a value for flexibleVersions. " +
+                        "Please use 0+ for all new messages.");
+            }
+            this.flexibleVersions = Versions.parse(flexibleVersions, Versions.NONE);
+            if ((!this.flexibleVersions().empty()) &&
+                    (this.flexibleVersions.highest() < Short.MAX_VALUE)) {
+                throw new RuntimeException("Field " + name + " specifies flexibleVersions " +
+                        this.flexibleVersions + ", which is not open-ended.  flexibleVersions must " +
+                        "be either none, or an open-ended range (that ends with a plus sign).");
+            }
+
+            if (listeners != null && !listeners.isEmpty() && type != MessageSpecType.REQUEST) {
+                throw new RuntimeException("The `requestScope` property is only valid for " +
+                        "messages with type `request`");
+            }
+            this.listeners = listeners;
+
+            if (latestVersionUnstable && type != MessageSpecType.REQUEST) {
+                throw new RuntimeException("The `latestVersionUnstable` property is only valid for " +
+                        "messages with type `request`");
+            }
+            this.latestVersionUnstable = latestVersionUnstable;
+
+            if (type == MessageSpecType.COORDINATOR_KEY) {
+                if (this.apiKey.isEmpty()) {
+                    throw new RuntimeException("The ApiKey must be set for messages " + name + " with type `coordinator-key`");
+                }
+                if (!this.validVersions().equals(new Versions((short) 0, ((short) 0)))) {
+                    throw new RuntimeException("The Versions must be set to `0` for messages " + name + " with type `coordinator-key`");
+                }
+                if (!this.flexibleVersions.empty()) {
+                    throw new RuntimeException("The FlexibleVersions are not supported for messages " + name + "  with type `coordinator-key`");
+                }
+            }
+
+            if (type == MessageSpecType.COORDINATOR_VALUE) {
+                if (this.apiKey.isEmpty()) {
+                    throw new RuntimeException("The ApiKey must be set for messages with type `coordinator-value`");
+                }
+            }
+        }
+    }
+
+    public StructSpec struct() {
+        return struct;
+    }
+
+    @JsonProperty("name")
+    public String name() {
+        return struct.name();
+    }
+
+    public boolean hasValidVersion() {
+        return !struct.versions().empty();
+    }
+
+    public Versions validVersions() {
+        return struct.versions();
+    }
+
+    @JsonProperty("validVersions")
+    public String validVersionsString() {
+        return struct.versionsString();
+    }
+
+    @JsonProperty("fields")
+    public List<FieldSpec> fields() {
+        return struct.fields();
+    }
+
+    @JsonProperty("apiKey")
+    public Optional<Short> apiKey() {
+        return apiKey;
+    }
+
+    @JsonProperty("type")
+    public MessageSpecType type() {
+        return type;
+    }
+
+    @JsonProperty("commonStructs")
+    public List<StructSpec> commonStructs() {
+        return commonStructs;
+    }
+
+    public Versions flexibleVersions() {
+        return flexibleVersions;
+    }
+
+    @JsonProperty("flexibleVersions")
+    public String flexibleVersionsString() {
+        return flexibleVersions.toString();
+    }
+
+    @JsonProperty("listeners")
+    public List<RequestListenerType> listeners() {
+        return listeners;
+    }
+
+    @JsonProperty("latestVersionUnstable")
+    public boolean latestVersionUnstable() {
+        return latestVersionUnstable;
+    }
+
+    public String dataClassName() {
+        switch (type) {
+            case HEADER:
+            case REQUEST:
+            case RESPONSE:
+                // We append the Data suffix to request/response/header classes to avoid
+                // collisions with existing objects. This can go away once the protocols
+                // have all been converted and we begin using the generated types directly.
+                return struct.name() + "Data";
+            default:
+                return struct.name();
+        }
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/MessageSpecType.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/MessageSpecType.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum MessageSpecType {
+    /**
+     * Kafka request RPCs.
+     */
+    @JsonProperty("request")
+    REQUEST,
+
+    /**
+     * Kafka response RPCs.
+     */
+    @JsonProperty("response")
+    RESPONSE,
+
+    /**
+     * Kafka RPC headers.
+     */
+    @JsonProperty("header")
+    HEADER,
+
+    /**
+     * KIP-631 controller records.
+     */
+    @JsonProperty("metadata")
+    METADATA,
+
+    /**
+     * Other message spec types.
+     */
+    @JsonProperty("data")
+    DATA,
+
+    @JsonProperty("coordinator-key")
+    COORDINATOR_KEY,
+
+    @JsonProperty("coordinator-value")
+    COORDINATOR_VALUE
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/MetadataJsonConvertersGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/MetadataJsonConvertersGenerator.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class MetadataJsonConvertersGenerator implements TypeClassGenerator {
+    private final HeaderGenerator headerGenerator;
+    private final CodeBuffer buffer;
+    private final TreeMap<Short, MessageSpec> apis;
+
+    public MetadataJsonConvertersGenerator(String packageName) {
+        this.headerGenerator = new HeaderGenerator(packageName);
+        this.apis = new TreeMap<>();
+        this.buffer = new CodeBuffer();
+    }
+
+    @Override
+    public String outputName() {
+        return MessageGenerator.METADATA_JSON_CONVERTERS_JAVA;
+    }
+
+    @Override
+    public void registerMessageType(MessageSpec spec) {
+        if (spec.type() == MessageSpecType.METADATA) {
+            short id = spec.apiKey().get();
+            MessageSpec prevSpec = apis.put(id, spec);
+            if (prevSpec != null) {
+                throw new RuntimeException("Duplicate metadata record entry for type " +
+                        id + ". Original claimant: " + prevSpec.name() + ". New " +
+                        "claimant: " + spec.name());
+            }
+        }
+    }
+
+    @Override
+    public void generateAndWrite(BufferedWriter writer) throws IOException {
+        buffer.printf("public class MetadataJsonConverters {%n");
+        buffer.incrementIndent();
+        generateWriteJson();
+        buffer.printf("%n");
+        generateReadJson();
+        buffer.printf("%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        headerGenerator.generate();
+
+        headerGenerator.buffer().write(writer);
+        buffer.write(writer);
+    }
+
+    private void generateWriteJson() {
+        headerGenerator.addImport(MessageGenerator.JSON_NODE_CLASS);
+        headerGenerator.addImport(MessageGenerator.API_MESSAGE_CLASS);
+
+        buffer.printf("public static JsonNode writeJson(ApiMessage apiMessage, short apiVersion) {%n");
+        buffer.incrementIndent();
+        buffer.printf("switch (apiMessage.apiKey()) {%n");
+        buffer.incrementIndent();
+        for (Map.Entry<Short, MessageSpec> entry : apis.entrySet()) {
+            String apiMessageClassName = MessageGenerator.capitalizeFirst(entry.getValue().name());
+            buffer.printf("case %d:%n", entry.getKey());
+            buffer.incrementIndent();
+            buffer.printf("return %sJsonConverter.write((%s) apiMessage, apiVersion);%n", apiMessageClassName, apiMessageClassName);
+            buffer.decrementIndent();
+        }
+        buffer.printf("default:%n");
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+        buffer.printf("throw new UnsupportedVersionException(\"Unknown metadata id \"" +
+                " + apiMessage.apiKey());%n");
+        buffer.decrementIndent();
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateReadJson() {
+        headerGenerator.addImport(MessageGenerator.JSON_NODE_CLASS);
+        headerGenerator.addImport(MessageGenerator.API_MESSAGE_CLASS);
+
+        buffer.printf("public static ApiMessage readJson(JsonNode json, short apiKey, short apiVersion) {%n");
+        buffer.incrementIndent();
+        buffer.printf("switch (apiKey) {%n");
+        buffer.incrementIndent();
+        for (Map.Entry<Short, MessageSpec> entry : apis.entrySet()) {
+            String apiMessageClassName = MessageGenerator.capitalizeFirst(entry.getValue().name());
+            buffer.printf("case %d:%n", entry.getKey());
+            buffer.incrementIndent();
+            buffer.printf("return %sJsonConverter.read(json, apiVersion);%n", apiMessageClassName);
+            buffer.decrementIndent();
+        }
+        buffer.printf("default:%n");
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+        buffer.printf("throw new UnsupportedVersionException(\"Unknown metadata id \"" +
+                " + apiKey);%n");
+        buffer.decrementIndent();
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/MetadataRecordTypeGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/MetadataRecordTypeGenerator.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+
+public final class MetadataRecordTypeGenerator implements TypeClassGenerator {
+    private final HeaderGenerator headerGenerator;
+    private final CodeBuffer buffer;
+    private final TreeMap<Short, MessageSpec> apis;
+
+    public MetadataRecordTypeGenerator(String packageName) {
+        this.headerGenerator = new HeaderGenerator(packageName);
+        this.apis = new TreeMap<>();
+        this.buffer = new CodeBuffer();
+    }
+
+    @Override
+    public String outputName() {
+        return MessageGenerator.METADATA_RECORD_TYPE_JAVA;
+    }
+
+    @Override
+    public void registerMessageType(MessageSpec spec) {
+        if (spec.type() == MessageSpecType.METADATA) {
+            short id = spec.apiKey().get();
+            MessageSpec prevSpec = apis.put(id, spec);
+            if (prevSpec != null) {
+                throw new RuntimeException("Duplicate metadata record entry for type " +
+                        id + ". Original claimant: " + prevSpec.name() + ". New " +
+                        "claimant: " + spec.name());
+            }
+        }
+    }
+
+    @Override
+    public void generateAndWrite(BufferedWriter writer) throws IOException {
+        generate();
+        write(writer);
+    }
+
+    private void generate() {
+        buffer.printf("public enum MetadataRecordType {%n");
+        buffer.incrementIndent();
+        generateEnumValues();
+        buffer.printf("%n");
+        generateInstanceVariables();
+        buffer.printf("%n");
+        generateEnumConstructor();
+        buffer.printf("%n");
+        generateFromApiKey();
+        buffer.printf("%n");
+        generateNewMetadataRecord();
+        buffer.printf("%n");
+        generateAccessor("id", "short");
+        buffer.printf("%n");
+        generateAccessor("lowestSupportedVersion", "short");
+        buffer.printf("%n");
+        generateAccessor("highestSupportedVersion", "short");
+        buffer.printf("%n");
+        generateToString();
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        headerGenerator.generate();
+    }
+
+    private void generateEnumValues() {
+        int numProcessed = 0;
+        for (Map.Entry<Short, MessageSpec> entry : apis.entrySet()) {
+            MessageSpec spec = entry.getValue();
+            String name = spec.name();
+            numProcessed++;
+            buffer.printf("%s(\"%s\", (short) %d, (short) %d, (short) %d)%s%n",
+                    MessageGenerator.toSnakeCase(name).toUpperCase(Locale.ROOT),
+                    MessageGenerator.capitalizeFirst(name),
+                    entry.getKey(),
+                    entry.getValue().validVersions().lowest(),
+                    entry.getValue().validVersions().highest(),
+                    (numProcessed == apis.size()) ? ";" : ",");
+        }
+    }
+
+    private void generateInstanceVariables() {
+        buffer.printf("private final String name;%n");
+        buffer.printf("private final short id;%n");
+        buffer.printf("private final short lowestSupportedVersion;%n");
+        buffer.printf("private final short highestSupportedVersion;%n");
+    }
+
+    private void generateEnumConstructor() {
+        buffer.printf("MetadataRecordType(String name, short id, short lowestSupportedVersion, short highestSupportedVersion) {%n");
+        buffer.incrementIndent();
+        buffer.printf("this.name = name;%n");
+        buffer.printf("this.id = id;%n");
+        buffer.printf("this.lowestSupportedVersion = lowestSupportedVersion;%n");
+        buffer.printf("this.highestSupportedVersion = highestSupportedVersion;%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateFromApiKey() {
+        buffer.printf("public static MetadataRecordType fromId(short id) {%n");
+        buffer.incrementIndent();
+        buffer.printf("switch (id) {%n");
+        buffer.incrementIndent();
+        for (Map.Entry<Short, MessageSpec> entry : apis.entrySet()) {
+            buffer.printf("case %d:%n", entry.getKey());
+            buffer.incrementIndent();
+            buffer.printf("return %s;%n", MessageGenerator.toSnakeCase(entry.getValue().name()).toUpperCase(Locale.ROOT));
+            buffer.decrementIndent();
+        }
+        buffer.printf("default:%n");
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+        buffer.printf("throw new UnsupportedVersionException(\"Unknown metadata id \"" +
+                " + id);%n");
+        buffer.decrementIndent();
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateNewMetadataRecord() {
+        headerGenerator.addImport(MessageGenerator.API_MESSAGE_CLASS);
+        buffer.printf("public ApiMessage newMetadataRecord() {%n");
+        buffer.incrementIndent();
+        buffer.printf("switch (id) {%n");
+        buffer.incrementIndent();
+        for (Map.Entry<Short, MessageSpec> entry : apis.entrySet()) {
+            buffer.printf("case %d:%n", entry.getKey());
+            buffer.incrementIndent();
+            buffer.printf("return new %s();%n",
+                    MessageGenerator.capitalizeFirst(entry.getValue().name()));
+            buffer.decrementIndent();
+        }
+        buffer.printf("default:%n");
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+        buffer.printf("throw new UnsupportedVersionException(\"Unknown metadata id \"" +
+                " + id);%n");
+        buffer.decrementIndent();
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateAccessor(String name, String type) {
+        buffer.printf("public %s %s() {%n", type, name);
+        buffer.incrementIndent();
+        buffer.printf("return this.%s;%n", name);
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateToString() {
+        buffer.printf("@Override%n");
+        buffer.printf("public String toString() {%n");
+        buffer.incrementIndent();
+        buffer.printf("return this.name();%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void write(BufferedWriter writer) throws IOException {
+        headerGenerator.buffer().write(writer);
+        buffer.write(writer);
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/RequestListenerType.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/RequestListenerType.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kroxylicious.kafka.message;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum RequestListenerType {
+
+    @JsonProperty("broker")
+    BROKER,
+
+    @JsonProperty("controller")
+    CONTROLLER
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/SchemaGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/SchemaGenerator.java
@@ -1,0 +1,394 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Generates Schemas for Kafka MessageData classes.
+ */
+final class SchemaGenerator {
+    /**
+     * Schema information for a particular message.
+     */
+    static class MessageInfo {
+        /**
+         * The versions of this message that we want to generate a schema for.
+         * This will be constrained by the valid versions for the parent objects.
+         * For example, if the parent message is valid for versions 0 and 1,
+         * we will only generate a version 0 and version 1 schema for child classes,
+         * even if their valid versions are "0+".
+         */
+        private final Versions versions;
+
+        /**
+         * Maps versions to schema declaration code.  If the schema for a
+         * particular version is the same as that of a previous version,
+         * there will be no entry in the map for it.
+         */
+        private final TreeMap<Short, CodeBuffer> schemaForVersion;
+
+        MessageInfo(Versions versions) {
+            this.versions = versions;
+            this.schemaForVersion = new TreeMap<>();
+        }
+    }
+
+    /**
+     * The header file generator.  This is shared with the MessageDataGenerator
+     * instance that owns this SchemaGenerator.
+     */
+    private final HeaderGenerator headerGenerator;
+
+    /**
+     * A registry with the structures we're generating.
+     */
+    private final StructRegistry structRegistry;
+
+    /**
+     * Maps message names to message information.
+     */
+    private final Map<String, MessageInfo> messages;
+
+    /**
+     * The versions that implement a KIP-482 flexible schema.
+     */
+    private Versions messageFlexibleVersions;
+
+    SchemaGenerator(HeaderGenerator headerGenerator, StructRegistry structRegistry) {
+        this.headerGenerator = headerGenerator;
+        this.structRegistry = structRegistry;
+        this.messages = new HashMap<>();
+    }
+
+    void generateSchemas(MessageSpec message) {
+        this.messageFlexibleVersions = message.flexibleVersions();
+
+        // First generate schemas for common structures so that they are
+        // available when we generate the inline structures
+        for (Iterator<StructSpec> iter = structRegistry.commonStructs(); iter.hasNext();) {
+            StructSpec struct = iter.next();
+            generateSchemas(struct.name(), struct, message.struct().versions());
+        }
+
+        // Generate schemas for inline structures
+        generateSchemas(message.dataClassName(), message.struct(), message.struct().versions());
+    }
+
+    void generateSchemas(String className, StructSpec struct, Versions parentVersions) {
+        Versions versions = parentVersions.intersect(struct.versions());
+        MessageInfo messageInfo = messages.get(className);
+        if (messageInfo != null) {
+            return;
+        }
+        messageInfo = new MessageInfo(versions);
+        messages.put(className, messageInfo);
+        // Process the leaf classes first.
+        for (FieldSpec field : struct.fields()) {
+            if (field.type().isStructArray()) {
+                FieldType.ArrayType arrayType = (FieldType.ArrayType) field.type();
+                generateSchemas(arrayType.elementType().toString(), structRegistry.findStruct(field), versions);
+            }
+            else if (field.type().isStruct()) {
+                generateSchemas(field.type().toString(), structRegistry.findStruct(field), versions);
+            }
+        }
+        CodeBuffer prev = null;
+        for (short v = versions.lowest(); v <= versions.highest(); v++) {
+            CodeBuffer cur = new CodeBuffer();
+            generateSchemaForVersion(struct, v, cur);
+            // If this schema version is different from the previous one,
+            // create a new map entry.
+            if (!cur.equals(prev)) {
+                messageInfo.schemaForVersion.put(v, cur);
+            }
+            prev = cur;
+        }
+    }
+
+    private void generateSchemaForVersion(StructSpec struct,
+                                          short version,
+                                          CodeBuffer buffer) {
+        // Find the last valid field index.
+        int lastValidIndex = struct.fields().size() - 1;
+        while (true) {
+            if (lastValidIndex < 0) {
+                break;
+            }
+            FieldSpec field = struct.fields().get(lastValidIndex);
+            if ((!field.taggedVersions().contains(version)) &&
+                    field.versions().contains(version)) {
+                break;
+            }
+            lastValidIndex--;
+        }
+        int finalLine = lastValidIndex;
+        if (messageFlexibleVersions.contains(version)) {
+            finalLine++;
+        }
+
+        headerGenerator.addImport(MessageGenerator.SCHEMA_CLASS);
+        buffer.printf("new Schema(%n");
+        buffer.incrementIndent();
+        for (int i = 0; i <= lastValidIndex; i++) {
+            FieldSpec field = struct.fields().get(i);
+            if ((!field.versions().contains(version)) ||
+                    field.taggedVersions().contains(version)) {
+                continue;
+            }
+            Versions fieldFlexibleVersions = field.flexibleVersions().orElse(messageFlexibleVersions);
+            headerGenerator.addImport(MessageGenerator.FIELD_CLASS);
+            buffer.printf("new Field(\"%s\", %s, \"%s\")%s%n",
+                    field.snakeCaseName(),
+                    fieldTypeToSchemaType(field, version, fieldFlexibleVersions),
+                    field.about(),
+                    i == finalLine ? "" : ",");
+        }
+        if (messageFlexibleVersions.contains(version)) {
+            generateTaggedFieldsSchemaForVersion(struct, version, buffer);
+        }
+        buffer.decrementIndent();
+        buffer.printf(");%n");
+    }
+
+    private void generateTaggedFieldsSchemaForVersion(StructSpec struct,
+                                                      short version, CodeBuffer buffer) {
+        headerGenerator.addStaticImport(MessageGenerator.TAGGED_FIELDS_SECTION_CLASS);
+
+        // Find the last valid tagged field index.
+        int lastValidIndex = struct.fields().size() - 1;
+        while (true) {
+            if (lastValidIndex < 0) {
+                break;
+            }
+            FieldSpec field = struct.fields().get(lastValidIndex);
+            if ((field.taggedVersions().contains(version)) &&
+                    field.versions().contains(version)) {
+                break;
+            }
+            lastValidIndex--;
+        }
+
+        buffer.printf("TaggedFieldsSection.of(%n");
+        buffer.incrementIndent();
+        for (int i = 0; i <= lastValidIndex; i++) {
+            FieldSpec field = struct.fields().get(i);
+            if ((!field.versions().contains(version)) ||
+                    (!field.taggedVersions().contains(version))) {
+                continue;
+            }
+            headerGenerator.addImport(MessageGenerator.FIELD_CLASS);
+            Versions fieldFlexibleVersions = field.flexibleVersions().orElse(messageFlexibleVersions);
+            buffer.printf("%d, new Field(\"%s\", %s, \"%s\")%s%n",
+                    field.tag().get(),
+                    field.snakeCaseName(),
+                    fieldTypeToSchemaType(field, version, fieldFlexibleVersions),
+                    field.about(),
+                    i == lastValidIndex ? "" : ",");
+        }
+        buffer.decrementIndent();
+        buffer.printf(")%n");
+    }
+
+    private String fieldTypeToSchemaType(FieldSpec field,
+                                         short version,
+                                         Versions fieldFlexibleVersions) {
+        return fieldTypeToSchemaType(field.type(),
+                field.nullableVersions().contains(version),
+                version,
+                fieldFlexibleVersions,
+                field.zeroCopy());
+    }
+
+    private String fieldTypeToSchemaType(FieldType type,
+                                         boolean nullable,
+                                         short version,
+                                         Versions fieldFlexibleVersions,
+                                         boolean zeroCopy) {
+        if (type instanceof FieldType.BoolFieldType) {
+            headerGenerator.addImport(MessageGenerator.TYPE_CLASS);
+            if (nullable) {
+                throw new RuntimeException("Type " + type + " cannot be nullable.");
+            }
+            return "Type.BOOLEAN";
+        }
+        else if (type instanceof FieldType.Int8FieldType) {
+            headerGenerator.addImport(MessageGenerator.TYPE_CLASS);
+            if (nullable) {
+                throw new RuntimeException("Type " + type + " cannot be nullable.");
+            }
+            return "Type.INT8";
+        }
+        else if (type instanceof FieldType.Int16FieldType) {
+            headerGenerator.addImport(MessageGenerator.TYPE_CLASS);
+            if (nullable) {
+                throw new RuntimeException("Type " + type + " cannot be nullable.");
+            }
+            return "Type.INT16";
+        }
+        else if (type instanceof FieldType.Uint16FieldType) {
+            headerGenerator.addImport(MessageGenerator.TYPE_CLASS);
+            if (nullable) {
+                throw new RuntimeException("Type " + type + " cannot be nullable.");
+            }
+            return "Type.UINT16";
+        }
+        else if (type instanceof FieldType.Uint32FieldType) {
+            headerGenerator.addImport(MessageGenerator.TYPE_CLASS);
+            if (nullable) {
+                throw new RuntimeException("Type " + type + " cannot be nullable.");
+            }
+            return "Type.UNSIGNED_INT32";
+        }
+        else if (type instanceof FieldType.Int32FieldType) {
+            headerGenerator.addImport(MessageGenerator.TYPE_CLASS);
+            if (nullable) {
+                throw new RuntimeException("Type " + type + " cannot be nullable.");
+            }
+            return "Type.INT32";
+        }
+        else if (type instanceof FieldType.Int64FieldType) {
+            headerGenerator.addImport(MessageGenerator.TYPE_CLASS);
+            if (nullable) {
+                throw new RuntimeException("Type " + type + " cannot be nullable.");
+            }
+            return "Type.INT64";
+        }
+        else if (type instanceof FieldType.UUIDFieldType) {
+            headerGenerator.addImport(MessageGenerator.TYPE_CLASS);
+            if (nullable) {
+                throw new RuntimeException("Type " + type + " cannot be nullable.");
+            }
+            return "Type.UUID";
+        }
+        else if (type instanceof FieldType.Float64FieldType) {
+            headerGenerator.addImport(MessageGenerator.TYPE_CLASS);
+            if (nullable) {
+                throw new RuntimeException("Type " + type + " cannot be nullable.");
+            }
+            return "Type.FLOAT64";
+        }
+        else if (type instanceof FieldType.StringFieldType) {
+            headerGenerator.addImport(MessageGenerator.TYPE_CLASS);
+            if (fieldFlexibleVersions.contains(version)) {
+                return nullable ? "Type.COMPACT_NULLABLE_STRING" : "Type.COMPACT_STRING";
+            }
+            else {
+                return nullable ? "Type.NULLABLE_STRING" : "Type.STRING";
+            }
+        }
+        else if (type instanceof FieldType.BytesFieldType) {
+            headerGenerator.addImport(MessageGenerator.TYPE_CLASS);
+            if (fieldFlexibleVersions.contains(version)) {
+                return nullable ? "Type.COMPACT_NULLABLE_BYTES" : "Type.COMPACT_BYTES";
+            }
+            else {
+                return nullable ? "Type.NULLABLE_BYTES" : "Type.BYTES";
+            }
+        }
+        else if (type.isRecords()) {
+            headerGenerator.addImport(MessageGenerator.TYPE_CLASS);
+            if (fieldFlexibleVersions.contains(version)) {
+                return nullable ? "Type.COMPACT_NULLABLE_RECORDS" : "Type.COMPACT_RECORDS";
+            }
+            else {
+                return nullable ? "Type.NULLABLE_RECORDS" : "Type.RECORDS";
+            }
+        }
+        else if (type.isArray()) {
+            if (fieldFlexibleVersions.contains(version)) {
+                headerGenerator.addImport(MessageGenerator.COMPACT_ARRAYOF_CLASS);
+                FieldType.ArrayType arrayType = (FieldType.ArrayType) type;
+                String prefix = nullable ? "CompactArrayOf.nullable" : "new CompactArrayOf";
+                return String.format("%s(%s)", prefix,
+                        fieldTypeToSchemaType(arrayType.elementType(), false, version, fieldFlexibleVersions, false));
+
+            }
+            else {
+                headerGenerator.addImport(MessageGenerator.ARRAYOF_CLASS);
+                FieldType.ArrayType arrayType = (FieldType.ArrayType) type;
+                String prefix = nullable ? "ArrayOf.nullable" : "new ArrayOf";
+                return String.format("%s(%s)", prefix,
+                        fieldTypeToSchemaType(arrayType.elementType(), false, version, fieldFlexibleVersions, false));
+            }
+        }
+        else if (type.isStruct()) {
+            if (nullable) {
+                headerGenerator.addImport(MessageGenerator.NULLABLE_SCHEMA_CLASS);
+            }
+            String schemaType = String.format("%s.SCHEMA_%d", type,
+                    floorVersion(type.toString(), version));
+            return nullable ? String.format("new NullableSchema(%s)", schemaType) : schemaType;
+        }
+        else {
+            throw new RuntimeException("Unsupported type " + type);
+        }
+    }
+
+    /**
+     * Find the lowest schema version for a given class that is the same as the
+     * given version.
+     */
+    private short floorVersion(String className, short v) {
+        MessageInfo message = messages.get(className);
+        return message.schemaForVersion.floorKey(v);
+    }
+
+    /**
+     * Write the message schema to the provided buffer.
+     *
+     * @param className     The class name.
+     * @param buffer        The destination buffer.
+     */
+    void writeSchema(String className, CodeBuffer buffer) {
+        MessageInfo messageInfo = messages.get(className);
+        Versions versions = messageInfo.versions;
+
+        for (short v = versions.lowest(); v <= versions.highest(); v++) {
+            CodeBuffer declaration = messageInfo.schemaForVersion.get(v);
+            if (declaration == null) {
+                buffer.printf("public static final Schema SCHEMA_%d = SCHEMA_%d;%n", v, v - 1);
+            }
+            else {
+                buffer.printf("public static final Schema SCHEMA_%d =%n", v);
+                buffer.incrementIndent();
+                declaration.write(buffer);
+                buffer.decrementIndent();
+            }
+            buffer.printf("%n");
+        }
+        buffer.printf("public static final Schema[] SCHEMAS = new Schema[] {%n");
+        buffer.incrementIndent();
+        for (short v = 0; v < versions.lowest(); v++) {
+            buffer.printf("null%s%n", (v == versions.highest()) ? "" : ",");
+        }
+        for (short v = versions.lowest(); v <= versions.highest(); v++) {
+            buffer.printf("SCHEMA_%d%s%n", v, (v == versions.highest()) ? "" : ",");
+        }
+        buffer.decrementIndent();
+        buffer.printf("};%n");
+        buffer.printf("%n");
+
+        buffer.printf("public static final short LOWEST_SUPPORTED_VERSION = %d;%n", versions.lowest());
+        buffer.printf("public static final short HIGHEST_SUPPORTED_VERSION = %d;%n", versions.highest());
+        buffer.printf("%n");
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/StructRegistry.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/StructRegistry.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * Contains structure data for Kafka MessageData classes.
+ */
+public final class StructRegistry {
+    private final Map<String, StructInfo> structs;
+    private final Set<String> commonStructNames;
+
+    static class StructInfo {
+        /**
+         * The specification for this structure.
+         */
+        private final StructSpec spec;
+
+        /**
+         * The versions which the parent(s) of this structure can have.  If this is a
+         * top-level structure, this will be equal to the versions which the
+         * overall message can have.
+         */
+        private final Versions parentVersions;
+
+        StructInfo(StructSpec spec, Versions parentVersions) {
+            this.spec = spec;
+            this.parentVersions = parentVersions;
+        }
+
+        public StructSpec spec() {
+            return spec;
+        }
+
+        public Versions parentVersions() {
+            return parentVersions;
+        }
+    }
+
+    public StructRegistry() {
+        this.structs = new TreeMap<>();
+        this.commonStructNames = new TreeSet<>();
+    }
+
+    /**
+     * Register all the structures contained a message spec.
+     */
+    public void register(MessageSpec message) throws Exception {
+        // Register common structures.
+        for (StructSpec struct : message.commonStructs()) {
+            if (!MessageGenerator.firstIsCapitalized(struct.name())) {
+                throw new RuntimeException("Can't process structure " + struct.name() +
+                        ": the first letter of structure names must be capitalized.");
+            }
+            if (structs.containsKey(struct.name())) {
+                throw new RuntimeException("Common struct " + struct.name() + " was specified twice.");
+            }
+            structs.put(struct.name(), new StructInfo(struct, struct.versions()));
+            commonStructNames.add(struct.name());
+        }
+        // Register inline structures.
+        addStructSpecs(message.validVersions(), message.fields());
+    }
+
+    private void addStructSpecs(Versions parentVersions, List<FieldSpec> fields) {
+        for (FieldSpec field : fields) {
+            String typeName = null;
+            if (field.type().isStructArray()) {
+                FieldType.ArrayType arrayType = (FieldType.ArrayType) field.type();
+                typeName = arrayType.elementName();
+            }
+            else if (field.type().isStruct()) {
+                FieldType.StructType structType = (FieldType.StructType) field.type();
+                typeName = structType.typeName();
+            }
+            if (typeName != null) {
+                if (commonStructNames.contains(typeName)) {
+                    // If we're using a common structure, we can't specify its fields.
+                    // The fields should be specified in the commonStructs area.
+                    if (!field.fields().isEmpty()) {
+                        throw new RuntimeException("Can't re-specify the common struct " +
+                                typeName + " as an inline struct.");
+                    }
+                }
+                else if (structs.containsKey(typeName)) {
+                    // Inline structures should only appear once.
+                    throw new RuntimeException("Struct " + typeName +
+                            " was specified twice.");
+                }
+                else {
+                    // Synthesize a StructSpec object out of the fields.
+                    StructSpec spec = new StructSpec(typeName,
+                            field.versions().toString(),
+                            Versions.NONE_STRING, // version deprecations not supported at field level
+                            field.fields());
+                    structs.put(typeName, new StructInfo(spec, parentVersions));
+                }
+
+                addStructSpecs(parentVersions.intersect(field.versions()), field.fields());
+            }
+        }
+    }
+
+    /**
+     * Locate the struct corresponding to a field.
+     */
+    public StructSpec findStruct(FieldSpec field) {
+        String structFieldName;
+        if (field.type().isArray()) {
+            FieldType.ArrayType arrayType = (FieldType.ArrayType) field.type();
+            structFieldName = arrayType.elementName();
+        }
+        else if (field.type().isStruct()) {
+            FieldType.StructType structType = (FieldType.StructType) field.type();
+            structFieldName = structType.typeName();
+        }
+        else {
+            throw new RuntimeException("Field " + field.name() +
+                    " cannot be treated as a structure.");
+        }
+        return findStruct(structFieldName);
+    }
+
+    public StructSpec findStruct(String structFieldName) {
+        StructInfo structInfo = structs.get(structFieldName);
+        if (structInfo == null) {
+            throw new RuntimeException("Unable to locate a specification for the structure " +
+                    structFieldName);
+        }
+        return structInfo.spec;
+    }
+
+    /**
+     * Return true if the field is a struct array with keys.
+     */
+    public boolean isStructArrayWithKeys(FieldSpec field) {
+        if (!field.type().isArray()) {
+            return false;
+        }
+        FieldType.ArrayType arrayType = (FieldType.ArrayType) field.type();
+        if (!arrayType.isStructArray()) {
+            return false;
+        }
+        StructInfo structInfo = structs.get(arrayType.elementName());
+        if (structInfo == null) {
+            throw new RuntimeException("Unable to locate a specification for the structure " +
+                    arrayType.elementName());
+        }
+        return structInfo.spec.hasKeys();
+    }
+
+    Set<String> commonStructNames() {
+        return commonStructNames;
+    }
+
+    /**
+     * Returns an iterator that will step through all the common structures.
+     */
+    Iterator<StructSpec> commonStructs() {
+        return new Iterator<StructSpec>() {
+            private final Iterator<String> iter = commonStructNames.iterator();
+
+            @Override
+            public boolean hasNext() {
+                return iter.hasNext();
+            }
+
+            @Override
+            public StructSpec next() {
+                return structs.get(iter.next()).spec;
+            }
+        };
+    }
+
+    Iterator<StructInfo> structs() {
+        return structs.values().iterator();
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/StructSpec.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/StructSpec.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public final class StructSpec {
+    private final String name;
+
+    private final Versions versions;
+
+    private final Versions deprecatedVersions;
+
+    private final List<FieldSpec> fields;
+
+    private final boolean hasKeys;
+
+    @JsonCreator
+    public StructSpec(@JsonProperty("name") String name,
+                      @JsonProperty("versions") String versions,
+                      @JsonProperty("deprecatedVersions") String deprecatedVersions,
+                      @JsonProperty("fields") List<FieldSpec> fields) {
+        this.name = Objects.requireNonNull(name);
+        this.versions = Versions.parse(versions, null);
+        if (this.versions == null) {
+            throw new RuntimeException("You must specify the version of the " +
+                    name + " structure.");
+        }
+        this.deprecatedVersions = Versions.parse(deprecatedVersions, Versions.NONE);
+        ArrayList<FieldSpec> newFields = new ArrayList<>();
+        if (fields != null) {
+            // Each field should have a unique tag ID (if the field has a tag ID).
+            HashSet<Integer> tags = new HashSet<>();
+            // Each field should have a unique name.
+            HashSet<String> names = new HashSet<>();
+            for (FieldSpec field : fields) {
+                field.tag().ifPresent(tag -> {
+                    if (!tags.add(tag)) {
+                        throw new RuntimeException("In " + name + ", field " + field.name() +
+                                " has a duplicate tag ID " + tag + ". All tags IDs " +
+                                "must be unique.");
+                    }
+                });
+                if (!names.add(field.name())) {
+                    throw new RuntimeException("In " + name + ", field " + field.name() +
+                            " has a duplicate name " + field.name() + ". All field names " +
+                            "must be unique.");
+                }
+                newFields.add(field);
+            }
+            // Tag IDs should be contiguous and start at 0. This optimizes space on the wire,
+            // since larger numbers take more space.
+            for (int i = 0; i < tags.size(); i++) {
+                if (!tags.contains(i)) {
+                    throw new RuntimeException("In " + name + ", the tag IDs are not " +
+                            "contiguous.  Make use of tag " + i + " before using any " +
+                            "higher tag IDs.");
+                }
+            }
+        }
+        this.fields = Collections.unmodifiableList(newFields);
+        this.hasKeys = this.fields.stream().anyMatch(FieldSpec::mapKey);
+    }
+
+    @JsonProperty
+    public String name() {
+        return name;
+    }
+
+    public Versions versions() {
+        return versions;
+    }
+
+    @JsonProperty
+    public String versionsString() {
+        return versions.toString();
+    }
+
+    public Versions deprecatedVersions() {
+        return deprecatedVersions;
+    }
+
+    @JsonProperty
+    public List<FieldSpec> fields() {
+        return fields;
+    }
+
+    boolean hasKeys() {
+        return hasKeys;
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/Target.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/Target.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.util.List;
+import java.util.function.Function;
+
+public final class Target {
+    private final FieldSpec field;
+    private final String sourceVariable;
+    private final String humanReadableName;
+    private final Function<String, String> assignmentStatementGenerator;
+
+    Target(FieldSpec field, String sourceVariable, String humanReadableName,
+           Function<String, String> assignmentStatementGenerator) {
+        this.field = field;
+        this.sourceVariable = sourceVariable;
+        this.humanReadableName = humanReadableName;
+        this.assignmentStatementGenerator = assignmentStatementGenerator;
+    }
+
+    public String assignmentStatement(String rightHandSide) {
+        return assignmentStatementGenerator.apply(rightHandSide);
+    }
+
+    public Target nonNullableCopy() {
+        FieldSpec nonNullableField = new FieldSpec(field.name(),
+                field.versionsString(),
+                field.fields(),
+                field.typeString(),
+                field.mapKey(),
+                Versions.NONE.toString(),
+                field.defaultString(),
+                field.ignorable(),
+                field.entityType(),
+                field.about(),
+                field.taggedVersionsString(),
+                field.flexibleVersionsString(),
+                field.tagInteger(),
+                field.zeroCopy());
+        return new Target(nonNullableField, sourceVariable, humanReadableName, assignmentStatementGenerator);
+    }
+
+    public Target arrayElementTarget(Function<String, String> assignmentStatementGenerator) {
+        if (!field.type().isArray()) {
+            throw new RuntimeException("Field " + field + " is not an array.");
+        }
+        FieldType.ArrayType arrayType = (FieldType.ArrayType) field.type();
+        FieldSpec elementField = new FieldSpec(field.name() + "Element",
+                field.versions().toString(),
+                List.of(),
+                arrayType.elementType().toString(),
+                false,
+                Versions.NONE.toString(),
+                "",
+                false,
+                EntityType.UNKNOWN,
+                "",
+                Versions.NONE.toString(),
+                field.flexibleVersionsString(),
+                null,
+                field.zeroCopy());
+        return new Target(elementField, "_element", humanReadableName + " element",
+                assignmentStatementGenerator);
+    }
+
+    public FieldSpec field() {
+        return field;
+    }
+
+    public String sourceVariable() {
+        return sourceVariable;
+    }
+
+    public String humanReadableName() {
+        return humanReadableName;
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/TypeClassGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/TypeClassGenerator.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+
+public interface TypeClassGenerator {
+    /**
+     * The short name of the type class file we are generating. For example,
+     * ApiMessageType.java.
+     */
+    String outputName();
+
+    /**
+     * Registers a message spec with the generator.
+     *
+     * @param spec      The spec to register.
+     */
+    void registerMessageType(MessageSpec spec);
+
+    /**
+     * Generate the type, and then write it out.
+     *
+     * @param writer    The writer to write out the state to.
+     */
+    void generateAndWrite(BufferedWriter writer) throws IOException;
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/VersionConditional.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/VersionConditional.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+/**
+ * Creates an if statement based on whether or not the current version
+ * falls within a given range.
+ */
+public final class VersionConditional {
+    /**
+     * Create a version conditional.
+     *
+     * @param containingVersions    The versions for which the conditional is true.
+     * @param possibleVersions      The range of possible versions.
+     * @return                      The version conditional.
+     */
+    static VersionConditional forVersions(Versions containingVersions,
+                                          Versions possibleVersions) {
+        return new VersionConditional(containingVersions, possibleVersions);
+    }
+
+    private final Versions containingVersions;
+    private final Versions possibleVersions;
+    private ClauseGenerator ifMember = null;
+    private ClauseGenerator ifNotMember = null;
+    private boolean alwaysEmitBlockScope = false;
+    private boolean allowMembershipCheckAlwaysFalse = true;
+
+    private VersionConditional(Versions containingVersions, Versions possibleVersions) {
+        this.containingVersions = containingVersions;
+        this.possibleVersions = possibleVersions;
+    }
+
+    VersionConditional ifMember(ClauseGenerator ifMember) {
+        this.ifMember = ifMember;
+        return this;
+    }
+
+    VersionConditional ifNotMember(ClauseGenerator ifNotMember) {
+        this.ifNotMember = ifNotMember;
+        return this;
+    }
+
+    /**
+     * If this is set, we will always create a new block scope, even if there
+     * are no 'if' statements.  This is useful for cases where we want to
+     * declare variables in the clauses without worrying if they conflict with
+     * other variables of the same name.
+     */
+    VersionConditional alwaysEmitBlockScope(boolean alwaysEmitBlockScope) {
+        this.alwaysEmitBlockScope = alwaysEmitBlockScope;
+        return this;
+    }
+
+    /**
+     * If this is set, VersionConditional#generate will throw an exception if
+     * the 'ifMember' clause is never used.  This is useful as a sanity check
+     * in some cases where it doesn't make sense for the condition to always be
+     * false.  For example, when generating a Message#write function,
+     * we might check that the version we're writing is supported.  It wouldn't
+     * make sense for this check to always be false, since that would mean that
+     * no versions at all were supported.
+     */
+    VersionConditional allowMembershipCheckAlwaysFalse(boolean allowMembershipCheckAlwaysFalse) {
+        this.allowMembershipCheckAlwaysFalse = allowMembershipCheckAlwaysFalse;
+        return this;
+    }
+
+    private void generateFullRangeCheck(Versions ifVersions,
+                                        Versions ifNotVersions,
+                                        CodeBuffer buffer) {
+        if (ifMember != null) {
+            buffer.printf("if ((_version >= %d) && (_version <= %d)) {%n",
+                    containingVersions.lowest(), containingVersions.highest());
+            buffer.incrementIndent();
+            ifMember.generate(ifVersions);
+            buffer.decrementIndent();
+            if (ifNotMember != null) {
+                buffer.printf("} else {%n");
+                buffer.incrementIndent();
+                ifNotMember.generate(ifNotVersions);
+                buffer.decrementIndent();
+            }
+            buffer.printf("}%n");
+        }
+        else if (ifNotMember != null) {
+            buffer.printf("if ((_version < %d) || (_version > %d)) {%n",
+                    containingVersions.lowest(), containingVersions.highest());
+            buffer.incrementIndent();
+            ifNotMember.generate(ifNotVersions);
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+    }
+
+    private void generateLowerRangeCheck(Versions ifVersions,
+                                         Versions ifNotVersions,
+                                         CodeBuffer buffer) {
+        if (ifMember != null) {
+            buffer.printf("if (_version >= %d) {%n", containingVersions.lowest());
+            buffer.incrementIndent();
+            ifMember.generate(ifVersions);
+            buffer.decrementIndent();
+            if (ifNotMember != null) {
+                buffer.printf("} else {%n");
+                buffer.incrementIndent();
+                ifNotMember.generate(ifNotVersions);
+                buffer.decrementIndent();
+            }
+            buffer.printf("}%n");
+        }
+        else if (ifNotMember != null) {
+            buffer.printf("if (_version < %d) {%n", containingVersions.lowest());
+            buffer.incrementIndent();
+            ifNotMember.generate(ifNotVersions);
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+    }
+
+    private void generateUpperRangeCheck(Versions ifVersions,
+                                         Versions ifNotVersions,
+                                         CodeBuffer buffer) {
+        if (ifMember != null) {
+            buffer.printf("if (_version <= %d) {%n", containingVersions.highest());
+            buffer.incrementIndent();
+            ifMember.generate(ifVersions);
+            buffer.decrementIndent();
+            if (ifNotMember != null) {
+                buffer.printf("} else {%n");
+                buffer.incrementIndent();
+                ifNotMember.generate(ifNotVersions);
+                buffer.decrementIndent();
+            }
+            buffer.printf("}%n");
+        }
+        else if (ifNotMember != null) {
+            buffer.printf("if (_version > %d) {%n", containingVersions.highest());
+            buffer.incrementIndent();
+            ifNotMember.generate(ifNotVersions);
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+    }
+
+    private void generateAlwaysTrueCheck(Versions ifVersions, CodeBuffer buffer) {
+        if (ifMember != null) {
+            if (alwaysEmitBlockScope) {
+                buffer.printf("{%n");
+                buffer.incrementIndent();
+            }
+            ifMember.generate(ifVersions);
+            if (alwaysEmitBlockScope) {
+                buffer.decrementIndent();
+                buffer.printf("}%n");
+            }
+        }
+    }
+
+    private void generateAlwaysFalseCheck(Versions ifNotVersions, CodeBuffer buffer) {
+        if (!allowMembershipCheckAlwaysFalse) {
+            throw new RuntimeException("Version ranges " + containingVersions +
+                    " and " + possibleVersions + " have no versions in common.");
+        }
+        if (ifNotMember != null) {
+            if (alwaysEmitBlockScope) {
+                buffer.printf("{%n");
+                buffer.incrementIndent();
+            }
+            ifNotMember.generate(ifNotVersions);
+            if (alwaysEmitBlockScope) {
+                buffer.decrementIndent();
+                buffer.printf("}%n");
+            }
+        }
+    }
+
+    void generate(CodeBuffer buffer) {
+        Versions ifVersions = possibleVersions.intersect(containingVersions);
+        Versions ifNotVersions = possibleVersions.subtract(containingVersions);
+        // In the case where ifNotVersions would be two ranges rather than one,
+        // we just pass in the original possibleVersions instead.
+        // This is slightly less optimal, but allows us to avoid dealing with
+        // multiple ranges.
+        if (ifNotVersions == null) {
+            ifNotVersions = possibleVersions;
+        }
+
+        if (possibleVersions.lowest() < containingVersions.lowest()) {
+            if (possibleVersions.highest() > containingVersions.highest()) {
+                generateFullRangeCheck(ifVersions, ifNotVersions, buffer);
+            }
+            else if (possibleVersions.highest() >= containingVersions.lowest()) {
+                generateLowerRangeCheck(ifVersions, ifNotVersions, buffer);
+            }
+            else {
+                generateAlwaysFalseCheck(ifNotVersions, buffer);
+            }
+        }
+        else if (possibleVersions.highest() >= containingVersions.lowest() &&
+                (possibleVersions.lowest() <= containingVersions.highest())) {
+            if (possibleVersions.highest() > containingVersions.highest()) {
+                generateUpperRangeCheck(ifVersions, ifNotVersions, buffer);
+            }
+            else {
+                generateAlwaysTrueCheck(ifVersions, buffer);
+            }
+        }
+        else {
+            generateAlwaysFalseCheck(ifNotVersions, buffer);
+        }
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/Versions.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/Versions.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.util.Objects;
+
+/**
+ * A version range.
+ *
+ * A range consists of two 16-bit numbers: the lowest version which is accepted, and the highest.
+ * Ranges are inclusive, meaning that both the lowest and the highest version are valid versions.
+ * The only exception to this is the NONE range, which contains no versions at all.
+ *
+ * Version ranges can be represented as strings.
+ *
+ * A single supported version V is represented as "V".
+ * A bounded range from A to B is represented as "A-B".
+ * All versions greater than A is represented as "A+".
+ * The NONE range is represented as the string "none".
+ */
+public final class Versions {
+    private final short lowest;
+    private final short highest;
+
+    public static Versions parse(String input, Versions defaultVersions) {
+        if (input == null) {
+            return defaultVersions;
+        }
+        String trimmedInput = input.trim();
+        if (trimmedInput.isEmpty()) {
+            return defaultVersions;
+        }
+        if (trimmedInput.equals(NONE_STRING)) {
+            return NONE;
+        }
+        if (trimmedInput.endsWith("+")) {
+            return new Versions(Short.parseShort(
+                    trimmedInput.substring(0, trimmedInput.length() - 1)),
+                    Short.MAX_VALUE);
+        }
+        else {
+            int dashIndex = trimmedInput.indexOf("-");
+            if (dashIndex < 0) {
+                short version = Short.parseShort(trimmedInput);
+                return new Versions(version, version);
+            }
+            return new Versions(
+                    Short.parseShort(trimmedInput.substring(0, dashIndex)),
+                    Short.parseShort(trimmedInput.substring(dashIndex + 1)));
+        }
+    }
+
+    public static final Versions ALL = new Versions((short) 0, Short.MAX_VALUE);
+
+    public static final Versions NONE = new Versions();
+
+    public static final String NONE_STRING = "none";
+
+    private Versions() {
+        this.lowest = 0;
+        this.highest = -1;
+    }
+
+    public Versions(short lowest, short highest) {
+        if ((lowest < 0) || (highest < 0)) {
+            throw new RuntimeException("Invalid version range " +
+                    lowest + " to " + highest);
+        }
+        this.lowest = lowest;
+        this.highest = highest;
+    }
+
+    public short lowest() {
+        return lowest;
+    }
+
+    public short highest() {
+        return highest;
+    }
+
+    public boolean empty() {
+        return lowest > highest;
+    }
+
+    @Override
+    public String toString() {
+        if (empty()) {
+            return NONE_STRING;
+        }
+        else if (lowest == highest) {
+            return String.valueOf(lowest);
+        }
+        else if (highest == Short.MAX_VALUE) {
+            return String.format("%d+", lowest);
+        }
+        else {
+            return String.format("%d-%d", lowest, highest);
+        }
+    }
+
+    /**
+     * Return the intersection of two version ranges.
+     *
+     * @param other     The other version range.
+     * @return          A new version range.
+     */
+    public Versions intersect(Versions other) {
+        short newLowest = lowest > other.lowest ? lowest : other.lowest;
+        short newHighest = highest < other.highest ? highest : other.highest;
+        if (newLowest > newHighest) {
+            return Versions.NONE;
+        }
+        return new Versions(newLowest, newHighest);
+    }
+
+    /**
+     * Return a new version range that trims some versions from this range, if possible.
+     * We can't trim any versions if the resulting range would be disjoint.
+     *
+     * Some examples:
+     * 1-4.trim(1-2) = 3-4
+     * 3+.trim(4+) = 3
+     * 4+.trim(3+) = none
+     * 1-5.trim(2-4) = null
+     *
+     * @param other                 The other version range.
+     * @return                      A new version range.
+     */
+    public Versions subtract(Versions other) {
+        if (other.lowest() <= lowest) {
+            if (other.highest >= highest) {
+                // Case 1: other is a superset of this. Trim everything.
+                return Versions.NONE;
+            }
+            else if (other.highest < lowest) {
+                // Case 2: other is a disjoint version range that is lower than this. Trim nothing.
+                return this;
+            }
+            else {
+                // Case 3: trim some values from the beginning of this range.
+                //
+                // Note: it is safe to assume that other.highest() + 1 will not overflow.
+                // The reason is because if other.highest() were Short.MAX_VALUE,
+                // other.highest() < highest could not be true.
+                return new Versions((short) (other.highest() + 1), highest);
+            }
+        }
+        else if (other.highest >= highest) {
+            int newHighest = other.lowest - 1;
+            if (newHighest < 0) {
+                // Case 4: other was NONE. Trim nothing.
+                return this;
+            }
+            else if (newHighest < highest) {
+                // Case 5: trim some values from the end of this range.
+                return new Versions(lowest, (short) newHighest);
+            }
+            else {
+                // Case 6: other is a disjoint range that is higher than this. Trim nothing.
+                return this;
+            }
+        }
+        else {
+            // Case 7: the difference between this and other would be two ranges, not one.
+            return null;
+        }
+    }
+
+    public boolean contains(short version) {
+        return version >= lowest && version <= highest;
+    }
+
+    public boolean contains(Versions other) {
+        if (other.empty()) {
+            return true;
+        }
+        return !((lowest > other.lowest) || (highest < other.highest));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lowest, highest);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof Versions)) {
+            return false;
+        }
+        Versions otherVersions = (Versions) other;
+        return lowest == otherVersions.lowest &&
+                highest == otherVersions.highest;
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/CodeBufferTest.java
+++ b/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/CodeBufferTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.io.StringWriter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Timeout(120)
+public class CodeBufferTest {
+
+    @Test
+    public void testWrite() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        buffer.printf("public static void main(String[] args) throws Exception {%n");
+        buffer.incrementIndent();
+        buffer.printf("System.out.println(\"%s\");%n", "hello world");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        StringWriter stringWriter = new StringWriter();
+        buffer.write(stringWriter);
+        assertEquals(
+                String.format("public static void main(String[] args) throws Exception {%n") +
+                        String.format("    System.out.println(\"hello world\");%n") +
+                        String.format("}%n"),
+                stringWriter.toString());
+    }
+
+    @Test
+    public void testEquals() {
+        CodeBuffer buffer1 = new CodeBuffer();
+        CodeBuffer buffer2 = new CodeBuffer();
+        assertEquals(buffer1, buffer2);
+        buffer1.printf("hello world");
+        assertNotEquals(buffer1, buffer2);
+        buffer2.printf("hello world");
+        assertEquals(buffer1, buffer2);
+        buffer1.printf("foo, bar, and baz");
+        buffer2.printf("foo, bar, and baz");
+        assertEquals(buffer1, buffer2);
+    }
+
+    @Test
+    public void testIndentMustBeNonNegative() {
+        CodeBuffer buffer = new CodeBuffer();
+        buffer.incrementIndent();
+        buffer.decrementIndent();
+        RuntimeException e = assertThrows(RuntimeException.class, buffer::decrementIndent);
+        assertTrue(e.getMessage().contains("Indent < 0"));
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/EntityTypeTest.java
+++ b/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/EntityTypeTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Timeout(120)
+public class EntityTypeTest {
+
+    @Test
+    public void testUnknownEntityType() {
+        for (FieldType type : new FieldType[]{
+                FieldType.StringFieldType.INSTANCE,
+                FieldType.Int8FieldType.INSTANCE,
+                FieldType.Int16FieldType.INSTANCE,
+                FieldType.Int32FieldType.INSTANCE,
+                FieldType.Int64FieldType.INSTANCE,
+                new FieldType.ArrayType(FieldType.StringFieldType.INSTANCE) }) {
+            EntityType.UNKNOWN.verifyTypeMatches("unknown", type);
+        }
+    }
+
+    @Test
+    public void testVerifyTypeMatches() {
+        EntityType.TRANSACTIONAL_ID.verifyTypeMatches("transactionalIdField",
+                FieldType.StringFieldType.INSTANCE);
+        EntityType.TRANSACTIONAL_ID.verifyTypeMatches("transactionalIdField",
+                new FieldType.ArrayType(FieldType.StringFieldType.INSTANCE));
+        EntityType.PRODUCER_ID.verifyTypeMatches("producerIdField",
+                FieldType.Int64FieldType.INSTANCE);
+        EntityType.PRODUCER_ID.verifyTypeMatches("producerIdField",
+                new FieldType.ArrayType(FieldType.Int64FieldType.INSTANCE));
+        EntityType.GROUP_ID.verifyTypeMatches("groupIdField",
+                FieldType.StringFieldType.INSTANCE);
+        EntityType.GROUP_ID.verifyTypeMatches("groupIdField",
+                new FieldType.ArrayType(FieldType.StringFieldType.INSTANCE));
+        EntityType.TOPIC_NAME.verifyTypeMatches("topicNameField",
+                FieldType.StringFieldType.INSTANCE);
+        EntityType.TOPIC_NAME.verifyTypeMatches("topicNameField",
+                new FieldType.ArrayType(FieldType.StringFieldType.INSTANCE));
+        EntityType.BROKER_ID.verifyTypeMatches("brokerIdField",
+                FieldType.Int32FieldType.INSTANCE);
+        EntityType.BROKER_ID.verifyTypeMatches("brokerIdField",
+                new FieldType.ArrayType(FieldType.Int32FieldType.INSTANCE));
+    }
+
+    private static void expectException(Runnable r) {
+        assertThrows(RuntimeException.class, r::run);
+    }
+
+    @Test
+    public void testVerifyTypeMismatches() {
+        expectException(() -> EntityType.TRANSACTIONAL_ID.verifyTypeMatches("transactionalIdField", FieldType.Int32FieldType.INSTANCE));
+        expectException(() -> EntityType.PRODUCER_ID.verifyTypeMatches("producerIdField", FieldType.StringFieldType.INSTANCE));
+        expectException(() -> EntityType.GROUP_ID.verifyTypeMatches("groupIdField", FieldType.Int8FieldType.INSTANCE));
+        expectException(() -> EntityType.TOPIC_NAME.verifyTypeMatches("topicNameField",
+                new FieldType.ArrayType(FieldType.Int64FieldType.INSTANCE)));
+        expectException(() -> EntityType.BROKER_ID.verifyTypeMatches("brokerIdField", FieldType.Int64FieldType.INSTANCE));
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/IsNullConditionalTest.java
+++ b/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/IsNullConditionalTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+@Timeout(120)
+public class IsNullConditionalTest {
+
+    @Test
+    public void testNullCheck() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        IsNullConditional.forName("foobar").nullableVersions(Versions.parse("2+", null)).possibleVersions(Versions.parse("0+", null))
+                .ifNull(() -> buffer.printf("System.out.println(\"null\");%n")).generate(buffer);
+        VersionConditionalTest.claimEquals(buffer,
+                "if (foobar == null) {%n",
+                "    System.out.println(\"null\");%n",
+                "}%n");
+    }
+
+    @Test
+    public void testAnotherNullCheck() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        IsNullConditional.forName("foobar").nullableVersions(Versions.parse("0+", null)).possibleVersions(Versions.parse("2+", null))
+                .ifNull(() -> buffer.printf("System.out.println(\"null\");%n")).ifShouldNotBeNull(() -> buffer.printf("System.out.println(\"not null\");%n"))
+                .generate(buffer);
+        VersionConditionalTest.claimEquals(buffer,
+                "if (foobar == null) {%n",
+                "    System.out.println(\"null\");%n",
+                "} else {%n",
+                "    System.out.println(\"not null\");%n",
+                "}%n");
+    }
+
+    @Test
+    public void testNotNullCheck() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        IsNullConditional.forName("foobar").nullableVersions(Versions.parse("0+", null)).possibleVersions(Versions.parse("2+", null))
+                .ifShouldNotBeNull(() -> buffer.printf("System.out.println(\"not null\");%n")).generate(buffer);
+        VersionConditionalTest.claimEquals(buffer,
+                "if (foobar != null) {%n",
+                "    System.out.println(\"not null\");%n",
+                "}%n");
+    }
+
+    @Test
+    public void testNeverNull() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        IsNullConditional.forName("baz").nullableVersions(Versions.parse("0-2", null)).possibleVersions(Versions.parse("3+", null))
+                .ifNull(() -> buffer.printf("System.out.println(\"null\");%n")).ifShouldNotBeNull(() -> buffer.printf("System.out.println(\"not null\");%n"))
+                .generate(buffer);
+        VersionConditionalTest.claimEquals(buffer,
+                "System.out.println(\"not null\");%n");
+    }
+
+    @Test
+    public void testNeverNullWithBlockScope() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        IsNullConditional.forName("baz").nullableVersions(Versions.parse("0-2", null)).possibleVersions(Versions.parse("3+", null))
+                .ifNull(() -> buffer.printf("System.out.println(\"null\");%n")).ifShouldNotBeNull(() -> buffer.printf("System.out.println(\"not null\");%n"))
+                .alwaysEmitBlockScope(true).generate(buffer);
+        VersionConditionalTest.claimEquals(buffer,
+                "{%n",
+                "    System.out.println(\"not null\");%n",
+                "}%n");
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/MessageDataGeneratorTest.java
+++ b/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/MessageDataGeneratorTest.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@Timeout(120)
+public class MessageDataGeneratorTest {
+
+    @Test
+    public void testNullDefaults() throws Exception {
+        MessageSpec testMessageSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                "{",
+                "  \"type\": \"request\",",
+                "  \"name\": \"FooBar\",",
+                "  \"validVersions\": \"0-2\",",
+                "  \"flexibleVersions\": \"none\",",
+                "  \"fields\": [",
+                "    { \"name\": \"field1\", \"type\": \"int32\", \"versions\": \"0+\" },",
+                "    { \"name\": \"field2\", \"type\": \"[]TestStruct\", \"versions\": \"1+\", ",
+                "    \"nullableVersions\": \"1+\", \"default\": \"null\", \"fields\": [",
+                "      { \"name\": \"field1\", \"type\": \"int32\", \"versions\": \"0+\" }",
+                "    ]},",
+                "    { \"name\": \"field3\", \"type\": \"bytes\", \"versions\": \"2+\", ",
+                "      \"nullableVersions\": \"2+\", \"default\": \"null\" }",
+                "  ]",
+                "}")), MessageSpec.class);
+        new MessageDataGenerator("org.apache.kafka.common.message").generate(testMessageSpec);
+    }
+
+    @Test
+    public void testNullDefaultsWithDeprecatedVersions() throws Exception {
+        MessageSpec testMessageSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                "{",
+                "  \"type\": \"request\",",
+                "  \"name\": \"FooBar\",",
+                "  \"validVersions\": \"0-4\",",
+                "  \"deprecatedVersions\": \"0-1\",",
+                "  \"flexibleVersions\": \"none\",",
+                "  \"fields\": [",
+                "    { \"name\": \"field1\", \"type\": \"int32\", \"versions\": \"0+\" },",
+                "    { \"name\": \"field2\", \"type\": \"[]TestStruct\", \"versions\": \"1+\", ",
+                "    \"nullableVersions\": \"1+\", \"default\": \"null\", \"fields\": [",
+                "      { \"name\": \"field1\", \"type\": \"int32\", \"versions\": \"0+\" }",
+                "    ]},",
+                "    { \"name\": \"field3\", \"type\": \"bytes\", \"versions\": \"2+\", ",
+                "      \"nullableVersions\": \"2+\", \"default\": \"null\" }",
+                "  ]",
+                "}")), MessageSpec.class);
+        new MessageDataGenerator("org.apache.kafka.common.message").generate(testMessageSpec);
+    }
+
+    private void assertStringContains(String substring, String value) {
+        assertTrue(value.contains(substring),
+                "Expected string to contain '" + substring + "', but it was " + value);
+    }
+
+    @Test
+    public void testInvalidNullDefaultForInt() throws Exception {
+        MessageSpec testMessageSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                "{",
+                "  \"type\": \"request\",",
+                "  \"name\": \"FooBar\",",
+                "  \"validVersions\": \"0-2\",",
+                "  \"flexibleVersions\": \"none\",",
+                "  \"fields\": [",
+                "    { \"name\": \"field1\", \"type\": \"int32\", \"versions\": \"0+\", \"default\": \"null\" }",
+                "  ]",
+                "}")), MessageSpec.class);
+        assertStringContains("Invalid default for int32",
+                assertThrows(RuntimeException.class, () -> new MessageDataGenerator("org.apache.kafka.common.message").generate(testMessageSpec)).getMessage());
+    }
+
+    @Test
+    public void testInvalidNullDefaultForPotentiallyNonNullableArray() throws Exception {
+        MessageSpec testMessageSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                "{",
+                "  \"type\": \"request\",",
+                "  \"name\": \"FooBar\",",
+                "  \"validVersions\": \"0-2\",",
+                "  \"flexibleVersions\": \"none\",",
+                "  \"fields\": [",
+                "    { \"name\": \"field1\", \"type\": \"[]int32\", \"versions\": \"0+\", \"nullableVersions\": \"1+\", ",
+                "    \"default\": \"null\" }",
+                "  ]",
+                "}")), MessageSpec.class);
+
+        assertStringContains("not all versions of this field are nullable",
+                assertThrows(RuntimeException.class, () -> new MessageDataGenerator("org.apache.kafka.common.message").generate(testMessageSpec)).getMessage());
+    }
+
+    /**
+     * Test attempting to create a field with an invalid name.  The name is
+     * invalid because it starts with an underscore.
+     */
+    @Test
+    public void testInvalidFieldName() {
+        assertStringContains("Invalid field name",
+                assertThrows(Throwable.class, () -> MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                        "{",
+                        "  \"type\": \"request\",",
+                        "  \"name\": \"FooBar\",",
+                        "  \"validVersions\": \"0-2\",",
+                        "  \"flexibleVersions\": \"0+\",",
+                        "  \"fields\": [",
+                        "    { \"name\": \"_badName\", \"type\": \"[]int32\", \"versions\": \"0+\" }",
+                        "  ]",
+                        "}")), MessageSpec.class)).getMessage());
+    }
+
+    @Test
+    public void testInvalidTagWithoutTaggedVersions() {
+        assertStringContains("If a tag is specified, taggedVersions must be specified as well.",
+                assertThrows(Throwable.class, () -> {
+                    MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                            "{",
+                            "  \"type\": \"request\",",
+                            "  \"name\": \"FooBar\",",
+                            "  \"validVersions\": \"0-2\",",
+                            "  \"flexibleVersions\": \"0+\",",
+                            "  \"fields\": [",
+                            "    { \"name\": \"field1\", \"type\": \"int32\", \"versions\": \"0+\", \"tag\": 0 }",
+                            "  ]",
+                            "}")), MessageSpec.class);
+                    fail("Expected the MessageSpec constructor to fail");
+                }).getMessage());
+    }
+
+    @Test
+    public void testInvalidNegativeTag() {
+        assertStringContains("Tags cannot be negative",
+                assertThrows(Throwable.class, () -> MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                        "{",
+                        "  \"type\": \"request\",",
+                        "  \"name\": \"FooBar\",",
+                        "  \"validVersions\": \"0-2\",",
+                        "  \"flexibleVersions\": \"0+\",",
+                        "  \"fields\": [",
+                        "    { \"name\": \"field1\", \"type\": \"int32\", \"versions\": \"0+\", ",
+                        "        \"tag\": -1, \"taggedVersions\": \"0+\" }",
+                        "  ]",
+                        "}")), MessageSpec.class)).getMessage());
+    }
+
+    @Test
+    public void testInvalidFlexibleVersionsRange() {
+        assertStringContains("flexibleVersions must be either none, or an open-ended range",
+                assertThrows(Throwable.class, () -> MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                        "{",
+                        "  \"type\": \"request\",",
+                        "  \"name\": \"FooBar\",",
+                        "  \"validVersions\": \"0-2\",",
+                        "  \"flexibleVersions\": \"0-2\",",
+                        "  \"fields\": [",
+                        "    { \"name\": \"field1\", \"type\": \"int32\", \"versions\": \"0+\" }",
+                        "  ]",
+                        "}")), MessageSpec.class)).getMessage());
+    }
+
+    @Test
+    public void testInvalidSometimesNullableTaggedField() {
+        assertStringContains("Either all tagged versions must be nullable, or none must be",
+                assertThrows(Throwable.class, () -> MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                        "{",
+                        "  \"type\": \"request\",",
+                        "  \"name\": \"FooBar\",",
+                        "  \"validVersions\": \"0-2\",",
+                        "  \"flexibleVersions\": \"0+\",",
+                        "  \"fields\": [",
+                        "    { \"name\": \"field1\", \"type\": \"string\", \"versions\": \"0+\", ",
+                        "        \"tag\": 0, \"taggedVersions\": \"0+\", \"nullableVersions\": \"1+\" }",
+                        "  ]",
+                        "}")), MessageSpec.class)).getMessage());
+    }
+
+    @Test
+    public void testInvalidTaggedVersionsNotASubsetOfVersions() {
+        assertStringContains("taggedVersions must be a subset of versions",
+                assertThrows(Throwable.class, () -> MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                        "{",
+                        "  \"type\": \"request\",",
+                        "  \"name\": \"FooBar\",",
+                        "  \"validVersions\": \"0-2\",",
+                        "  \"flexibleVersions\": \"0+\",",
+                        "  \"fields\": [",
+                        "    { \"name\": \"field1\", \"type\": \"string\", \"versions\": \"0-2\", ",
+                        "        \"tag\": 0, \"taggedVersions\": \"1+\" }",
+                        "  ]",
+                        "}")), MessageSpec.class)).getMessage());
+    }
+
+    @Test
+    public void testInvalidTaggedVersionsWithoutTag() {
+        assertStringContains("Please specify a tag, or remove the taggedVersions",
+                assertThrows(Throwable.class, () -> MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                        "{",
+                        "  \"type\": \"request\",",
+                        "  \"name\": \"FooBar\",",
+                        "  \"validVersions\": \"0-2\",",
+                        "  \"flexibleVersions\": \"0+\",",
+                        "  \"fields\": [",
+                        "    { \"name\": \"field1\", \"type\": \"string\", \"versions\": \"0+\", ",
+                        "        \"taggedVersions\": \"1+\" }",
+                        "  ]",
+                        "}")), MessageSpec.class)).getMessage());
+    }
+
+    @Test
+    public void testInvalidTaggedVersionsRange() {
+        assertStringContains("taggedVersions must be either none, or an open-ended range",
+                assertThrows(Throwable.class, () -> MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                        "{",
+                        "  \"type\": \"request\",",
+                        "  \"name\": \"FooBar\",",
+                        "  \"validVersions\": \"0-2\",",
+                        "  \"flexibleVersions\": \"0+\",",
+                        "  \"fields\": [",
+                        "    { \"name\": \"field1\", \"type\": \"string\", \"versions\": \"0+\", ",
+                        "        \"tag\": 0, \"taggedVersions\": \"1-2\" }",
+                        "  ]",
+                        "}")), MessageSpec.class)).getMessage());
+    }
+
+    @Test
+    public void testDuplicateTags() {
+        assertStringContains("duplicate tag",
+                assertThrows(Throwable.class, () -> MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                        "{",
+                        "  \"type\": \"request\",",
+                        "  \"name\": \"FooBar\",",
+                        "  \"validVersions\": \"0-2\",",
+                        "  \"flexibleVersions\": \"0+\",",
+                        "  \"fields\": [",
+                        "    { \"name\": \"field1\", \"type\": \"string\", \"versions\": \"0+\", ",
+                        "        \"tag\": 0, \"taggedVersions\": \"0+\" },",
+                        "    { \"name\": \"field2\", \"type\": \"int64\", \"versions\": \"0+\", ",
+                        "        \"tag\": 0, \"taggedVersions\": \"0+\" }",
+                        "  ]",
+                        "}")), MessageSpec.class)).getMessage());
+    }
+
+    @Test
+    public void testInvalidNullDefaultForNullableStruct() throws Exception {
+        MessageSpec testMessageSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                "{",
+                "  \"type\": \"request\",",
+                "  \"name\": \"FooBar\",",
+                "  \"validVersions\": \"0\",",
+                "  \"flexibleVersions\": \"none\",",
+                "  \"fields\": [",
+                "    { \"name\": \"struct1\", \"type\": \"MyStruct\", \"versions\": \"0+\", \"nullableVersions\": \"0+\", ",
+                "      \"default\": \"not-null\", \"fields\": [",
+                "        { \"name\": \"field1\", \"type\": \"string\", \"versions\": \"0+\" }",
+                "      ]",
+                "    }",
+                "  ]",
+                "}")), MessageSpec.class);
+
+        assertStringContains("Invalid default for struct field struct1.  The only valid default for a struct field " +
+                "is the empty struct or null",
+                assertThrows(RuntimeException.class, () -> new MessageDataGenerator("org.apache.kafka.common.message").generate(testMessageSpec)).getMessage());
+    }
+
+    @Test
+    public void testInvalidNullDefaultForPotentiallyNonNullableStruct() throws Exception {
+        MessageSpec testMessageSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                "{",
+                "  \"type\": \"request\",",
+                "  \"name\": \"FooBar\",",
+                "  \"validVersions\": \"0-1\",",
+                "  \"flexibleVersions\": \"none\",",
+                "  \"fields\": [",
+                "    { \"name\": \"struct1\", \"type\": \"MyStruct\", \"versions\": \"0+\", \"nullableVersions\": \"1+\", ",
+                "      \"default\": \"null\", \"fields\": [",
+                "        { \"name\": \"field1\", \"type\": \"string\", \"versions\": \"0+\" }",
+                "      ]",
+                "    }",
+                "  ]",
+                "}")), MessageSpec.class);
+
+        assertStringContains("not all versions of this field are nullable",
+                assertThrows(RuntimeException.class, () -> new MessageDataGenerator("org.apache.kafka.common.message").generate(testMessageSpec)).getMessage());
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/MessageGeneratorTest.java
+++ b/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/MessageGeneratorTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.io.BufferedWriter;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Timeout(120)
+public class MessageGeneratorTest {
+
+    @Test
+    public void testCapitalizeFirst() {
+        assertEquals("", MessageGenerator.capitalizeFirst(""));
+        assertEquals("AbC", MessageGenerator.capitalizeFirst("abC"));
+    }
+
+    @Test
+    public void testLowerCaseFirst() {
+        assertEquals("", MessageGenerator.lowerCaseFirst(""));
+        assertEquals("fORTRAN", MessageGenerator.lowerCaseFirst("FORTRAN"));
+        assertEquals("java", MessageGenerator.lowerCaseFirst("java"));
+    }
+
+    @Test
+    public void testFirstIsCapitalized() {
+        assertFalse(MessageGenerator.firstIsCapitalized(""));
+        assertTrue(MessageGenerator.firstIsCapitalized("FORTRAN"));
+        assertFalse(MessageGenerator.firstIsCapitalized("java"));
+    }
+
+    @Test
+    public void testToSnakeCase() {
+        assertEquals("", MessageGenerator.toSnakeCase(""));
+        assertEquals("foo_bar_baz", MessageGenerator.toSnakeCase("FooBarBaz"));
+        assertEquals("foo_bar_baz", MessageGenerator.toSnakeCase("fooBarBaz"));
+        assertEquals("fortran", MessageGenerator.toSnakeCase("FORTRAN"));
+    }
+
+    @Test
+    public void stripSuffixTest() {
+        assertEquals("FooBa", MessageGenerator.stripSuffix("FooBar", "r"));
+        assertEquals("", MessageGenerator.stripSuffix("FooBar", "FooBar"));
+        assertEquals("Foo", MessageGenerator.stripSuffix("FooBar", "Bar"));
+        assertThrows(RuntimeException.class, () -> MessageGenerator.stripSuffix("FooBar", "Baz"));
+    }
+
+    @Test
+    public void testConstants() {
+        assertEquals(0xFFFF, MessageGenerator.UNSIGNED_SHORT_MAX);
+        assertEquals(0xFFFFFFFFL, MessageGenerator.UNSIGNED_INT_MAX);
+    }
+
+    @Test
+    public void testGenerateAndWriteMessageClasses(@TempDir Path tempDir) throws Exception {
+        var generatorTypes = List.of("MessageDataGenerator", "JsonConverterGenerator");
+
+        MessageSpec testRequestSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", List.of(
+                "{",
+                "  \"apiKey\": 0,",
+                "  \"type\": \"request\",",
+                "  \"name\": \"FooBarRequest\",",
+                "  \"validVersions\": \"none\"",
+                "}")), MessageSpec.class);
+        MessageSpec testResponseSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", List.of(
+                "{",
+                "  \"apiKey\": 0,",
+                "  \"type\": \"response\",",
+                "  \"name\": \"FooBarResponse\",",
+                "  \"validVersions\": \"none\"",
+                "}")), MessageSpec.class);
+
+        var outputFiles = MessageGenerator.generateAndWriteMessageClasses(testRequestSpec, "kafka",
+                tempDir.toAbsolutePath().toString(), generatorTypes);
+        assertEquals(Set.of(), outputFiles);
+        outputFiles = MessageGenerator.generateAndWriteMessageClasses(testResponseSpec, "kafka",
+                tempDir.toAbsolutePath().toString(), generatorTypes);
+        assertEquals(Set.of(), outputFiles);
+        var typeGenerator = new ApiMessageTypeGenerator("kafka");
+        typeGenerator.registerMessageType(testRequestSpec);
+        typeGenerator.registerMessageType(testResponseSpec);
+        typeGenerator.generateAndWrite(new BufferedWriter(new StringWriter()));
+
+        testRequestSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                "{",
+                "  \"apiKey\": 0,",
+                "  \"type\": \"request\",",
+                "  \"name\": \"FooBarRequest\",",
+                "  \"validVersions\": \"0-2\",",
+                "  \"flexibleVersions\": \"none\",",
+                "  \"fields\": [",
+                "    { \"name\": \"field1\", \"type\": \"int32\", \"versions\": \"0+\" }",
+                "  ]",
+                "}")), MessageSpec.class);
+        testResponseSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                "{",
+                "  \"apiKey\": 0,",
+                "  \"type\": \"response\",",
+                "  \"name\": \"FooBarResponse\",",
+                "  \"validVersions\": \"0-2\",",
+                "  \"flexibleVersions\": \"none\",",
+                "  \"fields\": [",
+                "    { \"name\": \"field1\", \"type\": \"int32\", \"versions\": \"0+\" }",
+                "  ]",
+                "}")), MessageSpec.class);
+
+        outputFiles = MessageGenerator.generateAndWriteMessageClasses(testRequestSpec, "kafka",
+                tempDir.toAbsolutePath().toString(), generatorTypes);
+        assertEquals(Set.of("FooBarRequestDataJsonConverter.java", "FooBarRequestData.java"), outputFiles);
+        outputFiles = MessageGenerator.generateAndWriteMessageClasses(testResponseSpec, "kafka",
+                tempDir.toAbsolutePath().toString(), generatorTypes);
+        assertEquals(Set.of("FooBarResponseDataJsonConverter.java", "FooBarResponseData.java"), outputFiles);
+        typeGenerator = new ApiMessageTypeGenerator("kafka");
+        typeGenerator.registerMessageType(testRequestSpec);
+        typeGenerator.registerMessageType(testResponseSpec);
+        typeGenerator.generateAndWrite(new BufferedWriter(new StringWriter()));
+    }
+
+}

--- a/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/StructRegistryTest.java
+++ b/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/StructRegistryTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@Timeout(120)
+public class StructRegistryTest {
+
+    @Test
+    public void testCommonStructs() throws Exception {
+        MessageSpec testMessageSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                "{",
+                "  \"type\": \"request\",",
+                "  \"name\": \"LeaderAndIsrRequest\",",
+                "  \"validVersions\": \"0-4\",",
+                "  \"deprecatedVersions\": \"0-1\",",
+                "  \"flexibleVersions\": \"0+\",",
+                "  \"fields\": [",
+                "    { \"name\": \"field1\", \"type\": \"int32\", \"versions\": \"0+\" },",
+                "    { \"name\": \"field2\", \"type\": \"[]TestCommonStruct\", \"versions\": \"1+\" },",
+                "    { \"name\": \"field3\", \"type\": \"[]TestInlineStruct\", \"versions\": \"0+\", ",
+                "    \"fields\": [",
+                "      { \"name\": \"inlineField1\", \"type\": \"int64\", \"versions\": \"0+\" }",
+                "    ]}",
+                "  ],",
+                "  \"commonStructs\": [",
+                "    { \"name\": \"TestCommonStruct\", \"versions\": \"0+\", \"fields\": [",
+                "      { \"name\": \"commonField1\", \"type\": \"int64\", \"versions\": \"0+\" }",
+                "    ]}",
+                "  ]",
+                "}")), MessageSpec.class);
+        StructRegistry structRegistry = new StructRegistry();
+        structRegistry.register(testMessageSpec);
+        assertEquals(Collections.singleton("TestCommonStruct"), structRegistry.commonStructNames());
+        assertFalse(structRegistry.isStructArrayWithKeys(testMessageSpec.fields().get(1)));
+        assertFalse(structRegistry.isStructArrayWithKeys(testMessageSpec.fields().get(2)));
+        assertTrue(structRegistry.commonStructs().hasNext());
+        assertEquals("TestCommonStruct", structRegistry.commonStructs().next().name());
+    }
+
+    @Test
+    public void testReSpecifiedCommonStructError() throws Exception {
+        MessageSpec testMessageSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                "{",
+                "  \"type\": \"request\",",
+                "  \"name\": \"LeaderAndIsrRequest\",",
+                "  \"validVersions\": \"0-2\",",
+                "  \"flexibleVersions\": \"0+\",",
+                "  \"fields\": [",
+                "    { \"name\": \"field1\", \"type\": \"int32\", \"versions\": \"0+\" },",
+                "    { \"name\": \"field2\", \"type\": \"[]TestCommonStruct\", \"versions\": \"0+\", ",
+                "    \"fields\": [",
+                "      { \"name\": \"inlineField1\", \"type\": \"int64\", \"versions\": \"0+\" }",
+                "    ]}",
+                "  ],",
+                "  \"commonStructs\": [",
+                "    { \"name\": \"TestCommonStruct\", \"versions\": \"0+\", \"fields\": [",
+                "      { \"name\": \"commonField1\", \"type\": \"int64\", \"versions\": \"0+\" }",
+                "    ]}",
+                "  ]",
+                "}")), MessageSpec.class);
+        StructRegistry structRegistry = new StructRegistry();
+        try {
+            structRegistry.register(testMessageSpec);
+            fail("Expected StructRegistry#registry to fail");
+        }
+        catch (RuntimeException e) {
+            assertTrue(e.getMessage().contains("Can't re-specify the common struct TestCommonStruct " +
+                    "as an inline struct."));
+        }
+    }
+
+    @Test
+    public void testDuplicateCommonStructError() throws Exception {
+        MessageSpec testMessageSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                "{",
+                "  \"type\": \"request\",",
+                "  \"name\": \"LeaderAndIsrRequest\",",
+                "  \"validVersions\": \"0-2\",",
+                "  \"flexibleVersions\": \"0+\",",
+                "  \"fields\": [",
+                "    { \"name\": \"field1\", \"type\": \"int32\", \"versions\": \"0+\" }",
+                "  ],",
+                "  \"commonStructs\": [",
+                "    { \"name\": \"TestCommonStruct\", \"versions\": \"0+\", \"fields\": [",
+                "      { \"name\": \"commonField1\", \"type\": \"int64\", \"versions\": \"0+\" }",
+                "    ]},",
+                "    { \"name\": \"TestCommonStruct\", \"versions\": \"0+\", \"fields\": [",
+                "      { \"name\": \"commonField1\", \"type\": \"int64\", \"versions\": \"0+\" }",
+                "    ]}",
+                "  ]",
+                "}")), MessageSpec.class);
+        StructRegistry structRegistry = new StructRegistry();
+        try {
+            structRegistry.register(testMessageSpec);
+            fail("Expected StructRegistry#registry to fail");
+        }
+        catch (RuntimeException e) {
+            assertTrue(e.getMessage().contains("Common struct TestCommonStruct was specified twice."));
+        }
+    }
+
+    @Test
+    public void testSingleStruct() throws Exception {
+        MessageSpec testMessageSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                "{",
+                "  \"type\": \"request\",",
+                "  \"name\": \"LeaderAndIsrRequest\",",
+                "  \"validVersions\": \"0-2\",",
+                "  \"flexibleVersions\": \"0+\",",
+                "  \"fields\": [",
+                "    { \"name\": \"field1\", \"type\": \"int32\", \"versions\": \"0+\" },",
+                "    { \"name\": \"field2\", \"type\": \"TestInlineStruct\", \"versions\": \"0+\", ",
+                "    \"fields\": [",
+                "      { \"name\": \"inlineField1\", \"type\": \"int64\", \"versions\": \"0+\" }",
+                "    ]}",
+                "  ]",
+                "}")), MessageSpec.class);
+        StructRegistry structRegistry = new StructRegistry();
+        structRegistry.register(testMessageSpec);
+
+        FieldSpec field2 = testMessageSpec.fields().get(1);
+        assertTrue(field2.type().isStruct());
+        assertEquals("TestInlineStruct", field2.type().toString());
+        assertEquals("field2", field2.name());
+
+        assertEquals("TestInlineStruct", structRegistry.findStruct(field2).name());
+        assertFalse(structRegistry.isStructArrayWithKeys(field2));
+    }
+
+    @Test
+    public void testValidVersionsIsNone() throws Exception {
+        MessageSpec testMessageSpec = MessageGenerator.JSON_SERDE.readValue(String.join("", List.of(
+                "{",
+                "  \"type\": \"request\",",
+                "  \"name\": \"FooBar\",",
+                "  \"validVersions\": \"none\"",
+                "}")), MessageSpec.class);
+        StructRegistry structRegistry = new StructRegistry();
+        structRegistry.register(testMessageSpec);
+
+        assertFalse(testMessageSpec.hasValidVersion());
+        assertEquals(List.of(), testMessageSpec.fields());
+        assertFalse(structRegistry.structs().hasNext());
+        assertFalse(structRegistry.commonStructs().hasNext());
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/StructSpecTest.java
+++ b/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/StructSpecTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Timeout(120)
+public class StructSpecTest {
+    @Test
+    public void testNamesMustBeUnique() {
+        assertEquals("In LeaderAndIsrRequest, field field1 has a duplicate name field1. All field names must be unique.",
+                assertThrows(ValueInstantiationException.class,
+                        () -> MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                                "{",
+                                "  \"type\": \"request\",",
+                                "  \"name\": \"LeaderAndIsrRequest\",",
+                                "  \"validVersions\": \"0-4\",",
+                                "  \"deprecatedVersions\": \"0-1\",",
+                                "  \"flexibleVersions\": \"0+\",",
+                                "  \"fields\": [",
+                                "    { \"name\": \"field1\", \"type\": \"int32\", \"versions\": \"0+\" },",
+                                "    { \"name\": \"field1\", \"type\": \"[]int64\", \"versions\": \"1+\" }",
+                                "  ]",
+                                "}")), MessageSpec.class))
+                        .getCause().getMessage());
+    }
+
+    @Test
+    public void testTagsMustBeUnique() {
+        assertEquals("In LeaderAndIsrRequest, field field2 has a duplicate tag ID 0. All tags IDs must be unique.",
+                assertThrows(ValueInstantiationException.class,
+                        () -> MessageGenerator.JSON_SERDE.readValue(String.join("", Arrays.asList(
+                                "{",
+                                "  \"type\": \"request\",",
+                                "  \"name\": \"LeaderAndIsrRequest\",",
+                                "  \"validVersions\": \"0-4\",",
+                                "  \"deprecatedVersions\": \"0-1\",",
+                                "  \"flexibleVersions\": \"0+\",",
+                                "  \"fields\": [",
+                                "    { \"name\": \"field1\", \"type\": \"int32\", \"versions\": \"0+\", ",
+                                "        \"taggedVersions\": \"0+\", \"tag\": 0},",
+                                "    { \"name\": \"field2\", \"type\": \"[]int64\", \"versions\": \"0+\", ",
+                                "        \"taggedVersions\": \"0+\", \"tag\": 0 }",
+                                "  ]",
+                                "}")), MessageSpec.class))
+                        .getCause().getMessage());
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/VersionConditionalTest.java
+++ b/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/VersionConditionalTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.io.StringWriter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Timeout(120)
+public class VersionConditionalTest {
+
+    static void claimEquals(CodeBuffer buffer, String... lines) throws Exception {
+        StringWriter stringWriter = new StringWriter();
+        buffer.write(stringWriter);
+        StringBuilder expectedStringBuilder = new StringBuilder();
+        for (String line : lines) {
+            expectedStringBuilder.append(String.format(line));
+        }
+        assertEquals(expectedStringBuilder.toString(), stringWriter.toString());
+    }
+
+    @Test
+    public void testAlwaysFalseConditional() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.forVersions(Versions.parse("1-2", null), Versions.parse("3+", null)).ifMember(__ -> buffer.printf("System.out.println(\"hello world\");%n"))
+                .ifNotMember(__ -> buffer.printf("System.out.println(\"foobar\");%n")).generate(buffer);
+        claimEquals(buffer,
+                "System.out.println(\"foobar\");%n");
+    }
+
+    @Test
+    public void testAnotherAlwaysFalseConditional() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.forVersions(Versions.parse("3+", null), Versions.parse("1-2", null)).ifMember(__ -> buffer.printf("System.out.println(\"hello world\");%n"))
+                .ifNotMember(__ -> buffer.printf("System.out.println(\"foobar\");%n")).generate(buffer);
+        claimEquals(buffer,
+                "System.out.println(\"foobar\");%n");
+    }
+
+    @Test
+    public void testAllowMembershipCheckAlwaysFalseFails() {
+        try {
+            CodeBuffer buffer = new CodeBuffer();
+            VersionConditional.forVersions(Versions.parse("1-2", null), Versions.parse("3+", null))
+                    .ifMember(__ -> buffer.printf("System.out.println(\"hello world\");%n")).ifNotMember(__ -> buffer.printf("System.out.println(\"foobar\");%n"))
+                    .allowMembershipCheckAlwaysFalse(false).generate(buffer);
+        }
+        catch (RuntimeException e) {
+            assertTrue(e.getMessage().contains("no versions in common"));
+        }
+    }
+
+    @Test
+    public void testAlwaysTrueConditional() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.forVersions(Versions.parse("1-5", null), Versions.parse("2-4", null)).ifMember(__ -> buffer.printf("System.out.println(\"hello world\");%n"))
+                .ifNotMember(__ -> buffer.printf("System.out.println(\"foobar\");%n")).allowMembershipCheckAlwaysFalse(false).generate(buffer);
+        claimEquals(buffer,
+                "System.out.println(\"hello world\");%n");
+    }
+
+    @Test
+    public void testAlwaysTrueConditionalWithAlwaysEmitBlockScope() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.forVersions(Versions.parse("1-5", null), Versions.parse("2-4", null)).ifMember(__ -> buffer.printf("System.out.println(\"hello world\");%n"))
+                .ifNotMember(__ -> buffer.printf("System.out.println(\"foobar\");%n")).alwaysEmitBlockScope(true).generate(buffer);
+        claimEquals(buffer,
+                "{%n",
+                "    System.out.println(\"hello world\");%n",
+                "}%n");
+    }
+
+    @Test
+    public void testLowerRangeCheckWithElse() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.forVersions(Versions.parse("1+", null), Versions.parse("0-100", null)).ifMember(__ -> buffer.printf("System.out.println(\"hello world\");%n"))
+                .ifNotMember(__ -> buffer.printf("System.out.println(\"foobar\");%n")).generate(buffer);
+        claimEquals(buffer,
+                "if (_version >= 1) {%n",
+                "    System.out.println(\"hello world\");%n",
+                "} else {%n",
+                "    System.out.println(\"foobar\");%n",
+                "}%n");
+    }
+
+    @Test
+    public void testLowerRangeCheckWithIfMember() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.forVersions(Versions.parse("1+", null), Versions.parse("0-100", null)).ifMember(__ -> buffer.printf("System.out.println(\"hello world\");%n"))
+                .generate(buffer);
+        claimEquals(buffer,
+                "if (_version >= 1) {%n",
+                "    System.out.println(\"hello world\");%n",
+                "}%n");
+    }
+
+    @Test
+    public void testLowerRangeCheckWithIfNotMember() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.forVersions(Versions.parse("1+", null), Versions.parse("0-100", null))
+                .ifNotMember(__ -> buffer.printf("System.out.println(\"hello world\");%n")).generate(buffer);
+        claimEquals(buffer,
+                "if (_version < 1) {%n",
+                "    System.out.println(\"hello world\");%n",
+                "}%n");
+    }
+
+    @Test
+    public void testUpperRangeCheckWithElse() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.forVersions(Versions.parse("0-10", null), Versions.parse("4+", null)).ifMember(__ -> buffer.printf("System.out.println(\"hello world\");%n"))
+                .ifNotMember(__ -> buffer.printf("System.out.println(\"foobar\");%n")).generate(buffer);
+        claimEquals(buffer,
+                "if (_version <= 10) {%n",
+                "    System.out.println(\"hello world\");%n",
+                "} else {%n",
+                "    System.out.println(\"foobar\");%n",
+                "}%n");
+    }
+
+    @Test
+    public void testUpperRangeCheckWithIfMember() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.forVersions(Versions.parse("0-10", null), Versions.parse("4+", null)).ifMember(__ -> buffer.printf("System.out.println(\"hello world\");%n"))
+                .generate(buffer);
+        claimEquals(buffer,
+                "if (_version <= 10) {%n",
+                "    System.out.println(\"hello world\");%n",
+                "}%n");
+    }
+
+    @Test
+    public void testUpperRangeCheckWithIfNotMember() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.forVersions(Versions.parse("1+", null), Versions.parse("0-100", null))
+                .ifNotMember(__ -> buffer.printf("System.out.println(\"hello world\");%n")).generate(buffer);
+        claimEquals(buffer,
+                "if (_version < 1) {%n",
+                "    System.out.println(\"hello world\");%n",
+                "}%n");
+    }
+
+    @Test
+    public void testFullRangeCheck() throws Exception {
+        CodeBuffer buffer = new CodeBuffer();
+        VersionConditional.forVersions(Versions.parse("5-10", null), Versions.parse("1+", null)).ifMember(__ -> buffer.printf("System.out.println(\"hello world\");%n"))
+                .allowMembershipCheckAlwaysFalse(false).generate(buffer);
+        claimEquals(buffer,
+                "if ((_version >= 5) && (_version <= 10)) {%n",
+                "    System.out.println(\"hello world\");%n",
+                "}%n");
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/VersionsTest.java
+++ b/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/VersionsTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Timeout(120)
+public class VersionsTest {
+
+    private static Versions newVersions(int lower, int higher) {
+        if ((lower < Short.MIN_VALUE) || (lower > Short.MAX_VALUE)) {
+            throw new RuntimeException("lower bound out of range.");
+        }
+        if ((higher < Short.MIN_VALUE) || (higher > Short.MAX_VALUE)) {
+            throw new RuntimeException("higher bound out of range.");
+        }
+        return new Versions((short) lower, (short) higher);
+    }
+
+    @Test
+    public void testVersionsParse() {
+        assertEquals(Versions.NONE, Versions.parse(" none ", null));
+        assertEquals(Versions.NONE, Versions.parse(null, Versions.NONE));
+        assertEquals(Versions.ALL, Versions.parse(" ", Versions.ALL));
+        assertEquals(Versions.ALL, Versions.parse("", Versions.ALL));
+        assertEquals(newVersions(4, 5), Versions.parse(" 4-5 ", null));
+    }
+
+    @Test
+    public void testRoundTrips() {
+        testRoundTrip(Versions.ALL, "0+");
+        testRoundTrip(newVersions(1, 3), "1-3");
+        testRoundTrip(newVersions(2, 2), "2");
+        testRoundTrip(newVersions(3, Short.MAX_VALUE), "3+");
+        testRoundTrip(Versions.NONE, "none");
+    }
+
+    private void testRoundTrip(Versions versions, String string) {
+        assertEquals(string, versions.toString());
+        assertEquals(versions, Versions.parse(versions.toString(), null));
+    }
+
+    @Test
+    public void testIntersections() {
+        assertEquals(newVersions(2, 3), newVersions(1, 3).intersect(
+                newVersions(2, 4)));
+        assertEquals(newVersions(3, 3), newVersions(0, Short.MAX_VALUE).intersect(
+                newVersions(3, 3)));
+        assertEquals(Versions.NONE, newVersions(9, Short.MAX_VALUE).intersect(
+                newVersions(2, 8)));
+        assertEquals(Versions.NONE, Versions.NONE.intersect(Versions.NONE));
+    }
+
+    @Test
+    public void testContains() {
+        assertTrue(newVersions(2, 3).contains((short) 3));
+        assertTrue(newVersions(2, 3).contains((short) 2));
+        assertFalse(newVersions(0, 1).contains((short) 2));
+        assertTrue(newVersions(0, Short.MAX_VALUE).contains((short) 100));
+        assertFalse(newVersions(2, Short.MAX_VALUE).contains((short) 0));
+        assertTrue(newVersions(2, 3).contains(newVersions(2, 3)));
+        assertTrue(newVersions(2, 3).contains(newVersions(2, 2)));
+        assertFalse(newVersions(2, 3).contains(newVersions(2, 4)));
+        assertTrue(newVersions(2, 3).contains(Versions.NONE));
+        assertTrue(Versions.ALL.contains(newVersions(1, 2)));
+    }
+
+    @Test
+    public void testSubtract() {
+        assertEquals(Versions.NONE, Versions.NONE.subtract(Versions.NONE));
+        assertEquals(newVersions(0, 0),
+                newVersions(0, 0).subtract(Versions.NONE));
+        assertEquals(newVersions(1, 1),
+                newVersions(1, 2).subtract(newVersions(2, 2)));
+        assertEquals(newVersions(2, 2),
+                newVersions(1, 2).subtract(newVersions(1, 1)));
+        assertNull(newVersions(0, Short.MAX_VALUE).subtract(newVersions(1, 100)));
+        assertEquals(newVersions(10, 10),
+                newVersions(1, 10).subtract(newVersions(1, 9)));
+        assertEquals(newVersions(1, 1),
+                newVersions(1, 10).subtract(newVersions(2, 10)));
+        assertEquals(newVersions(2, 4),
+                newVersions(2, Short.MAX_VALUE).subtract(newVersions(5, Short.MAX_VALUE)));
+        assertEquals(newVersions(5, Short.MAX_VALUE),
+                newVersions(0, Short.MAX_VALUE).subtract(newVersions(0, 4)));
+    }
+}

--- a/kroxylicious-proxy-core/pom.xml
+++ b/kroxylicious-proxy-core/pom.xml
@@ -34,6 +34,7 @@
     <modules>
         <module>../kroxylicious-annotations</module>
         <module>../kroxylicious-krpc-plugin</module>
+        <module>../kroxylicious-kafka-message-generator</module>
         <module>../kroxylicious-kafka-message-tools</module>
         <module>../kroxylicious-bom</module>
         <module>../kroxylicious-api</module>

--- a/pom.xml
+++ b/pom.xml
@@ -703,8 +703,7 @@
                                     <exclude>**/*.password</exclude>
                                     <!-- JSON-based formats that cannot carry a license header -->
                                     <exclude>**/*.excalidraw</exclude>
-                                    <!-- Forked from Apache Kafka; retains original ASF copyright headers -->
-                                    <exclude>**/kroxylicious-kafka-message-generator/src/**</exclude>
+
                                 </excludes>
                             </licenseSet>
                         </licenseSets>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <kroxy.extension.version>0.15.0</kroxy.extension.version>
         <log4j.version>2.26.1</log4j.version>
         <caffeine.version>3.2.4</caffeine.version>
+        <argparse4j.version>0.7.0</argparse4j.version>
         <picocli.version>4.7.7</picocli.version>
         <netty.version>4.2.17.Final</netty.version>
         <netty.epoll.architecture>linux-x86_64</netty.epoll.architecture>
@@ -185,6 +186,12 @@
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-runtime</artifactId>
                 <version>4.13.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>net.sourceforge.argparse4j</groupId>
+                <artifactId>argparse4j</artifactId>
+                <version>${argparse4j.version}</version>
             </dependency>
 
             <dependency>
@@ -696,6 +703,8 @@
                                     <exclude>**/*.password</exclude>
                                     <!-- JSON-based formats that cannot carry a license header -->
                                     <exclude>**/*.excalidraw</exclude>
+                                    <!-- Forked from Apache Kafka; retains original ASF copyright headers -->
+                                    <exclude>kroxylicious-kafka-message-generator/src/**</exclude>
                                 </excludes>
                             </licenseSet>
                         </licenseSets>

--- a/pom.xml
+++ b/pom.xml
@@ -704,7 +704,7 @@
                                     <!-- JSON-based formats that cannot carry a license header -->
                                     <exclude>**/*.excalidraw</exclude>
                                     <!-- Forked from Apache Kafka; retains original ASF copyright headers -->
-                                    <exclude>kroxylicious-kafka-message-generator/src/**</exclude>
+                                    <exclude>**/kroxylicious-kafka-message-generator/src/**</exclude>
                                 </excludes>
                             </licenseSet>
                         </licenseSets>

--- a/pom.xml
+++ b/pom.xml
@@ -703,6 +703,11 @@
                                     <exclude>**/*.password</exclude>
                                     <!-- JSON-based formats that cannot carry a license header -->
                                     <exclude>**/*.excalidraw</exclude>
+                                    <!-- Forked Kafka source retains ASF headers; the module-level
+                                         check enforces the ASF template. Paths are root-relative because
+                                         this exclusion only needs to work during the root-level scan. -->
+                                    <exclude>kroxylicious-kafka-message-generator/src/**</exclude>
+                                    <exclude>kroxylicious-kafka-message-generator/etc/**</exclude>
 
                                 </excludes>
                             </licenseSet>


### PR DESCRIPTION
## Summary

Introduces the `kroxylicious-kafka-message-generator` module as the first step of [#4578](https://github.com/kroxylicious/kroxylicious/issues/4578) / [proposal 116](https://github.com/kroxylicious/kroxylicious-design/blob/main/proposals/116-kafka-api-migration.md).

- Forks 26 source files from `generator/src/main/java/org/apache/kafka/message/` in the Apache Kafka repository at tag `4.3.0` (commit `a9ce3221537b8653448750697915607dc7936cf3`)
- Source files retain their original ASF copyright headers, redistributed under Apache 2.0
- Only change from upstream: package renamed `org.apache.kafka.message` → `io.kroxylicious.kafka.message`
- The `checker/` sub-package (schema evolution tooling with a JGit dependency) is intentionally omitted — not needed for code generation
- Forked at 4.3.0 specifically because that is where the internal package reorganisation (`record.internal.*`, `utils.internals.*`) landed; our own copies of those classes will mirror those locations
- `argparse4j 0.7.0` added to root dependency management (matches upstream Kafka's version)
- Checkstyle, ErrorProne, SpotBugs, and Javadoc doclint suppressed for this module pending a conformance clean-up task
- `mvn verify` passes

The next step on this branch is to modify the generator to emit `*Data` classes under `io.kroxylicious.kafka.*` rather than `org.apache.kafka.*`.

## Test plan

- [ ] `mvn verify -pl kroxylicious-kafka-message-generator -am` passes

Relates-to: #4578

🤖 Generated with [Claude Code](https://claude.com/claude-code)