### PR TITLE
feat(scram-credential-store): add keystore-based SCRAM credential provider

### DIFF
--- a/kroxylicious-bom/pom.xml
+++ b/kroxylicious-bom/pom.xml
@@ -186,6 +186,12 @@
 
             <dependency>
                 <groupId>io.kroxylicious</groupId>
+                <artifactId>kroxylicious-scram-credential-store-provider-keystore</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.kroxylicious</groupId>
                 <artifactId>kroxylicious-record-encryption</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/kroxylicious-runtime-plugins/pom.xml
+++ b/kroxylicious-runtime-plugins/pom.xml
@@ -39,6 +39,7 @@
         <module>../kroxylicious-kms-tls-support</module>
         <module>../kroxylicious-kms-providers</module>
         <module>../kroxylicious-scram-credential-store</module>
+        <module>../kroxylicious-scram-credential-store-providers</module>
         <module>../kroxylicious-filter-test-support</module>
         <module>../kroxylicious-filter-archetype</module>
         <module>../kroxylicious-filters</module>

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/README.md
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/README.md
@@ -21,7 +21,7 @@ credentialStore: KeystoreScramCredentialStore
 credentialStoreConfig:
   file: /path/to/credentials.jks
   storePassword:
-    password: "keystore-password"
+    passwordFile: /etc/kroxylicious/keystore-password.txt
   storeType: PKCS12
 ```
 

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/README.md
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/README.md
@@ -1,0 +1,160 @@
+# KeyStore SCRAM Credential Store
+
+Java KeyStore-based implementation of the SCRAM credential store for SASL authentication.
+
+## Overview
+
+This module provides a production-ready credential store that loads SCRAM credentials from a Java KeyStore file. Credentials are loaded into memory at startup for fast, synchronous lookups during authentication.
+
+## Features
+
+- **SCRAM-SHA-256 and SCRAM-SHA-512 support** - Stores salted, hashed credentials
+- **Java KeyStore integration** - Uses standard JKS or PKCS12 KeyStore formats
+- **Secure credential storage** - Never stores plaintext passwords
+- **Fast lookups** - In-memory cache for sub-millisecond credential retrieval
+- **Password-protected** - KeyStore and individual keys protected by passwords
+
+## Configuration
+
+```yaml
+credentialStore: KeystoreScramCredentialStore
+credentialStoreConfig:
+  file: /path/to/credentials.jks
+  storePassword:
+    password: "keystore-password"
+  storeType: PKCS12
+```
+
+### Configuration Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `file` | string | Yes | - | Path to the KeyStore file |
+| `storePassword` | PasswordProvider | Yes | - | Password for the KeyStore |
+| `keyPassword` | PasswordProvider | No | Same as storePassword | Password for individual keys |
+| `storeType` | string | No | Platform default | KeyStore type (e.g., "PKCS12", "JKS") |
+
+## KeyStore Format
+
+The KeyStore must contain `SecretKey` entries where:
+- **Alias**: The username
+- **Key bytes**: JSON-serialised `ScramCredential` data
+
+### Credential JSON Format
+
+```json
+{
+  "username": "alice",
+  "salt": "FJz8jKVn7gKxR1wKGHXRXw==",
+  "iterations": 4096,
+  "serverKey": "yP4LXM+6b8SvL0N9i8fJQj5kJ5w=",
+  "storedKey": "I8k2r9SvL0N9i8fJQj5kJ5wyP4L=",
+  "hashAlgorithm": "SHA-256"
+}
+```
+
+## Generating Credentials
+
+### Using Java Code
+
+```java
+import io.kroxylicious.scram.credentialstore.keystore.TestCredentialGenerator;
+
+Path keystorePath = Paths.get("credentials.jks");
+String password = "keystore-password";
+
+var generator = new TestCredentialGenerator();
+generator.generateKeyStore(
+    keystorePath,
+    password,
+    "alice", "alice-secret",
+    "bob", "bob-secret"
+);
+```
+
+### Using Kafka's SCRAM Tools
+
+You can also generate SCRAM credentials using Kafka's built-in tools and manually create the KeyStore:
+
+```bash
+# Generate SCRAM credentials using Kafka
+kafka-configs --bootstrap-server localhost:9092 \
+  --alter --entity-type users --entity-name alice \
+  --add-config 'SCRAM-SHA-256=[password=alice-secret]'
+```
+
+Then extract the generated credentials and store them in the KeyStore format described above.
+
+## Security Considerations
+
+### KeyStore Protection
+
+- **File permissions**: Restrict KeyStore file to 600 (owner read/write only)
+- **Strong passwords**: Use strong, randomly generated passwords via `PasswordProvider`
+- **Prefer PKCS12**: Modern PKCS12 format is more secure than legacy JKS
+
+### Credential Security
+
+- **No plaintext passwords**: Only salted, hashed credentials are stored
+- **Sufficient iterations**: Default 4096 iterations (higher is more secure but slower)
+- **Secure generation**: Use cryptographically random salts
+
+### Operational Security
+
+- **Rotate credentials**: Periodically update user passwords
+- **Monitor access**: Log authentication attempts (success/failure)
+- **Backup safely**: Encrypt KeyStore backups
+
+## Limitations
+
+### Current Version
+
+- **Static credentials**: KeyStore is loaded once at startup; changes require restart
+- **In-memory only**: All credentials held in memory (consider size for large user bases)
+- **No hot reload**: Cannot dynamically reload credentials from file
+
+### Future Enhancements
+
+- File watching for dynamic credential updates
+- Credential caching with TTL
+- Support for remote KeyStore locations
+
+## Example Usage
+
+```yaml
+filters:
+  - type: SaslTermination
+    config:
+      mechanisms:
+        SCRAM-SHA-256:
+          credentialStore: KeystoreScramCredentialStore
+          credentialStoreConfig:
+            file: /etc/kroxylicious/credentials.p12
+            storePassword:
+              file: /etc/kroxylicious/keystore-password.txt
+            storeType: PKCS12
+```
+
+## Troubleshooting
+
+### "Failed to load KeyStore"
+
+- **Check file path**: Ensure the file exists and is readable
+- **Check password**: Verify storePassword is correct
+- **Check format**: Ensure storeType matches actual KeyStore type
+
+### "Failed to recover key for alias"
+
+- **Check key password**: If keyPassword differs from storePassword, ensure it's correct
+- **Check alias**: Verify username aliases match those in the KeyStore
+
+### "Invalid credential for alias"
+
+- **Check JSON format**: Ensure SecretKey bytes are valid JSON matching the schema
+- **Check credential values**: Ensure all required fields are present and valid
+
+## See Also
+
+- [SCRAM Credential Store API](../../kroxylicious-scram-credential-store/)
+- [SASL Termination Filter](../../kroxylicious-filters/kroxylicious-sasl-termination/)
+- [RFC 5802 - SCRAM](https://tools.ietf.org/html/rfc5802)

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/README.md
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/README.md
@@ -37,7 +37,8 @@ credentialStoreConfig:
 ## KeyStore Format
 
 The KeyStore must contain `SecretKey` entries where:
-- **Alias**: The username
+- **Alias**: The lowercase hex SHA-256 hash of the username (UTF-8 encoded). Using a hash prevents
+  leaking usernames if the KeyStore is inspected directly.
 - **Key bytes**: JSON-serialised `ScramCredential` data
 
 ### Credential JSON Format
@@ -54,23 +55,6 @@ The KeyStore must contain `SecretKey` entries where:
 ```
 
 ## Generating Credentials
-
-### Using Java Code
-
-```java
-import io.kroxylicious.scram.credentialstore.keystore.TestCredentialGenerator;
-
-Path keystorePath = Paths.get("credentials.jks");
-String password = "keystore-password";
-
-var generator = new TestCredentialGenerator();
-generator.generateKeyStore(
-    keystorePath,
-    password,
-    "alice", "alice-secret",
-    "bob", "bob-secret"
-);
-```
 
 ### Using Kafka's SCRAM Tools
 

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/pom.xml
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/pom.xml
@@ -64,6 +64,27 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <!-- https://junit-pioneer.org/docs/environment-variables/#warnings-for-reflective-access -->
+                <configuration>
+                    <argLine>
+                        @{jacoco.argline}
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/pom.xml
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kroxylicious</groupId>
+        <artifactId>kroxylicious-scram-credential-store-providers</artifactId>
+        <version>0.24.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>kroxylicious-scram-credential-store-provider-keystore</artifactId>
+    <name>KeyStore SCRAM Credential Store</name>
+    <description>Java KeyStore-based SCRAM credential store provider</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-scram-credential-store</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-api</artifactId>
+        </dependency>
+
+        <!-- third party dependencies - build and compile -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/pom.xml
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/pom.xml
@@ -53,11 +53,6 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
         </dependency>
-        <dependency>
-            <groupId>info.picocli</groupId>
-            <artifactId>picocli</artifactId>
-        </dependency>
-
         <!-- test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -67,11 +62,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreFilePermissions.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreFilePermissions.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.scram.credentialstore.keystore;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.KeyStoreException;
+import java.util.EnumSet;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.scram.credentialstore.CredentialServiceUnavailableException;
+
+/**
+ * Shared file permission checks for keystore files.
+ */
+final class KeystoreFilePermissions {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KeystoreFilePermissions.class);
+    static final String PERMISSION_CHECK_ENV_VAR = "KROXYLICIOUS_DANGEROUSLY_CHANGE_PERMISSION_CHECK";
+
+    private static final Set<PosixFilePermission> STRICT_INSECURE_PERMISSIONS = EnumSet.of(
+            PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_WRITE,
+            PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_WRITE);
+
+    private static final Set<PosixFilePermission> RELAXED_INSECURE_PERMISSIONS = EnumSet.of(
+            PosixFilePermission.GROUP_WRITE,
+            PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_WRITE);
+
+    private KeystoreFilePermissions() {
+    }
+
+    static void checkForCredentialStore(Path path) throws CredentialServiceUnavailableException {
+        if (!Files.exists(path)) {
+            return;
+        }
+        PosixFileAttributeView posixView = Files.getFileAttributeView(path, PosixFileAttributeView.class);
+        if (posixView == null) {
+            return;
+        }
+        try {
+            Set<PosixFilePermission> perms = posixView.readAttributes().permissions();
+            Set<PosixFilePermission> insecure = getInsecurePermissions();
+            Set<PosixFilePermission> found = EnumSet.copyOf(insecure);
+            found.retainAll(perms);
+            if (!found.isEmpty()) {
+                throw new CredentialServiceUnavailableException(
+                        "KeyStore file " + path + " has insecure permissions: " + PosixFilePermissions.toString(perms) +
+                                ". Remove group and world access (e.g. chmod 600).");
+            }
+        }
+        catch (IOException e) {
+            throw new CredentialServiceUnavailableException(
+                    "Failed to check permissions on KeyStore file: " + path, e);
+        }
+    }
+
+    static void check(Path path) throws KeyStoreException {
+        if (!Files.exists(path)) {
+            return;
+        }
+        PosixFileAttributeView posixView = Files.getFileAttributeView(path, PosixFileAttributeView.class);
+        if (posixView == null) {
+            return;
+        }
+        try {
+            Set<PosixFilePermission> perms = posixView.readAttributes().permissions();
+            Set<PosixFilePermission> insecure = getInsecurePermissions();
+            Set<PosixFilePermission> found = EnumSet.copyOf(insecure);
+            found.retainAll(perms);
+            if (!found.isEmpty()) {
+                throw new KeyStoreException(
+                        "KeyStore file " + path + " has insecure permissions: " + PosixFilePermissions.toString(perms) +
+                                ". Remove group and world access (e.g. chmod 600).");
+            }
+        }
+        catch (IOException e) {
+            throw new KeyStoreException(
+                    "Failed to check permissions on KeyStore file: " + path, e);
+        }
+    }
+
+    static void setOwnerOnly(Path path) throws IOException {
+        PosixFileAttributeView posixView = Files.getFileAttributeView(path, PosixFileAttributeView.class);
+        if (posixView != null) {
+            Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rw-------"));
+        }
+    }
+
+    private static Set<PosixFilePermission> getInsecurePermissions() {
+        String envValue = System.getenv(PERMISSION_CHECK_ENV_VAR);
+        if ("0640".equals(envValue)) {
+            LOGGER.atWarn()
+                    .addKeyValue("envVar", PERMISSION_CHECK_ENV_VAR)
+                    .addKeyValue("value", envValue)
+                    .log("Relaxed file permission check is active: group-readable files are permitted");
+            return RELAXED_INSECURE_PERMISSIONS;
+        }
+        if (envValue != null && !envValue.isEmpty()) {
+            LOGGER.atWarn()
+                    .addKeyValue("envVar", PERMISSION_CHECK_ENV_VAR)
+                    .addKeyValue("value", envValue)
+                    .log("Unrecognized value for permission check env var, using strict default (0600)");
+        }
+        return STRICT_INSECURE_PERMISSIONS;
+    }
+}

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreFilePermissions.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreFilePermissions.java
@@ -12,7 +12,6 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.security.KeyStoreException;
 import java.util.EnumSet;
 import java.util.Set;
 
@@ -61,31 +60,6 @@ final class KeystoreFilePermissions {
         }
         catch (IOException e) {
             throw new CredentialServiceUnavailableException(
-                    "Failed to check permissions on KeyStore file: " + path, e);
-        }
-    }
-
-    static void check(Path path) throws KeyStoreException {
-        if (!Files.exists(path)) {
-            return;
-        }
-        PosixFileAttributeView posixView = Files.getFileAttributeView(path, PosixFileAttributeView.class);
-        if (posixView == null) {
-            return;
-        }
-        try {
-            Set<PosixFilePermission> perms = posixView.readAttributes().permissions();
-            Set<PosixFilePermission> insecure = getInsecurePermissions();
-            Set<PosixFilePermission> found = EnumSet.copyOf(insecure);
-            found.retainAll(perms);
-            if (!found.isEmpty()) {
-                throw new KeyStoreException(
-                        "KeyStore file " + path + " has insecure permissions: " + PosixFilePermissions.toString(perms) +
-                                ". Remove group and world access (e.g. chmod 600).");
-            }
-        }
-        catch (IOException e) {
-            throw new KeyStoreException(
                     "Failed to check permissions on KeyStore file: " + path, e);
         }
     }

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStore.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStore.java
@@ -105,11 +105,10 @@ public class KeystoreScramCredentialStore implements ScramCredentialStore {
      * @param keyStore the loaded KeyStore
      * @param keyPassword the password for individual keys
      * @return map of username to credential
-     * @throws CredentialServiceUnavailableException if extraction fails
+     * @throws CredentialServiceUnavailableException if extraction fails or any entry is malformed
      */
     private Map<String, ScramCredential> extractCredentials(KeyStore keyStore, char[] keyPassword) throws CredentialServiceUnavailableException {
         Map<String, ScramCredential> credentials = new HashMap<>();
-        int skippedEntries = 0;
 
         try {
             Enumeration<String> aliases = keyStore.aliases();
@@ -118,53 +117,37 @@ public class KeystoreScramCredentialStore implements ScramCredentialStore {
 
                 if (!keyStore.isKeyEntry(alias)) {
                     LOGGER.atDebug().addKeyValue("alias", alias).log("Skipping non-key entry");
-                    skippedEntries++;
                     continue;
                 }
 
+                KeyStore.Entry entry;
                 try {
-                    KeyStore.Entry entry = keyStore.getEntry(alias, new KeyStore.PasswordProtection(keyPassword));
-
-                    if (!(entry instanceof KeyStore.SecretKeyEntry secretKeyEntry)) {
-                        LOGGER.atDebug().addKeyValue("alias", alias).log("Skipping non-SecretKey entry");
-                        skippedEntries++;
-                        continue;
-                    }
-
-                    SecretKey secretKey = secretKeyEntry.getSecretKey();
-                    byte[] credentialBytes = secretKey.getEncoded();
-
-                    ScramCredential credential = serializer.deserialize(credentialBytes, alias);
-                    credentials.put(credential.username(), credential);
-
-                    LOGGER.atDebug().addKeyValue("username", credential.username()).log("Loaded credential");
+                    entry = keyStore.getEntry(alias, new KeyStore.PasswordProtection(keyPassword));
                 }
                 catch (UnrecoverableEntryException e) {
-                    LOGGER.atWarn()
-                            .addKeyValue("alias", alias)
-                            .setCause(LOGGER.isDebugEnabled() ? e : null)
-                            .addKeyValue("error", e.getMessage())
-                            .log(LOGGER.isDebugEnabled()
-                                    ? "Failed to recover entry - incorrect password?"
-                                    : "Failed to recover entry - incorrect password? Increase log level to DEBUG for stacktrace");
-                    skippedEntries++;
+                    throw new CredentialServiceUnavailableException(
+                            "Failed to recover KeyStore entry for alias '" + alias + "' - incorrect key password?", e);
+                }
+
+                if (!(entry instanceof KeyStore.SecretKeyEntry secretKeyEntry)) {
+                    LOGGER.atDebug().addKeyValue("alias", alias).log("Skipping non-SecretKey entry");
+                    continue;
+                }
+
+                SecretKey secretKey = secretKeyEntry.getSecretKey();
+                byte[] credentialBytes = secretKey.getEncoded();
+
+                ScramCredential credential;
+                try {
+                    credential = serializer.deserialize(credentialBytes, alias);
                 }
                 catch (IllegalArgumentException e) {
-                    LOGGER.atWarn()
-                            .addKeyValue("alias", alias)
-                            .setCause(LOGGER.isDebugEnabled() ? e : null)
-                            .addKeyValue("error", e.getMessage())
-                            .log(LOGGER.isDebugEnabled()
-                                    ? "Failed to deserialize credential"
-                                    : "Failed to deserialize credential, increase log level to DEBUG for stacktrace");
-                    skippedEntries++;
+                    throw new CredentialServiceUnavailableException(
+                            "Malformed credential in KeyStore entry for alias '" + alias + "'", e);
                 }
-            }
 
-            if (skippedEntries > 0) {
-                LOGGER.atInfo()
-                        .addKeyValue("skippedEntries", skippedEntries)
-                        .log("Skipped KeyStore entries (non-SecretKey or invalid credentials)");
+                credentials.put(credential.username(), credential);
+                LOGGER.atDebug().addKeyValue("username", credential.username()).log("Loaded credential");
             }
 
             return Collections.unmodifiableMap(credentials);

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStore.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStore.java
@@ -14,6 +14,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableEntryException;
 import java.security.cert.CertificateException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -86,12 +87,16 @@ public class KeystoreScramCredentialStore implements ScramCredentialStore {
 
             char[] storePassword = config.storePassword().getProvidedPassword().toCharArray();
             char[] keyPassword = config.effectiveKeyPassword().getProvidedPassword().toCharArray();
-
-            try (FileInputStream fis = new FileInputStream(config.file())) {
-                keyStore.load(fis, storePassword);
+            try {
+                try (FileInputStream fis = new FileInputStream(config.file())) {
+                    keyStore.load(fis, storePassword);
+                }
+                return extractCredentials(keyStore, keyPassword);
             }
-
-            return extractCredentials(keyStore, keyPassword);
+            finally {
+                Arrays.fill(storePassword, '\0');
+                Arrays.fill(keyPassword, '\0');
+            }
         }
         catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException e) {
             throw new CredentialServiceUnavailableException(

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStore.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStore.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.scram.credentialstore.keystore;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableEntryException;
+import java.security.cert.CertificateException;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.crypto.SecretKey;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.scram.credentialstore.CredentialServiceUnavailableException;
+import io.kroxylicious.scram.credentialstore.ScramCredential;
+import io.kroxylicious.scram.credentialstore.ScramCredentialStore;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * KeyStore-based implementation of {@link ScramCredentialStore}.
+ * <p>
+ * Loads all SCRAM credentials from a Java KeyStore file into memory at construction time.
+ * Credentials are stored as {@link SecretKey} entries with a hex-encoded SHA-256 hash of the
+ * username as the alias. The original username is stored within the JSON payload.
+ * </p>
+ */
+public class KeystoreScramCredentialStore implements ScramCredentialStore {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KeystoreScramCredentialStore.class);
+
+    private final Map<String, ScramCredential> credentialCache;
+    private final ScramCredentialSerializer serializer;
+
+    /**
+     * Create a new KeyStore-based credential store.
+     *
+     * @param config the configuration
+     * @throws CredentialServiceUnavailableException if the KeyStore cannot be loaded
+     */
+    public KeystoreScramCredentialStore(KeystoreScramCredentialStoreConfig config) throws CredentialServiceUnavailableException {
+        this.serializer = new ScramCredentialSerializer();
+        this.credentialCache = loadKeyStore(config);
+        LOGGER.atInfo()
+                .addKeyValue("count", credentialCache.size())
+                .addKeyValue("file", config.file())
+                .log("Loaded SCRAM credentials from KeyStore");
+    }
+
+    @Override
+    public CompletionStage<ScramCredential> lookupCredential(String username) {
+        Objects.requireNonNull(username, "username must not be null");
+
+        ScramCredential credential = credentialCache.get(username);
+        return CompletableFuture.completedFuture(credential);
+    }
+
+    /**
+     * Load the KeyStore and extract all SCRAM credentials.
+     *
+     * @param config the configuration
+     * @return map of username to credential
+     * @throws CredentialServiceUnavailableException if loading fails
+     */
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "File path comes from trusted configuration")
+    private Map<String, ScramCredential> loadKeyStore(KeystoreScramCredentialStoreConfig config) throws CredentialServiceUnavailableException {
+        KeystoreFilePermissions.checkForCredentialStore(Path.of(config.file()));
+        try {
+            KeyStore keyStore = KeyStore.getInstance(config.effectiveStoreType());
+
+            char[] storePassword = config.storePassword().getProvidedPassword().toCharArray();
+            char[] keyPassword = config.effectiveKeyPassword().getProvidedPassword().toCharArray();
+
+            try (FileInputStream fis = new FileInputStream(config.file())) {
+                keyStore.load(fis, storePassword);
+            }
+
+            return extractCredentials(keyStore, keyPassword);
+        }
+        catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException e) {
+            throw new CredentialServiceUnavailableException(
+                    "Failed to load KeyStore from: " + config.file(), e);
+        }
+    }
+
+    /**
+     * Extract all SCRAM credentials from the KeyStore.
+     *
+     * @param keyStore the loaded KeyStore
+     * @param keyPassword the password for individual keys
+     * @return map of username to credential
+     * @throws CredentialServiceUnavailableException if extraction fails
+     */
+    private Map<String, ScramCredential> extractCredentials(KeyStore keyStore, char[] keyPassword) throws CredentialServiceUnavailableException {
+        Map<String, ScramCredential> credentials = new HashMap<>();
+        int skippedEntries = 0;
+
+        try {
+            Enumeration<String> aliases = keyStore.aliases();
+            while (aliases.hasMoreElements()) {
+                String alias = aliases.nextElement();
+
+                if (!keyStore.isKeyEntry(alias)) {
+                    LOGGER.atDebug().addKeyValue("alias", alias).log("Skipping non-key entry");
+                    skippedEntries++;
+                    continue;
+                }
+
+                try {
+                    KeyStore.Entry entry = keyStore.getEntry(alias, new KeyStore.PasswordProtection(keyPassword));
+
+                    if (!(entry instanceof KeyStore.SecretKeyEntry secretKeyEntry)) {
+                        LOGGER.atDebug().addKeyValue("alias", alias).log("Skipping non-SecretKey entry");
+                        skippedEntries++;
+                        continue;
+                    }
+
+                    SecretKey secretKey = secretKeyEntry.getSecretKey();
+                    byte[] credentialBytes = secretKey.getEncoded();
+
+                    ScramCredential credential = serializer.deserialize(credentialBytes, alias);
+                    credentials.put(credential.username(), credential);
+
+                    LOGGER.atDebug().addKeyValue("username", credential.username()).log("Loaded credential");
+                }
+                catch (UnrecoverableEntryException e) {
+                    LOGGER.atWarn()
+                            .addKeyValue("alias", alias)
+                            .setCause(LOGGER.isDebugEnabled() ? e : null)
+                            .addKeyValue("error", e.getMessage())
+                            .log(LOGGER.isDebugEnabled()
+                                    ? "Failed to recover entry - incorrect password?"
+                                    : "Failed to recover entry - incorrect password? Increase log level to DEBUG for stacktrace");
+                    skippedEntries++;
+                }
+                catch (IllegalArgumentException e) {
+                    LOGGER.atWarn()
+                            .addKeyValue("alias", alias)
+                            .setCause(LOGGER.isDebugEnabled() ? e : null)
+                            .addKeyValue("error", e.getMessage())
+                            .log(LOGGER.isDebugEnabled()
+                                    ? "Failed to deserialize credential"
+                                    : "Failed to deserialize credential, increase log level to DEBUG for stacktrace");
+                    skippedEntries++;
+                }
+            }
+
+            if (skippedEntries > 0) {
+                LOGGER.atInfo()
+                        .addKeyValue("skippedEntries", skippedEntries)
+                        .log("Skipped KeyStore entries (non-SecretKey or invalid credentials)");
+            }
+
+            return Collections.unmodifiableMap(credentials);
+        }
+        catch (KeyStoreException | NoSuchAlgorithmException e) {
+            throw new CredentialServiceUnavailableException("Failed to extract credentials from KeyStore", e);
+        }
+    }
+}

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStore.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStore.java
@@ -29,6 +29,7 @@ import io.kroxylicious.scram.credentialstore.CredentialServiceUnavailableExcepti
 import io.kroxylicious.scram.credentialstore.ScramCredential;
 import io.kroxylicious.scram.credentialstore.ScramCredentialStore;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
@@ -125,6 +126,7 @@ public class KeystoreScramCredentialStore implements ScramCredentialStore {
         }
     }
 
+    @Nullable
     private ScramCredential extractCredential(KeyStore keyStore, String alias, char[] keyPassword)
             throws KeyStoreException, NoSuchAlgorithmException, CredentialServiceUnavailableException {
         if (!keyStore.isKeyEntry(alias)) {

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStore.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStore.java
@@ -22,8 +22,6 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-import javax.crypto.SecretKey;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,13 +35,14 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * KeyStore-based implementation of {@link ScramCredentialStore}.
  * <p>
  * Loads all SCRAM credentials from a Java KeyStore file into memory at construction time.
- * Credentials are stored as {@link SecretKey} entries with a hex-encoded SHA-256 hash of the
+ * Credentials are stored as {@link javax.crypto.SecretKey} entries with a hex-encoded SHA-256 hash of the
  * username as the alias. The original username is stored within the JSON payload.
  * </p>
  */
 public class KeystoreScramCredentialStore implements ScramCredentialStore {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KeystoreScramCredentialStore.class);
+    private static final String ALIAS_LOG_KEY = "alias";
 
     private final Map<String, ScramCredential> credentialCache;
     private final ScramCredentialSerializer serializer;
@@ -109,51 +108,57 @@ public class KeystoreScramCredentialStore implements ScramCredentialStore {
      */
     private Map<String, ScramCredential> extractCredentials(KeyStore keyStore, char[] keyPassword) throws CredentialServiceUnavailableException {
         Map<String, ScramCredential> credentials = new HashMap<>();
-
         try {
             Enumeration<String> aliases = keyStore.aliases();
             while (aliases.hasMoreElements()) {
                 String alias = aliases.nextElement();
-
-                if (!keyStore.isKeyEntry(alias)) {
-                    LOGGER.atDebug().addKeyValue("alias", alias).log("Skipping non-key entry");
-                    continue;
+                ScramCredential credential = extractCredential(keyStore, alias, keyPassword);
+                if (credential != null) {
+                    credentials.put(credential.username(), credential);
+                    LOGGER.atDebug().addKeyValue("username", credential.username()).log("Loaded credential");
                 }
-
-                KeyStore.Entry entry;
-                try {
-                    entry = keyStore.getEntry(alias, new KeyStore.PasswordProtection(keyPassword));
-                }
-                catch (UnrecoverableEntryException e) {
-                    throw new CredentialServiceUnavailableException(
-                            "Failed to recover KeyStore entry for alias '" + alias + "' - incorrect key password?", e);
-                }
-
-                if (!(entry instanceof KeyStore.SecretKeyEntry secretKeyEntry)) {
-                    LOGGER.atDebug().addKeyValue("alias", alias).log("Skipping non-SecretKey entry");
-                    continue;
-                }
-
-                SecretKey secretKey = secretKeyEntry.getSecretKey();
-                byte[] credentialBytes = secretKey.getEncoded();
-
-                ScramCredential credential;
-                try {
-                    credential = serializer.deserialize(credentialBytes, alias);
-                }
-                catch (IllegalArgumentException e) {
-                    throw new CredentialServiceUnavailableException(
-                            "Malformed credential in KeyStore entry for alias '" + alias + "'", e);
-                }
-
-                credentials.put(credential.username(), credential);
-                LOGGER.atDebug().addKeyValue("username", credential.username()).log("Loaded credential");
             }
-
             return Collections.unmodifiableMap(credentials);
         }
         catch (KeyStoreException | NoSuchAlgorithmException e) {
             throw new CredentialServiceUnavailableException("Failed to extract credentials from KeyStore", e);
+        }
+    }
+
+    private ScramCredential extractCredential(KeyStore keyStore, String alias, char[] keyPassword)
+            throws KeyStoreException, NoSuchAlgorithmException, CredentialServiceUnavailableException {
+        if (!keyStore.isKeyEntry(alias)) {
+            LOGGER.atDebug().addKeyValue(ALIAS_LOG_KEY, alias).log("Skipping non-key entry");
+            return null;
+        }
+        KeyStore.Entry entry = getKeystoreEntry(keyStore, alias, keyPassword);
+        if (!(entry instanceof KeyStore.SecretKeyEntry secretKeyEntry)) {
+            LOGGER.atDebug().addKeyValue(ALIAS_LOG_KEY, alias).log("Skipping non-SecretKey entry");
+            return null;
+        }
+        return deserializeCredential(secretKeyEntry, alias);
+    }
+
+    private KeyStore.Entry getKeystoreEntry(KeyStore keyStore, String alias, char[] keyPassword)
+            throws KeyStoreException, NoSuchAlgorithmException, CredentialServiceUnavailableException {
+        try {
+            return keyStore.getEntry(alias, new KeyStore.PasswordProtection(keyPassword));
+        }
+        catch (UnrecoverableEntryException e) {
+            throw new CredentialServiceUnavailableException(
+                    "Failed to recover KeyStore entry for alias '" + alias + "' - incorrect key password?", e);
+        }
+    }
+
+    private ScramCredential deserializeCredential(KeyStore.SecretKeyEntry secretKeyEntry, String alias)
+            throws CredentialServiceUnavailableException {
+        byte[] credentialBytes = secretKeyEntry.getSecretKey().getEncoded();
+        try {
+            return serializer.deserialize(credentialBytes, alias);
+        }
+        catch (IllegalArgumentException e) {
+            throw new CredentialServiceUnavailableException(
+                    "Malformed credential in KeyStore entry for alias '" + alias + "'", e);
         }
     }
 }

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreConfig.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreConfig.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.scram.credentialstore.keystore;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.kroxylicious.proxy.config.secret.PasswordProvider;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Configuration for KeyStore-based SCRAM credential store.
+ *
+ * @param file path to the Java KeyStore file
+ * @param storePassword password provider for the KeyStore
+ * @param keyPassword optional password provider for individual keys (defaults to storePassword if not specified)
+ * @param storeType KeyStore type (e.g., "PKCS12", "JKS"). Defaults to KeyStore.getDefaultType() if not specified.
+ */
+public record KeystoreScramCredentialStoreConfig(
+                                                 @JsonProperty(required = true) String file,
+                                                 @JsonProperty(required = true) PasswordProvider storePassword,
+                                                 @Nullable PasswordProvider keyPassword,
+                                                 @Nullable String storeType) {
+
+    /**
+     * Canonical constructor with validation.
+     */
+    public KeystoreScramCredentialStoreConfig {
+        if (file == null) {
+            throw new IllegalArgumentException("file must not be null");
+        }
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("file must not be empty");
+        }
+        if (storePassword == null) {
+            throw new IllegalArgumentException("storePassword must not be null");
+        }
+    }
+
+    /**
+     * Get the key password, defaulting to store password if not specified.
+     *
+     * @return the key password provider
+     */
+    public PasswordProvider effectiveKeyPassword() {
+        return keyPassword != null ? keyPassword : storePassword;
+    }
+
+    /**
+     * Get the store type, defaulting to platform default if not specified.
+     *
+     * @return the KeyStore type
+     */
+    public String effectiveStoreType() {
+        return storeType != null ? storeType : java.security.KeyStore.getDefaultType();
+    }
+}

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreService.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreService.java
@@ -57,6 +57,7 @@ public class KeystoreScramCredentialStoreService implements ScramCredentialStore
      * Creates a new {@code KeystoreScramCredentialStoreService}.
      */
     public KeystoreScramCredentialStoreService() {
+        // Default no-arg constructor required by the plugin framework
     }
 
     @Override

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreService.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreService.java
@@ -53,6 +53,12 @@ public class KeystoreScramCredentialStoreService implements ScramCredentialStore
     private boolean initialized = false;
     private boolean closed = false;
 
+    /**
+     * Creates a new {@code KeystoreScramCredentialStoreService}.
+     */
+    public KeystoreScramCredentialStoreService() {
+    }
+
     @Override
     public void initialize(KeystoreScramCredentialStoreConfig config) {
         if (initialized) {

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreService.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreService.java
@@ -22,7 +22,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * {@link javax.crypto.SecretKey} entries where:
  * </p>
  * <ul>
- *     <li>The alias is the username</li>
+ *     <li>The alias is the lowercase hex SHA-256 hash of the username (UTF-8 encoded)</li>
  *     <li>The key bytes contain JSON-serialized {@link io.kroxylicious.scram.credentialstore.ScramCredential} data</li>
  * </ul>
  *

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreService.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreService.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.scram.credentialstore.keystore;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.scram.credentialstore.ScramCredentialStore;
+import io.kroxylicious.scram.credentialstore.ScramCredentialStoreService;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Service for creating KeyStore-based SCRAM credential stores.
+ * <p>
+ * This service loads credentials from a Java KeyStore file. The KeyStore should contain
+ * {@link javax.crypto.SecretKey} entries where:
+ * </p>
+ * <ul>
+ *     <li>The alias is the username</li>
+ *     <li>The key bytes contain JSON-serialized {@link io.kroxylicious.scram.credentialstore.ScramCredential} data</li>
+ * </ul>
+ *
+ * <h2>Configuration</h2>
+ * <pre>{@code
+ * credentialStore: KeystoreScramCredentialStore
+ * credentialStoreConfig:
+ *   file: /path/to/credentials.jks
+ *   storePassword:
+ *     password: "keystore-password"
+ *   storeType: PKCS12
+ * }</pre>
+ *
+ * <h2>Lifecycle</h2>
+ * <ol>
+ *     <li>{@link #initialize(KeystoreScramCredentialStoreConfig)} - Load and validate configuration</li>
+ *     <li>{@link #buildCredentialStore()} - Create credential store instances (may be called multiple times)</li>
+ *     <li>{@link #close()} - Clean up resources (idempotent)</li>
+ * </ol>
+ */
+@Plugin(configType = KeystoreScramCredentialStoreConfig.class)
+public class KeystoreScramCredentialStoreService implements ScramCredentialStoreService<KeystoreScramCredentialStoreConfig> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KeystoreScramCredentialStoreService.class);
+
+    @Nullable
+    private KeystoreScramCredentialStoreConfig config;
+    private boolean initialized = false;
+    private boolean closed = false;
+
+    @Override
+    public void initialize(KeystoreScramCredentialStoreConfig config) {
+        if (initialized) {
+            throw new IllegalStateException("Service has already been initialized");
+        }
+        if (closed) {
+            throw new IllegalStateException("Service has been closed");
+        }
+
+        this.config = config;
+        this.initialized = true;
+
+        LOGGER.atInfo().addKeyValue("file", config.file()).log("Initialized KeyStore credential store service");
+    }
+
+    @Override
+    public ScramCredentialStore buildCredentialStore() {
+        if (!initialized) {
+            throw new IllegalStateException("Service has not been initialized");
+        }
+        if (closed) {
+            throw new IllegalStateException("Service has been closed");
+        }
+
+        try {
+            return new KeystoreScramCredentialStore(config);
+        }
+        catch (io.kroxylicious.scram.credentialstore.CredentialServiceUnavailableException e) {
+            throw new IllegalStateException("Failed to build credential store", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            return; // Idempotent
+        }
+
+        closed = true;
+        LOGGER.info("Closed KeyStore credential store service");
+    }
+}

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreService.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreService.java
@@ -32,7 +32,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * credentialStoreConfig:
  *   file: /path/to/credentials.jks
  *   storePassword:
- *     password: "keystore-password"
+ *     passwordFile: /etc/kroxylicious/keystore-password.txt
  *   storeType: PKCS12
  * }</pre>
  *

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialSerializer.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialSerializer.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.scram.credentialstore.keystore;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.kroxylicious.scram.credentialstore.ScramCredential;
+import io.kroxylicious.scram.credentialstore.ScramHashAlgorithm;
+
+/**
+ * Serializes and deserializes {@link ScramCredential} objects to/from JSON for storage in KeyStore.
+ * <p>
+ * The JSON payload includes a {@code version} field to allow the format to be evolved
+ * while maintaining backwards compatibility.
+ * </p>
+ */
+public class ScramCredentialSerializer {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    static final int CURRENT_VERSION = 1;
+
+    /**
+     * Serialize a SCRAM credential to JSON bytes.
+     *
+     * @param credential the credential to serialize
+     * @return JSON bytes suitable for storing in a KeyStore SecretKey
+     * @throws IllegalArgumentException if serialization fails
+     */
+    public byte[] serialize(ScramCredential credential) {
+        try {
+            var versioned = new VersionedCredential(
+                    CURRENT_VERSION,
+                    credential.username(),
+                    credential.salt(),
+                    credential.iterations(),
+                    credential.serverKey(),
+                    credential.storedKey(),
+                    credential.hashAlgorithm().algorithmName());
+            return OBJECT_MAPPER.writeValueAsBytes(versioned);
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException("Failed to serialize credential for user: " + credential.username(), e);
+        }
+    }
+
+    /**
+     * Deserialize a SCRAM credential from JSON bytes.
+     *
+     * @param bytes JSON bytes from a KeyStore SecretKey
+     * @param alias the KeyStore alias (used for error messages)
+     * @return the deserialized credential
+     * @throws IllegalArgumentException if deserialization or validation fails
+     */
+    public ScramCredential deserialize(byte[] bytes, String alias) {
+        VersionedCredential versioned;
+        try {
+            versioned = OBJECT_MAPPER.readValue(bytes, VersionedCredential.class);
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException("Failed to deserialize credential for alias: " + alias, e);
+        }
+        if (versioned.version() != CURRENT_VERSION) {
+            throw new IllegalArgumentException(
+                    "Unsupported credential version " + versioned.version() + " for alias: " + alias
+                            + " (expected " + CURRENT_VERSION + ")");
+        }
+        try {
+            return new ScramCredential(
+                    versioned.username(),
+                    versioned.salt(),
+                    versioned.iterations(),
+                    versioned.serverKey(),
+                    versioned.storedKey(),
+                    ScramHashAlgorithm.fromAlgorithmName(versioned.hashAlgorithm()));
+        }
+        catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid credential for alias: " + alias, e);
+        }
+    }
+
+    // Sensitive byte[] fields (salt, serverKey, storedKey) live in the JVM heap for the
+    // lifetime of this object. This is an accepted risk: the same data already resides in
+    // the ScramCredential record that this type feeds into, and there is no practical way
+    // to guarantee memory clearing in a JVM (GC copies, JIT dead-store elimination).
+    // See the "Accepted risk: credential material in JVM heap" section of proposal 124.
+    @SuppressWarnings("ArrayRecordComponent") // defensive copies, equals and hashCode are overridden
+    record VersionedCredential(
+                               @JsonProperty(required = true) int version,
+                               @JsonProperty(required = true) String username,
+                               @JsonProperty(required = true) byte[] salt,
+                               @JsonProperty(required = true) int iterations,
+                               @JsonProperty(required = true) byte[] serverKey,
+                               @JsonProperty(required = true) byte[] storedKey,
+                               @JsonProperty(required = true) String hashAlgorithm) {
+
+        VersionedCredential {
+            salt = salt != null ? salt.clone() : null;
+            serverKey = serverKey != null ? serverKey.clone() : null;
+            storedKey = storedKey != null ? storedKey.clone() : null;
+        }
+
+        @Override
+        public byte[] salt() {
+            return salt != null ? salt.clone() : null;
+        }
+
+        @Override
+        public byte[] serverKey() {
+            return serverKey != null ? serverKey.clone() : null;
+        }
+
+        @Override
+        public byte[] storedKey() {
+            return storedKey != null ? storedKey.clone() : null;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof VersionedCredential that)) {
+                return false;
+            }
+            return version == that.version
+                    && iterations == that.iterations
+                    && Objects.equals(username, that.username)
+                    && Arrays.equals(salt, that.salt)
+                    && Arrays.equals(serverKey, that.serverKey)
+                    && Arrays.equals(storedKey, that.storedKey)
+                    && Objects.equals(hashAlgorithm, that.hashAlgorithm);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = Objects.hash(version, username, iterations, hashAlgorithm);
+            result = 31 * result + Arrays.hashCode(salt);
+            result = 31 * result + Arrays.hashCode(serverKey);
+            result = 31 * result + Arrays.hashCode(storedKey);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "VersionedCredential{version=" + version
+                    + ", username='" + username + "'"
+                    + ", iterations=" + iterations
+                    + ", hashAlgorithm='" + hashAlgorithm + "'"
+                    + "}";
+        }
+    }
+}

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialSerializer.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialSerializer.java
@@ -32,6 +32,7 @@ public class ScramCredentialSerializer {
      * Creates a new {@code ScramCredentialSerializer}.
      */
     public ScramCredentialSerializer() {
+        // Default constructor - uses the shared static ObjectMapper
     }
 
     /**
@@ -134,16 +135,16 @@ public class ScramCredentialSerializer {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof VersionedCredential that)) {
-                return false;
+            if (o instanceof VersionedCredential(var otherVersion, var otherUsername, var otherSalt, var otherIterations, var otherServerKey, var otherStoredKey, var otherHashAlgorithm)) {
+                return version == otherVersion
+                        && iterations == otherIterations
+                        && Objects.equals(username, otherUsername)
+                        && Arrays.equals(salt, otherSalt)
+                        && Arrays.equals(serverKey, otherServerKey)
+                        && Arrays.equals(storedKey, otherStoredKey)
+                        && Objects.equals(hashAlgorithm, otherHashAlgorithm);
             }
-            return version == that.version
-                    && iterations == that.iterations
-                    && Objects.equals(username, that.username)
-                    && Arrays.equals(salt, that.salt)
-                    && Arrays.equals(serverKey, that.serverKey)
-                    && Arrays.equals(storedKey, that.storedKey)
-                    && Objects.equals(hashAlgorithm, that.hashAlgorithm);
+            return false;
         }
 
         @Override

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialSerializer.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialSerializer.java
@@ -29,6 +29,12 @@ public class ScramCredentialSerializer {
     static final int CURRENT_VERSION = 1;
 
     /**
+     * Creates a new {@code ScramCredentialSerializer}.
+     */
+    public ScramCredentialSerializer() {
+    }
+
+    /**
      * Serialize a SCRAM credential to JSON bytes.
      *
      * @param credential the credential to serialize

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/TestCredentialGenerator.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/TestCredentialGenerator.java
@@ -7,12 +7,15 @@
 package io.kroxylicious.scram.credentialstore.keystore;
 
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.security.KeyStore;
+import java.security.KeyStoreException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.security.cert.CertificateException;
 import java.util.HexFormat;
 
 import javax.crypto.SecretKey;
@@ -67,7 +70,7 @@ public class TestCredentialGenerator {
                                  Path outputPath,
                                  String storePassword,
                                  String... users)
-            throws Exception {
+            throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException {
         generateKeyStore(outputPath, storePassword, storePassword, ScramMechanism.SCRAM_SHA_256, users);
     }
 
@@ -87,7 +90,7 @@ public class TestCredentialGenerator {
                                  String keyPassword,
                                  ScramMechanism mechanism,
                                  String... users)
-            throws Exception {
+            throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException {
         if (users.length % 2 != 0) {
             throw new IllegalArgumentException("users must contain alternating username/password pairs");
         }

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/TestCredentialGenerator.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/TestCredentialGenerator.java
@@ -35,14 +35,28 @@ public class TestCredentialGenerator {
     private static final int SALT_LENGTH = 20;
     private final SecureRandom secureRandom;
 
+    /**
+     * Creates a generator using a default {@link SecureRandom}.
+     */
     public TestCredentialGenerator() {
         this(new SecureRandom());
     }
 
+    /**
+     * Creates a generator using the given {@link SecureRandom}.
+     * @param secureRandom the source of randomness
+     */
     public TestCredentialGenerator(SecureRandom secureRandom) {
         this.secureRandom = secureRandom;
     }
 
+    /**
+     * Generates a PKCS12 keystore containing SCRAM-SHA-256 credentials.
+     * @param outputPath path to write the keystore file
+     * @param storePassword password for the keystore
+     * @param users alternating username/password pairs
+     * @throws Exception if keystore generation fails
+     */
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "File path comes from trusted test configuration")
     public void generateKeyStore(
                                  Path outputPath,
@@ -52,6 +66,14 @@ public class TestCredentialGenerator {
         generateKeyStore(outputPath, storePassword, ScramMechanism.SCRAM_SHA_256, users);
     }
 
+    /**
+     * Generates a PKCS12 keystore containing SCRAM credentials for the given mechanism.
+     * @param outputPath path to write the keystore file
+     * @param storePassword password for the keystore
+     * @param mechanism the SCRAM mechanism to use
+     * @param users alternating username/password pairs
+     * @throws Exception if keystore generation fails
+     */
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "File path comes from trusted test configuration")
     public void generateKeyStore(
                                  Path outputPath,
@@ -88,6 +110,13 @@ public class TestCredentialGenerator {
         KeystoreFilePermissions.setOwnerOnly(outputPath);
     }
 
+    /**
+     * Generates a single SCRAM credential for the given user.
+     * @param username the username
+     * @param password the password
+     * @param mechanism the SCRAM mechanism to use
+     * @return the generated credential
+     */
     public ScramCredential generateScramCredential(
                                                    String username,
                                                    String password,

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/TestCredentialGenerator.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/TestCredentialGenerator.java
@@ -27,7 +27,11 @@ import io.kroxylicious.scram.credentialstore.ScramHashAlgorithm;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
- * Utility for generating test keystores with SCRAM credentials.
+ * Utility for generating KeyStore files populated with SCRAM credentials, for use in tests.
+ * <p>
+ * This class lives in {@code src/main} so it can be used by tests in other modules
+ * (e.g. integration tests) that depend on this module.
+ * </p>
  */
 public class TestCredentialGenerator {
 
@@ -52,8 +56,9 @@ public class TestCredentialGenerator {
 
     /**
      * Generates a PKCS12 keystore containing SCRAM-SHA-256 credentials.
+     * The key password is the same as the store password.
      * @param outputPath path to write the keystore file
-     * @param storePassword password for the keystore
+     * @param storePassword password for the keystore and each individual key entry
      * @param users alternating username/password pairs
      * @throws Exception if keystore generation fails
      */
@@ -63,13 +68,14 @@ public class TestCredentialGenerator {
                                  String storePassword,
                                  String... users)
             throws Exception {
-        generateKeyStore(outputPath, storePassword, ScramMechanism.SCRAM_SHA_256, users);
+        generateKeyStore(outputPath, storePassword, storePassword, ScramMechanism.SCRAM_SHA_256, users);
     }
 
     /**
      * Generates a PKCS12 keystore containing SCRAM credentials for the given mechanism.
      * @param outputPath path to write the keystore file
      * @param storePassword password for the keystore
+     * @param keyPassword password for each individual key entry
      * @param mechanism the SCRAM mechanism to use
      * @param users alternating username/password pairs
      * @throws Exception if keystore generation fails
@@ -78,6 +84,7 @@ public class TestCredentialGenerator {
     public void generateKeyStore(
                                  Path outputPath,
                                  String storePassword,
+                                 String keyPassword,
                                  ScramMechanism mechanism,
                                  String... users)
             throws Exception {
@@ -99,7 +106,7 @@ public class TestCredentialGenerator {
 
             SecretKey secretKey = new SecretKeySpec(credentialBytes, "AES");
             KeyStore.SecretKeyEntry entry = new KeyStore.SecretKeyEntry(secretKey);
-            KeyStore.PasswordProtection protection = new KeyStore.PasswordProtection(storePassword.toCharArray());
+            KeyStore.PasswordProtection protection = new KeyStore.PasswordProtection(keyPassword.toCharArray());
 
             keyStore.setEntry(hashUsername(username), entry, protection);
         }

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/TestCredentialGenerator.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/TestCredentialGenerator.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.scram.credentialstore.keystore;
+
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.HexFormat;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.kafka.common.security.scram.internals.ScramFormatter;
+import org.apache.kafka.common.security.scram.internals.ScramMechanism;
+
+import io.kroxylicious.scram.credentialstore.ScramCredential;
+import io.kroxylicious.scram.credentialstore.ScramHashAlgorithm;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Utility for generating test keystores with SCRAM credentials.
+ */
+public class TestCredentialGenerator {
+
+    private static final int DEFAULT_ITERATIONS = 10000;
+    private static final int SALT_LENGTH = 20;
+    private final SecureRandom secureRandom;
+
+    public TestCredentialGenerator() {
+        this(new SecureRandom());
+    }
+
+    public TestCredentialGenerator(SecureRandom secureRandom) {
+        this.secureRandom = secureRandom;
+    }
+
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "File path comes from trusted test configuration")
+    public void generateKeyStore(
+                                 Path outputPath,
+                                 String storePassword,
+                                 String... users)
+            throws Exception {
+        generateKeyStore(outputPath, storePassword, ScramMechanism.SCRAM_SHA_256, users);
+    }
+
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "File path comes from trusted test configuration")
+    public void generateKeyStore(
+                                 Path outputPath,
+                                 String storePassword,
+                                 ScramMechanism mechanism,
+                                 String... users)
+            throws Exception {
+        if (users.length % 2 != 0) {
+            throw new IllegalArgumentException("users must contain alternating username/password pairs");
+        }
+
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(null, storePassword.toCharArray());
+
+        for (int i = 0; i < users.length; i += 2) {
+            String username = users[i];
+            String password = users[i + 1];
+
+            ScramCredential credential = generateScramCredential(username, password, mechanism);
+
+            ScramCredentialSerializer serializer = new ScramCredentialSerializer();
+            byte[] credentialBytes = serializer.serialize(credential);
+
+            SecretKey secretKey = new SecretKeySpec(credentialBytes, "AES");
+            KeyStore.SecretKeyEntry entry = new KeyStore.SecretKeyEntry(secretKey);
+            KeyStore.PasswordProtection protection = new KeyStore.PasswordProtection(storePassword.toCharArray());
+
+            keyStore.setEntry(hashUsername(username), entry, protection);
+        }
+
+        try (FileOutputStream fos = new FileOutputStream(outputPath.toFile())) {
+            keyStore.store(fos, storePassword.toCharArray());
+        }
+        KeystoreFilePermissions.setOwnerOnly(outputPath);
+    }
+
+    public ScramCredential generateScramCredential(
+                                                   String username,
+                                                   String password,
+                                                   ScramMechanism mechanism) {
+        try {
+            byte[] salt = new byte[SALT_LENGTH];
+            secureRandom.nextBytes(salt);
+
+            ScramFormatter formatter = new ScramFormatter(mechanism);
+
+            byte[] saltedPassword = formatter.saltedPassword(password, salt, DEFAULT_ITERATIONS);
+            byte[] serverKey = formatter.serverKey(saltedPassword);
+            byte[] clientKey = formatter.clientKey(saltedPassword);
+            byte[] storedKey = formatter.storedKey(clientKey);
+
+            ScramHashAlgorithm hashAlgorithm = mechanism == ScramMechanism.SCRAM_SHA_256 ? ScramHashAlgorithm.SHA_256 : ScramHashAlgorithm.SHA_512;
+
+            return new ScramCredential(
+                    username,
+                    salt,
+                    DEFAULT_ITERATIONS,
+                    serverKey,
+                    storedKey,
+                    hashAlgorithm);
+        }
+        catch (Exception e) {
+            throw new IllegalArgumentException("Failed to generate SCRAM credential", e);
+        }
+    }
+
+    static String hashUsername(String username) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(username.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+}

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/TestCredentialGenerator.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/TestCredentialGenerator.java
@@ -63,7 +63,10 @@ public class TestCredentialGenerator {
      * @param outputPath path to write the keystore file
      * @param storePassword password for the keystore and each individual key entry
      * @param users alternating username/password pairs
-     * @throws Exception if keystore generation fails
+     * @throws KeyStoreException if the keystore type is not available
+     * @throws NoSuchAlgorithmException if the SCRAM algorithm is not available
+     * @throws CertificateException if a certificate in the keystore could not be loaded
+     * @throws IOException if the keystore file cannot be written
      */
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "File path comes from trusted test configuration")
     public void generateKeyStore(
@@ -81,7 +84,10 @@ public class TestCredentialGenerator {
      * @param keyPassword password for each individual key entry
      * @param mechanism the SCRAM mechanism to use
      * @param users alternating username/password pairs
-     * @throws Exception if keystore generation fails
+     * @throws KeyStoreException if the keystore type is not available
+     * @throws NoSuchAlgorithmException if the SCRAM algorithm is not available
+     * @throws CertificateException if a certificate in the keystore could not be loaded
+     * @throws IOException if the keystore file cannot be written
      */
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "File path comes from trusted test configuration")
     public void generateKeyStore(

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/package-info.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/package-info.java
@@ -5,62 +5,27 @@
  */
 
 /**
- * Pluggable SASL credential store API.
+ * Java KeyStore-backed implementation of the SCRAM credential store SPI.
  * <p>
- * This package provides an abstraction for SCRAM credential storage, allowing
- * SASL termination filters to authenticate clients against various backing stores
- * such as files, databases, LDAP directories, or external identity providers.
+ * This package provides {@link io.kroxylicious.scram.credentialstore.keystore.KeystoreScramCredentialStoreService},
+ * a {@link io.kroxylicious.scram.credentialstore.ScramCredentialStoreService} plugin that loads
+ * SCRAM credentials from a Java KeyStore file (JKS or PKCS12) at startup for fast, synchronous
+ * lookups during SASL authentication.
  * </p>
  *
- * <h2>Core Interfaces</h2>
+ * <h2>KeyStore Format</h2>
+ * <p>
+ * Credentials are stored as {@link javax.crypto.SecretKey} entries. Each entry:
+ * </p>
  * <ul>
- *     <li>{@link io.kroxylicious.scram.credentialstore.ScramCredentialStoreService} -
- *         Service interface for discovering and initialising credential stores</li>
- *     <li>{@link io.kroxylicious.scram.credentialstore.ScramCredentialStore} -
- *         Store interface for looking up credentials</li>
+ *     <li>Uses the SHA-256 hex-encoded hash of the username as its alias</li>
+ *     <li>Contains JSON-serialized {@link io.kroxylicious.scram.credentialstore.ScramCredential}
+ *         data as the key bytes</li>
  * </ul>
- *
- * <h2>Data Types</h2>
- * <ul>
- *     <li>{@link io.kroxylicious.scram.credentialstore.ScramCredential} -
- *         Immutable SCRAM credential with validation</li>
- * </ul>
- *
- * <h2>Exception Handling</h2>
- * <ul>
- *     <li>{@link io.kroxylicious.scram.credentialstore.CredentialLookupException} -
- *         Base exception for lookup failures</li>
- *     <li>{@link io.kroxylicious.scram.credentialstore.CredentialServiceUnavailableException} -
- *         Service is unavailable</li>
- *     <li>{@link io.kroxylicious.scram.credentialstore.CredentialServiceTimeoutException} -
- *         Operation timed out</li>
- * </ul>
- *
- * <h2>Usage Example</h2>
- * <pre>{@code
- * // Initialise service
- * ScramCredentialStoreService<MyConfig> service = ...;
- * service.initialize(config);
- *
- * // Build credential store
- * ScramCredentialStore store = service.buildCredentialStore();
- *
- * // Look up credential asynchronously
- * CompletionStage<ScramCredential> stage = store.lookupCredential("alice");
- * stage.thenAccept(credential -> {
- *     if (credential != null) {
- *         // Authenticate using credential
- *     } else {
- *         // User not found
- *     }
- * }).exceptionally(error -> {
- *     // Handle service failure
- *     return null;
- * });
- *
- * // Clean up
- * service.close();
- * }</pre>
+ * <p>
+ * Using a hash of the username as the alias prevents leaking usernames if the
+ * KeyStore file is inspected directly.
+ * </p>
  */
 @ReturnValuesAreNonnullByDefault
 @DefaultAnnotationForParameters(NonNull.class)

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/package-info.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/package-info.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * Pluggable SASL credential store API.
+ * <p>
+ * This package provides an abstraction for SCRAM credential storage, allowing
+ * SASL termination filters to authenticate clients against various backing stores
+ * such as files, databases, LDAP directories, or external identity providers.
+ * </p>
+ *
+ * <h2>Core Interfaces</h2>
+ * <ul>
+ *     <li>{@link io.kroxylicious.scram.credentialstore.ScramCredentialStoreService} -
+ *         Service interface for discovering and initialising credential stores</li>
+ *     <li>{@link io.kroxylicious.scram.credentialstore.ScramCredentialStore} -
+ *         Store interface for looking up credentials</li>
+ * </ul>
+ *
+ * <h2>Data Types</h2>
+ * <ul>
+ *     <li>{@link io.kroxylicious.scram.credentialstore.ScramCredential} -
+ *         Immutable SCRAM credential with validation</li>
+ * </ul>
+ *
+ * <h2>Exception Handling</h2>
+ * <ul>
+ *     <li>{@link io.kroxylicious.scram.credentialstore.CredentialLookupException} -
+ *         Base exception for lookup failures</li>
+ *     <li>{@link io.kroxylicious.scram.credentialstore.CredentialServiceUnavailableException} -
+ *         Service is unavailable</li>
+ *     <li>{@link io.kroxylicious.scram.credentialstore.CredentialServiceTimeoutException} -
+ *         Operation timed out</li>
+ * </ul>
+ *
+ * <h2>Usage Example</h2>
+ * <pre>{@code
+ * // Initialise service
+ * ScramCredentialStoreService<MyConfig> service = ...;
+ * service.initialize(config);
+ *
+ * // Build credential store
+ * ScramCredentialStore store = service.buildCredentialStore();
+ *
+ * // Look up credential asynchronously
+ * CompletionStage<ScramCredential> stage = store.lookupCredential("alice");
+ * stage.thenAccept(credential -> {
+ *     if (credential != null) {
+ *         // Authenticate using credential
+ *     } else {
+ *         // User not found
+ *     }
+ * }).exceptionally(error -> {
+ *     // Handle service failure
+ *     return null;
+ * });
+ *
+ * // Clean up
+ * service.close();
+ * }</pre>
+ */
+@ReturnValuesAreNonnullByDefault
+@DefaultAnnotationForParameters(NonNull.class)
+@DefaultAnnotation(NonNull.class)
+package io.kroxylicious.scram.credentialstore.keystore;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotationForParameters;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/resources/META-INF/services/io.kroxylicious.scram.credentialstore.ScramCredentialStoreService
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/resources/META-INF/services/io.kroxylicious.scram.credentialstore.ScramCredentialStoreService
@@ -1,0 +1,1 @@
+io.kroxylicious.scram.credentialstore.keystore.KeystoreScramCredentialStoreService

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreFilePermissionsTest.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreFilePermissionsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.scram.credentialstore.keystore;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermissions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+
+import io.kroxylicious.scram.credentialstore.CredentialServiceUnavailableException;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class KeystoreFilePermissionsTest {
+
+    @Test
+    @SetEnvironmentVariable(key = KeystoreFilePermissions.PERMISSION_CHECK_ENV_VAR, value = "0640")
+    void shouldAllowGroupReadableFileInRelaxedMode(@TempDir Path tempDir) throws IOException {
+        // Given
+        Path file = createFile(tempDir);
+        assumePosixPermissions(file);
+        Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rw-r-----"));
+
+        // When/Then
+        assertThatCode(() -> KeystoreFilePermissions.checkForCredentialStore(file))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = KeystoreFilePermissions.PERMISSION_CHECK_ENV_VAR, value = "0640")
+    void shouldRejectGroupWritableFileEvenInRelaxedMode(@TempDir Path tempDir) throws IOException {
+        // Given
+        Path file = createFile(tempDir);
+        assumePosixPermissions(file);
+        Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rw--w----"));
+
+        // When/Then
+        assertThatThrownBy(() -> KeystoreFilePermissions.checkForCredentialStore(file))
+                .isInstanceOf(CredentialServiceUnavailableException.class)
+                .hasMessageContaining("insecure permissions");
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = KeystoreFilePermissions.PERMISSION_CHECK_ENV_VAR, value = "unrecognized-value")
+    void shouldUseStrictModeForUnrecognizedEnvVarValue(@TempDir Path tempDir) throws IOException {
+        // Given
+        Path file = createFile(tempDir);
+        assumePosixPermissions(file);
+        Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rw-r-----"));
+
+        // When/Then - group-readable is insecure in strict mode
+        assertThatThrownBy(() -> KeystoreFilePermissions.checkForCredentialStore(file))
+                .isInstanceOf(CredentialServiceUnavailableException.class)
+                .hasMessageContaining("insecure permissions");
+    }
+
+    private static Path createFile(Path dir) throws IOException {
+        return Files.createTempFile(dir, "keystore-perm-test", ".tmp");
+    }
+
+    private static void assumePosixPermissions(Path path) {
+        assumeTrue(
+                Files.getFileAttributeView(path, PosixFileAttributeView.class) != null,
+                "POSIX file permissions not supported on this platform");
+    }
+}

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreConfigTest.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreConfigTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.scram.credentialstore.keystore;
+
+import java.security.KeyStore;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.secret.InlinePassword;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class KeystoreScramCredentialStoreConfigTest {
+
+    private static final InlinePassword DUMMY_PASSWORD = new InlinePassword("secret");
+
+    @Test
+    void shouldRejectNullFile() {
+        assertThatThrownBy(() -> new KeystoreScramCredentialStoreConfig(null, DUMMY_PASSWORD, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("file must not be null");
+    }
+
+    @Test
+    void shouldRejectEmptyFile() {
+        assertThatThrownBy(() -> new KeystoreScramCredentialStoreConfig("", DUMMY_PASSWORD, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("file must not be empty");
+    }
+
+    @Test
+    void shouldRejectNullStorePassword() {
+        assertThatThrownBy(() -> new KeystoreScramCredentialStoreConfig("keystore.p12", null, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("storePassword must not be null");
+    }
+
+    @Test
+    void shouldUseDefaultKeyStoreTypeWhenStoreTypeIsNull() {
+        // Given
+        var config = new KeystoreScramCredentialStoreConfig("keystore.p12", DUMMY_PASSWORD, null, null);
+
+        // When
+        String type = config.effectiveStoreType();
+
+        // Then
+        assertThat(type).isEqualTo(KeyStore.getDefaultType());
+    }
+}

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreServiceTest.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreServiceTest.java
@@ -8,6 +8,8 @@ package io.kroxylicious.scram.credentialstore.keystore;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermissions;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,10 +44,8 @@ class KeystoreScramCredentialStoreServiceTest {
                 STORE_PASSWORD,
                 "alice", "alice-secret");
 
-        if (java.nio.file.Files.getFileAttributeView(keystorePath,
-                java.nio.file.attribute.PosixFileAttributeView.class) != null) {
-            java.nio.file.Files.setPosixFilePermissions(keystorePath,
-                    java.nio.file.attribute.PosixFilePermissions.fromString("rw-------"));
+        if (Files.getFileAttributeView(keystorePath, PosixFileAttributeView.class) != null) {
+            Files.setPosixFilePermissions(keystorePath, PosixFilePermissions.fromString("rw-------"));
         }
 
         config = new KeystoreScramCredentialStoreConfig(

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreServiceTest.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreServiceTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.scram.credentialstore.keystore;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.kroxylicious.proxy.config.secret.InlinePassword;
+import io.kroxylicious.scram.credentialstore.ScramCredentialStore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class KeystoreScramCredentialStoreServiceTest {
+
+    private static final String STORE_PASSWORD = "test-password";
+
+    @TempDir
+    Path tempDir;
+
+    private Path keystorePath;
+    private KeystoreScramCredentialStoreConfig config;
+    private KeystoreScramCredentialStoreService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        keystorePath = tempDir.resolve("test-credentials.jks");
+
+        var generator = new TestCredentialGenerator();
+        generator.generateKeyStore(
+                keystorePath,
+                STORE_PASSWORD,
+                "alice", "alice-secret");
+
+        if (java.nio.file.Files.getFileAttributeView(keystorePath,
+                java.nio.file.attribute.PosixFileAttributeView.class) != null) {
+            java.nio.file.Files.setPosixFilePermissions(keystorePath,
+                    java.nio.file.attribute.PosixFilePermissions.fromString("rw-------"));
+        }
+
+        config = new KeystoreScramCredentialStoreConfig(
+                keystorePath.toString(),
+                new InlinePassword(STORE_PASSWORD),
+                null,
+                "PKCS12");
+
+        service = new KeystoreScramCredentialStoreService();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (service != null) {
+            service.close();
+        }
+        if (keystorePath != null && Files.exists(keystorePath)) {
+            Files.delete(keystorePath);
+        }
+    }
+
+    @Test
+    void shouldInitializeSuccessfully() {
+        assertThatCode(() -> service.initialize(config))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldBuildCredentialStoreAfterInitialize() {
+        service.initialize(config);
+        ScramCredentialStore store = service.buildCredentialStore();
+
+        assertThat(store).isNotNull()
+                .isInstanceOf(KeystoreScramCredentialStore.class);
+    }
+
+    @Test
+    void shouldBuildMultipleStores() {
+        service.initialize(config);
+
+        ScramCredentialStore store1 = service.buildCredentialStore();
+        ScramCredentialStore store2 = service.buildCredentialStore();
+
+        assertThat(store1).isNotNull();
+        assertThat(store2).isNotNull();
+        assertThat(store1).isNotSameAs(store2);
+    }
+
+    @Test
+    void shouldRejectBuildBeforeInitialize() {
+        assertThatThrownBy(() -> service.buildCredentialStore())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not been initialized");
+    }
+
+    @Test
+    void shouldRejectDoubleInitialize() {
+        service.initialize(config);
+
+        assertThatThrownBy(() -> service.initialize(config))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("already been initialized");
+    }
+
+    @Test
+    void shouldRejectBuildAfterClose() {
+        service.initialize(config);
+        service.close();
+
+        assertThatThrownBy(() -> service.buildCredentialStore())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("been closed");
+    }
+
+    @Test
+    void shouldRejectInitializeAfterClose() {
+        service.close();
+
+        assertThatThrownBy(() -> service.initialize(config))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("been closed");
+    }
+
+    @Test
+    void shouldAllowMultipleClose() {
+        service.initialize(config);
+
+        assertThatCode(() -> {
+            service.close();
+            service.close();
+            service.close();
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldAllowCloseWithoutInitialize() {
+        try (KeystoreScramCredentialStoreService uninitializedService = new KeystoreScramCredentialStoreService()) {
+
+            assertThatCode(uninitializedService::close)
+                    .doesNotThrowAnyException();
+        }
+    }
+}

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreTest.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreTest.java
@@ -6,11 +6,15 @@
 
 package io.kroxylicious.scram.credentialstore.keystore;
 
+import java.io.FileOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.security.KeyStore;
 import java.util.concurrent.CompletionStage;
+
+import javax.crypto.spec.SecretKeySpec;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -209,19 +213,79 @@ class KeystoreScramCredentialStoreTest {
     }
 
     @Test
-    void shouldUseSeparateKeyPasswordWhenProvided() {
+    void shouldUseSeparateKeyPasswordWhenProvided() throws Exception {
+        // Given
         String keyPassword = "different-key-password";
-
-        // For this test, we'd need to generate a keystore with different key passwords
-        // but TestCredentialGenerator currently uses the same password for both
-        // This test documents the intended behaviour
+        Path keystoreWithSeparateKeyPassword = tempDir.resolve("separate-key-pw.p12");
+        var generator = new TestCredentialGenerator();
+        generator.generateKeyStore(keystoreWithSeparateKeyPassword,
+                STORE_PASSWORD, keyPassword,
+                org.apache.kafka.common.security.scram.internals.ScramMechanism.SCRAM_SHA_256,
+                "alice", ALICE_PASSWORD);
+        if (Files.getFileAttributeView(keystoreWithSeparateKeyPassword, PosixFileAttributeView.class) != null) {
+            Files.setPosixFilePermissions(keystoreWithSeparateKeyPassword, PosixFilePermissions.fromString("rw-------"));
+        }
         KeystoreScramCredentialStoreConfig configWithKeyPassword = new KeystoreScramCredentialStoreConfig(
-                keystorePath.toString(),
+                keystoreWithSeparateKeyPassword.toString(),
                 new InlinePassword(STORE_PASSWORD),
-                new InlinePassword(STORE_PASSWORD), // Same for now
+                new InlinePassword(keyPassword),
                 "PKCS12");
 
+        // When/Then
         assertThatCode(() -> new KeystoreScramCredentialStore(configWithKeyPassword))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldFailIfKeyPasswordIsWrong() throws Exception {
+        // Given
+        String keyPassword = "correct-key-password";
+        Path keystoreWithKeyPassword = tempDir.resolve("key-pw.p12");
+        var generator = new TestCredentialGenerator();
+        generator.generateKeyStore(keystoreWithKeyPassword,
+                STORE_PASSWORD, keyPassword,
+                org.apache.kafka.common.security.scram.internals.ScramMechanism.SCRAM_SHA_256,
+                "alice", ALICE_PASSWORD);
+        if (Files.getFileAttributeView(keystoreWithKeyPassword, PosixFileAttributeView.class) != null) {
+            Files.setPosixFilePermissions(keystoreWithKeyPassword, PosixFilePermissions.fromString("rw-------"));
+        }
+        KeystoreScramCredentialStoreConfig configWithWrongKeyPassword = new KeystoreScramCredentialStoreConfig(
+                keystoreWithKeyPassword.toString(),
+                new InlinePassword(STORE_PASSWORD),
+                new InlinePassword("wrong-key-password"),
+                "PKCS12");
+
+        // When/Then
+        assertThatThrownBy(() -> new KeystoreScramCredentialStore(configWithWrongKeyPassword))
+                .isInstanceOf(CredentialServiceUnavailableException.class);
+    }
+
+    @Test
+    void shouldFailIfEntryIsMalformed() throws Exception {
+        // Given - a keystore with a SecretKey entry containing garbage (not valid JSON)
+        Path malformedKeystorePath = tempDir.resolve("malformed.p12");
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        ks.load(null, STORE_PASSWORD.toCharArray());
+        byte[] garbage = new byte[]{ 1, 2, 3, 4, 5 };
+        ks.setEntry(
+                TestCredentialGenerator.hashUsername("alice"),
+                new KeyStore.SecretKeyEntry(new SecretKeySpec(garbage, "AES")),
+                new KeyStore.PasswordProtection(STORE_PASSWORD.toCharArray()));
+        try (FileOutputStream fos = new FileOutputStream(malformedKeystorePath.toFile())) {
+            ks.store(fos, STORE_PASSWORD.toCharArray());
+        }
+        if (Files.getFileAttributeView(malformedKeystorePath, PosixFileAttributeView.class) != null) {
+            Files.setPosixFilePermissions(malformedKeystorePath, PosixFilePermissions.fromString("rw-------"));
+        }
+        KeystoreScramCredentialStoreConfig malformedConfig = new KeystoreScramCredentialStoreConfig(
+                malformedKeystorePath.toString(),
+                new InlinePassword(STORE_PASSWORD),
+                null,
+                "PKCS12");
+
+        // When/Then
+        assertThatThrownBy(() -> new KeystoreScramCredentialStore(malformedConfig))
+                .isInstanceOf(CredentialServiceUnavailableException.class)
+                .hasMessageContaining("Malformed credential");
     }
 }

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreTest.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreTest.java
@@ -6,12 +6,18 @@
 
 package io.kroxylicious.scram.credentialstore.keystore;
 
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.security.KeyPairGenerator;
 import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
 import java.util.concurrent.CompletionStage;
 
 import javax.crypto.spec.SecretKeySpec;
@@ -197,6 +203,55 @@ class KeystoreScramCredentialStoreTest {
         assertRejectsPermission("rw--w----");
     }
 
+    @Test
+    void shouldSkipTrustedCertificateEntries() throws Exception {
+        // Given - a keystore that also has a trusted certificate entry (non-key entry)
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        try (FileInputStream fis = new FileInputStream(keystorePath.toFile())) {
+            ks.load(fis, STORE_PASSWORD.toCharArray());
+        }
+        ks.setCertificateEntry("trusted-ca", loadTestCertificate());
+        try (FileOutputStream fos = new FileOutputStream(keystorePath.toFile())) {
+            ks.store(fos, STORE_PASSWORD.toCharArray());
+        }
+        KeystoreFilePermissions.setOwnerOnly(keystorePath);
+
+        // When
+        KeystoreScramCredentialStore loaded = new KeystoreScramCredentialStore(config);
+
+        // Then - credential entries are still accessible; certificate entry was silently skipped
+        assertThat(loaded.lookupCredential("alice").toCompletableFuture().join()).isNotNull();
+        assertThat(loaded.lookupCredential("bob").toCompletableFuture().join()).isNotNull();
+    }
+
+    @Test
+    void shouldSkipPrivateKeyEntries() throws Exception {
+        // Given - a keystore that also has a private key entry (key entry, but not a SecretKeyEntry)
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        try (FileInputStream fis = new FileInputStream(keystorePath.toFile())) {
+            ks.load(fis, STORE_PASSWORD.toCharArray());
+        }
+        Certificate cert = loadTestCertificate();
+        var kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(1024);
+        var kp = kpg.generateKeyPair();
+        ks.setEntry(
+                "private-key-entry",
+                new KeyStore.PrivateKeyEntry(kp.getPrivate(), new Certificate[]{ cert }),
+                new KeyStore.PasswordProtection(STORE_PASSWORD.toCharArray()));
+        try (FileOutputStream fos = new FileOutputStream(keystorePath.toFile())) {
+            ks.store(fos, STORE_PASSWORD.toCharArray());
+        }
+        KeystoreFilePermissions.setOwnerOnly(keystorePath);
+
+        // When
+        KeystoreScramCredentialStore loaded = new KeystoreScramCredentialStore(config);
+
+        // Then - credential entries are still accessible; private key entry was silently skipped
+        assertThat(loaded.lookupCredential("alice").toCompletableFuture().join()).isNotNull();
+        assertThat(loaded.lookupCredential("bob").toCompletableFuture().join()).isNotNull();
+    }
+
     private void assertRejectsPermission(String permString) throws Exception {
         assumePosixPermissions();
         Files.setPosixFilePermissions(keystorePath, PosixFilePermissions.fromString(permString));
@@ -210,6 +265,32 @@ class KeystoreScramCredentialStoreTest {
         org.junit.jupiter.api.Assumptions.assumeTrue(
                 Files.getFileAttributeView(keystorePath, PosixFileAttributeView.class) != null,
                 "POSIX file permissions not supported on this platform");
+    }
+
+    // Self-signed test certificate (CN=localhost), used only to populate non-credential keystore entries.
+    private static final String TEST_CERT_PEM = """
+            -----BEGIN CERTIFICATE-----
+            MIICzDCCAbSgAwIBAgIJAPnSacXpIgPLMA0GCSqGSIb3DQEBDAUAMBQxEjAQBgNV
+            BAMTCWxvY2FsaG9zdDAeFw0yMzA2MjIxNDAyNDBaFw0zMzA0MzAxNDAyNDBaMBQx
+            EjAQBgNVBAMTCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+            ggEBAJrZWdUMnO7X6v7yyBprtmISUTmnMuuFU2G83FQXSRSZiF18xB6nHyF7cZoP
+            uBBBsJkBF+NHyGnK3QHsP1ZAgsd3IUxKZxChDY4ELHQEnJ08y0E8vMO5D8X2EIlP
+            YwN9T+ReZfPp39SGuNc4pmpO29kGDxtIaEjVsCM6Sy32vayWn+7j2QkJvMlIt52w
+            ev3aFNSfnI6lUMopgji5HibW0Wg+tUdbzQVTHpbsZjUSx07WUyZiKh9bCj78jOCU
+            xeyvce7wKmW8OryWHSV1L96ATVCaa7j8dMl2WVcL5NdsrbzG48c4qoNGQlNuXP3k
+            1Fak+B8HQuAy64KtgU7puRiIsE8CAwEAAaMhMB8wHQYDVR0OBBYEFGK4jT23mUpt
+            SDF83zfem+JglvIRMA0GCSqGSIb3DQEBDAUAA4IBAQAlcTRvYNVOH4LCU9K42GEQ
+            kTtli4uTeHNEDUX/GVnGqxIjofPCg2pTBLPkYQmKCnElaHqdKJOG8snw2NiFD0sN
+            K1T+JPHvAnAVN0OVFBKZMTqK4sDm9bYzN1hCUKc4cWj9l/YXQ6uHFXSDxhek+qvI
+            4yF/fSDBuYhf4w0Uyr4rmpC0dV+hdPFooFkdqprlkyI7ntCbqzzXMDuqKW7UyTN8
+            GiY5W+u1+slIINm5o2UwzC2FpBRkWDwd/hxMHdcL6txYUDQF+Xy9xRKv9JIeOaXg
+            0M91ZTBSxfxr2cn41AulsTENc6vKvz8Zhd8XSZWHlsGVRTQSAV3ibz+KF+mAYeRG
+            -----END CERTIFICATE-----
+            """;
+
+    private static Certificate loadTestCertificate() throws Exception {
+        return CertificateFactory.getInstance("X.509")
+                .generateCertificate(new ByteArrayInputStream(TEST_CERT_PEM.getBytes(StandardCharsets.UTF_8)));
     }
 
     @Test

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreTest.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/KeystoreScramCredentialStoreTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.scram.credentialstore.keystore;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.concurrent.CompletionStage;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.kroxylicious.proxy.config.secret.InlinePassword;
+import io.kroxylicious.scram.credentialstore.CredentialServiceUnavailableException;
+import io.kroxylicious.scram.credentialstore.ScramCredential;
+import io.kroxylicious.scram.credentialstore.ScramHashAlgorithm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class KeystoreScramCredentialStoreTest {
+
+    private static final String STORE_PASSWORD = "test-password";
+    private static final String ALICE_PASSWORD = "alice-secret";
+    private static final String BOB_PASSWORD = "bob-secret-pw";
+
+    @TempDir
+    Path tempDir;
+
+    private Path keystorePath;
+    private KeystoreScramCredentialStoreConfig config;
+    private KeystoreScramCredentialStore store;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        keystorePath = tempDir.resolve("test-credentials.jks");
+
+        // Generate test keystore with two users
+        var generator = new TestCredentialGenerator();
+        generator.generateKeyStore(
+                keystorePath,
+                STORE_PASSWORD,
+                "alice", ALICE_PASSWORD,
+                "bob", BOB_PASSWORD);
+
+        if (Files.getFileAttributeView(keystorePath, PosixFileAttributeView.class) != null) {
+            Files.setPosixFilePermissions(keystorePath, PosixFilePermissions.fromString("rw-------"));
+        }
+
+        config = new KeystoreScramCredentialStoreConfig(
+                keystorePath.toString(),
+                new InlinePassword(STORE_PASSWORD),
+                null,
+                "PKCS12");
+
+        store = new KeystoreScramCredentialStore(config);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (keystorePath != null && Files.exists(keystorePath)) {
+            Files.delete(keystorePath);
+        }
+    }
+
+    @Test
+    void shouldLookupExistingCredential() {
+        CompletionStage<ScramCredential> future = store.lookupCredential("alice");
+        ScramCredential credential = future.toCompletableFuture().join();
+
+        assertThat(credential).isNotNull();
+        assertThat(credential.username()).isEqualTo("alice");
+        assertThat(credential.hashAlgorithm()).isEqualTo(ScramHashAlgorithm.SHA_256);
+        assertThat(credential.iterations()).isEqualTo(10000);
+        assertThat(credential.salt()).isNotEmpty();
+        assertThat(credential.serverKey()).isNotEmpty();
+        assertThat(credential.storedKey()).isNotEmpty();
+    }
+
+    @Test
+    void shouldReturnNullForNonExistentUser() {
+        CompletionStage<ScramCredential> future = store.lookupCredential("charlie");
+        ScramCredential credential = future.toCompletableFuture().join();
+
+        assertThat(credential).isNull();
+    }
+
+    @Test
+    void shouldLookupMultipleUsers() {
+        ScramCredential alice = store.lookupCredential("alice").toCompletableFuture().join();
+        ScramCredential bob = store.lookupCredential("bob").toCompletableFuture().join();
+
+        assertThat(alice).isNotNull();
+        assertThat(bob).isNotNull();
+        assertThat(alice.username()).isEqualTo("alice");
+        assertThat(bob.username()).isEqualTo("bob");
+
+        // Different users should have different credentials
+        assertThat(alice.salt()).isNotEqualTo(bob.salt());
+        assertThat(alice.serverKey()).isNotEqualTo(bob.serverKey());
+        assertThat(alice.storedKey()).isNotEqualTo(bob.storedKey());
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we're testing that the null argument is rejected
+    @Test
+    void shouldRejectNullUsername() {
+        assertThatThrownBy(() -> store.lookupCredential(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("username");
+    }
+
+    @Test
+    void shouldThrowExceptionForNonExistentKeyStore() {
+        KeystoreScramCredentialStoreConfig badConfig = new KeystoreScramCredentialStoreConfig(
+                "/non/existent/keystore.jks",
+                new InlinePassword(STORE_PASSWORD),
+                null,
+                "PKCS12");
+
+        assertThatThrownBy(() -> new KeystoreScramCredentialStore(badConfig))
+                .isInstanceOf(CredentialServiceUnavailableException.class)
+                .hasMessageContaining("Failed to load KeyStore");
+    }
+
+    @Test
+    void shouldThrowExceptionForInvalidPassword() {
+        KeystoreScramCredentialStoreConfig badConfig = new KeystoreScramCredentialStoreConfig(
+                keystorePath.toString(),
+                new InlinePassword("wrong-password"),
+                null,
+                "PKCS12");
+
+        assertThatThrownBy(() -> new KeystoreScramCredentialStore(badConfig))
+                .isInstanceOf(CredentialServiceUnavailableException.class)
+                .hasMessageContaining("Failed to load KeyStore");
+    }
+
+    @Test
+    void shouldHandleEmptyKeyStore() throws Exception {
+        Path emptyKeystorePath = tempDir.resolve("empty.jks");
+        var generator = new TestCredentialGenerator();
+        generator.generateKeyStore(emptyKeystorePath, STORE_PASSWORD);
+        if (Files.getFileAttributeView(emptyKeystorePath, PosixFileAttributeView.class) != null) {
+            Files.setPosixFilePermissions(emptyKeystorePath, PosixFilePermissions.fromString("rw-------"));
+        }
+
+        KeystoreScramCredentialStoreConfig emptyConfig = new KeystoreScramCredentialStoreConfig(
+                emptyKeystorePath.toString(),
+                new InlinePassword(STORE_PASSWORD),
+                null,
+                "PKCS12");
+
+        KeystoreScramCredentialStore emptyStore = new KeystoreScramCredentialStore(emptyConfig);
+        ScramCredential credential = emptyStore.lookupCredential("anyone").toCompletableFuture().join();
+
+        assertThat(credential).isNull();
+    }
+
+    @Test
+    void shouldAcceptOwnerOnlyPermissions() throws Exception {
+        assumePosixPermissions();
+        Files.setPosixFilePermissions(keystorePath, PosixFilePermissions.fromString("rw-------"));
+
+        assertThatCode(() -> new KeystoreScramCredentialStore(config))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldRejectWorldReadable() throws Exception {
+        assertRejectsPermission("rw-r--r--");
+    }
+
+    @Test
+    void shouldRejectWorldWritable() throws Exception {
+        assertRejectsPermission("rw----rw-");
+    }
+
+    @Test
+    void shouldRejectGroupReadable() throws Exception {
+        assertRejectsPermission("rw-r-----");
+    }
+
+    @Test
+    void shouldRejectGroupWritable() throws Exception {
+        assertRejectsPermission("rw--w----");
+    }
+
+    private void assertRejectsPermission(String permString) throws Exception {
+        assumePosixPermissions();
+        Files.setPosixFilePermissions(keystorePath, PosixFilePermissions.fromString(permString));
+
+        assertThatThrownBy(() -> new KeystoreScramCredentialStore(config))
+                .isInstanceOf(CredentialServiceUnavailableException.class)
+                .hasMessageContaining("insecure permissions");
+    }
+
+    private void assumePosixPermissions() {
+        org.junit.jupiter.api.Assumptions.assumeTrue(
+                Files.getFileAttributeView(keystorePath, PosixFileAttributeView.class) != null,
+                "POSIX file permissions not supported on this platform");
+    }
+
+    @Test
+    void shouldUseSeparateKeyPasswordWhenProvided() {
+        String keyPassword = "different-key-password";
+
+        // For this test, we'd need to generate a keystore with different key passwords
+        // but TestCredentialGenerator currently uses the same password for both
+        // This test documents the intended behaviour
+        KeystoreScramCredentialStoreConfig configWithKeyPassword = new KeystoreScramCredentialStoreConfig(
+                keystorePath.toString(),
+                new InlinePassword(STORE_PASSWORD),
+                new InlinePassword(STORE_PASSWORD), // Same for now
+                "PKCS12");
+
+        assertThatCode(() -> new KeystoreScramCredentialStore(configWithKeyPassword))
+                .doesNotThrowAnyException();
+    }
+}

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialRoundTripTest.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialRoundTripTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.scram.credentialstore.keystore;
+
+import org.apache.kafka.common.security.scram.internals.ScramFormatter;
+import org.apache.kafka.common.security.scram.internals.ScramMechanism;
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.scram.credentialstore.ScramCredential;
+import io.kroxylicious.scram.credentialstore.ScramHashAlgorithm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that credentials work correctly with Kafka's SCRAM implementation after round-tripping through JSON.
+ */
+class ScramCredentialRoundTripTest {
+
+    @Test
+    void shouldCreateCredentialsThatMatchKafkaScramFormatter() throws Exception {
+        // Given - a known password and salt
+        String password = "test-password";
+        byte[] salt = new byte[]{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 };
+        int iterations = 4096;
+        ScramMechanism mechanism = ScramMechanism.SCRAM_SHA_256;
+
+        // When - we generate using ScramFormatter directly
+        ScramFormatter formatter = new ScramFormatter(mechanism);
+        byte[] saltedPassword = formatter.saltedPassword(password, salt, iterations);
+        byte[] expectedServerKey = formatter.serverKey(saltedPassword);
+        byte[] expectedClientKey = formatter.clientKey(saltedPassword);
+        byte[] expectedStoredKey = formatter.storedKey(expectedClientKey);
+
+        // And - create our ScramCredential
+        ScramCredential credential = new ScramCredential(
+                "testuser",
+                salt,
+                iterations,
+                expectedServerKey,
+                expectedStoredKey,
+                ScramHashAlgorithm.SHA_256);
+
+        // Then - the credential should contain the exact same bytes
+        assertThat(credential.salt()).isEqualTo(salt);
+        assertThat(credential.serverKey()).isEqualTo(expectedServerKey);
+        assertThat(credential.storedKey()).isEqualTo(expectedStoredKey);
+
+        // And - after round-trip through JSON
+        ScramCredentialSerializer serializer = new ScramCredentialSerializer();
+        byte[] json = serializer.serialize(credential);
+        ScramCredential deserialized = serializer.deserialize(json, "testuser");
+
+        // Then - all bytes should match exactly
+        assertThat(deserialized.salt()).isEqualTo(salt);
+        assertThat(deserialized.serverKey()).isEqualTo(expectedServerKey);
+        assertThat(deserialized.storedKey()).isEqualTo(expectedStoredKey);
+
+        // And - when converted to Kafka's format (note: parameter order is salt, storedKey, serverKey, iterations)
+        org.apache.kafka.common.security.scram.ScramCredential kafkaCredential = new org.apache.kafka.common.security.scram.ScramCredential(
+                deserialized.salt(),
+                deserialized.storedKey(),
+                deserialized.serverKey(),
+                deserialized.iterations());
+
+        // Then - the values should match what we expect
+        assertThat(kafkaCredential.salt()).isEqualTo(salt);
+        assertThat(kafkaCredential.serverKey()).isEqualTo(expectedServerKey);
+        assertThat(kafkaCredential.storedKey()).isEqualTo(expectedStoredKey);
+        assertThat(kafkaCredential.iterations()).isEqualTo(iterations);
+    }
+
+    @Test
+    void shouldPrintJsonFormatForDebugging() {
+        // This test helps us see what the JSON looks like
+        ScramCredential credential = new ScramCredential(
+                "alice",
+                new byte[]{ 1, 2, 3 },
+                4096,
+                new byte[]{ 4, 5, 6 },
+                new byte[]{ 7, 8, 9 },
+                ScramHashAlgorithm.SHA_256);
+
+        ScramCredentialSerializer serializer = new ScramCredentialSerializer();
+        byte[] json = serializer.serialize(credential);
+
+        // Verify it round-trips
+        ScramCredential deserialized = serializer.deserialize(json, "alice");
+        assertThat(deserialized.username()).isEqualTo("alice");
+        assertThat(deserialized.salt()).isEqualTo(new byte[]{ 1, 2, 3 });
+        assertThat(deserialized.serverKey()).isEqualTo(new byte[]{ 4, 5, 6 });
+        assertThat(deserialized.storedKey()).isEqualTo(new byte[]{ 7, 8, 9 });
+    }
+}

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialSerializerTest.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialSerializerTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.scram.credentialstore.keystore;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.kroxylicious.scram.credentialstore.ScramCredential;
+import io.kroxylicious.scram.credentialstore.ScramHashAlgorithm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for JSON serialization and deserialization of ScramCredential.
+ */
+class ScramCredentialSerializerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ScramCredentialSerializer serializer = new ScramCredentialSerializer();
+
+    @Test
+    void shouldIncludeVersionFieldInSerializedJson() throws Exception {
+        // Given
+        ScramCredential original = new ScramCredential(
+                "alice",
+                new byte[]{ 1, 2, 3, 4, 5 },
+                4096,
+                new byte[]{ 10, 20, 30, 40, 50 },
+                new byte[]{ 11, 21, 31, 41, 51 },
+                ScramHashAlgorithm.SHA_256);
+
+        // When
+        byte[] serialized = serializer.serialize(original);
+        String json = new String(serialized, java.nio.charset.StandardCharsets.UTF_8);
+
+        // Then
+        assertThat(json).contains("\"version\":" + ScramCredentialSerializer.CURRENT_VERSION);
+        assertThat(json).contains("\"username\":\"alice\"");
+        assertThat(json).contains("\"iterations\":4096");
+        assertThat(json).contains("\"hashAlgorithm\":\"SHA-256\"");
+    }
+
+    @Test
+    void shouldRoundTripCredentialViaSerializer() throws Exception {
+        // Given
+        ScramCredential original = new ScramCredential(
+                "bob",
+                new byte[]{ (byte) 0xFF, (byte) 0xEE, (byte) 0xDD },
+                8192,
+                new byte[]{ (byte) 0xAA, (byte) 0xBB, (byte) 0xCC },
+                new byte[]{ (byte) 0x11, (byte) 0x22, (byte) 0x33 },
+                ScramHashAlgorithm.SHA_512);
+
+        // When - serialize
+        byte[] serialized = serializer.serialize(original);
+
+        // Then - deserialize
+        ScramCredential deserialized = serializer.deserialize(serialized, "bob");
+
+        // Then - should match original
+        assertThat(deserialized.username()).isEqualTo(original.username());
+        assertThat(deserialized.salt()).isEqualTo(original.salt());
+        assertThat(deserialized.iterations()).isEqualTo(original.iterations());
+        assertThat(deserialized.serverKey()).isEqualTo(original.serverKey());
+        assertThat(deserialized.storedKey()).isEqualTo(original.storedKey());
+        assertThat(deserialized.hashAlgorithm()).isEqualTo(original.hashAlgorithm());
+    }
+
+    @Test
+    void shouldHandleMinimumByteArraysViaSerializer() {
+        // Given
+        ScramCredential original = new ScramCredential(
+                "test",
+                new byte[]{ 1 },
+                4096,
+                new byte[]{ 2 },
+                new byte[]{ 3 },
+                ScramHashAlgorithm.SHA_256);
+
+        // When
+        byte[] serialized = serializer.serialize(original);
+        ScramCredential deserialized = serializer.deserialize(serialized, "test");
+
+        // Then
+        assertThat(deserialized.salt()).isEqualTo(original.salt());
+        assertThat(deserialized.serverKey()).isEqualTo(original.serverKey());
+        assertThat(deserialized.storedKey()).isEqualTo(original.storedKey());
+    }
+
+    @Test
+    void shouldRejectUnsupportedVersion() {
+        // Given
+        String json = """
+                {"version":99,"username":"alice","salt":"AQIDBAU=","iterations":4096,
+                 "serverKey":"ChQeKDI=","storedKey":"CxUfKTM=","hashAlgorithm":"SHA-256"}
+                """;
+
+        // When/Then
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                () -> serializer.deserialize(json.getBytes(java.nio.charset.StandardCharsets.UTF_8), "test"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported credential version 99");
+    }
+
+    @Test
+    void shouldDefensiveCopyArraysOnConstruction() {
+        // Given - mutable arrays
+        byte[] salt = { 1, 2, 3 };
+        byte[] serverKey = { 4, 5, 6 };
+        byte[] storedKey = { 7, 8, 9 };
+
+        // When - create credential
+        ScramCredential credential = new ScramCredential(
+                "user",
+                salt,
+                4096,
+                serverKey,
+                storedKey,
+                ScramHashAlgorithm.SHA_256);
+
+        // Then - modify original arrays
+        salt[0] = 99;
+        serverKey[0] = 99;
+        storedKey[0] = 99;
+
+        // And - credential should be unaffected
+        assertThat(credential.salt()).isEqualTo(new byte[]{ 1, 2, 3 });
+        assertThat(credential.serverKey()).isEqualTo(new byte[]{ 4, 5, 6 });
+        assertThat(credential.storedKey()).isEqualTo(new byte[]{ 7, 8, 9 });
+    }
+
+    @Test
+    void shouldDefensiveCopyArraysOnAccess() {
+        // Given
+        ScramCredential credential = new ScramCredential(
+                "user",
+                new byte[]{ 1, 2, 3 },
+                4096,
+                new byte[]{ 4, 5, 6 },
+                new byte[]{ 7, 8, 9 },
+                ScramHashAlgorithm.SHA_256);
+
+        // When - get arrays and modify them
+        byte[] salt = credential.salt();
+        byte[] serverKey = credential.serverKey();
+        byte[] storedKey = credential.storedKey();
+
+        salt[0] = 99;
+        serverKey[0] = 99;
+        storedKey[0] = 99;
+
+        // Then - subsequent access should return original values
+        assertThat(credential.salt()).isEqualTo(new byte[]{ 1, 2, 3 });
+        assertThat(credential.serverKey()).isEqualTo(new byte[]{ 4, 5, 6 });
+        assertThat(credential.storedKey()).isEqualTo(new byte[]{ 7, 8, 9 });
+    }
+
+    @Test
+    void shouldImplementEqualsCorrectlyWithArrays() {
+        // Given - two credentials with same content
+        ScramCredential credential1 = new ScramCredential(
+                "user",
+                new byte[]{ 1, 2, 3 },
+                4096,
+                new byte[]{ 4, 5, 6 },
+                new byte[]{ 7, 8, 9 },
+                ScramHashAlgorithm.SHA_256);
+
+        ScramCredential credential2 = new ScramCredential(
+                "user",
+                new byte[]{ 1, 2, 3 },
+                4096,
+                new byte[]{ 4, 5, 6 },
+                new byte[]{ 7, 8, 9 },
+                ScramHashAlgorithm.SHA_256);
+
+        // Then - should be equal
+        assertThat(credential1).isEqualTo(credential2);
+        assertThat(credential1.hashCode()).isEqualTo(credential2.hashCode());
+    }
+
+    @Test
+    void shouldImplementEqualsCorrectlyWithDifferentArrays() {
+        // Given - two credentials with different salt
+        ScramCredential credential1 = new ScramCredential(
+                "user",
+                new byte[]{ 1, 2, 3 },
+                4096,
+                new byte[]{ 4, 5, 6 },
+                new byte[]{ 7, 8, 9 },
+                ScramHashAlgorithm.SHA_256);
+
+        ScramCredential credential2 = new ScramCredential(
+                "user",
+                new byte[]{ 1, 2, 4 }, // Different
+                4096,
+                new byte[]{ 4, 5, 6 },
+                new byte[]{ 7, 8, 9 },
+                ScramHashAlgorithm.SHA_256);
+
+        // Then - should not be equal
+        assertThat(credential1).isNotEqualTo(credential2);
+    }
+}

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialSerializerTest.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialSerializerTest.java
@@ -186,6 +186,21 @@ class ScramCredentialSerializerTest {
     }
 
     @Test
+    void shouldRejectUnknownHashAlgorithm() {
+        // Given
+        String json = """
+                {"version":1,"username":"alice","salt":"AQIDBAU=","iterations":4096,
+                 "serverKey":"ChQeKDI=","storedKey":"CxUfKTM=","hashAlgorithm":"UNKNOWN-ALGO"}
+                """;
+
+        // When/Then
+        byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+        assertThatThrownBy(() -> serializer.deserialize(bytes, "test-alias"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid credential for alias: test-alias");
+    }
+
+    @Test
     void shouldImplementEqualsCorrectlyWithDifferentArrays() {
         // Given - two credentials with different salt
         ScramCredential credential1 = new ScramCredential(

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialSerializerTest.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialSerializerTest.java
@@ -181,8 +181,8 @@ class ScramCredentialSerializerTest {
                 ScramHashAlgorithm.SHA_256);
 
         // Then - should be equal
-        assertThat(credential1).isEqualTo(credential2);
-        assertThat(credential1).hasSameHashCodeAs(credential2);
+        assertThat(credential1).isEqualTo(credential2)
+                .hasSameHashCodeAs(credential2);
     }
 
     @Test

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialSerializerTest.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialSerializerTest.java
@@ -8,8 +8,6 @@ package io.kroxylicious.scram.credentialstore.keystore;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.kroxylicious.scram.credentialstore.ScramCredential;
 import io.kroxylicious.scram.credentialstore.ScramHashAlgorithm;
 
@@ -20,7 +18,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class ScramCredentialSerializerTest {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
     private final ScramCredentialSerializer serializer = new ScramCredentialSerializer();
 
     @Test

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialSerializerTest.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/ScramCredentialSerializerTest.java
@@ -6,12 +6,15 @@
 
 package io.kroxylicious.scram.credentialstore.keystore;
 
+import java.nio.charset.StandardCharsets;
+
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.scram.credentialstore.ScramCredential;
 import io.kroxylicious.scram.credentialstore.ScramHashAlgorithm;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for JSON serialization and deserialization of ScramCredential.
@@ -21,7 +24,7 @@ class ScramCredentialSerializerTest {
     private final ScramCredentialSerializer serializer = new ScramCredentialSerializer();
 
     @Test
-    void shouldIncludeVersionFieldInSerializedJson() throws Exception {
+    void shouldIncludeVersionFieldInSerializedJson() {
         // Given
         ScramCredential original = new ScramCredential(
                 "alice",
@@ -33,17 +36,18 @@ class ScramCredentialSerializerTest {
 
         // When
         byte[] serialized = serializer.serialize(original);
-        String json = new String(serialized, java.nio.charset.StandardCharsets.UTF_8);
+        String json = new String(serialized, StandardCharsets.UTF_8);
 
         // Then
-        assertThat(json).contains("\"version\":" + ScramCredentialSerializer.CURRENT_VERSION);
-        assertThat(json).contains("\"username\":\"alice\"");
-        assertThat(json).contains("\"iterations\":4096");
-        assertThat(json).contains("\"hashAlgorithm\":\"SHA-256\"");
+        assertThat(json)
+                .contains("\"version\":" + ScramCredentialSerializer.CURRENT_VERSION)
+                .contains("\"username\":\"alice\"")
+                .contains("\"iterations\":4096")
+                .contains("\"hashAlgorithm\":\"SHA-256\"");
     }
 
     @Test
-    void shouldRoundTripCredentialViaSerializer() throws Exception {
+    void shouldRoundTripCredentialViaSerializer() {
         // Given
         ScramCredential original = new ScramCredential(
                 "bob",
@@ -98,8 +102,8 @@ class ScramCredentialSerializerTest {
                 """;
 
         // When/Then
-        org.assertj.core.api.Assertions.assertThatThrownBy(
-                () -> serializer.deserialize(json.getBytes(java.nio.charset.StandardCharsets.UTF_8), "test"))
+        byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+        assertThatThrownBy(() -> serializer.deserialize(bytes, "test"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Unsupported credential version 99");
     }
@@ -178,7 +182,7 @@ class ScramCredentialSerializerTest {
 
         // Then - should be equal
         assertThat(credential1).isEqualTo(credential2);
-        assertThat(credential1.hashCode()).isEqualTo(credential2.hashCode());
+        assertThat(credential1).hasSameHashCodeAs(credential2);
     }
 
     @Test

--- a/kroxylicious-scram-credential-store-providers/pom.xml
+++ b/kroxylicious-scram-credential-store-providers/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kroxylicious</groupId>
+        <artifactId>kroxylicious-parent</artifactId>
+        <version>0.24.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kroxylicious-scram-credential-store-providers</artifactId>
+
+    <name>SCRAM Credential Store provider implementations</name>
+    <description>SCRAM Credential Store provider implementations</description>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>kroxylicious-scram-credential-store-provider-keystore</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>credential-store-use-public-api</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>io.kroxylicious</exclude>
+                                    </excludes>
+                                    <includes combine.children="append">
+                                        <include>io.kroxylicious:kroxylicious-scram-credential-store</include>
+                                        <include>io.kroxylicious:kroxylicious-api</include>
+                                        <include>io.kroxylicious:kroxylicious-annotations</include>
+                                    </includes>
+                                </bannedDependencies>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION



### Type of change

- Enhancement / new feature

### Description

Implements a Java KeyStore-backed SCRAM credential store provider, the first concrete implementation of the ScramCredentialStoreService SPI introduced in #4532.

The new module `kroxylicious-scram-credential-store-provider-keystore` provides:

- `KeystoreScramCredentialStoreService`: Plugin implementing the `ScramCredentialStoreService` SPI with initialize/build/close lifecycle management
- `KeystoreScramCredentialStore`: Loads SCRAM credentials from a Java `KeyStore` file (JKS or PKCS12) into an in-memory map at startup for fast, synchronous lookups during SASL authentication
- `ScramCredentialSerializer`: Versioned JSON serialization format for `ScramCredential` data stored as `SecretKey` entries, with defensive byte-array copies
- `KeystoreFilePermissions`: POSIX file permission validation that rejects keystores with group/world access (configurable via `KROXYLICIOUS_DANGEROUSLY_CHANGE_PERMISSION_CHECK` env var to allow 0640)
- `TestCredentialGenerator`: Utility for generating test keystores with SCRAM-SHA-256/512 credentials using Kafka's `ScramFormatter`

Configuration example:

```yaml
  credentialStore: KeystoreScramCredentialStore
  credentialStoreConfig:
    file: /etc/kroxylicious/credentials.p12
    storePassword:
      file: /etc/kroxylicious/keystore-password.txt
    storeType: PKCS12
```

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

### Additional Context

Part of [proposal 124](https://github.com/kroxylicious/design/blob/main/proposals/124-sasl-termination.md). But note that the name of the module and package differs from that in Proposal 124, using `scram` instead of `sasl`, as discussed on Slack.

The SPI was added in #4532; this PR provides the first provider implementation so that the SASL termination filter can authenticate clients using credentials stored in a standard Java KeyStore file. Credentials are pre-hashed (salt, serverKey, storedKey) - no plaintext passwords are stored.

The CLI part will be provided later per separate issue #4518. This makes for a slightly awkward split, but helps keep the PRs of a manageable size. Documentation will also be provided later per separate issue #4521.

Fixes #4517