### PR TITLE
fix(kms): add missing HTTP request timeouts, standardize to 20s

### DIFF
--- a/changelog/unreleased/04464-kms-http-request-timeouts.yaml
+++ b/changelog/unreleased/04464-kms-http-request-timeouts.yaml
@@ -1,0 +1,4 @@
+title: "fix(kms): apply missing HTTP request timeouts and standardize KMS provider timeouts to 20s"
+type: fixed
+issues:
+  - 4464

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKms.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKms.java
@@ -218,12 +218,14 @@ public class AwsKms implements Kms<String, AwsKmsEdek> {
         return awsUrl;
     }
 
-    private CompletionStage<HttpRequest> createRequest(Object request, String target) {
+    @VisibleForTesting
+    CompletionStage<HttpRequest> createRequest(Object request, String target) {
         var body = getBody(request).getBytes(UTF_8);
 
         return credentialsProvider.getCredentials()
                 .thenApply(c -> AwsV4SigningHttpRequestBuilder.newBuilder(c, region, "kms", Instant.now())
                         .uri(getAwsUrl())
+                        .timeout(timeout)
                         .header(CONTENT_TYPE_HEADER, APPLICATION_X_AMZ_JSON_1_1)
                         .header(X_AMZ_TARGET_HEADER, target)
                         .POST(HttpRequest.BodyPublishers.ofByteArray(body))

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/credentials/Ec2MetadataCredentialsProvider.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/credentials/Ec2MetadataCredentialsProvider.java
@@ -101,6 +101,11 @@ public class Ec2MetadataCredentialsProvider extends AbstractRefreshingCredential
                 .build();
     }
 
+    @VisibleForTesting
+    HttpClient getHttpClient() {
+        return client;
+    }
+
     @Override
     protected CompletionStage<SecurityCredentials> fetchCredentials() {
         return getToken()
@@ -140,7 +145,8 @@ public class Ec2MetadataCredentialsProvider extends AbstractRefreshingCredential
                 .thenApply(Ec2MetadataCredentialsProvider::checkResponseStatus);
     }
 
-    private HttpRequest createTokenRequest() {
+    @VisibleForTesting
+    HttpRequest createTokenRequest() {
         return HttpRequest.newBuilder()
                 .uri(getMetadataEndpoint().resolve(TOKEN_RETRIEVAL_ENDPOINT))
                 .header(AWS_METADATA_TOKEN_TTL_SECONDS_HEADER, AWS_TOKEN_EXPIRATION_SECONDS)

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/credentials/Ec2MetadataCredentialsProvider.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/credentials/Ec2MetadataCredentialsProvider.java
@@ -49,8 +49,8 @@ public class Ec2MetadataCredentialsProvider extends AbstractRefreshingCredential
     };
     @SuppressWarnings("java:S1313")
     private static final URI DEFAULT_IP4_METADATA_ENDPOINT = URI.create("http://169.254.169.254/");
-    private static final Duration HTTP_REQUEST_TIMEOUT = Duration.ofSeconds(10);
-    private static final Duration HTTP_CONNECT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration HTTP_REQUEST_TIMEOUT = Duration.ofSeconds(20);
+    private static final Duration HTTP_CONNECT_TIMEOUT = Duration.ofSeconds(20);
     private static final String AWS_METADATA_TOKEN_TTL_SECONDS_HEADER = "X-aws-ec2-metadata-token-ttl-seconds";
     private static final String AWS_METADATA_TOKEN_HEADER = "X-aws-ec2-metadata-token";
     private static final String AWS_TOKEN_EXPIRATION_SECONDS = "60";

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/credentials/PodIdentityCredentialsProvider.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/credentials/PodIdentityCredentialsProvider.java
@@ -115,18 +115,28 @@ public class PodIdentityCredentialsProvider extends AbstractRefreshingCredential
                 .build();
     }
 
+    @VisibleForTesting
+    HttpClient getHttpClient() {
+        return client;
+    }
+
     @Override
     protected CompletionStage<PodIdentityCredentials> fetchCredentials() {
         var token = readAuthorizationToken();
-        var request = HttpRequest.newBuilder()
+        var request = createCredentialsRequest(token);
+        return client.sendAsync(request, HttpResponse.BodyHandlers.ofByteArray())
+                .thenApply(this::parseCredentialsResponse);
+    }
+
+    @VisibleForTesting
+    HttpRequest createCredentialsRequest(String token) {
+        return HttpRequest.newBuilder()
                 .uri(credentialsFullUri)
                 .header("Authorization", token)
                 .header("Accept", "application/json")
                 .timeout(HTTP_REQUEST_TIMEOUT)
                 .GET()
                 .build();
-        return client.sendAsync(request, HttpResponse.BodyHandlers.ofByteArray())
-                .thenApply(this::parseCredentialsResponse);
     }
 
     @Override

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/credentials/PodIdentityCredentialsProvider.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/credentials/PodIdentityCredentialsProvider.java
@@ -58,8 +58,8 @@ public class PodIdentityCredentialsProvider extends AbstractRefreshingCredential
     private static final TypeReference<PodIdentityCredentials> CREDENTIALS_TYPE_REF = new TypeReference<>() {
     };
 
-    private static final Duration HTTP_REQUEST_TIMEOUT = Duration.ofSeconds(10);
-    private static final Duration HTTP_CONNECT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration HTTP_REQUEST_TIMEOUT = Duration.ofSeconds(20);
+    private static final Duration HTTP_CONNECT_TIMEOUT = Duration.ofSeconds(20);
 
     static final String ENV_FULL_URI = "AWS_CONTAINER_CREDENTIALS_FULL_URI";
     static final String ENV_AUTH_TOKEN_FILE = "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE";

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/credentials/WebIdentityCredentialsProvider.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/credentials/WebIdentityCredentialsProvider.java
@@ -62,8 +62,8 @@ public class WebIdentityCredentialsProvider extends AbstractRefreshingCredential
     private static final TypeReference<StsErrorEnvelope> ERROR_TYPE_REF = new TypeReference<>() {
     };
 
-    private static final Duration HTTP_REQUEST_TIMEOUT = Duration.ofSeconds(10);
-    private static final Duration HTTP_CONNECT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration HTTP_REQUEST_TIMEOUT = Duration.ofSeconds(20);
+    private static final Duration HTTP_CONNECT_TIMEOUT = Duration.ofSeconds(20);
     private static final String STS_API_VERSION = "2011-06-15";
     private static final String STS_ACTION = "AssumeRoleWithWebIdentity";
     private static final int MAX_SESSION_NAME_LENGTH = 64;

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/credentials/WebIdentityCredentialsProvider.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/credentials/WebIdentityCredentialsProvider.java
@@ -175,6 +175,11 @@ public class WebIdentityCredentialsProvider extends AbstractRefreshingCredential
                 .build();
     }
 
+    @VisibleForTesting
+    HttpClient getHttpClient() {
+        return client;
+    }
+
     @Override
     protected CompletionStage<AssumedRoleCredentials> fetchCredentials() {
         var token = readWebIdentityToken();
@@ -220,7 +225,8 @@ public class WebIdentityCredentialsProvider extends AbstractRefreshingCredential
         }
     }
 
-    private HttpRequest createAssumeRoleRequest(String webIdentityToken) {
+    @VisibleForTesting
+    HttpRequest createAssumeRoleRequest(String webIdentityToken) {
         var form = new StringBuilder()
                 .append("Action=").append(STS_ACTION)
                 .append("&Version=").append(STS_API_VERSION)

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTest.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.kms.provider.aws.kms;
 
 import java.net.URI;
+import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
@@ -23,6 +24,7 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 
 import io.kroxylicious.kms.provider.aws.kms.config.Config;
 import io.kroxylicious.kms.provider.aws.kms.config.LongTermCredentialsProviderConfig;
+import io.kroxylicious.kms.provider.aws.kms.model.DescribeKeyRequest;
 import io.kroxylicious.kms.service.DekPair;
 import io.kroxylicious.kms.service.DestroyableRawSecretKey;
 import io.kroxylicious.kms.service.KmsException;
@@ -73,6 +75,24 @@ class AwsKmsTest {
     void afterEach() {
         Optional.ofNullable(awsKmsService).ifPresent(AwsKmsService::close);
         server.resetAll();
+    }
+
+    @Test
+    void appliesConnectTimeout() {
+        // given/when
+        var connectTimeout = kms.getHttpClient().connectTimeout();
+        // then
+        assertThat(connectTimeout).hasValue(Duration.ofSeconds(20));
+    }
+
+    @Test
+    void appliesRequestTimeout() {
+        // given
+        var request = kms.createRequest(new DescribeKeyRequest(AwsKms.ALIAS_PREFIX + "alias"), "TrentService.DescribeKey");
+        // when
+        HttpRequest builtRequest = request.toCompletableFuture().join();
+        // then
+        assertThat(builtRequest.timeout()).hasValue(Duration.ofSeconds(20));
     }
 
     @Test

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTest.java
@@ -7,7 +7,6 @@
 package io.kroxylicious.kms.provider.aws.kms;
 
 import java.net.URI;
-import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
@@ -79,19 +78,18 @@ class AwsKmsTest {
 
     @Test
     void appliesConnectTimeout() {
-        // given/when
+        // When
         var connectTimeout = kms.getHttpClient().connectTimeout();
-        // then
+        // Then
         assertThat(connectTimeout).hasValue(Duration.ofSeconds(20));
     }
 
     @Test
     void appliesRequestTimeout() {
-        // given
-        var request = kms.createRequest(new DescribeKeyRequest(AwsKms.ALIAS_PREFIX + "alias"), "TrentService.DescribeKey");
-        // when
-        HttpRequest builtRequest = request.toCompletableFuture().join();
-        // then
+        // When
+        var builtRequest = kms.createRequest(new DescribeKeyRequest(AwsKms.ALIAS_PREFIX + "alias"), "TrentService.DescribeKey")
+                .toCompletableFuture().join();
+        // Then
         assertThat(builtRequest.timeout()).hasValue(Duration.ofSeconds(20));
     }
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/credentials/Ec2MetadataCredentialsProviderTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/credentials/Ec2MetadataCredentialsProviderTest.java
@@ -108,6 +108,28 @@ class Ec2MetadataCredentialsProviderTest {
     }
 
     @Test
+    void appliesConnectTimeout() {
+        // Given
+        try (var provider = new Ec2MetadataCredentialsProvider(config)) {
+            // When
+            var connectTimeout = provider.getHttpClient().connectTimeout();
+            // Then
+            assertThat(connectTimeout).hasValue(Duration.ofSeconds(20));
+        }
+    }
+
+    @Test
+    void appliesRequestTimeout() {
+        // Given
+        try (var provider = new Ec2MetadataCredentialsProvider(config)) {
+            // When
+            var request = provider.createTokenRequest();
+            // Then
+            assertThat(request.timeout()).hasValue(Duration.ofSeconds(20));
+        }
+    }
+
+    @Test
     void credentialFromKnownGood() {
 
         metadataServer.stubFor(

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/credentials/PodIdentityCredentialsProviderTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/credentials/PodIdentityCredentialsProviderTest.java
@@ -108,6 +108,30 @@ class PodIdentityCredentialsProviderTest {
     }
 
     @Test
+    void appliesConnectTimeout() {
+        // Given
+        var cfg = config(credentialsUri, tokenFile);
+        try (var provider = new PodIdentityCredentialsProvider(cfg, emptyEnv, SYSTEM_CLOCK)) {
+            // When
+            var connectTimeout = provider.getHttpClient().connectTimeout();
+            // Then
+            assertThat(connectTimeout).hasValue(Duration.ofSeconds(20));
+        }
+    }
+
+    @Test
+    void appliesRequestTimeout() {
+        // Given
+        var cfg = config(credentialsUri, tokenFile);
+        try (var provider = new PodIdentityCredentialsProvider(cfg, emptyEnv, SYSTEM_CLOCK)) {
+            // When
+            var request = provider.createCredentialsRequest("bearer-token-value");
+            // Then
+            assertThat(request.timeout()).hasValue(Duration.ofSeconds(20));
+        }
+    }
+
+    @Test
     void resolvesUriFromEnv() {
         var cfg = config(null, tokenFile);
         var env = envOf(Map.of(PodIdentityCredentialsProvider.ENV_FULL_URI, credentialsUri.toString()));

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/credentials/WebIdentityCredentialsProviderTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/credentials/WebIdentityCredentialsProviderTest.java
@@ -101,6 +101,30 @@ class WebIdentityCredentialsProviderTest {
     }
 
     @Test
+    void appliesConnectTimeout() {
+        // Given
+        var cfg = config(ROLE_ARN, tokenFile, null, null);
+        try (var provider = new WebIdentityCredentialsProvider(cfg, DEFAULT_REGION, emptyEnv, SYSTEM_CLOCK)) {
+            // When
+            var connectTimeout = provider.getHttpClient().connectTimeout();
+            // Then
+            assertThat(connectTimeout).hasValue(Duration.ofSeconds(20));
+        }
+    }
+
+    @Test
+    void appliesRequestTimeout() {
+        // Given
+        var cfg = config(ROLE_ARN, tokenFile, null, null);
+        try (var provider = new WebIdentityCredentialsProvider(cfg, DEFAULT_REGION, emptyEnv, SYSTEM_CLOCK)) {
+            // When
+            var request = provider.createAssumeRoleRequest("header.payload.signature");
+            // Then
+            assertThat(request.timeout()).hasValue(Duration.ofSeconds(20));
+        }
+    }
+
+    @Test
     void resolvesRoleArnFromEnv() {
         var cfg = config(null, tokenFile, null, null);
         var env = envOf(Map.of(WebIdentityCredentialsProvider.ENV_ROLE_ARN, ROLE_ARN));

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/auth/ManagedIdentityAccessTokenService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/auth/ManagedIdentityAccessTokenService.java
@@ -50,6 +50,9 @@ import static java.time.temporal.ChronoUnit.SECONDS;
  */
 public class ManagedIdentityAccessTokenService implements BearerTokenService {
 
+    private static final Duration CONNECT_TIMEOUT = Duration.of(20, SECONDS);
+    private static final Duration REQUEST_TIMEOUT = Duration.of(20, SECONDS);
+
     private final ManagedIdentityCredentialsConfig managedIdentityCredentialsConfig;
     private final Clock clock;
     private static final Logger LOGGER = LoggerFactory.getLogger(ManagedIdentityAccessTokenService.class);
@@ -71,15 +74,19 @@ public class ManagedIdentityAccessTokenService implements BearerTokenService {
         this.clock = clock;
         HttpClient.Builder builder = HttpClient.newBuilder();
         httpClient = builder
-                .connectTimeout(Duration.of(10, SECONDS))
+                .connectTimeout(CONNECT_TIMEOUT)
                 .followRedirects(HttpClient.Redirect.NEVER)
                 .version(HttpClient.Version.HTTP_1_1)
                 .build();
     }
 
-    @Override
-    public CompletionStage<BearerToken> getBearerToken() {
-        HttpRequest request = HttpRequest.newBuilder()
+    HttpClient getHttpClient() {
+        return httpClient;
+    }
+
+    HttpRequest getHttpRequest() {
+        return HttpRequest.newBuilder()
+                .timeout(REQUEST_TIMEOUT)
                 .uri(URI.create(
                         managedIdentityCredentialsConfig.identityServiceURL()
                                 + "/metadata/identity/oauth2/token?api-version=2018-02-01&resource="
@@ -87,6 +94,11 @@ public class ManagedIdentityAccessTokenService implements BearerTokenService {
                 .header("Metadata", "true")
                 .GET()
                 .build();
+    }
+
+    @Override
+    public CompletionStage<BearerToken> getBearerToken() {
+        HttpRequest request = getHttpRequest();
         Instant messageSend = clock.instant();
         CompletableFuture<HttpResponse<String>> responseCompletableFuture = httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString());
         CompletableFuture<AccessTokenResponse> future = responseCompletableFuture.thenApply(ManagedIdentityAccessTokenService::getAccessTokenResponse);

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/auth/ManagedIdentityAccessTokenService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/auth/ManagedIdentityAccessTokenService.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kroxylicious.kms.provider.azure.MalformedResponseBodyException;
 import io.kroxylicious.kms.provider.azure.UnexpectedHttpStatusCodeException;
 import io.kroxylicious.kms.provider.azure.config.auth.ManagedIdentityCredentialsConfig;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 
@@ -80,10 +81,12 @@ public class ManagedIdentityAccessTokenService implements BearerTokenService {
                 .build();
     }
 
+    @VisibleForTesting
     HttpClient getHttpClient() {
         return httpClient;
     }
 
+    @VisibleForTesting
     HttpRequest getHttpRequest() {
         return HttpRequest.newBuilder()
                 .timeout(REQUEST_TIMEOUT)

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/auth/OauthClientCredentialsTokenService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/auth/OauthClientCredentialsTokenService.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kroxylicious.kms.provider.azure.MalformedResponseBodyException;
 import io.kroxylicious.kms.provider.azure.UnexpectedHttpStatusCodeException;
 import io.kroxylicious.kms.provider.azure.config.auth.Oauth2ClientCredentialsConfig;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
 import io.kroxylicious.testing.kms.tls.TlsHttpClientConfigurator;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
@@ -89,6 +90,7 @@ public class OauthClientCredentialsTokenService implements BearerTokenService {
                 .build();
     }
 
+    @VisibleForTesting
     HttpClient getHttpClient() {
         return httpClient;
     }
@@ -108,6 +110,7 @@ public class OauthClientCredentialsTokenService implements BearerTokenService {
         // httpclient only closable in JDK21, use reflection?
     }
 
+    @VisibleForTesting
     HttpRequest getHttpRequest() {
         Map<String, String> formData = new LinkedHashMap<>();
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/auth/OauthClientCredentialsTokenService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/auth/OauthClientCredentialsTokenService.java
@@ -57,6 +57,9 @@ import static java.time.temporal.ChronoUnit.SECONDS;
  */
 public class OauthClientCredentialsTokenService implements BearerTokenService {
 
+    private static final Duration CONNECT_TIMEOUT = Duration.of(20, SECONDS);
+    private static final Duration REQUEST_TIMEOUT = Duration.of(20, SECONDS);
+
     private final Oauth2ClientCredentialsConfig oauth2ClientCredentialsConfig;
     private final Clock clock;
     private static final Logger LOGGER = LoggerFactory.getLogger(OauthClientCredentialsTokenService.class);
@@ -80,10 +83,14 @@ public class OauthClientCredentialsTokenService implements BearerTokenService {
         var tlsConfigurator = new TlsHttpClientConfigurator(oauth2ClientCredentialsConfig.tls());
         tlsConfigurator.apply(builder);
         httpClient = builder
-                .connectTimeout(Duration.of(10, SECONDS))
+                .connectTimeout(CONNECT_TIMEOUT)
                 .followRedirects(HttpClient.Redirect.NEVER)
                 .version(HttpClient.Version.HTTP_1_1)
                 .build();
+    }
+
+    HttpClient getHttpClient() {
+        return httpClient;
     }
 
     @Override
@@ -101,7 +108,7 @@ public class OauthClientCredentialsTokenService implements BearerTokenService {
         // httpclient only closable in JDK21, use reflection?
     }
 
-    private HttpRequest getHttpRequest() {
+    HttpRequest getHttpRequest() {
         Map<String, String> formData = new LinkedHashMap<>();
 
         formData.put("grant_type", "client_credentials");
@@ -117,6 +124,7 @@ public class OauthClientCredentialsTokenService implements BearerTokenService {
         String tokenUrl = oauth2ClientCredentialsConfig.oauthEndpoint() + "/" + oauth2ClientCredentialsConfig.tenantId() + "/oauth2/v2.0/token";
 
         return HttpRequest.newBuilder()
+                .timeout(REQUEST_TIMEOUT)
                 .uri(URI.create(tokenUrl))
                 .header("Content-Type", "application/x-www-form-urlencoded")
                 .POST(HttpRequest.BodyPublishers.ofString(formBody))

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/keyvault/KeyVaultClient.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/keyvault/KeyVaultClient.java
@@ -38,6 +38,8 @@ public class KeyVaultClient implements AutoCloseable {
      * The version of the Azure Key Vault REST API used by this client.
      */
     public static final String API_VERSION = "7.4";
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(20L);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(20L);
     private final BearerTokenService service;
     private final HttpClient client;
     private final AzureKeyVaultConfig config;
@@ -57,7 +59,7 @@ public class KeyVaultClient implements AutoCloseable {
         HttpClient.Builder builder = HttpClient.newBuilder();
         var tlsConfigurator = new TlsHttpClientConfigurator(config.tls());
         tlsConfigurator.apply(builder);
-        this.client = builder.version(HttpClient.Version.HTTP_1_1).followRedirects(HttpClient.Redirect.NEVER).connectTimeout(Duration.ofSeconds(10L)).build();
+        this.client = builder.version(HttpClient.Version.HTTP_1_1).followRedirects(HttpClient.Redirect.NEVER).connectTimeout(CONNECT_TIMEOUT).build();
     }
 
     /**
@@ -112,9 +114,14 @@ public class KeyVaultClient implements AutoCloseable {
                 });
     }
 
-    private HttpRequest getKeyRequest(String vaultName, String keyName, BearerToken bearerToken) {
+    HttpClient getHttpClient() {
+        return client;
+    }
+
+    HttpRequest getKeyRequest(String vaultName, String keyName, BearerToken bearerToken) {
         String getKey = config.keyVaultUrl(vaultName) + "/keys/" + keyName + "?api-version=" + API_VERSION;
         return HttpRequest.newBuilder()
+                .timeout(REQUEST_TIMEOUT)
                 .header("Authorization", "Bearer " + bearerToken.token())
                 .uri(URI.create(getKey)).GET().build();
     }
@@ -147,13 +154,14 @@ public class KeyVaultClient implements AutoCloseable {
                 });
     }
 
-    private HttpRequest wrapOrUnwrapKeyRequest(WrappingKey wrappingKey, byte[] bytes, BearerToken bearerToken, String operation) {
+    HttpRequest wrapOrUnwrapKeyRequest(WrappingKey wrappingKey, byte[] bytes, BearerToken bearerToken, String operation) {
         String wrapKey = config.keyVaultUrl(wrappingKey.vaultName()) + "/keys/" + wrappingKey.keyName() + "/" + wrappingKey.keyVersion() + "/" + operation
                 + "?api-version=" + API_VERSION;
         WrapOrUnwrapRequest value = WrapOrUnwrapRequest.from(wrappingKey.supportedKeyType().getWrapAlgorithm(), bytes);
         try {
             byte[] bodyBytes = mapper.writer().writeValueAsBytes(value);
             return HttpRequest.newBuilder()
+                    .timeout(REQUEST_TIMEOUT)
                     .header("Content-Type", "application/json")
                     .header("Authorization", "Bearer " + bearerToken.token())
                     .uri(URI.create(wrapKey)).POST(HttpRequest.BodyPublishers.ofByteArray(bodyBytes)).build();

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/keyvault/KeyVaultClient.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/keyvault/KeyVaultClient.java
@@ -26,6 +26,7 @@ import io.kroxylicious.kms.provider.azure.auth.BearerToken;
 import io.kroxylicious.kms.provider.azure.auth.BearerTokenService;
 import io.kroxylicious.kms.provider.azure.config.AzureKeyVaultConfig;
 import io.kroxylicious.kms.service.KmsException;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
 import io.kroxylicious.testing.kms.tls.TlsHttpClientConfigurator;
 
 /**
@@ -114,10 +115,12 @@ public class KeyVaultClient implements AutoCloseable {
                 });
     }
 
+    @VisibleForTesting
     HttpClient getHttpClient() {
         return client;
     }
 
+    @VisibleForTesting
     HttpRequest getKeyRequest(String vaultName, String keyName, BearerToken bearerToken) {
         String getKey = config.keyVaultUrl(vaultName) + "/keys/" + keyName + "?api-version=" + API_VERSION;
         return HttpRequest.newBuilder()
@@ -154,6 +157,7 @@ public class KeyVaultClient implements AutoCloseable {
                 });
     }
 
+    @VisibleForTesting
     HttpRequest wrapOrUnwrapKeyRequest(WrappingKey wrappingKey, byte[] bytes, BearerToken bearerToken, String operation) {
         String wrapKey = config.keyVaultUrl(wrappingKey.vaultName()) + "/keys/" + wrappingKey.keyName() + "/" + wrappingKey.keyVersion() + "/" + operation
                 + "?api-version=" + API_VERSION;

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/auth/ManagedIdentityAccessTokenServiceTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/auth/ManagedIdentityAccessTokenServiceTest.java
@@ -8,6 +8,7 @@ package io.kroxylicious.kms.provider.azure.auth;
 
 import java.net.URI;
 import java.net.URLEncoder;
+import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Duration;
@@ -108,6 +109,30 @@ class ManagedIdentityAccessTokenServiceTest {
                                 "/metadata/identity/oauth2/token?api-version=2018-02-01&resource=" + URLEncoder.encode(TARGET_RESOURCE, StandardCharsets.UTF_8));
                         assertThat(request.getHeader("Metadata")).isEqualTo("true");
                     });
+        }
+    }
+
+    @Test
+    void appliesConnectTimeout() {
+        // given
+        try (ManagedIdentityAccessTokenService service = new ManagedIdentityAccessTokenService(
+                new ManagedIdentityCredentialsConfig(TARGET_RESOURCE, URI.create(server.baseUrl())), Clock.systemUTC())) {
+            // when
+            var connectTimeout = service.getHttpClient().connectTimeout();
+            // then
+            assertThat(connectTimeout).hasValue(Duration.ofSeconds(20));
+        }
+    }
+
+    @Test
+    void appliesRequestTimeout() {
+        // given
+        try (ManagedIdentityAccessTokenService service = new ManagedIdentityAccessTokenService(
+                new ManagedIdentityCredentialsConfig(TARGET_RESOURCE, URI.create(server.baseUrl())), Clock.systemUTC())) {
+            // when
+            HttpRequest request = service.getHttpRequest();
+            // then
+            assertThat(request.timeout()).hasValue(Duration.ofSeconds(20));
         }
     }
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/auth/ManagedIdentityAccessTokenServiceTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/auth/ManagedIdentityAccessTokenServiceTest.java
@@ -114,24 +114,24 @@ class ManagedIdentityAccessTokenServiceTest {
 
     @Test
     void appliesConnectTimeout() {
-        // given
+        // Given
         try (ManagedIdentityAccessTokenService service = new ManagedIdentityAccessTokenService(
                 new ManagedIdentityCredentialsConfig(TARGET_RESOURCE, URI.create(server.baseUrl())), Clock.systemUTC())) {
-            // when
+            // When
             var connectTimeout = service.getHttpClient().connectTimeout();
-            // then
+            // Then
             assertThat(connectTimeout).hasValue(Duration.ofSeconds(20));
         }
     }
 
     @Test
     void appliesRequestTimeout() {
-        // given
+        // Given
         try (ManagedIdentityAccessTokenService service = new ManagedIdentityAccessTokenService(
                 new ManagedIdentityCredentialsConfig(TARGET_RESOURCE, URI.create(server.baseUrl())), Clock.systemUTC())) {
-            // when
+            // When
             HttpRequest request = service.getHttpRequest();
-            // then
+            // Then
             assertThat(request.timeout()).hasValue(Duration.ofSeconds(20));
         }
     }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/auth/OauthClientCredentialsTokenServiceTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/auth/OauthClientCredentialsTokenServiceTest.java
@@ -127,28 +127,28 @@ class OauthClientCredentialsTokenServiceTest {
 
     @Test
     void appliesConnectTimeout() {
-        // given
+        // Given
         try (OauthClientCredentialsTokenService service = new OauthClientCredentialsTokenService(
                 new Oauth2ClientCredentialsConfig(URI.create(server.baseUrl()), TENANT_ID, new InlinePassword(CLIENT_ID), new InlinePassword(CLIENT_SECRET),
                         URI.create("https://vault.azure.net/.default"), null),
                 Clock.systemUTC())) {
-            // when
+            // When
             var connectTimeout = service.getHttpClient().connectTimeout();
-            // then
+            // Then
             assertThat(connectTimeout).hasValue(Duration.ofSeconds(20));
         }
     }
 
     @Test
     void appliesRequestTimeout() {
-        // given
+        // Given
         try (OauthClientCredentialsTokenService service = new OauthClientCredentialsTokenService(
                 new Oauth2ClientCredentialsConfig(URI.create(server.baseUrl()), TENANT_ID, new InlinePassword(CLIENT_ID), new InlinePassword(CLIENT_SECRET),
                         URI.create("https://vault.azure.net/.default"), null),
                 Clock.systemUTC())) {
-            // when
+            // When
             HttpRequest request = service.getHttpRequest();
-            // then
+            // Then
             assertThat(request.timeout()).hasValue(Duration.ofSeconds(20));
         }
     }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/auth/OauthClientCredentialsTokenServiceTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/auth/OauthClientCredentialsTokenServiceTest.java
@@ -8,6 +8,7 @@ package io.kroxylicious.kms.provider.azure.auth;
 
 import java.net.URI;
 import java.net.URLEncoder;
+import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Duration;
@@ -22,6 +23,7 @@ import org.assertj.core.api.ThrowableAssertAlternative;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -120,6 +122,34 @@ class OauthClientCredentialsTokenServiceTest {
                         assertThat(request.getBodyAsString()).isEqualTo(
                                 "grant_type=client_credentials&client_id=" + CLIENT_ID + "&client_secret=" + CLIENT_SECRET + "&scope=" + scope);
                     });
+        }
+    }
+
+    @Test
+    void appliesConnectTimeout() {
+        // given
+        try (OauthClientCredentialsTokenService service = new OauthClientCredentialsTokenService(
+                new Oauth2ClientCredentialsConfig(URI.create(server.baseUrl()), TENANT_ID, new InlinePassword(CLIENT_ID), new InlinePassword(CLIENT_SECRET),
+                        URI.create("https://vault.azure.net/.default"), null),
+                Clock.systemUTC())) {
+            // when
+            var connectTimeout = service.getHttpClient().connectTimeout();
+            // then
+            assertThat(connectTimeout).hasValue(Duration.ofSeconds(20));
+        }
+    }
+
+    @Test
+    void appliesRequestTimeout() {
+        // given
+        try (OauthClientCredentialsTokenService service = new OauthClientCredentialsTokenService(
+                new Oauth2ClientCredentialsConfig(URI.create(server.baseUrl()), TENANT_ID, new InlinePassword(CLIENT_ID), new InlinePassword(CLIENT_SECRET),
+                        URI.create("https://vault.azure.net/.default"), null),
+                Clock.systemUTC())) {
+            // when
+            HttpRequest request = service.getHttpRequest();
+            // then
+            assertThat(request.timeout()).hasValue(Duration.ofSeconds(20));
         }
     }
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/keyvault/KeyVaultClientTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/keyvault/KeyVaultClientTest.java
@@ -137,34 +137,34 @@ class KeyVaultClientTest {
 
     @Test
     void appliesConnectTimeout() {
-        // given
+        // Given
         try (KeyVaultClient keyVaultClient = getKeyVaultClient(getBaseUri())) {
-            // when
+            // When
             var connectTimeout = keyVaultClient.getHttpClient().connectTimeout();
-            // then
+            // Then
             assertThat(connectTimeout).hasValue(Duration.ofSeconds(20));
         }
     }
 
     @Test
     void appliesRequestTimeoutToGetKeyRequest() {
-        // given
+        // Given
         try (KeyVaultClient keyVaultClient = getKeyVaultClient(getBaseUri())) {
-            // when
+            // When
             HttpRequest request = keyVaultClient.getKeyRequest(VAULT_NAME, KEY_NAME, BEARER_TOKEN);
-            // then
+            // Then
             assertThat(request.timeout()).hasValue(Duration.ofSeconds(20));
         }
     }
 
     @Test
     void appliesRequestTimeoutToWrapOrUnwrapKeyRequest() {
-        // given
+        // Given
         try (KeyVaultClient keyVaultClient = getKeyVaultClient(getBaseUri())) {
             WrappingKey wrappingKey = new WrappingKey(KEY_NAME, KEY_VERSION, SupportedKeyType.RSA, "myvault");
-            // when
+            // When
             HttpRequest request = keyVaultClient.wrapOrUnwrapKeyRequest(wrappingKey, DEK_BYTES, BEARER_TOKEN, "wrapkey");
-            // then
+            // Then
             assertThat(request.timeout()).hasValue(Duration.ofSeconds(20));
         }
     }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/keyvault/KeyVaultClientTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/keyvault/KeyVaultClientTest.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.kms.provider.azure.keyvault;
 
 import java.net.URI;
+import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -132,6 +133,40 @@ class KeyVaultClientTest {
 
     private static String getBaseUri() {
         return server.baseUrl();
+    }
+
+    @Test
+    void appliesConnectTimeout() {
+        // given
+        try (KeyVaultClient keyVaultClient = getKeyVaultClient(getBaseUri())) {
+            // when
+            var connectTimeout = keyVaultClient.getHttpClient().connectTimeout();
+            // then
+            assertThat(connectTimeout).hasValue(Duration.ofSeconds(20));
+        }
+    }
+
+    @Test
+    void appliesRequestTimeoutToGetKeyRequest() {
+        // given
+        try (KeyVaultClient keyVaultClient = getKeyVaultClient(getBaseUri())) {
+            // when
+            HttpRequest request = keyVaultClient.getKeyRequest(VAULT_NAME, KEY_NAME, BEARER_TOKEN);
+            // then
+            assertThat(request.timeout()).hasValue(Duration.ofSeconds(20));
+        }
+    }
+
+    @Test
+    void appliesRequestTimeoutToWrapOrUnwrapKeyRequest() {
+        // given
+        try (KeyVaultClient keyVaultClient = getKeyVaultClient(getBaseUri())) {
+            WrappingKey wrappingKey = new WrappingKey(KEY_NAME, KEY_VERSION, SupportedKeyType.RSA, "myvault");
+            // when
+            HttpRequest request = keyVaultClient.wrapOrUnwrapKeyRequest(wrappingKey, DEK_BYTES, BEARER_TOKEN, "wrapkey");
+            // then
+            assertThat(request.timeout()).hasValue(Duration.ofSeconds(20));
+        }
     }
 
     @CsvSource({ "301", "302", "303", "400", "401", "404", "500", "201" })

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/main/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKms.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/main/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKms.java
@@ -12,6 +12,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -57,6 +58,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * It uses its <a href="https://support.fortanix.com/apidocs/">REST API</a>.
  */
 public class FortanixDsmKms implements Kms<String, FortanixDsmKmsEdek> {
+
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(20);
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -187,10 +190,12 @@ public class FortanixDsmKms implements Kms<String, FortanixDsmKmsEdek> {
         return fortanixDsmUrl;
     }
 
-    private HttpRequest.Builder createRequestBuilder(Object request, String path) {
+    @VisibleForTesting
+    HttpRequest.Builder createRequestBuilder(Object request, String path) {
         var body = getBody(request).getBytes(UTF_8);
 
         return HttpRequest.newBuilder()
+                .timeout(REQUEST_TIMEOUT)
                 .uri(getEndpointUrl().resolve(path))
                 .header("Content-Type", "application/json")
                 .header("Accept", "application/json")

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/main/java/io/kroxylicious/kms/provider/fortanix/dsm/session/ApiKeySessionProvider.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/main/java/io/kroxylicious/kms/provider/fortanix/dsm/session/ApiKeySessionProvider.java
@@ -76,7 +76,7 @@ public class ApiKeySessionProvider implements SessionProvider {
 
     private static final TypeReference<SessionAuthResponse> SESSION_AUTH_RESPONSE = new TypeReference<SessionAuthResponse>() {
     };
-    private static final Duration HTTP_REQUEST_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration HTTP_REQUEST_TIMEOUT = Duration.ofSeconds(20);
     private static final double DEFAULT_CREDENTIALS_LIFETIME_FACTOR = 0.80;
     static final String SESSION_AUTH_ENDPOINT = "/sys/v1/session/auth";
     static final String SESSION_TERMINATE_ENDPOINT = "/sys/v1/session/terminate";

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/test/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKmsTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/test/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKmsTest.java
@@ -104,17 +104,17 @@ class FortanixDsmKmsTest {
 
     @Test
     void appliesConnectTimeout() {
-        // given/when
+        // When
         var connectTimeout = kms.getHttpClient().connectTimeout();
-        // then
+        // Then
         assertThat(connectTimeout).hasValue(Duration.ofSeconds(20));
     }
 
     @Test
     void appliesRequestTimeout() {
-        // given/when
+        // When
         var request = kms.createRequestBuilder(new SecurityObjectDescriptor(null, "alias", null), KEYS_INFO_ENDPOINT).build();
-        // then
+        // Then
         assertThat(request.timeout()).hasValue(Duration.ofSeconds(20));
     }
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/test/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKmsTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/src/test/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKmsTest.java
@@ -32,6 +32,7 @@ import io.kroxylicious.kms.provider.fortanix.dsm.config.ApiKeySessionProviderCon
 import io.kroxylicious.kms.provider.fortanix.dsm.config.Config;
 import io.kroxylicious.kms.provider.fortanix.dsm.model.DecryptResponse;
 import io.kroxylicious.kms.provider.fortanix.dsm.model.EncryptResponse;
+import io.kroxylicious.kms.provider.fortanix.dsm.model.SecurityObjectDescriptor;
 import io.kroxylicious.kms.provider.fortanix.dsm.model.SecurityObjectResponse;
 import io.kroxylicious.kms.provider.fortanix.dsm.session.Session;
 import io.kroxylicious.kms.provider.fortanix.dsm.session.SessionProvider;
@@ -99,6 +100,22 @@ class FortanixDsmKmsTest {
     void afterEach() {
         Optional.ofNullable(kmsService).ifPresent(KmsService::close);
         server.resetAll();
+    }
+
+    @Test
+    void appliesConnectTimeout() {
+        // given/when
+        var connectTimeout = kms.getHttpClient().connectTimeout();
+        // then
+        assertThat(connectTimeout).hasValue(Duration.ofSeconds(20));
+    }
+
+    @Test
+    void appliesRequestTimeout() {
+        // given/when
+        var request = kms.createRequestBuilder(new SecurityObjectDescriptor(null, "alias", null), KEYS_INFO_ENDPOINT).build();
+        // then
+        assertThat(request.timeout()).hasValue(Duration.ofSeconds(20));
     }
 
     @Test

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKms.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKms.java
@@ -116,6 +116,7 @@ public class CipherTrustKms implements Kms<WrappingKey, CipherTrustEdek> {
     private final URI endpointUrl;
     private final BearerTokenService tokenService;
     private final HttpClient client;
+    private final Duration timeout;
 
     /**
      * Create a CipherTrust Manager KMS instance.
@@ -136,6 +137,7 @@ public class CipherTrustKms implements Kms<WrappingKey, CipherTrustEdek> {
 
         this.endpointUrl = endpointUrl;
         this.tokenService = tokenService;
+        this.timeout = timeout;
         this.client = createClient(timeout, tlsConfigurator);
     }
 
@@ -324,8 +326,10 @@ public class CipherTrustKms implements Kms<WrappingKey, CipherTrustEdek> {
         return client;
     }
 
-    private HttpRequest buildGetRequest(URI uri, String bearerToken) {
+    @VisibleForTesting
+    HttpRequest buildGetRequest(URI uri, String bearerToken) {
         return HttpRequest.newBuilder()
+                .timeout(timeout)
                 .uri(uri)
                 .header("Authorization", bearerToken(bearerToken))
                 .header("Accept", JSON_CONTENT_TYPE)
@@ -333,8 +337,10 @@ public class CipherTrustKms implements Kms<WrappingKey, CipherTrustEdek> {
                 .build();
     }
 
-    private HttpRequest buildPostJsonRequest(URI uri, String bearerToken, String jsonBody) {
+    @VisibleForTesting
+    HttpRequest buildPostJsonRequest(URI uri, String bearerToken, String jsonBody) {
         return HttpRequest.newBuilder()
+                .timeout(timeout)
                 .uri(uri)
                 .header("Authorization", bearerToken(bearerToken))
                 .header("Content-Type", JSON_CONTENT_TYPE)

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/AbstractTokenService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/AbstractTokenService.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kroxylicious.kms.provider.thales.ciphertrust.model.AuthRequest;
 import io.kroxylicious.kms.provider.thales.ciphertrust.model.AuthResponse;
 import io.kroxylicious.kms.service.KmsException;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 /**
  * Abstract base class for CipherTrust Manager authentication token services.
@@ -90,6 +91,7 @@ abstract class AbstractTokenService implements BearerTokenService {
                 .build();
     }
 
+    @VisibleForTesting
     HttpClient getHttpClient() {
         return client;
     }
@@ -140,6 +142,7 @@ abstract class AbstractTokenService implements BearerTokenService {
         }
     }
 
+    @VisibleForTesting
     HttpRequest buildAuthenticationRequest(AuthRequest authRequest) throws JsonProcessingException {
         String requestBody = OBJECT_MAPPER.writeValueAsString(authRequest);
         return HttpRequest.newBuilder()

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/AbstractTokenService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/main/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/AbstractTokenService.java
@@ -23,6 +23,7 @@ import java.util.function.UnaryOperator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.kroxylicious.kms.provider.thales.ciphertrust.model.AuthRequest;
@@ -59,6 +60,11 @@ abstract class AbstractTokenService implements BearerTokenService {
     protected final HttpClient client;
 
     /**
+     * HTTP request timeout applied to authentication requests.
+     */
+    protected final Duration timeout;
+
+    /**
      * Create an authentication token service.
      *
      * @param endpointUrl base URL of CipherTrust Manager instance
@@ -73,6 +79,7 @@ abstract class AbstractTokenService implements BearerTokenService {
         Objects.requireNonNull(tlsConfigurator, "tlsConfigurator cannot be null");
 
         this.authEndpoint = endpointUrl.resolve("/api/v1/auth/tokens/");
+        this.timeout = timeout;
         this.client = createClient(timeout, tlsConfigurator);
     }
 
@@ -81,6 +88,10 @@ abstract class AbstractTokenService implements BearerTokenService {
                 .followRedirects(HttpClient.Redirect.NORMAL)
                 .connectTimeout(timeout)
                 .build();
+    }
+
+    HttpClient getHttpClient() {
+        return client;
     }
 
     /**
@@ -96,14 +107,7 @@ abstract class AbstractTokenService implements BearerTokenService {
                     .addKeyValue("operation", operationType)
                     .addKeyValue("authRequest", authRequest)
                     .log("sending authentication request");
-            String requestBody = OBJECT_MAPPER.writeValueAsString(authRequest);
-
-            HttpRequest httpRequest = HttpRequest.newBuilder()
-                    .uri(authEndpoint)
-                    .header("Content-Type", "application/json")
-                    .header("Accept", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8))
-                    .build();
+            HttpRequest httpRequest = buildAuthenticationRequest(authRequest);
 
             return client.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofByteArray())
                     .thenApply(response -> {
@@ -134,6 +138,17 @@ abstract class AbstractTokenService implements BearerTokenService {
                     .log("failed to serialize authentication request");
             return CompletableFuture.failedFuture(new KmsException("Failed to serialize authentication request", e));
         }
+    }
+
+    HttpRequest buildAuthenticationRequest(AuthRequest authRequest) throws JsonProcessingException {
+        String requestBody = OBJECT_MAPPER.writeValueAsString(authRequest);
+        return HttpRequest.newBuilder()
+                .timeout(timeout)
+                .uri(authEndpoint)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8))
+                .build();
     }
 
     /**

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKmsTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKmsTest.java
@@ -89,25 +89,25 @@ class CipherTrustKmsTest {
 
     @Test
     void appliesConnectTimeout() {
-        // given/when
+        // When
         var connectTimeout = kms.getHttpClient().connectTimeout();
-        // then
+        // Then
         assertThat(connectTimeout).hasValue(Duration.ofSeconds(20));
     }
 
     @Test
     void appliesRequestTimeoutToGetRequest() {
-        // given/when
+        // When
         var request = kms.buildGetRequest(URI.create(server.baseUrl() + "/api/v1/vault/random"), MOCK_JWT_TOKEN);
-        // then
+        // Then
         assertThat(request.timeout()).hasValue(Duration.ofSeconds(20));
     }
 
     @Test
     void appliesRequestTimeoutToPostJsonRequest() {
-        // given/when
+        // When
         var request = kms.buildPostJsonRequest(URI.create(server.baseUrl() + "/api/v1/crypto/encrypt"), MOCK_JWT_TOKEN, "{}");
-        // then
+        // Then
         assertThat(request.timeout()).hasValue(Duration.ofSeconds(20));
     }
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKmsTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/CipherTrustKmsTest.java
@@ -88,6 +88,30 @@ class CipherTrustKmsTest {
     }
 
     @Test
+    void appliesConnectTimeout() {
+        // given/when
+        var connectTimeout = kms.getHttpClient().connectTimeout();
+        // then
+        assertThat(connectTimeout).hasValue(Duration.ofSeconds(20));
+    }
+
+    @Test
+    void appliesRequestTimeoutToGetRequest() {
+        // given/when
+        var request = kms.buildGetRequest(URI.create(server.baseUrl() + "/api/v1/vault/random"), MOCK_JWT_TOKEN);
+        // then
+        assertThat(request.timeout()).hasValue(Duration.ofSeconds(20));
+    }
+
+    @Test
+    void appliesRequestTimeoutToPostJsonRequest() {
+        // given/when
+        var request = kms.buildPostJsonRequest(URI.create(server.baseUrl() + "/api/v1/crypto/encrypt"), MOCK_JWT_TOKEN, "{}");
+        // then
+        assertThat(request.timeout()).hasValue(Duration.ofSeconds(20));
+    }
+
+    @Test
     void resolveAlias() {
         // Stub key lookup endpoint
         String keyId = "test-key-id-12345";

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/ClientCertificateTokenServiceTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/ClientCertificateTokenServiceTest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 
+import io.kroxylicious.kms.provider.thales.ciphertrust.model.AuthRequest;
 import io.kroxylicious.kms.provider.thales.ciphertrust.model.AuthResponse;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -121,6 +122,22 @@ class ClientCertificateTokenServiceTest {
         assertThatThrownBy(() -> new ClientCertificateTokenService(VALID_ENDPOINT, TEST_CLIENT_ID, TEST_TIMEOUT, null))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessageContaining("tlsConfigurator cannot be null");
+    }
+
+    @Test
+    void appliesConnectTimeout() {
+        // given/when
+        var connectTimeout = service.getHttpClient().connectTimeout();
+        // then
+        assertThat(connectTimeout).hasValue(TEST_TIMEOUT);
+    }
+
+    @Test
+    void appliesRequestTimeout() throws JsonProcessingException {
+        // given/when
+        var request = service.buildAuthenticationRequest(AuthRequest.withClientCredential(TEST_CLIENT_ID));
+        // then
+        assertThat(request.timeout()).hasValue(TEST_TIMEOUT);
     }
 
     @Test

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/ClientCertificateTokenServiceTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-thales-ciphertrust-manager/src/test/java/io/kroxylicious/kms/provider/thales/ciphertrust/auth/ClientCertificateTokenServiceTest.java
@@ -126,17 +126,17 @@ class ClientCertificateTokenServiceTest {
 
     @Test
     void appliesConnectTimeout() {
-        // given/when
+        // When
         var connectTimeout = service.getHttpClient().connectTimeout();
-        // then
+        // Then
         assertThat(connectTimeout).hasValue(TEST_TIMEOUT);
     }
 
     @Test
     void appliesRequestTimeout() throws JsonProcessingException {
-        // given/when
+        // When
         var request = service.buildAuthenticationRequest(AuthRequest.withClientCredential(TEST_CLIENT_ID));
-        // then
+        // Then
         assertThat(request.timeout()).hasValue(TEST_TIMEOUT);
     }
 


### PR DESCRIPTION
## Problem

KMS provider HTTP clients set a connect timeout but several never called `HttpRequest.Builder.timeout()`. A server that accepts the TCP connection but never responds hangs the request indefinitely: Azure Key Vault (`KeyVaultClient`), Azure auth (`OauthClientCredentialsTokenService`, `ManagedIdentityAccessTokenService`), AWS KMS (`AwsKms`), Thales CipherTrust (`CipherTrustKms`, `AbstractTokenService`), and Fortanix DSM (`FortanixDsmKms`).

Timeout values were also inconsistent across providers (10s vs 20s), including within the same provider (Fortanix's `ApiKeySessionProvider` used 10s request timeout against a 20s connect timeout on the same client).

## Fix

Added the missing `.timeout()` calls at every request-building site, and standardized every KMS provider's connect and request timeout to 20 seconds. Each class keeps its own local `Duration` literal rather than a shared constant, matching the existing pattern of `VaultKms` (already correct, unchanged).

## Impact

User-facing: requests to unresponsive KMS backends now fail with a timeout instead of hanging forever. Providers previously using 10s (Azure, AWS credential providers) now allow up to 20s before timing out.

## Test plan

- Unit tests added asserting `HttpClient.connectTimeout()` and `HttpRequest.timeout()` for every touched class, run via `mvn test` per module (all green).

Closes #4464

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>