### PR TITLE
docs(record-encryption) enhance document and remove warnings

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/pom.xml
+++ b/kroxylicious-filters/kroxylicious-record-encryption/pom.xml
@@ -25,10 +25,6 @@
     <description>Kroxylicious Filter to encrypt and decrypt records
     </description>
 
-    <properties>
-        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
-    </properties>
-
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
@@ -67,6 +67,13 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 @Plugin(configType = RecordEncryptionConfig.class)
 public class RecordEncryption<K, E> implements FilterFactory<RecordEncryptionConfig, SharedEncryptionContext<K, E>> {
 
+    /**
+     * Creates a new factory instance, invoked by the plugin framework.
+     */
+    public RecordEncryption() {
+        // nothing to initialise: state is created in initialize(FilterFactoryContext, RecordEncryptionConfig)
+    }
+
     static final ScheduledExecutorService RETRY_POOL = Executors.newSingleThreadScheduledExecutor(r -> {
         Thread retryThread = new Thread(r, "kmsRetry");
         retryThread.setDaemon(true);

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryptionMetrics.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryptionMetrics.java
@@ -13,6 +13,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static io.micrometer.core.instrument.Metrics.globalRegistry;
 
+/**
+ * Factory methods for the meters published by the filter.
+ */
 public class RecordEncryptionMetrics {
 
     /**
@@ -22,18 +25,30 @@ public class RecordEncryptionMetrics {
         // private constructor
     }
 
+    /** The name of the metric label holding the virtual cluster name. */
     public static final String VIRTUAL_CLUSTER_LABEL = "virtual_cluster";
+    /** The name of the metric label holding the topic name. */
     public static final String TOPIC_NAME = "topic_name";
 
     // Base Metric Names
     private static final String ENCRYPTED_RECORDS = "kroxylicious_filter_record_encryption_encrypted_records";
     private static final String PLAIN_RECORDS = "kroxylicious_filter_record_encryption_plain_records";
 
+    /**
+     * Creates a provider of counters of the records which the filter encrypted.
+     * @param clusterName the name of the virtual cluster.
+     * @return a provider of counters of the records which the filter encrypted.
+     */
     public static Meter.MeterProvider<Counter> encryptedRecordsCounter(String clusterName) {
         return buildCounterMeterProvider(ENCRYPTED_RECORDS, "A count of the number of records which the filter encrypted.",
                 clusterName);
     }
 
+    /**
+     * Creates a provider of counters of the records the filter sent without encrypting them.
+     * @param clusterName the name of the virtual cluster.
+     * @return a provider of counters of the records the filter sent without encrypting them.
+     */
     public static Meter.MeterProvider<Counter> plainRecordsCounter(String clusterName) {
         return buildCounterMeterProvider(PLAIN_RECORDS, "A count of records the filter sent without encrypting them.",
                 clusterName);

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/TemplateKekSelector.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/TemplateKekSelector.java
@@ -14,8 +14,20 @@ import io.kroxylicious.proxy.plugin.Plugin;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * A {@link KekSelectorService} which builds KEK selectors that derive the KEK alias
+ * from the topic name using a template.
+ * @param <K> The type of KEK id.
+ */
 @Plugin(configType = TemplateConfig.class)
 public class TemplateKekSelector<K> implements KekSelectorService<TemplateConfig, K> {
+
+    /**
+     * Creates a new selector service instance, invoked by the plugin framework.
+     */
+    public TemplateKekSelector() {
+        // nothing to initialise: state is created in buildSelector(Kms, TemplateConfig)
+    }
 
     @NonNull
     @Override

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/UnresolvedKeyException.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/UnresolvedKeyException.java
@@ -12,6 +12,10 @@ import io.kroxylicious.filter.encryption.common.EncryptionException;
  * The encryption operation failed because we could not resolve a Key for some of the records.
  */
 public class UnresolvedKeyException extends EncryptionException {
+    /**
+     * Creates an exception with the given message.
+     * @param message the detail message.
+     */
     public UnresolvedKeyException(String message) {
         super(message);
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/common/AbstractResolver.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/common/AbstractResolver.java
@@ -27,6 +27,10 @@ public abstract class AbstractResolver<E extends Enum<E>, T extends PersistedIde
     private final Map<Byte, T> idMapping;
     private final Map<T, Byte> reverseIdMapping;
 
+    /**
+     * Creates a resolver of the given implementations.
+     * @param impls the implementations to resolve between, must not be empty.
+     */
     protected AbstractResolver(Collection<T> impls) {
         if (Objects.requireNonNull(impls).isEmpty()) {
             throw new IllegalArgumentException("impls cannot be empty");
@@ -56,6 +60,11 @@ public abstract class AbstractResolver<E extends Enum<E>, T extends PersistedIde
         throw new EncryptionException(msg);
     }
 
+    /**
+     * Creates a new resolver which resolves only between the implementations named by the given elements.
+     * @param e the names of the implementations included in the subset.
+     * @return a new resolver for the named implementations.
+     */
     @SafeVarargs
     protected final S subset(E... e) {
         var m = new HashMap<>(nameMapping);

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/common/EncryptionException.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/common/EncryptionException.java
@@ -15,6 +15,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * Exceptions to do with encryption.
  */
 public class EncryptionException extends RuntimeException {
+    /** The exception to be sent to the client. */
     @NonNull
     private final ApiException apiException;
 
@@ -36,6 +37,10 @@ public class EncryptionException extends RuntimeException {
         this.apiException = apiException;
     }
 
+    /**
+     * Returns the exception to be sent to the client.
+     * @return the exception to be sent to the client.
+     */
     public ApiException getApiException() {
         return apiException;
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/common/FilterThreadExecutor.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/common/FilterThreadExecutor.java
@@ -21,6 +21,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class FilterThreadExecutor {
     private final Executor executor;
 
+    /**
+     * Creates a filter thread executor.
+     * @param executor the executor which executes work on the filter thread.
+     */
     public FilterThreadExecutor(@NonNull Executor executor) {
         Objects.requireNonNull(executor);
         this.executor = executor;

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/common/PersistedIdentifiable.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/common/PersistedIdentifiable.java
@@ -31,11 +31,13 @@ public interface PersistedIdentifiable<E extends Enum<E>> {
 
     /**
      * Returns the id to be used when serializing a reference to an implementation.
+     * @return the id to be used when serializing a reference to an implementation.
      */
     byte serializedId();
 
     /**
      * Returns the name to be used to refer to the implementation.
+     * @return the name to be used to refer to the implementation.
      */
     E name();
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/common/RecordEncryptionUtil.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/common/RecordEncryptionUtil.java
@@ -19,11 +19,20 @@ import org.apache.kafka.common.utils.CloseableIterator;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Utility methods shared between the encryption and decryption paths.
+ */
 public class RecordEncryptionUtil {
 
     private RecordEncryptionUtil() {
     }
 
+    /**
+     * Joins the given completion stages into a single completion stage which completes with the list of their results.
+     * @param stages the completion stages to join.
+     * @param <T> the result type of the completion stages.
+     * @return a completion stage that completes with the list of the results of the given stages.
+     */
     @SuppressWarnings("unchecked")
     public static <T> CompletionStage<List<T>> join(List<? extends CompletionStage<T>> stages) {
         CompletableFuture<T>[] futures = stages.stream().map(CompletionStage::toCompletableFuture).toArray(CompletableFuture[]::new);
@@ -31,6 +40,11 @@ public class RecordEncryptionUtil {
                 .thenApply(ignored -> Stream.of(futures).map(CompletableFuture::join).toList());
     }
 
+    /**
+     * Counts the records in all the batches of the given memory records.
+     * @param records the memory records.
+     * @return the total number of records.
+     */
     public static int totalRecordsInBatches(@NonNull MemoryRecords records) {
         int totalRecords = 0;
         for (MutableRecordBatch batch : records.batches()) {

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/DekManagerConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/DekManagerConfig.java
@@ -14,6 +14,9 @@ import static java.util.Objects.requireNonNullElse;
  * @param maxEncryptionsPerDek maximum number of encryptions that will be performed by a DEK
  */
 public record DekManagerConfig(Long maxEncryptionsPerDek) {
+    /**
+     * Creates a DEK manager config, applying the default number of encryptions per DEK if null.
+     */
     public DekManagerConfig {
         maxEncryptionsPerDek = requireNonNullElse(maxEncryptionsPerDek, 5_000_000L);
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/EncryptionBufferConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/EncryptionBufferConfig.java
@@ -13,6 +13,10 @@ package io.kroxylicious.filter.encryption.config;
  * @param maxSizeBytes the maximum size of the encryption buffer
  */
 public record EncryptionBufferConfig(int minSizeBytes, int maxSizeBytes) {
+    /**
+     * Creates an encryption buffer config.
+     * @throws IllegalArgumentException if either size is not positive, or the minimum exceeds the maximum.
+     */
     public EncryptionBufferConfig {
         if (minSizeBytes <= 0) {
             throw new IllegalArgumentException("minSizeBytes must be greater than zero");

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/EncryptionConfigurationException.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/EncryptionConfigurationException.java
@@ -14,6 +14,10 @@ import io.kroxylicious.filter.encryption.common.EncryptionException;
  */
 public class EncryptionConfigurationException extends EncryptionException {
 
+    /**
+     * Creates an exception with the given message.
+     * @param message the detail message.
+     */
     public EncryptionConfigurationException(String message) {
         super(message);
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/EncryptionVersion.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/EncryptionVersion.java
@@ -16,7 +16,9 @@ package io.kroxylicious.filter.encryption.config;
  */
 public enum EncryptionVersion {
 
+    /** Version 1, used by pre-release versions of the filter. No longer supported. */
     V1_UNSUPPORTED,
+    /** Version 2, the initial supported encryption version. */
     V2;
 
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/KekSelectorService.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/KekSelectorService.java
@@ -16,6 +16,12 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @param <K> the type of key
  */
 public interface KekSelectorService<C, K> {
+    /**
+     * Builds a KEK selector which selects KEKs from the given KMS.
+     * @param kms the KMS from which the selected KEKs are obtained.
+     * @param options the configuration of the selector.
+     * @return a KEK selector.
+     */
     @NonNull
     TopicNameBasedKekSelector<K> buildSelector(@NonNull Kms<K, ?> kms, C options);
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/KmsCacheConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/KmsCacheConfig.java
@@ -11,6 +11,18 @@ import java.util.function.Function;
 
 import static java.util.Objects.requireNonNullElse;
 
+/**
+ * Configuration of the caches which sit in front of the KMS.
+ *
+ * @param decryptedDekCacheSize The maximum number of decrypted DEKs to cache.
+ * @param decryptedDekExpireAfterAccessDuration How long after last access a decrypted DEK is removed from the cache.
+ * @param resolvedAliasCacheSize The maximum number of resolved aliases to cache.
+ * @param resolvedAliasExpireAfterWriteDuration How long after being cached a resolved alias is removed from the cache.
+ * @param resolvedAliasRefreshAfterWriteDuration How long after being cached a resolved alias becomes eligible for a refresh.
+ * @param notFoundAliasExpireAfterWriteDuration How long an unresolvable alias is remembered before the KMS is asked to resolve it again.
+ * @param encryptionDekCacheRefreshAfterWriteDuration How long after being cached a DEK used for encryption becomes eligible for a refresh.
+ * @param encryptionDekCacheExpireAfterWriteDuration How long after being cached a DEK used for encryption is removed from the cache.
+ */
 public record KmsCacheConfig(
                              Integer decryptedDekCacheSize,
                              Duration decryptedDekExpireAfterAccessDuration,
@@ -21,6 +33,9 @@ public record KmsCacheConfig(
                              Duration encryptionDekCacheRefreshAfterWriteDuration,
                              Duration encryptionDekCacheExpireAfterWriteDuration) {
 
+    /**
+     * Creates a KMS cache config, applying defaults for any null argument.
+     */
     public KmsCacheConfig {
         decryptedDekCacheSize = requireNonNullElse(decryptedDekCacheSize, 1000);
         decryptedDekExpireAfterAccessDuration = requireNonNullElse(decryptedDekExpireAfterAccessDuration, Duration.ofHours(1));

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/ParcelVersion.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/ParcelVersion.java
@@ -10,5 +10,6 @@ package io.kroxylicious.filter.encryption.config;
  * The version of the parcel schema used to persist information in the parcel.
  */
 public enum ParcelVersion {
+    /** Version 1 of the parcel schema. */
     V1
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/RecordEncryptionConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/RecordEncryptionConfig.java
@@ -17,6 +17,15 @@ import io.kroxylicious.proxy.plugin.PluginImplName;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * The configuration for the {@link io.kroxylicious.filter.encryption.RecordEncryption} filter factory.
+ * @param kms The name of the KMS service implementation providing the key management.
+ * @param kmsConfig The KMS service implementation's configuration.
+ * @param selector The name of the KEK selector service implementation used to select the KEK for a topic.
+ * @param selectorConfig The KEK selector service implementation's configuration.
+ * @param experimental Experimental configuration properties, subject to change without notice.
+ * @param unresolvedKeyPolicy The policy applied when the KEK for a topic cannot be resolved.
+ */
 public record RecordEncryptionConfig(@JsonProperty(required = true) @PluginImplName(KmsService.class) String kms,
                                      @PluginImplConfig(implNameProperty = "kms") Object kmsConfig,
 
@@ -25,12 +34,20 @@ public record RecordEncryptionConfig(@JsonProperty(required = true) @PluginImplN
                                      @JsonProperty Map<String, Object> experimental,
                                      @JsonProperty UnresolvedKeyPolicy unresolvedKeyPolicy) {
 
+    /** The default initial size, in bytes, of the buffer used to hold an encrypted record. */
     public static final int RECORD_BUFFER_DEFAULT_INITIAL_BYTES = 1024 * 1024;
 
+    /**
+     * Creates a record encryption config, applying an empty map if {@code experimental} is null.
+     */
     public RecordEncryptionConfig {
         experimental = experimental == null ? Map.of() : experimental;
     }
 
+    /**
+     * Returns the configuration of the caches which sit in front of the KMS.
+     * @return the configuration of the caches which sit in front of the KMS.
+     */
     public KmsCacheConfig kmsCache() {
         Integer decryptedDekCacheSize = getExperimentalInt("decryptedDekCacheSize");
         Long decryptedDekExpireAfterAccessSeconds = getExperimentalLong("decryptedDekExpireAfterAccessSeconds");
@@ -44,12 +61,20 @@ public record RecordEncryptionConfig(@JsonProperty(required = true) @PluginImplN
                 resolvedAliasRefreshAfterWriteSeconds, notFoundAliasExpireAfterWriteSeconds, encryptionDekRefreshAfterWriteSeconds, encryptionDekExpireAfterWriteSeconds);
     }
 
+    /**
+     * Returns the configuration of the encryption buffer size limits.
+     * @return the configuration of the encryption buffer size limits.
+     */
     public EncryptionBufferConfig encryptionBuffer() {
         Integer minimumBufSize = getExperimentalIntOrElse("encryptionBufferMinimumSizeBytes", RECORD_BUFFER_DEFAULT_INITIAL_BYTES);
         Integer maximumBufSize = getExperimentalIntOrElse("encryptionBufferMaximumSizeBytes", 1024 * 1024 * 8);
         return new EncryptionBufferConfig(minimumBufSize, maximumBufSize);
     }
 
+    /**
+     * Returns the configuration of the DEK manager.
+     * @return the configuration of the DEK manager.
+     */
     public DekManagerConfig dekManager() {
         Long maxEncryptionsPerDek = getExperimentalLong("maxEncryptionsPerDek");
         return new DekManagerConfig(maxEncryptionsPerDek);
@@ -78,6 +103,11 @@ public record RecordEncryptionConfig(@JsonProperty(required = true) @PluginImplN
         }).orElse(null);
     }
 
+    /**
+     * Returns the policy applied when the KEK for a topic cannot be resolved, defaulting to
+     * {@link UnresolvedKeyPolicy#PASSTHROUGH_UNENCRYPTED}.
+     * @return the policy applied when the KEK for a topic cannot be resolved.
+     */
     @Override
     public UnresolvedKeyPolicy unresolvedKeyPolicy() {
         return unresolvedKeyPolicy == null ? UnresolvedKeyPolicy.PASSTHROUGH_UNENCRYPTED : unresolvedKeyPolicy;

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/RecordField.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/RecordField.java
@@ -13,7 +13,9 @@ import java.util.Set;
  * Enumerates the parts of a Kafka Record that can be encrypted.
  */
 public enum RecordField {
+    /** The value of the record. */
     RECORD_VALUE((byte) 1),
+    /** The values of the record's headers. */
     RECORD_HEADER_VALUES((byte) (1 << 1));
 
     private final byte code;
@@ -24,12 +26,22 @@ public enum RecordField {
         this.code = code;
     }
 
+    /**
+     * Serializes the given set of record fields to a bitset.
+     * @param recordField the record fields to serialize.
+     * @return the bitset representing the given record fields.
+     */
     public static byte toBits(Set<RecordField> recordField) {
         return (byte) recordField.stream()
                 .mapToInt(w -> w.code).reduce((x, y) -> x | y)
                 .orElse(0);
     }
 
+    /**
+     * Deserializes a set of record fields from the given bitset.
+     * @param b the bitset representing a set of record fields.
+     * @return the set of record fields represented by the given bitset.
+     */
     public static Set<RecordField> fromBits(byte b) {
         var result = EnumSet.noneOf(RecordField.class);
         if ((b & RecordField.RECORD_VALUE.code) != 0) {

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TemplateConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TemplateConfig.java
@@ -6,4 +6,9 @@
 
 package io.kroxylicious.filter.encryption.config;
 
+/**
+ * The configuration for the {@link io.kroxylicious.filter.encryption.TemplateKekSelector} plugin.
+ * @param template The template used to derive the KEK alias from the topic name. The {@code $(topicName)}
+ *        placeholder is replaced with the name of the topic.
+ */
 public record TemplateConfig(String template) {}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TopicNameBasedKekSelector.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TopicNameBasedKekSelector.java
@@ -18,6 +18,13 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public abstract class TopicNameBasedKekSelector<K> {
 
     /**
+     * Creates a selector.
+     */
+    protected TopicNameBasedKekSelector() {
+        // this class holds no state of its own
+    }
+
+    /**
      * Returns a completion stage whose value, on successful completion, is a topic name selection containing the
      * resolved key ids for topics which could be resolved, and a set of unresolved topic names.
      * @param topicNames A set of topic names

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TopicNameKekSelection.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TopicNameKekSelection.java
@@ -20,6 +20,11 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @param <K> the type of key
  */
 public record TopicNameKekSelection<K>(@NonNull Map<String, K> topicNameToKekId, @NonNull Set<String> unresolvedTopicNames) {
+    /**
+     * Creates a topic name KEK selection.
+     * @throws NullPointerException if either component is null.
+     * @throws IllegalArgumentException if any value of {@code topicNameToKekId} is null.
+     */
     public TopicNameKekSelection {
         Objects.requireNonNull(topicNameToKekId);
         List<Map.Entry<String, K>> entriesWithNullValue = topicNameToKekId.entrySet().stream().filter(e -> e.getValue() == null).toList();

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/WrapperVersion.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/WrapperVersion.java
@@ -10,8 +10,10 @@ package io.kroxylicious.filter.encryption.config;
  * The version of the wrapper schema used to persist information in the wrapper.
  */
 public enum WrapperVersion {
+    /** Version 1, used by pre-release versions of the filter. No longer supported. */
     V1_UNSUPPORTED,
 
+    /** Version 2 of the wrapper schema. */
     V2;
 
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/Aad.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/Aad.java
@@ -17,5 +17,12 @@ import io.kroxylicious.filter.encryption.config.AadSpec;
  * Abstraction for constructing the AAD passed to an AEAD cipher.
  */
 public interface Aad extends PersistedIdentifiable<AadSpec> {
+    /**
+     * Computes the AAD for the given batch of records.
+     * @param topicName the name of the topic to which the batch is being produced, or from which it is being fetched.
+     * @param partitionId the index of the partition to which the batch is being produced, or from which it is being fetched.
+     * @param batch the batch of records.
+     * @return a buffer containing the AAD.
+     */
     ByteBuffer computeAad(String topicName, int partitionId, RecordBatch batch);
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/AadNone.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/AadNone.java
@@ -13,8 +13,13 @@ import org.apache.kafka.common.utils.ByteUtils;
 
 import io.kroxylicious.filter.encryption.config.AadSpec;
 
+/**
+ * An {@link Aad} which computes an empty AAD, meaning no additional data is
+ * authenticated by the cipher.
+ */
 public class AadNone implements Aad {
 
+    /** The singleton instance of this AAD. */
     public static final AadNone INSTANCE = new AadNone();
 
     private AadNone() {

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/AadResolver.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/AadResolver.java
@@ -12,6 +12,9 @@ import java.util.List;
 import io.kroxylicious.filter.encryption.common.AbstractResolver;
 import io.kroxylicious.filter.encryption.config.AadSpec;
 
+/**
+ * A resolver of {@link AadSpec}s to their corresponding {@link Aad}s.
+ */
 public class AadResolver extends AbstractResolver<AadSpec, Aad, AadResolver> {
 
     private static final AadResolver ALL = new AadResolver(List.of(AadNone.INSTANCE));
@@ -20,6 +23,11 @@ public class AadResolver extends AbstractResolver<AadSpec, Aad, AadResolver> {
         super(impls);
     }
 
+    /**
+     * Creates a resolver of the AADs corresponding to the given AAD specs.
+     * @param aadSpec the AAD specs to resolve between.
+     * @return a resolver of the AADs corresponding to the given AAD specs.
+     */
     public static AadResolver of(AadSpec... aadSpec) {
         return ALL.subset(aadSpec);
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/Encryption.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/Encryption.java
@@ -23,7 +23,9 @@ import io.kroxylicious.filter.encryption.dek.CipherSpecResolver;
  */
 public class Encryption implements PersistedIdentifiable<EncryptionVersion> {
 
+    /** The encryption used by pre-release versions of the filter. No longer supported. */
     public static final Encryption V1 = new Encryption((byte) 1, EncryptionVersion.V1_UNSUPPORTED, WrapperV1.INSTANCE, ParcelV1.INSTANCE);
+    /** The encryption corresponding to {@link EncryptionVersion#V2}. */
     public static final Encryption V2 = new Encryption((byte) 2, EncryptionVersion.V2,
             new WrapperV2(
                     CipherSpecResolver.of(CipherSpec.AES_256_GCM_128),
@@ -68,10 +70,18 @@ public class Encryption implements PersistedIdentifiable<EncryptionVersion> {
         return version;
     }
 
+    /**
+     * Returns the wrapper used by this version of the encryption.
+     * @return the wrapper used by this version of the encryption.
+     */
     public Wrapper wrapper() {
         return wrapper;
     }
 
+    /**
+     * Returns the parcel used by this version of the encryption.
+     * @return the parcel used by this version of the encryption.
+     */
     public Parcel parcel() {
         return parcel;
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/EncryptionHeader.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/EncryptionHeader.java
@@ -6,6 +6,9 @@
 
 package io.kroxylicious.filter.encryption.crypto;
 
+/**
+ * Holds the name of the record header used to identify encrypted records.
+ */
 public class EncryptionHeader {
 
     /**

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/EncryptionResolver.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/EncryptionResolver.java
@@ -12,8 +12,12 @@ import java.util.List;
 import io.kroxylicious.filter.encryption.common.AbstractResolver;
 import io.kroxylicious.filter.encryption.config.EncryptionVersion;
 
+/**
+ * A resolver of {@link EncryptionVersion}s to their corresponding {@link Encryption}s.
+ */
 public class EncryptionResolver extends AbstractResolver<EncryptionVersion, Encryption, EncryptionResolver> {
 
+    /** A resolver of all the known {@link Encryption}s. */
     public static final EncryptionResolver ALL = new EncryptionResolver(List.of(Encryption.V1, Encryption.V2));
 
     EncryptionResolver(Collection<Encryption> impls) {

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/Parcel.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/Parcel.java
@@ -24,13 +24,34 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * What gets included depends on the {@link RecordField}s.
  */
 public interface Parcel extends PersistedIdentifiable<ParcelVersion> {
+    /**
+     * Returns the number of bytes required by {@link #writeParcel(Set, Record, ByteBuffer)}
+     * to serialize the parcel for the given record.
+     * @param recordFields the fields of the record included in the parcel.
+     * @param kafkaRecord the record.
+     * @return the number of bytes required to serialize the parcel.
+     */
     int sizeOfParcel(@NonNull Set<RecordField> recordFields,
                      @NonNull Record kafkaRecord);
 
+    /**
+     * Serializes the parcel for the given record to the given buffer, which should have at least
+     * {@link #sizeOfParcel(Set, Record)} bytes {@linkplain ByteBuffer#remaining() remaining}.
+     * @param recordFields the fields of the record included in the parcel.
+     * @param kafkaRecord the record.
+     * @param parcel the buffer to serialize the parcel to.
+     */
     void writeParcel(@NonNull Set<RecordField> recordFields,
                      @NonNull Record kafkaRecord,
                      @NonNull ByteBuffer parcel);
 
+    /**
+     * Reads a previously-serialized parcel from the given buffer, passing the deserialized record
+     * value and headers to the given consumer.
+     * @param parcel the buffer to read the parcel from.
+     * @param encryptedRecord the encrypted record from which the parcel was decrypted.
+     * @param consumer the consumer of the deserialized record value and headers.
+     */
     void readParcel(@NonNull ByteBuffer parcel,
                     @NonNull Record encryptedRecord,
                     @NonNull BiConsumer<ByteBuffer, Header[]> consumer);

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/ParcelV1.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/ParcelV1.java
@@ -24,11 +24,17 @@ import io.kroxylicious.filter.encryption.config.RecordField;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Version 1 of the parcel schema.
+ */
 public class ParcelV1 implements Parcel {
 
+    /** The singleton instance of this parcel. */
     public static final ParcelV1 INSTANCE = new ParcelV1();
 
+    /** The length marker used to represent a null record value or header value. */
     public static final int NULL_MARKER = -1;
+    /** The length marker used to represent a record field which is not included in the parcel. */
     public static final int ABSENT_MARKER = -2;
 
     private static final Header[] ABSENT_HEADERS = new Header[0];

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/ParcelVersionResolver.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/ParcelVersionResolver.java
@@ -12,8 +12,12 @@ import java.util.List;
 import io.kroxylicious.filter.encryption.common.AbstractResolver;
 import io.kroxylicious.filter.encryption.config.ParcelVersion;
 
+/**
+ * A resolver of {@link ParcelVersion}s to their corresponding {@link Parcel}s.
+ */
 public class ParcelVersionResolver extends AbstractResolver<ParcelVersion, Parcel, ParcelVersionResolver> {
 
+    /** A resolver of all the known {@link Parcel}s. */
     public static final ParcelVersionResolver ALL = new ParcelVersionResolver(List.of(ParcelV1.INSTANCE));
 
     private ParcelVersionResolver(Collection<Parcel> impls) {

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/Wrapper.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/Wrapper.java
@@ -29,6 +29,15 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  *  any {@link Aad} and the ciphertext of the {@link Parcel}.
  */
 public interface Wrapper extends PersistedIdentifiable<WrapperVersion> {
+    /**
+     * Decrypts a parcel in place, returning a buffer containing the plaintext parcel.
+     * @param ciphertextParcel the buffer containing the ciphertext of the parcel.
+     * @param aad the AAD to be verified as part of the decryption.
+     * @param parameterBuffer the buffer containing the cipher parameters.
+     * @param encryptor the decryptor to be used to decrypt the parcel.
+     * @param <E> the type of encrypted DEK.
+     * @return a buffer containing the plaintext parcel.
+     */
     static <E> ByteBuffer decryptParcel(
                                         ByteBuffer ciphertextParcel,
                                         ByteBuffer aad,
@@ -40,6 +49,21 @@ public interface Wrapper extends PersistedIdentifiable<WrapperVersion> {
         return plaintext;
     }
 
+    /**
+     * Serializes the wrapper for the given record to the given buffer, encrypting the record's parcel.
+     * @param edekSerde the serde for the encrypted DEK.
+     * @param edek the encrypted DEK.
+     * @param topicName the name of the topic to which the record is being produced.
+     * @param partitionId the index of the partition to which the record is being produced.
+     * @param batch the batch containing the record.
+     * @param kafkaRecord the record.
+     * @param encryptor the encryptor to be used to encrypt the parcel.
+     * @param parcel the parcel used to serialize the record's fields.
+     * @param aadSpec the AAD to be included in the encryption.
+     * @param recordFields the fields of the record included in the parcel.
+     * @param buffer the buffer to serialize the wrapper to.
+     * @param <E> the type of encrypted DEK.
+     */
     <E> void writeWrapper(
                           @NonNull Serde<E> edekSerde,
                           @NonNull E edek,
@@ -53,6 +77,19 @@ public interface Wrapper extends PersistedIdentifiable<WrapperVersion> {
                           @NonNull Set<RecordField> recordFields,
                           @NonNull ByteBuffer buffer);
 
+    /**
+     * Reads a previously-serialized wrapper from the given buffer, decrypting the parcel and passing
+     * the deserialized record value and headers to the given consumer.
+     * @param parcel the parcel used to deserialize the record's fields.
+     * @param topicName the name of the topic from which the record is being fetched.
+     * @param partition the index of the partition from which the record is being fetched.
+     * @param batch the batch containing the record.
+     * @param record the encrypted record.
+     * @param wrapper the buffer to read the wrapper from.
+     * @param decryptor the decryptor to be used to decrypt the parcel.
+     * @param consumer the consumer of the deserialized record value and headers.
+     * @param <E> the type of encrypted DEK.
+     */
     <E> void read(
                   @NonNull Parcel parcel,
                   @NonNull String topicName,
@@ -63,6 +100,16 @@ public interface Wrapper extends PersistedIdentifiable<WrapperVersion> {
                   Dek<E>.Decryptor decryptor,
                   @NonNull BiConsumer<ByteBuffer, Header[]> consumer);
 
+    /**
+     * Reads the cipher manager and encrypted DEK from a previously-serialized wrapper,
+     * applying the given function to them and returning the result.
+     * @param wrapper the buffer to read the wrapper from.
+     * @param serde the serde for the encrypted DEK.
+     * @param fn the function applied to the cipher manager and encrypted DEK.
+     * @param <E> the type of encrypted DEK.
+     * @param <T> the type returned by the function.
+     * @return the result of applying the function.
+     */
     <E, T> T readSpecAndEdek(
                              ByteBuffer wrapper,
                              Serde<E> serde,

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/WrapperV1.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/WrapperV1.java
@@ -24,9 +24,18 @@ import io.kroxylicious.kms.service.Serde;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Version 1 of the wrapper schema, used by pre-release versions of the filter.
+ * No longer supported: all its operations throw {@link EncryptionException}.
+ */
 public class WrapperV1 implements Wrapper {
 
+    /** The singleton instance of this wrapper. */
     public static final WrapperV1 INSTANCE = new WrapperV1();
+
+    private WrapperV1() {
+        // singleton: use INSTANCE
+    }
 
     @Override
     public byte serializedId() {

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/WrapperV2.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/WrapperV2.java
@@ -49,9 +49,16 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public class WrapperV2 implements Wrapper {
 
+    /** The resolver of the ciphers supported by this wrapper. */
     public final CipherSpecResolver cipherSpecResolver;
+    /** The resolver of the AADs supported by this wrapper. */
     public final AadResolver aadResolver;
 
+    /**
+     * Creates a wrapper.
+     * @param cipherSpecResolver the resolver of the ciphers supported by this wrapper.
+     * @param aadResolver the resolver of the AADs supported by this wrapper.
+     */
     public WrapperV2(CipherSpecResolver cipherSpecResolver,
                      AadResolver aadResolver) {
         this.cipherSpecResolver = cipherSpecResolver;

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/decrypt/DecryptState.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/decrypt/DecryptState.java
@@ -16,6 +16,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 /**
  * Helper class to group together some state for decryption.
  * Either both, or neither, of the given {@code decryptionVersion} and {@code encryptor} should be null.
+ * @param <E> The type of encrypted DEK.
  */
 public final class DecryptState<E> {
 
@@ -31,25 +32,46 @@ public final class DecryptState<E> {
     @Nullable
     private Dek<E>.Decryptor decryptor;
 
+    /**
+     * Creates a decrypt state without a decryptor.
+     * @param encryptionUsed the encryption used by the record being decrypted, or null if the record was not encrypted.
+     */
     public DecryptState(
                         Encryption encryptionUsed) {
         this.encryptionUsed = encryptionUsed;
         this.decryptor = null;
     }
 
+    /**
+     * Returns whether this state represents a record which was not encrypted.
+     * @return true if the record was not encrypted.
+     */
     public boolean isNone() {
         return encryptionUsed == null;
     }
 
+    /**
+     * Sets the decryptor to be used to decrypt the record.
+     * @param decryptor the decryptor to be used to decrypt the record.
+     * @return this decrypt state.
+     */
     public DecryptState<E> withDecryptor(Dek<E>.Decryptor decryptor) {
         this.decryptor = decryptor;
         return this;
     }
 
+    /**
+     * Returns the encryption used by the record being decrypted, or null if the record was not encrypted.
+     * @return the encryption used by the record being decrypted, or null if the record was not encrypted.
+     */
     public Encryption encryptionUsed() {
         return encryptionUsed;
     }
 
+    /**
+     * Returns the decryptor to be used to decrypt the record, or null if not yet set.
+     * @return the decryptor to be used to decrypt the record, or null if not yet set.
+     */
     @Nullable
     public Dek<E>.Decryptor decryptor() {
         return decryptor;

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/decrypt/DecryptionDekCache.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/decrypt/DecryptionDekCache.java
@@ -37,12 +37,24 @@ public class DecryptionDekCache<K, E> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DecryptionDekCache.class);
 
+    /** The value to pass as {@code dekCacheMaxItems} for a cache with no maximum size. */
     public static final int NO_MAX_CACHE_SIZE = -1;
     private final DekManager<K, E> dekManager;
 
+    /**
+     * The key to the cache.
+     * Either both, or neither, of {@code cipherManager} and {@code edek} must be null.
+     * @param <E> The type of encrypted DEK.
+     * @param cipherManager The cipher manager, or null if the record was not encrypted.
+     * @param edek The encrypted DEK, or null if the record was not encrypted.
+     */
     public record CacheKey<E>(
                               @Nullable CipherManager cipherManager,
                               @Nullable E edek) {
+        /**
+         * Creates a cache key.
+         * @throws IllegalArgumentException if exactly one of the components is null.
+         */
         public CacheKey {
             if (cipherManager == null ^ edek == null) {
                 throw new IllegalArgumentException();
@@ -59,7 +71,10 @@ public class DecryptionDekCache<K, E> {
             return UNENCRYPTED;
         }
 
-        /** Tests whether this cache key is the sentinel value representing unencrypted records */
+        /**
+         * Tests whether this cache key is the sentinel value representing unencrypted records
+         * @return true if this cache key represents unencrypted records.
+         */
         public boolean isUnencrypted() {
             return cipherManager == null || edek == null;
         }
@@ -67,6 +82,12 @@ public class DecryptionDekCache<K, E> {
 
     private final AsyncLoadingCache<CacheKey<E>, Dek<E>> decryptorCache;
 
+    /**
+     * Creates a decryption DEK cache.
+     * @param dekManager the DEK manager used to decrypt encrypted DEKs on a cache miss.
+     * @param dekCacheExecutor the executor used to load cache entries, or null to use the cache's default executor.
+     * @param dekCacheMaxItems the maximum number of DEKs to cache, or {@link #NO_MAX_CACHE_SIZE} for no maximum.
+     */
     public DecryptionDekCache(@NonNull DekManager<K, E> dekManager,
                               @Nullable Executor dekCacheExecutor,
                               int dekCacheMaxItems) {

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/decrypt/InBandDecryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/decrypt/InBandDecryptionManager.java
@@ -50,6 +50,13 @@ public class InBandDecryptionManager<K, E> implements DecryptionManager {
 
     private final EncryptionResolver encryptionResolver;
 
+    /**
+     * Creates a decryption manager.
+     * @param encryptionResolver the resolver of the encryptions supported by this manager.
+     * @param dekManager the DEK manager used to decrypt encrypted DEKs.
+     * @param dekCache the cache of DEKs used for decryption.
+     * @param filterThreadExecutor the executor used to complete futures on the filter thread.
+     */
     public InBandDecryptionManager(EncryptionResolver encryptionResolver,
                                    @NonNull DekManager<K, E> dekManager,
                                    @NonNull DecryptionDekCache<K, E> dekCache,

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/decrypt/RecordDecryptor.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/decrypt/RecordDecryptor.java
@@ -21,6 +21,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A {@link RecordTransform} that decrypts records that were previously encrypted by {@link io.kroxylicious.filter.encryption.encrypt.RecordEncryptor}.
+ * @param <E> The type of encrypted DEK.
  */
 public class RecordDecryptor<E> implements RecordTransform<DecryptState<E>> {
 
@@ -31,6 +32,11 @@ public class RecordDecryptor<E> implements RecordTransform<DecryptState<E>> {
     private ByteBuffer transformedValue;
     private Header[] transformedHeaders;
 
+    /**
+     * Creates a record decryptor.
+     * @param topicName the name of the topic from which the records are being fetched.
+     * @param partition the index of the partition from which the records are being fetched.
+     */
     public RecordDecryptor(@NonNull String topicName, int partition) {
         this.topicName = Objects.requireNonNull(topicName);
         this.partition = partition;

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/Aes.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/Aes.java
@@ -18,8 +18,12 @@ import javax.crypto.spec.GCMParameterSpec;
 
 import io.kroxylicious.filter.encryption.config.CipherSpec;
 
+/**
+ * A {@link CipherManager} for the AES cipher in GCM mode.
+ */
 public class Aes implements CipherManager {
 
+    /** AES in GCM mode using a 256-bit key and a 128-bit authentication tag. */
     public static final Aes AES_256_GCM_128 = new Aes("AES/GCM/NoPadding", 256, (byte) 0, CipherSpec.AES_256_GCM_128);
 
     private static final int IV_SIZE_BYTES = 12;

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/BufferTooSmallException.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/BufferTooSmallException.java
@@ -6,7 +6,14 @@
 
 package io.kroxylicious.filter.encryption.dek;
 
+/**
+ * Indicates that an allocated buffer had too few bytes remaining for an
+ * encryption or decryption operation to be completed.
+ */
 public class BufferTooSmallException extends RuntimeException {
+    /**
+     * Creates an exception with no message or cause.
+     */
     public BufferTooSmallException() {
         super();
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/ChaChaPoly.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/ChaChaPoly.java
@@ -20,9 +20,13 @@ import io.kroxylicious.filter.encryption.config.CipherSpec;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * A {@link CipherManager} for the ChaCha20-Poly1305 cipher.
+ */
 public class ChaChaPoly implements CipherManager {
     private static final int NONCE_SIZE_BYTES = 12;
 
+    /** The singleton instance of this cipher manager. */
     public static final ChaChaPoly INSTANCE = new ChaChaPoly();
 
     private ChaChaPoly() {

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/CipherManager.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/CipherManager.java
@@ -20,6 +20,10 @@ import io.kroxylicious.filter.encryption.config.CipherSpec;
  */
 public interface CipherManager extends PersistedIdentifiable<CipherSpec> {
 
+    /**
+     * The value returned by {@link #constantParamsSize()} when the size of the serialized
+     * parameters depends on the parameters themselves.
+     */
     int VARIABLE_SIZE_PARAMETERS = -1;
 
     @Override
@@ -28,13 +32,23 @@ public interface CipherManager extends PersistedIdentifiable<CipherSpec> {
     @Override
     CipherSpec name();
 
+    /**
+     * Returns the maximum number of encryption operations which may safely be
+     * performed using a single key with this cipher.
+     * @return the maximum number of encryption operations per key.
+     */
     long maxEncryptionsPerKey();
 
+    /**
+     * Creates a new {@link Cipher} instance for this cipher.
+     * @return a new cipher instance.
+     */
     Cipher newCipher();
 
     /**
      * Return a supplier of parameters for use with the cipher.
      * The supplier need not be thread-safe.
+     * @return a supplier of cipher parameters.
      */
     Supplier<AlgorithmParameterSpec> paramSupplier();
 
@@ -43,6 +57,7 @@ public interface CipherManager extends PersistedIdentifiable<CipherSpec> {
      * does not depend on the parameters, then returns the number.
      * Otherwise, if the number of bytes required by  {@link #writeParameters(ByteBuffer, AlgorithmParameterSpec)} is variable
      * returns {@link #VARIABLE_SIZE_PARAMETERS}.
+     * @return the number of bytes required to serialize the parameters, or {@link #VARIABLE_SIZE_PARAMETERS}.
      */
     int constantParamsSize();
 
@@ -50,12 +65,16 @@ public interface CipherManager extends PersistedIdentifiable<CipherSpec> {
      * Return the number of bytes required by {@link #writeParameters(ByteBuffer, AlgorithmParameterSpec)}
      * to serialize the given parameters.
      * If {@link #constantParamsSize()} returns a number >= 0 then this must return the same number.
+     * @param parameterSpec the parameters to be serialized.
+     * @return the number of bytes required to serialize the given parameters.
      */
     int size(AlgorithmParameterSpec parameterSpec);
 
     /**
      * Serialize the given parameters to the given buffer, which should have at least
      * {@link #size(AlgorithmParameterSpec)} bytes {@linkplain ByteBuffer#remaining() remaining}.
+     * @param parametersBuffer the buffer to serialize the parameters to.
+     * @param params the parameters to be serialized.
      */
     void writeParameters(
                          ByteBuffer parametersBuffer,
@@ -66,6 +85,8 @@ public interface CipherManager extends PersistedIdentifiable<CipherSpec> {
      * The implementation should know how many bytes to read, so the number of
      * {@linkplain ByteBuffer#remaining() remaining} bytes need only be ≥ (not =)
      * the {@link #size(AlgorithmParameterSpec)} at the time the buffer was written.
+     * @param parametersBuffer the buffer to read the parameters from.
+     * @return the deserialized parameters.
      */
     AlgorithmParameterSpec readParameters(ByteBuffer parametersBuffer);
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/CipherSpecResolver.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/CipherSpecResolver.java
@@ -12,12 +12,20 @@ import java.util.List;
 import io.kroxylicious.filter.encryption.common.AbstractResolver;
 import io.kroxylicious.filter.encryption.config.CipherSpec;
 
+/**
+ * A resolver of {@link CipherSpec}s to their corresponding {@link CipherManager}s.
+ */
 public class CipherSpecResolver extends AbstractResolver<CipherSpec, CipherManager, CipherSpecResolver> {
 
+    /** A resolver of all the known {@link CipherManager}s. */
     public static final CipherSpecResolver ALL = new CipherSpecResolver(List.of(
             Aes.AES_256_GCM_128,
             ChaChaPoly.INSTANCE));
 
+    /**
+     * Creates a resolver of the given cipher managers.
+     * @param impls the cipher managers to resolve between.
+     */
     public CipherSpecResolver(Collection<CipherManager> impls) {
         super(impls);
     }
@@ -27,6 +35,11 @@ public class CipherSpecResolver extends AbstractResolver<CipherSpec, CipherManag
         return new UnknownCipherSpecException(msg);
     }
 
+    /**
+     * Creates a resolver of the cipher managers corresponding to the given cipher specs.
+     * @param cipherSpec the cipher specs to resolve between.
+     * @return a resolver of the cipher managers corresponding to the given cipher specs.
+     */
     public static CipherSpecResolver of(CipherSpec... cipherSpec) {
         return ALL.subset(cipherSpec);
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/Dek.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/Dek.java
@@ -171,11 +171,20 @@ public final class Dek<E> {
         }
     }
 
+    /**
+     * Returns whether the key has been destroyed.
+     * @return true if the key has been destroyed.
+     * @see <a href="#destruction">Destruction</a> in the class Javadoc.
+     */
     public boolean isDestroyed() {
         SecretKey secretKey = atomicKey.get();
         return secretKey == null || secretKey.isDestroyed();
     }
 
+    /**
+     * Returns the encrypted DEK.
+     * @return the encrypted DEK.
+     */
     public E edek() {
         return edek;
     }
@@ -205,6 +214,7 @@ public final class Dek<E> {
 
         /**
          * Returns the encrypted DEK.
+         * @return the encrypted DEK.
          */
         public @NonNull E edek() {
             return Dek.this.edek();
@@ -307,6 +317,10 @@ public final class Dek<E> {
             }
         }
 
+        /**
+         * Returns the manager for the cipher supported by this encryptor.
+         * @return the manager for the cipher supported by this encryptor.
+         */
         public @NonNull CipherManager cipherManager() {
             return cipherManager;
         }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekException.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekException.java
@@ -6,15 +6,29 @@
 
 package io.kroxylicious.filter.encryption.dek;
 
+/**
+ * The base class for exceptions relating to the use of {@link Dek}s.
+ */
 public class DekException extends RuntimeException {
+    /**
+     * Creates an exception with the given message.
+     * @param message the detail message.
+     */
     public DekException(String message) {
         super(message);
     }
 
+    /**
+     * Creates an exception with no message or cause.
+     */
     public DekException() {
         super();
     }
 
+    /**
+     * Creates an exception with the given cause.
+     * @param cause the cause of this exception.
+     */
     public DekException(Throwable cause) {
         super(cause);
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekManager.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekManager.java
@@ -30,6 +30,11 @@ public class DekManager<K, E> {
     private final Kms<K, E> kms;
     private final long maxEncryptionsPerDek;
 
+    /**
+     * Creates a DEK manager.
+     * @param kms the KMS from which DEKs are generated and with which encrypted DEKs are decrypted.
+     * @param maxEncryptionsPerDek the maximum number of encryption operations allowed per generated DEK.
+     */
     public DekManager(Kms<K, E> kms, long maxEncryptionsPerDek) {
         this.kms = kms;
         this.maxEncryptionsPerDek = maxEncryptionsPerDek;
@@ -38,6 +43,7 @@ public class DekManager<K, E> {
     /**
      * Returns the KMS's serde for encrypted DEKs.
      *
+     * @return the KMS's serde for encrypted DEKs.
      * @see Kms#edekSerde()
      */
     public Serde<E> edekSerde() {

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekUsageException.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekUsageException.java
@@ -11,6 +11,10 @@ package io.kroxylicious.filter.encryption.dek;
  * to encrypt when its limit on number of encryption operations has been reached.
  */
 public class DekUsageException extends DekException {
+    /**
+     * Creates an exception with the given message.
+     * @param message the detail message.
+     */
     public DekUsageException(String message) {
         super(message);
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DestroyedDekException.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DestroyedDekException.java
@@ -11,6 +11,9 @@ package io.kroxylicious.filter.encryption.dek;
  */
 public class DestroyedDekException extends DekException {
 
+    /**
+     * Creates an exception with no message or cause.
+     */
     public DestroyedDekException() {
         super();
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/ExhaustedDekException.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/ExhaustedDekException.java
@@ -12,6 +12,10 @@ package io.kroxylicious.filter.encryption.dek;
  * In theory this should never be thrown in practice.
  */
 public class ExhaustedDekException extends DekException {
+    /**
+     * Creates an exception with the given message.
+     * @param msg the detail message.
+     */
     public ExhaustedDekException(String msg) {
         super(msg);
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/UnknownCipherSpecException.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/UnknownCipherSpecException.java
@@ -10,6 +10,10 @@ package io.kroxylicious.filter.encryption.dek;
  * Indicates an attempt to deserialize a persisted reference to a CipherSpec, but the persisted identifier was unknown.
  */
 public class UnknownCipherSpecException extends DekException {
+    /**
+     * Creates an exception with the given message.
+     * @param message the detail message.
+     */
     public UnknownCipherSpecException(String message) {
         super(message);
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/EncryptionDekCache.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/EncryptionDekCache.java
@@ -39,6 +39,7 @@ public class EncryptionDekCache<K, E> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EncryptionDekCache.class);
 
+    /** The value to pass as {@code dekCacheMaxItems} for a cache with no maximum size. */
     public static final int NO_MAX_CACHE_SIZE = -1;
     private CipherSpecResolver cipherSpecResolver;
     private final AtomicLong invalidationCount = new AtomicLong(0L);
@@ -53,6 +54,14 @@ public class EncryptionDekCache<K, E> {
 
     private final AsyncLoadingCache<CacheKey<K>, Dek<E>> dekCache;
 
+    /**
+     * Creates an encryption DEK cache.
+     * @param dekManager the DEK manager used to generate DEKs on a cache miss.
+     * @param dekCacheExecutor the executor used to load cache entries, or null to use the cache's default executor.
+     * @param dekCacheMaxItems the maximum number of DEKs to cache, or {@link #NO_MAX_CACHE_SIZE} for no maximum.
+     * @param refreshAfterWrite how long after being cached a DEK becomes eligible for a refresh.
+     * @param expireAfterWrite how long after being cached a DEK is removed from the cache.
+     */
     public EncryptionDekCache(@NonNull DekManager<K, E> dekManager,
                               @Nullable Executor dekCacheExecutor,
                               int dekCacheMaxItems,

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/EncryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/EncryptionManager.java
@@ -23,6 +23,8 @@ public interface EncryptionManager<K> {
     /**
      * Asynchronously encrypt the given {@code records} using the current DEK for the given KEK returning a MemoryRecords object which will contain all records
      * transformed according to the {@code encryptionScheme}.
+     * @param topicName The name of the topic to which the records are being produced.
+     * @param partition The index of the partition to which the records are being produced.
      * @param encryptionScheme The encryption scheme.
      * @param records The MemoryRecords to be encrypted.
      * @param bufferAllocator Allocator of ByteBufferOutputStream

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/EncryptionScheme.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/EncryptionScheme.java
@@ -17,6 +17,7 @@ import io.kroxylicious.filter.encryption.crypto.AadNone;
  * Describes how a record should be encrypted
  * @param kekId The KEK identifier to be used. Not null.
  * @param recordFields The fields of the record that should be encrypted with the given KEK. Neither null nor empty.
+ * @param aadSpec The AAD to be included in the encryption. Not null.
  * @param <K> The type of KEK identifier.
  */
 public record EncryptionScheme<K>(
@@ -24,6 +25,11 @@ public record EncryptionScheme<K>(
                                   Set<RecordField> recordFields,
                                   Aad aadSpec) {
 
+    /**
+     * Creates an encryption scheme.
+     * @throws NullPointerException if any component is null.
+     * @throws IllegalArgumentException if {@code recordFields} is empty.
+     */
     public EncryptionScheme {
         Objects.requireNonNull(kekId);
         if (Objects.requireNonNull(recordFields).isEmpty()) {
@@ -32,6 +38,11 @@ public record EncryptionScheme<K>(
         Objects.requireNonNull(aadSpec);
     }
 
+    /**
+     * Creates an encryption scheme with the {@link AadNone} AAD.
+     * @param kekId The KEK identifier to be used. Not null.
+     * @param recordFields The fields of the record that should be encrypted with the given KEK. Neither null nor empty.
+     */
     public EncryptionScheme(
                             K kekId,
                             Set<RecordField> recordFields) {

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManager.java
@@ -31,6 +31,13 @@ import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * An implementation of {@link EncryptionManager}
+ * that uses envelope encryption and stores the KEK id and encrypted DEK
+ * alongside the record ("in-band").
+ * @param <K> The type of KEK id.
+ * @param <E> The type of the encrypted DEK.
+ */
 public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
 
     private static final int MAX_ATTEMPTS = 100;
@@ -47,6 +54,15 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
     private final int recordBufferInitialBytes;
     private final int recordBufferMaxBytes;
 
+    /**
+     * Creates an encryption manager.
+     * @param encryption the encryption used on the produce path.
+     * @param edekSerde the serde for encrypted DEKs.
+     * @param recordBufferInitialBytes the initial size, in bytes, of the buffer used to hold the encrypted record.
+     * @param recordBufferMaxBytes the maximum size, in bytes, of the buffer used to hold the encrypted record.
+     * @param dekCache the cache of DEKs used for encryption.
+     * @param filterThreadExecutor the executor used to complete futures on the filter thread.
+     */
     public InBandEncryptionManager(@NonNull Encryption encryption,
                                    @NonNull Serde<E> edekSerde,
                                    int recordBufferInitialBytes,
@@ -68,6 +84,11 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
 
     }
 
+    /**
+     * Returns the current DEK for the given encryption scheme, obtaining a new DEK from the cache if necessary.
+     * @param encryptionScheme the encryption scheme.
+     * @return a completion stage that completes with the current DEK for the given encryption scheme.
+     */
     @VisibleForTesting
     public CompletionStage<Dek<E>> currentDek(@NonNull EncryptionScheme<K> encryptionScheme) {
         // todo should we add some scheduled timeout as well? or should we rely on the KMS to timeout appropriately.

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/RecordEncryptor.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/RecordEncryptor.java
@@ -28,6 +28,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 /**
  * A {@link RecordTransform} that encrypts records so that they can be later decrypted by {@link io.kroxylicious.filter.encryption.decrypt.RecordDecryptor}.
  * @param <K> The type of KEK id
+ * @param <E> The type of encrypted DEK.
  */
 public class RecordEncryptor<K, E> implements RecordTransform<Dek<E>.Encryptor> {
 
@@ -49,7 +50,9 @@ public class RecordEncryptor<K, E> implements RecordTransform<Dek<E>.Encryptor> 
     private RecordBatch batch;
 
     /**
-     * Constructor (obviously).
+     * Creates a record encryptor.
+     * @param topicName The name of the topic to which the records are being produced.
+     * @param partition The index of the partition to which the records are being produced.
      * @param encryption The encryption version
      * @param encryptionScheme The encryption scheme for this key
      * @param edekSerde Serde for the encrypted DEK.

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/RequestNotSatisfiable.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/RequestNotSatisfiable.java
@@ -18,10 +18,19 @@ import io.kroxylicious.filter.encryption.common.EncryptionException;
  * records in a batch for some reason.
  */
 public class RequestNotSatisfiable extends EncryptionException {
+    /**
+     * Creates an exception with the given message.
+     * @param message the detail message.
+     */
     public RequestNotSatisfiable(String message) {
         super(message);
     }
 
+    /**
+     * Creates an exception with the given message and client-facing exception.
+     * @param message the detail message.
+     * @param apiException the exception to be sent to the client.
+     */
     public RequestNotSatisfiable(String message, ApiException apiException) {
         super(message, apiException);
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/kms/BackoffStrategy.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/kms/BackoffStrategy.java
@@ -8,6 +8,10 @@ package io.kroxylicious.filter.encryption.kms;
 
 import java.time.Duration;
 
+/**
+ * A strategy for computing how long to delay the next attempt at an action,
+ * based on the number of previous consecutive failures.
+ */
 public interface BackoffStrategy {
 
     /**

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/kms/CachingKms.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/kms/CachingKms.java
@@ -57,6 +57,19 @@ public class CachingKms<K, E> implements Kms<K, E> {
         notFoundAliasCache = Caffeine.newBuilder().expireAfterWrite(notFoundAliasExpireAfterWrite).build();
     }
 
+    /**
+     * Wraps the given KMS with caching of resolved aliases and decrypted DEKs.
+     * @param delegate the KMS to be wrapped.
+     * @param decryptDekCacheMaxSize the maximum number of decrypted DEKs to cache.
+     * @param decryptDekExpireAfterAccess how long after last access a decrypted DEK is removed from the cache.
+     * @param resolveAliasCacheMaxSize the maximum number of resolved aliases to cache.
+     * @param resolveAliasExpireAfterWrite how long after being cached a resolved alias is removed from the cache.
+     * @param resolveAliasRefreshAfterWrite how long after being cached a resolved alias becomes eligible for a refresh.
+     * @param notFoundAliasExpireAfterWrite how long an unresolvable alias is remembered before the delegate is asked to resolve it again.
+     * @param <A> The type of Key Encryption Key id.
+     * @param <B> The type of encrypted Data Encryption Key.
+     * @return a caching KMS wrapping the delegate.
+     */
     @NonNull
     public static <A, B> Kms<A, B> wrap(Kms<A, B> delegate,
                                         long decryptDekCacheMaxSize,

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/kms/ExponentialJitterBackoffStrategy.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/kms/ExponentialJitterBackoffStrategy.java
@@ -11,6 +11,10 @@ import java.util.Random;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * A {@link BackoffStrategy} which increases the delay exponentially with the number of
+ * failures, adding a random jitter, up to a maximum delay.
+ */
 public class ExponentialJitterBackoffStrategy implements BackoffStrategy {
 
     @NonNull
@@ -20,6 +24,14 @@ public class ExponentialJitterBackoffStrategy implements BackoffStrategy {
     private final double multiplier;
     private final Random random;
 
+    /**
+     * Creates an exponential jitter backoff strategy.
+     * @param initialDelay the delay for the first retry, must be greater than zero.
+     * @param maximumDelay the upper bound on the computed delay, must be greater than zero.
+     * @param multiplier the factor by which the delay grows with each failure, must be greater than one.
+     * @param random the source of randomness used to compute the jitter.
+     * @throws IllegalArgumentException if any argument is outside its permitted range.
+     */
     public ExponentialJitterBackoffStrategy(@NonNull Duration initialDelay,
                                             @NonNull Duration maximumDelay,
                                             double multiplier,

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/kms/InstrumentedKms.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/kms/InstrumentedKms.java
@@ -18,6 +18,11 @@ import io.kroxylicious.kms.service.UnknownKeyException;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * A KMS decorator which counts the attempts at, and outcomes of, the delegate's operations.
+ * @param <K> The type of Key Encryption Key id.
+ * @param <E> The type of encrypted Data Encryption Key.
+ */
 public class InstrumentedKms<K, E> implements Kms<K, E> {
     private final Kms<K, E> delegate;
     private final KmsMetrics metrics;
@@ -27,6 +32,14 @@ public class InstrumentedKms<K, E> implements Kms<K, E> {
         this.metrics = metrics;
     }
 
+    /**
+     * Wraps the given KMS with instrumentation.
+     * @param kms the KMS to be wrapped.
+     * @param metrics the metrics with which the KMS operations are counted.
+     * @param <A> The type of Key Encryption Key id.
+     * @param <B> The type of encrypted Data Encryption Key.
+     * @return an instrumented KMS wrapping the delegate.
+     */
     public static <A, B> Kms<A, B> wrap(Kms<A, B> kms, KmsMetrics metrics) {
         return new InstrumentedKms<>(kms, metrics);
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/kms/KmsMetrics.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/kms/KmsMetrics.java
@@ -8,22 +8,52 @@ package io.kroxylicious.filter.encryption.kms;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Metrics counting the attempts at, and outcomes of, KMS operations.
+ */
 public interface KmsMetrics {
+    /**
+     * The outcome of a KMS operation.
+     */
     enum OperationOutcome {
+        /** The operation succeeded. */
         SUCCESS,
+        /** The operation failed with an unexpected exception. */
         EXCEPTION,
+        /** The operation failed because the key or alias was not found. */
         NOT_FOUND
     }
 
+    /**
+     * Counts an attempt to generate a DEK pair.
+     */
     void countGenerateDekPairAttempt();
 
+    /**
+     * Counts the outcome of an attempt to generate a DEK pair.
+     * @param outcome the outcome of the operation.
+     */
     void countGenerateDekPairOutcome(@NonNull OperationOutcome outcome);
 
+    /**
+     * Counts an attempt to decrypt an encrypted DEK.
+     */
     void countDecryptEdekAttempt();
 
+    /**
+     * Counts the outcome of an attempt to decrypt an encrypted DEK.
+     * @param outcome the outcome of the operation.
+     */
     void countDecryptEdekOutcome(@NonNull OperationOutcome outcome);
 
+    /**
+     * Counts an attempt to resolve an alias.
+     */
     void countResolveAliasAttempt();
 
+    /**
+     * Counts the outcome of an attempt to resolve an alias.
+     * @param outcome the outcome of the operation.
+     */
     void countResolveAliasOutcome(@NonNull OperationOutcome outcome);
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/kms/MicrometerKmsMetrics.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/kms/MicrometerKmsMetrics.java
@@ -14,17 +14,31 @@ import io.micrometer.core.instrument.Tag;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * A {@link KmsMetrics} implementation which publishes counters to a Micrometer registry.
+ */
 public class MicrometerKmsMetrics implements KmsMetrics {
+    /** The prefix of the KMS operation meter names. */
     public static final String KMS_OPERATION_PREFIX = "kroxylicious_kms_operation";
+    /** The name of the counter of KMS operation attempts. */
     public static final String ATTEMPT_COUNTER_NAME = KMS_OPERATION_PREFIX + "_attempt_total";
+    /** The name of the counter of KMS operation outcomes. */
     public static final String OUTCOME_COUNTER_NAME = KMS_OPERATION_PREFIX + "_outcome_total";
+    /** The key of the tag identifying the KMS operation. */
     public static final String OPERATION_TAG_KEY = "operation";
+    /** The tag identifying the generate DEK pair operation. */
     public static final Tag OPERATION_GENERATE_DEK_PAIR_TAG = Tag.of(OPERATION_TAG_KEY, "generate_dek_pair");
+    /** The tag identifying the decrypt encrypted DEK operation. */
     public static final Tag OPERATION_DECRYPT_EDEK_TAG = Tag.of(OPERATION_TAG_KEY, "decrypt_edek");
+    /** The tag identifying the resolve alias operation. */
     public static final Tag OPERATION_RESOLVE_ALIAS_TAG = Tag.of(OPERATION_TAG_KEY, "resolve_alias");
+    /** The key of the tag identifying the operation outcome. */
     public static final String OUTCOME_TAG_KEY = "outcome";
+    /** The tag identifying the success outcome. */
     public static final Tag SUCCESS_OUTCOME_TAG = Tag.of(OUTCOME_TAG_KEY, "success");
+    /** The tag identifying the not-found outcome. */
     public static final Tag NOT_FOUND_OUTCOME_TAG = Tag.of(OUTCOME_TAG_KEY, "not_found");
+    /** The tag identifying the exception outcome. */
     public static final Tag EXCEPTION_OUTCOME_TAG = Tag.of(OUTCOME_TAG_KEY, "exception");
     private final Counter generateDekPairAttempts;
     private final Counter generateDekPairSuccesses;
@@ -56,6 +70,11 @@ public class MicrometerKmsMetrics implements KmsMetrics {
         resolveAliasExceptions = outcomeCounterForOperation(registry, OPERATION_RESOLVE_ALIAS_TAG, EXCEPTION_OUTCOME_TAG);
     }
 
+    /**
+     * Creates KMS metrics publishing to the given registry.
+     * @param registry the registry to which the counters are published.
+     * @return KMS metrics publishing to the given registry.
+     */
     public static KmsMetrics create(MeterRegistry registry) {
         return new MicrometerKmsMetrics(registry);
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/kms/ResilientKms.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/kms/ResilientKms.java
@@ -32,6 +32,12 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
 
+/**
+ * A KMS decorator which retries failed operations, delaying each retry according to a
+ * {@link BackoffStrategy}.
+ * @param <K> The type of Key Encryption Key id.
+ * @param <E> The type of encrypted Data Encryption Key.
+ */
 public class ResilientKms<K, E> implements Kms<K, E> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResilientKms.class);
@@ -50,6 +56,16 @@ public class ResilientKms<K, E> implements Kms<K, E> {
         this.retries = retries;
     }
 
+    /**
+     * Wraps the given KMS with retries.
+     * @param delegate the KMS to be wrapped.
+     * @param executorService the executor used to schedule the delayed retries.
+     * @param strategy the strategy used to compute the delay before each retry.
+     * @param retries the maximum number of attempts at an operation.
+     * @param <K> The type of Key Encryption Key id.
+     * @param <E> The type of encrypted Data Encryption Key.
+     * @return a resilient KMS wrapping the delegate.
+     */
     public static <K, E> Kms<K, E> wrap(@NonNull Kms<K, E> delegate,
                                         @NonNull ScheduledExecutorService executorService,
                                         @NonNull BackoffStrategy strategy,
@@ -82,6 +98,14 @@ public class ResilientKms<K, E> implements Kms<K, E> {
         return retry("resolveAlias", () -> inner.resolveAlias(alias));
     }
 
+    /**
+     * Invokes the given operation, retrying it if it fails.
+     * @param name the name of the operation, used in logging and error messages.
+     * @param operation the operation to be invoked.
+     * @param <A> the result type of the operation.
+     * @return a completion stage that completes with the result of the operation, or fails
+     *         if the operation did not succeed within the configured number of attempts.
+     */
     public <A> CompletionStage<A> retry(String name, Supplier<CompletionStage<A>> operation) {
         return retry(name, operation, 0, null);
     }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

- Added Javadoc comments to clarify the purpose and parameters of various classes and methods in the encryption package.
- Improved documentation for `RecordDecryptor`, `Aes`, `ChaChaPoly`, `CipherManager`, `CipherSpecResolver`, `Dek`, `DekManager`, and other related classes.
- Included descriptions for exception classes such as `DekException`, `DestroyedDekException`, and `ExhaustedDekException`.
- Enhanced the `KmsMetrics` interface with detailed comments on operation outcomes and metrics counting methods.
- Updated `ResilientKms` and `CachingKms` classes to include documentation on their functionality and parameters.
### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [X] PR references related GitHub issue(s) so they are closed on merging. Closes: #4553
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
