### PR TITLE
build(deps): bump kroxy.extension.version from 0.15.0 to 0.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <re2j.version>1.8</re2j.version>
         <junit.version>5.14.4</junit.version>
         <kafka.version>4.2.0</kafka.version>
-        <kroxy.extension.version>0.15.0</kroxy.extension.version>
+        <kroxy.extension.version>0.16.0</kroxy.extension.version>
         <log4j.version>2.26.1</log4j.version>
         <caffeine.version>3.2.4</caffeine.version>
         <argparse4j.version>0.7.0</argparse4j.version>


### PR DESCRIPTION
## Intent

Manual bump of the `kroxylicious-junit5-extension` / `testing-api` dependency version, ahead of the next dependabot cycle.

Closes #3944 by the extension adding uuids to its auto-generated topic names to prevent collisions.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>