### PR TITLE
docs(operator-test-support) enhance documentation and remove warnings

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/pom.xml
@@ -26,9 +26,6 @@
         resources easier.
     </description>
 
-    <properties>
-        <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
-    </properties>
 
     <dependencyManagement>
         <dependencies>

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/ClusterUser.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/ClusterUser.java
@@ -38,6 +38,14 @@ public class ClusterUser {
         this.namespace = namespace;
     }
 
+    /**
+     * Creates the given resource in the test namespace.
+     *
+     * @param <T> the resource type
+     * @param resource the resource to create
+     * @return the created resource, as returned by the API server
+     * @throws KubernetesClientException if the creation fails
+     */
     @NonNull
     public <T extends HasMetadata> T create(@NonNull T resource) {
         try {
@@ -49,6 +57,15 @@ public class ClusterUser {
         }
     }
 
+    /**
+     * Gets the named resource from the test namespace.
+     *
+     * @param <T> the resource type
+     * @param type the resource class
+     * @param name the resource name
+     * @return the resource, or {@code null} if it does not exist
+     * @throws KubernetesClientException if the get fails
+     */
     @Nullable
     public <T extends HasMetadata> T get(@NonNull Class<T> type, @NonNull String name) {
         try {
@@ -60,6 +77,14 @@ public class ClusterUser {
         }
     }
 
+    /**
+     * Replaces the given resource in the test namespace.
+     *
+     * @param <T> the resource type
+     * @param resource the resource to replace
+     * @return the updated resource, as returned by the API server
+     * @throws KubernetesClientException if the replacement fails
+     */
     @NonNull
     public <T extends HasMetadata> T replace(@NonNull T resource) {
         try {
@@ -71,6 +96,14 @@ public class ClusterUser {
         }
     }
 
+    /**
+     * Deletes the given resource from the test namespace.
+     *
+     * @param <T> the resource type
+     * @param resource the resource to delete
+     * @return {@code true} if exactly one resource was deleted without causes, {@code false} otherwise
+     * @throws KubernetesClientException if the deletion fails
+     */
     public <T extends HasMetadata> boolean delete(@NonNull T resource) {
         try {
             var result = client.resource(resource).inNamespace(namespace).delete();
@@ -82,6 +115,13 @@ public class ClusterUser {
         }
     }
 
+    /**
+     * Returns the client operation for the given resource type, scoped to the test namespace.
+     *
+     * @param <T> the resource type
+     * @param type the resource class
+     * @return the namespaced operation for the given resource type
+     */
     @NonNull
     public <T extends HasMetadata> NonNamespaceOperation<T, KubernetesResourceList<T>, Resource<T>> resources(@NonNull Class<T> type) {
         return client.resources(type).inNamespace(namespace);

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/ExternalOperator.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/ExternalOperator.java
@@ -37,6 +37,7 @@ public class ExternalOperator {
      * patches the status subresource. Re-fetching avoids 409 Conflict errors when
      * the resourceVersion has advanced since any earlier fetch.
      *
+     * @param <T>           the resource type
      * @param type          resource class
      * @param name          resource name
      * @param statusMutator sets status on the fresh resource and returns it

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/KubernetesResourceUtil.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/KubernetesResourceUtil.java
@@ -17,6 +17,12 @@ public final class KubernetesResourceUtil {
     private KubernetesResourceUtil() {
     }
 
+    /**
+     * Returns the metadata name of the given resource.
+     *
+     * @param resource the resource
+     * @return the resource's metadata name
+     */
     public static String name(HasMetadata resource) {
         return resource.getMetadata().getName();
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
@@ -261,6 +261,8 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
 
     /**
      * Returns the Kubernetes namespace created for this test.
+     *
+     * @return the namespace name
      */
     public String getNamespace() {
         return localOperatorExtension.getNamespace();
@@ -273,6 +275,8 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
      * operator reactions. The operator is the system-under-test; the {@code ClusterUser} is the actor.
      * <p>
      * Must be called after {@code beforeAll}.
+     *
+     * @return a cluster user scoped to the test namespace
      */
     @NonNull
     public ClusterUser clusterUser() {
@@ -287,16 +291,27 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
      * patching status to avoid 409 Conflict errors from concurrent reconciliation.
      * <p>
      * Must be called after {@code beforeAll}.
+     *
+     * @return an external operator stub scoped to the test namespace
      */
     @NonNull
     public ExternalOperator externalOperator() {
         return new ExternalOperator(clusterUserClient, localOperatorExtension.getNamespace());
     }
 
+    /**
+     * Returns a new builder for configuring a {@link LocalKroxyliciousOperatorExtension}.
+     *
+     * @return a new builder
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Builder for {@link LocalKroxyliciousOperatorExtension}.
+     * At least one reconciler must be registered via {@link #withReconciler(Reconciler)}.
+     */
     public static final class Builder {
         private final List<Reconciler<?>> reconcilers = new ArrayList<>();
         private final List<Class<?>> additionalCRDs = new ArrayList<>();
@@ -309,17 +324,37 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
         private Builder() {
         }
 
+        /**
+         * Registers a reconciler to run in the operator under test.
+         *
+         * @param reconciler the reconciler
+         * @return this builder
+         */
         public Builder withReconciler(@NonNull Reconciler<?> reconciler) {
             this.reconcilers.add(reconciler);
             return this;
         }
 
+        /**
+         * Registers an additional custom resource type whose CRD should be installed
+         * alongside the standard Kroxylicious CRDs.
+         *
+         * @param crd the custom resource class
+         * @return this builder
+         */
         @SuppressWarnings("unused")
         public Builder withAdditionalCRD(@NonNull Class<?> crd) {
             this.additionalCRDs.add(crd);
             return this;
         }
 
+        /**
+         * Registers additional custom resource types whose CRDs should be installed
+         * alongside the standard Kroxylicious CRDs.
+         *
+         * @param crds the custom resource classes
+         * @return this builder
+         */
         @SuppressWarnings("unused")
         public Builder withAdditionalCRDs(@NonNull Class<?>... crds) {
             this.additionalCRDs.addAll(Arrays.asList(crds));
@@ -329,6 +364,9 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
         /**
          * Registers an action to run after RBAC setup but before the operator starts.
          * Useful for installing third-party CRDs that the operator watches.
+         *
+         * @param action the setup action
+         * @return this builder
          */
         @SuppressWarnings("unused")
         public Builder withSetupAction(@NonNull Executable action) {
@@ -339,6 +377,9 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
         /**
          * Registers an action to run after the operator stops.
          * Useful for cleaning up third-party CRDs installed via {@link #withSetupAction}.
+         *
+         * @param action the teardown action
+         * @return this builder
          */
         @SuppressWarnings("unused")
         public Builder withTeardownAction(@NonNull Executable action) {
@@ -350,6 +391,9 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
          * Registers additional resource types to delete between tests (in {@code afterEach}).
          * Use this for third-party CRD resources (e.g. Strimzi {@code Kafka}) that tests create
          * and that the extension does not clean up automatically.
+         *
+         * @param types the resource types to clean up between tests
+         * @return this builder
          */
         @SuppressWarnings("unused")
         @SafeVarargs
@@ -358,6 +402,13 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
             return this;
         }
 
+        /**
+         * Sets the directory from which install manifests (e.g. cluster roles) are loaded.
+         * If not called, the default is {@code packaging/install}.
+         *
+         * @param dir the install manifests directory
+         * @return this builder
+         */
         @SuppressWarnings("unused")
         public Builder withInstallManifestsDir(@NonNull String dir) {
             this.installManifestsDir = dir;
@@ -367,6 +418,9 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
         /**
          * Replaces all cluster role glob(s) used to load RBAC rules with the given values.
          * If not called, the default is {@value DEFAULT_CLUSTER_ROLE_GLOB}.
+         *
+         * @param globs the cluster role file globs
+         * @return this builder
          */
         public Builder replaceClusterRoleGlobs(@NonNull String... globs) {
             this.clusterRoleGlobs.clear();
@@ -374,6 +428,12 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
             return this;
         }
 
+        /**
+         * Builds the extension.
+         *
+         * @return a new {@link LocalKroxyliciousOperatorExtension}
+         * @throws IllegalStateException if no reconciler has been registered
+         */
         public LocalKroxyliciousOperatorExtension build() {
             return new LocalKroxyliciousOperatorExtension(this);
         }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
@@ -91,10 +91,22 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
     private final List<ClusterRole> clusterRoles;
     private final List<ClusterRoleBinding> roleBindings;
 
+    /**
+     * Creates an RBAC handler loading cluster roles from the given directory.
+     *
+     * @param resourceDirectory directory containing the cluster role YAML files
+     * @param clusterRoleFileGlobs globs (relative to the resource directory) selecting the cluster role files; must not be empty
+     */
     public LocallyRunningOperatorRbacHandler(String resourceDirectory, String... clusterRoleFileGlobs) {
         this(Path.of(resourceDirectory), OperatorTestUtils::kubeClient, clusterRoleFileGlobs);
     }
 
+    /**
+     * Creates an RBAC handler loading cluster roles from the given directory.
+     *
+     * @param resourceDirectory directory containing the cluster role YAML files
+     * @param clusterRoleFileGlobs globs (relative to the resource directory) selecting the cluster role files; must not be empty
+     */
     public LocallyRunningOperatorRbacHandler(Path resourceDirectory, String... clusterRoleFileGlobs) {
         this(resourceDirectory, OperatorTestUtils::kubeClient, clusterRoleFileGlobs);
     }
@@ -201,6 +213,13 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
 
     }
 
+    /**
+     * Creates and returns a new Kubernetes client that impersonates a user with the operator's RBAC rights.
+     * Pass this client to {@code LocallyRunOperatorExtension} so that the operator under test runs with
+     * production-like permissions. The caller is responsible for closing the returned client.
+     *
+     * @return a Kubernetes client restricted to the operator's RBAC rights
+     */
     @NonNull
     public KubernetesClient operatorClient() {
         return OperatorTestUtils.kubeClient(
@@ -213,12 +232,22 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
     /**
      * Creates and returns a new Kubernetes client with the RBAC rights of a cluster user (via the admin client).
      * The caller is responsible for closing the returned client.
+     *
+     * @return a Kubernetes client with the RBAC rights of a cluster user
      */
     @NonNull
     public KubernetesClient userClient() {
         return adminClientFactory.get();
     }
 
+    /**
+     * Returns a {@link TestActor} that performs resource operations with the given client,
+     * scoped to the namespace of the given operator extension.
+     *
+     * @param client the Kubernetes client to use for the test's interactions
+     * @param operatorExtension the operator extension supplying the test namespace
+     * @return a test actor scoped to the extension's namespace
+     */
     @NonNull
     public TestActor testActor(@NonNull KubernetesClient client, @NonNull AbstractOperatorExtension operatorExtension) {
         return new TestActor() {
@@ -274,27 +303,91 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
         };
     }
 
+    /**
+     * Performs the test's interactions with Kubernetes, where more privileges are required than
+     * the operator's own RBAC rights allow. Operations are scoped to the test namespace unless
+     * stated otherwise.
+     */
     public interface TestActor {
+        /**
+         * Creates the given resource in the test namespace.
+         *
+         * @param <T> the resource type
+         * @param resource the resource to create
+         * @return the created resource, as returned by the API server
+         */
         @NonNull
         <T extends HasMetadata> T create(@NonNull T resource);
 
+        /**
+         * Gets the named resource from the test namespace.
+         *
+         * @param <T> the resource type
+         * @param type the resource class
+         * @param name the resource name
+         * @return the resource, or {@code null} if it does not exist
+         */
         @Nullable
         <T extends HasMetadata> T get(@NonNull Class<T> type, @NonNull String name);
 
+        /**
+         * Gets the named resource from the given namespace.
+         *
+         * @param <T> the resource type
+         * @param type the resource class
+         * @param name the resource name
+         * @param namespace the namespace to get the resource from
+         * @return the resource, or {@code null} if it does not exist
+         */
         @Nullable
         <T extends HasMetadata> T getInNamespace(@NonNull Class<T> type, @NonNull String name, @NonNull String namespace);
 
+        /**
+         * Replaces the given resource in the test namespace.
+         *
+         * @param <T> the resource type
+         * @param resource the resource to replace
+         * @return the updated resource, as returned by the API server
+         */
         @NonNull
         <T extends HasMetadata> T replace(@NonNull T resource);
 
+        /**
+         * Patches the status subresource of the given resource in the test namespace.
+         *
+         * @param <T> the resource type
+         * @param resource the resource whose status should be patched
+         * @return the patched resource, as returned by the API server
+         */
         @NonNull
         <T extends HasMetadata> T patchStatus(@NonNull T resource);
 
+        /**
+         * Deletes the given resource from the test namespace.
+         *
+         * @param <T> the resource type
+         * @param resource the resource to delete
+         * @return {@code true} if exactly one resource was deleted without causes, {@code false} otherwise
+         */
         <T extends HasMetadata> boolean delete(@NonNull T resource);
 
+        /**
+         * Returns the client operation for the given resource type, scoped to the test namespace.
+         *
+         * @param <T> the resource type
+         * @param type the resource class
+         * @return the namespaced operation for the given resource type
+         */
         @NonNull
         <T extends HasMetadata> NonNamespaceOperation<T, KubernetesResourceList<T>, Resource<T>> resources(@NonNull Class<T> type);
 
+        /**
+         * Determines whether the cluster supports the given resource type.
+         *
+         * @param <T> the resource type
+         * @param type the resource class
+         * @return {@code true} if the cluster supports the given resource type
+         */
         <T extends KubernetesResource> boolean supports(@NonNull Class<T> type);
     }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/OperatorTestUtils.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/OperatorTestUtils.java
@@ -15,6 +15,10 @@ import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Utilities for obtaining Kubernetes clients in operator tests and probing whether
+ * a Kubernetes cluster is available.
+ */
 public class OperatorTestUtils {
 
     private OperatorTestUtils() {
@@ -31,14 +35,33 @@ public class OperatorTestUtils {
             .withConnectionTimeout(1000)
             .endConfig();
 
+    /**
+     * Creates a Kubernetes client with default configuration.
+     * The caller is responsible for closing the returned client.
+     *
+     * @return a new Kubernetes client
+     */
     public static @NonNull KubernetesClient kubeClient() {
         return kubeClient(new KubernetesClientBuilder());
     }
 
+    /**
+     * Creates a Kubernetes client from the given builder.
+     * The caller is responsible for closing the returned client.
+     *
+     * @param kubernetesClientBuilder the builder used to create the client
+     * @return a new Kubernetes client
+     */
     public static @NonNull KubernetesClient kubeClient(KubernetesClientBuilder kubernetesClientBuilder) {
         return Objects.requireNonNull(kubernetesClientBuilder.build(), "KubernetesClientBuilder.build() returned null");
     }
 
+    /**
+     * Determines whether a Kubernetes cluster is reachable, using short timeouts so that
+     * the probe fails quickly when no cluster is running (e.g. on a developer's machine).
+     *
+     * @return {@code true} if a Kubernetes cluster is reachable
+     */
     public static boolean isKubeClientAvailable() {
         return isKubeClientAvailable(PRESENCE_PROBING_KUBE_CLIENT_BUILD);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/AbstractStatusAssert.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/AbstractStatusAssert.java
@@ -19,6 +19,13 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 
 import io.kroxylicious.kubernetes.api.common.Condition;
 
+/**
+ * Base class for assertions on custom resource statuses, providing assertions on the
+ * {@code observedGeneration} and {@code conditions} common to all Kroxylicious statuses.
+ *
+ * @param <A> the status type
+ * @param <S> the self type
+ */
 @SuppressWarnings("java:S2160") // equals on superclass checks reference equality, not object equality
 abstract class AbstractStatusAssert<A, S extends AbstractStatusAssert<A, S>> extends AbstractObjectAssert<S, A> {
     private final Function<A, Long> observedGenerationAccessor;
@@ -35,40 +42,82 @@ abstract class AbstractStatusAssert<A, S extends AbstractStatusAssert<A, S>> ext
 
     }
 
+    /**
+     * Returns an assertion on the status's observed generation.
+     *
+     * @return an assertion on the observed generation
+     */
     public AbstractLongAssert<?> observedGeneration() {
         return Assertions.assertThat(observedGenerationAccessor.apply(actual));
     }
 
+    /**
+     * Asserts that the status has the given observed generation.
+     *
+     * @param observedGeneration the expected observed generation
+     * @return this assertion
+     */
     @SuppressWarnings("unchecked")
     public S hasObservedGeneration(Long observedGeneration) {
         observedGeneration().isEqualTo(observedGeneration);
         return (S) this;
     }
 
+    /**
+     * Asserts that the status's observed generation equals the metadata generation of the given resource.
+     *
+     * @param thing the resource whose metadata generation the status should reflect
+     * @return this assertion
+     */
     @SuppressWarnings("unchecked")
     public S hasObservedGenerationInSyncWithMetadataOf(HasMetadata thing) {
         hasObservedGeneration(thing.getMetadata().getGeneration());
         return (S) this;
     }
 
+    /**
+     * Returns a list assertion on the status's conditions.
+     *
+     * @return a list assertion on the conditions
+     */
     public ListAssert<Condition.Status> conditions() {
         return Assertions.assertThat(conditionsAccessor.apply(actual))
                 .asInstanceOf(InstanceOfAssertFactories.list(Condition.Status.class));
     }
 
+    /**
+     * Asserts that the status has exactly one condition and returns an assertion on it.
+     *
+     * @return an assertion on the single condition
+     */
     public ConditionAssert singleCondition() {
         return conditions().singleElement(AssertFactory.condition());
     }
 
+    /**
+     * Returns an assertion on the status's condition list.
+     *
+     * @return an assertion on the condition list
+     */
     public ConditionListAssert conditionList() {
         var conditions = conditionsAccessor.apply(actual);
         return ConditionListAssert.assertThat(conditions);
     }
 
+    /**
+     * Returns an assertion on the status's first condition.
+     *
+     * @return an assertion on the first condition
+     */
     public ConditionAssert firstCondition() {
         return conditions().first(AssertFactory.condition());
     }
 
+    /**
+     * Returns an assertion on the status's last condition.
+     *
+     * @return an assertion on the last condition
+     */
     public ConditionAssert lastCondition() {
         return conditions().last(AssertFactory.condition());
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/AssertFactory.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/AssertFactory.java
@@ -12,6 +12,10 @@ import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyStatus;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Clusters;
 
+/**
+ * Factories for use with AssertJ's {@code asInstanceOf} and element navigation methods,
+ * producing the custom assertions in this package.
+ */
 public class AssertFactory {
     /**
      * Prevent construction of utility class
@@ -20,14 +24,29 @@ public class AssertFactory {
         // private constructor
     }
 
+    /**
+     * Returns a factory producing {@link KafkaProxyStatusAssert}.
+     *
+     * @return a factory producing {@link KafkaProxyStatusAssert}
+     */
     public static InstanceOfAssertFactory<KafkaProxyStatus, KafkaProxyStatusAssert> status() {
         return new InstanceOfAssertFactory<>(KafkaProxyStatus.class, KafkaProxyStatusAssert::assertThat);
     }
 
+    /**
+     * Returns a factory producing {@link ConditionAssert}.
+     *
+     * @return a factory producing {@link ConditionAssert}
+     */
     public static InstanceOfAssertFactory<Condition, ConditionAssert> condition() {
         return new InstanceOfAssertFactory<>(Condition.class, ConditionAssert::assertThat);
     }
 
+    /**
+     * Returns a factory producing {@link ClusterAssert}.
+     *
+     * @return a factory producing {@link ClusterAssert}
+     */
     public static InstanceOfAssertFactory<Clusters, ClusterAssert> cluster() {
         return new InstanceOfAssertFactory<>(Clusters.class, ClusterAssert::assertThat);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/ClusterAssert.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/ClusterAssert.java
@@ -15,29 +15,64 @@ import org.assertj.core.api.ListAssert;
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Clusters;
 
+/**
+ * Assertions on a cluster entry ({@link Clusters}) within a {@code KafkaProxy} status.
+ */
 public class ClusterAssert extends AbstractObjectAssert<ClusterAssert, Clusters> {
+    /**
+     * Creates an assertion on the given cluster.
+     *
+     * @param o the cluster to assert on
+     */
     protected ClusterAssert(
                             Clusters o) {
         super(o, ClusterAssert.class);
     }
 
+    /**
+     * Creates an assertion on the given cluster.
+     *
+     * @param actual the cluster to assert on
+     * @return a new assertion
+     */
     public static ClusterAssert assertThat(Clusters actual) {
         return new ClusterAssert(actual);
     }
 
+    /**
+     * Returns an assertion on the cluster's name.
+     *
+     * @return an assertion on the cluster's name
+     */
     public AbstractStringAssert<?> name() {
         return Assertions.assertThat(actual.getName());
     }
 
+    /**
+     * Asserts that the cluster has the given name.
+     *
+     * @param s the expected name
+     * @return this assertion
+     */
     public ClusterAssert nameIsEqualTo(String s) {
         name().isEqualTo(s);
         return this;
     }
 
+    /**
+     * Returns a list assertion on the cluster's conditions.
+     *
+     * @return a list assertion on the conditions
+     */
     public ListAssert<Condition> conditions() {
         return Assertions.assertThat(actual.getConditions()).asInstanceOf(InstanceOfAssertFactories.list(Condition.class));
     }
 
+    /**
+     * Asserts that the cluster has exactly one condition and returns an assertion on it.
+     *
+     * @return an assertion on the single condition
+     */
     public ConditionAssert singleCondition() {
         return conditions().singleElement(AssertFactory.condition());
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/ConditionAssert.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/ConditionAssert.java
@@ -22,86 +22,189 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 
 import io.kroxylicious.kubernetes.api.common.Condition;
 
+/**
+ * Assertions on a status {@link Condition}.
+ */
 @SuppressWarnings("UnusedReturnValue")
 public class ConditionAssert extends AbstractObjectAssert<ConditionAssert, Condition> {
+    /**
+     * Creates an assertion on the given condition.
+     *
+     * @param o the condition to assert on
+     */
     protected ConditionAssert(
                               Condition o) {
         super(o, ConditionAssert.class);
     }
 
+    /**
+     * Creates an assertion on the given condition.
+     *
+     * @param actual the condition to assert on
+     * @return a new assertion
+     */
     public static ConditionAssert assertThat(Condition actual) {
         return new ConditionAssert(actual);
     }
 
+    /**
+     * Returns an assertion on the condition's observed generation.
+     *
+     * @return an assertion on the observed generation
+     */
     public AbstractLongAssert<?> observedGeneration() {
         return Assertions.assertThat(actual.getObservedGeneration());
     }
 
+    /**
+     * Asserts that the condition has the given observed generation.
+     *
+     * @param expected the expected observed generation
+     * @return this assertion
+     */
     public ConditionAssert hasObservedGeneration(Long expected) {
         observedGeneration().isEqualTo(expected);
         return this;
     }
 
+    /**
+     * Asserts that the condition's observed generation equals the metadata generation of the given resource.
+     *
+     * @param thing the resource whose metadata generation the condition should reflect
+     * @return this assertion
+     */
     public ConditionAssert hasObservedGenerationInSyncWithMetadataOf(HasMetadata thing) {
         hasObservedGeneration(thing.getMetadata().getGeneration());
         return this;
     }
 
+    /**
+     * Returns an assertion on the condition's type.
+     *
+     * @return an assertion on the type
+     */
     public AbstractComparableAssert<?, Condition.Type> type() {
         return Assertions.assertThat(actual.getType());
     }
 
+    /**
+     * Asserts that the condition has the given type.
+     *
+     * @param expected the expected type
+     * @return this assertion
+     */
     public ConditionAssert hasType(Condition.Type expected) {
         type().describedAs(actual.toString()).isEqualTo(expected);
         return this;
     }
 
+    /**
+     * Returns an assertion on the condition's message.
+     *
+     * @return an assertion on the message
+     */
     public AbstractStringAssert<?> message() {
         return Assertions.assertThat(actual.getMessage());
     }
 
+    /**
+     * Asserts that the condition has an empty message.
+     *
+     * @return this assertion
+     */
     public ConditionAssert hasNoMessage() {
         message().isEmpty();
         return this;
     }
 
+    /**
+     * Asserts that the condition has the given message.
+     *
+     * @param expected the expected message
+     * @return this assertion
+     */
     public ConditionAssert hasMessage(String expected) {
         message().describedAs(actual.toString()).isEqualTo(expected);
         return this;
     }
 
+    /**
+     * Asserts that the condition's message satisfies the given requirements.
+     *
+     * @param expected the requirements the message must satisfy
+     * @return this assertion
+     */
     public ConditionAssert hasMessage(ThrowingConsumer<String> expected) {
         message().describedAs(actual.toString()).satisfies(expected);
         return this;
     }
 
+    /**
+     * Returns an assertion on the condition's reason.
+     *
+     * @return an assertion on the reason
+     */
     public AbstractStringAssert<?> reason() {
         return Assertions.assertThat(actual.getReason());
     }
 
+    /**
+     * Asserts that the condition has the given reason.
+     *
+     * @param expected the expected reason
+     * @return this assertion
+     */
     public ConditionAssert hasReason(String expected) {
         reason().describedAs(actual.toString()).isEqualTo(expected);
         return this;
     }
 
+    /**
+     * Returns an assertion on the condition's status.
+     *
+     * @return an assertion on the status
+     */
     public ObjectAssert<Condition.Status> status() {
         return Assertions.assertThat(actual.getStatus()).asInstanceOf(InstanceOfAssertFactories.type(Condition.Status.class));
     }
 
+    /**
+     * Asserts that the condition has the given status.
+     *
+     * @param expected the expected status
+     * @return this assertion
+     */
     public ConditionAssert hasStatus(Condition.Status expected) {
         status().describedAs(actual.toString()).isEqualTo(expected);
         return this;
     }
 
+    /**
+     * Returns an assertion on the condition's last transition time.
+     *
+     * @return an assertion on the last transition time
+     */
     public AbstractInstantAssert<?> lastTransitionTime() {
         return Assertions.assertThat(actual.getLastTransitionTime());
     }
 
+    /**
+     * Asserts that the condition has the given last transition time.
+     *
+     * @param time the expected last transition time
+     * @return this assertion
+     */
     public ConditionAssert hasLastTransitionTime(Instant time) {
         lastTransitionTime().isEqualTo(time);
         return this;
     }
 
+    /**
+     * Asserts that this is an {@code Accepted} condition with status {@code True},
+     * the standard reason and no message.
+     *
+     * @return this assertion
+     */
     public ConditionAssert isAcceptedTrue() {
         hasType(Condition.Type.Accepted);
         hasStatus(Condition.Status.TRUE);
@@ -110,12 +213,27 @@ public class ConditionAssert extends AbstractObjectAssert<ConditionAssert, Condi
         return this;
     }
 
+    /**
+     * Asserts that this is an {@code Accepted} condition with status {@code True},
+     * the standard reason, no message, and an observed generation in sync with the given resource.
+     *
+     * @param thing the resource whose metadata generation the condition should reflect
+     * @return this assertion
+     */
     public ConditionAssert isAcceptedTrue(HasMetadata thing) {
         isAcceptedTrue()
                 .hasObservedGenerationInSyncWithMetadataOf(thing);
         return this;
     }
 
+    /**
+     * Asserts that this is an {@code Accepted} condition with status {@code False}
+     * and the given reason and message.
+     *
+     * @param reason the expected reason
+     * @param message the expected message
+     * @return this assertion
+     */
     public ConditionAssert isAcceptedFalse(String reason, String message) {
         hasType(Condition.Type.Accepted);
         hasStatus(Condition.Status.FALSE);
@@ -124,6 +242,14 @@ public class ConditionAssert extends AbstractObjectAssert<ConditionAssert, Condi
         return this;
     }
 
+    /**
+     * Asserts that this is a {@code ResolvedRefs} condition with status {@code Unknown}
+     * and the given reason and message.
+     *
+     * @param reason the expected reason
+     * @param message the expected message
+     * @return this assertion
+     */
     public ConditionAssert isResolvedRefsUnknown(String reason, String message) {
         hasType(Condition.Type.ResolvedRefs);
         hasStatus(Condition.Status.UNKNOWN);
@@ -132,10 +258,26 @@ public class ConditionAssert extends AbstractObjectAssert<ConditionAssert, Condi
         return this;
     }
 
+    /**
+     * Asserts that this is a {@code ResolvedRefs} condition with status {@code False}
+     * and the given reason and message.
+     *
+     * @param reason the expected reason
+     * @param expectedMessage the expected message
+     * @return this assertion
+     */
     public ConditionAssert isResolvedRefsFalse(String reason, String expectedMessage) {
         return isResolvedRefsFalse(reason, (String actualMessage) -> message().describedAs(actualMessage).isEqualTo(expectedMessage));
     }
 
+    /**
+     * Asserts that this is a {@code ResolvedRefs} condition with status {@code False},
+     * the given reason and a message satisfying the given requirements.
+     *
+     * @param reason the expected reason
+     * @param messageAssertion the requirements the message must satisfy
+     * @return this assertion
+     */
     public ConditionAssert isResolvedRefsFalse(String reason, ThrowingConsumer<String> messageAssertion) {
         hasType(Condition.Type.ResolvedRefs);
         hasStatus(Condition.Status.FALSE);
@@ -144,6 +286,12 @@ public class ConditionAssert extends AbstractObjectAssert<ConditionAssert, Condi
         return this;
     }
 
+    /**
+     * Asserts that this is a {@code ResolvedRefs} condition with status {@code True},
+     * the standard reason and no message.
+     *
+     * @return this assertion
+     */
     public ConditionAssert isResolvedRefsTrue() {
         hasType(Condition.Type.ResolvedRefs);
         hasStatus(Condition.Status.TRUE);
@@ -152,12 +300,27 @@ public class ConditionAssert extends AbstractObjectAssert<ConditionAssert, Condi
         return this;
     }
 
+    /**
+     * Asserts that this is a {@code ResolvedRefs} condition with status {@code True},
+     * the standard reason, no message, and an observed generation in sync with the given resource.
+     *
+     * @param thing the resource whose metadata generation the condition should reflect
+     * @return this assertion
+     */
     public ConditionAssert isResolvedRefsTrue(HasMetadata thing) {
         isResolvedRefsTrue()
                 .hasObservedGenerationInSyncWithMetadataOf(thing);
         return this;
     }
 
+    /**
+     * Asserts that this is a {@code Ready} condition with status {@code Unknown}
+     * and the given reason and message.
+     *
+     * @param reason the expected reason
+     * @param message the expected message
+     * @return this assertion
+     */
     public ConditionAssert isReadyUnknown(String reason, String message) {
         hasType(Condition.Type.Ready);
         hasStatus(Condition.Status.UNKNOWN);
@@ -166,6 +329,14 @@ public class ConditionAssert extends AbstractObjectAssert<ConditionAssert, Condi
         return this;
     }
 
+    /**
+     * Asserts that this is a {@code Ready} condition with status {@code False}
+     * and the given reason and message.
+     *
+     * @param reason the expected reason
+     * @param message the expected message
+     * @return this assertion
+     */
     public ConditionAssert isReadyFalse(String reason, String message) {
         hasType(Condition.Type.Ready);
         hasStatus(Condition.Status.FALSE);
@@ -174,6 +345,12 @@ public class ConditionAssert extends AbstractObjectAssert<ConditionAssert, Condi
         return this;
     }
 
+    /**
+     * Asserts that this is a {@code Ready} condition with status {@code True},
+     * the standard reason and no message.
+     *
+     * @return this assertion
+     */
     public ConditionAssert isReadyTrue() {
         hasType(Condition.Type.Ready);
         hasStatus(Condition.Status.TRUE);
@@ -182,6 +359,14 @@ public class ConditionAssert extends AbstractObjectAssert<ConditionAssert, Condi
         return this;
     }
 
+    /**
+     * Asserts that this is an {@code Accepted} condition with status {@code Unknown}
+     * and the given reason and message.
+     *
+     * @param reason the expected reason
+     * @param message the expected message
+     * @return this assertion
+     */
     public ConditionAssert isAcceptedUnknown(String reason, String message) {
         hasType(Condition.Type.Accepted);
         hasStatus(Condition.Status.UNKNOWN);

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/ConditionListAssert.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/ConditionListAssert.java
@@ -17,12 +17,26 @@ import org.assertj.core.util.Lists;
 
 import io.kroxylicious.kubernetes.api.common.Condition;
 
+/**
+ * Assertions on a list of status {@link Condition}s.
+ */
 public class ConditionListAssert extends AbstractListAssert<ConditionListAssert, List<Condition>, Condition, ConditionAssert> {
+    /**
+     * Creates an assertion on the given condition list.
+     *
+     * @param o the condition list to assert on
+     */
     protected ConditionListAssert(
                                   List<Condition> o) {
         super(o, ConditionListAssert.class);
     }
 
+    /**
+     * Creates an assertion on the given condition list.
+     *
+     * @param actual the condition list to assert on
+     * @return a new assertion
+     */
     public static ConditionListAssert assertThat(List<Condition> actual) {
         return new ConditionListAssert(actual);
     }
@@ -39,12 +53,25 @@ public class ConditionListAssert extends AbstractListAssert<ConditionListAssert,
         return assertThat(Lists.newArrayList(iterable));
     }
 
+    /**
+     * Asserts that the list contains conditions of exactly the given types and no others.
+     *
+     * @param types the expected condition types
+     * @return this assertion
+     */
     public ConditionListAssert containsOnlyTypes(Condition.Type... types) {
         Map<Condition.Type, Condition> s = actual.stream().collect(Collectors.toMap(Condition::getType, Function.identity()));
         Assertions.assertThat(s).as("unexpected types in list").containsOnlyKeys(types);
         return this;
     }
 
+    /**
+     * Asserts that the list contains exactly one condition of the given type and
+     * returns an assertion on it.
+     *
+     * @param type the condition type to look for
+     * @return an assertion on the single condition of the given type
+     */
     public ConditionAssert singleOfType(Condition.Type type) {
         var ofType = actual.stream().filter(condition -> type.equals(condition.getType())).toList();
         assertThat(ofType).as("expected exactly one condition with type=" + type).hasSize(1);

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/KafkaProtocolFilterStatusAssert.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/KafkaProtocolFilterStatusAssert.java
@@ -8,7 +8,15 @@ package io.kroxylicious.testing.operator.assertj;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProtocolFilterStatus;
 
+/**
+ * Assertions on a {@link KafkaProtocolFilterStatus}.
+ */
 public class KafkaProtocolFilterStatusAssert extends AbstractStatusAssert<KafkaProtocolFilterStatus, KafkaProtocolFilterStatusAssert> {
+    /**
+     * Creates an assertion on the given status.
+     *
+     * @param o the status to assert on
+     */
     protected KafkaProtocolFilterStatusAssert(
                                               KafkaProtocolFilterStatus o) {
         super(o, KafkaProtocolFilterStatusAssert.class,
@@ -16,6 +24,12 @@ public class KafkaProtocolFilterStatusAssert extends AbstractStatusAssert<KafkaP
                 KafkaProtocolFilterStatus::getConditions);
     }
 
+    /**
+     * Creates an assertion on the given status.
+     *
+     * @param actual the status to assert on
+     * @return a new assertion
+     */
     public static KafkaProtocolFilterStatusAssert assertThat(KafkaProtocolFilterStatus actual) {
         return new KafkaProtocolFilterStatusAssert(actual);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/KafkaProxyIngressStatusAssert.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/KafkaProxyIngressStatusAssert.java
@@ -8,7 +8,15 @@ package io.kroxylicious.testing.operator.assertj;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressStatus;
 
+/**
+ * Assertions on a {@link KafkaProxyIngressStatus}.
+ */
 public class KafkaProxyIngressStatusAssert extends AbstractStatusAssert<KafkaProxyIngressStatus, KafkaProxyIngressStatusAssert> {
+    /**
+     * Creates an assertion on the given status.
+     *
+     * @param o the status to assert on
+     */
     protected KafkaProxyIngressStatusAssert(
                                             KafkaProxyIngressStatus o) {
         super(o, KafkaProxyIngressStatusAssert.class,
@@ -16,6 +24,12 @@ public class KafkaProxyIngressStatusAssert extends AbstractStatusAssert<KafkaPro
                 KafkaProxyIngressStatus::getConditions);
     }
 
+    /**
+     * Creates an assertion on the given status.
+     *
+     * @param actual the status to assert on
+     * @return a new assertion
+     */
     public static KafkaProxyIngressStatusAssert assertThat(KafkaProxyIngressStatus actual) {
         return new KafkaProxyIngressStatusAssert(actual);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/KafkaProxyStatusAssert.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/KafkaProxyStatusAssert.java
@@ -15,7 +15,15 @@ import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyStatus;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Clusters;
 
+/**
+ * Assertions on a {@link KafkaProxyStatus}.
+ */
 public class KafkaProxyStatusAssert extends AbstractStatusAssert<KafkaProxyStatus, KafkaProxyStatusAssert> {
+    /**
+     * Creates an assertion on the given status.
+     *
+     * @param o the status to assert on
+     */
     protected KafkaProxyStatusAssert(
                                      KafkaProxyStatus o) {
         super(o, KafkaProxyStatusAssert.class,
@@ -23,6 +31,12 @@ public class KafkaProxyStatusAssert extends AbstractStatusAssert<KafkaProxyStatu
                 KafkaProxyStatus::getConditions);
     }
 
+    /**
+     * Creates an assertion on the given status.
+     *
+     * @param actual the status to assert on
+     * @return a new assertion
+     */
     public static KafkaProxyStatusAssert assertThat(KafkaProxyStatus actual) {
         return new KafkaProxyStatusAssert(actual);
     }
@@ -43,11 +57,21 @@ public class KafkaProxyStatusAssert extends AbstractStatusAssert<KafkaProxyStatu
         return conditions().singleElement(AssertFactory.condition());
     }
 
+    /**
+     * Returns a list assertion on the status's clusters.
+     *
+     * @return a list assertion on the clusters
+     */
     public ListAssert<Clusters> clusters() {
         return Assertions.assertThat(actual.getClusters())
                 .asInstanceOf(InstanceOfAssertFactories.list(io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Clusters.class));
     }
 
+    /**
+     * Asserts that the status has the given replica count.
+     *
+     * @param expectedReplicaCount the expected replica count
+     */
     public void replicas(int expectedReplicaCount) {
         Assertions.assertThat(actual.getReplicas()).isEqualTo(expectedReplicaCount);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/KafkaServiceStatusAssert.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/KafkaServiceStatusAssert.java
@@ -14,7 +14,15 @@ import org.assertj.core.api.ListAssert;
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceStatus;
 
+/**
+ * Assertions on a {@link KafkaServiceStatus}.
+ */
 public class KafkaServiceStatusAssert extends AbstractStatusAssert<KafkaServiceStatus, KafkaServiceStatusAssert> {
+    /**
+     * Creates an assertion on the given status.
+     *
+     * @param o the status to assert on
+     */
     protected KafkaServiceStatusAssert(
                                        KafkaServiceStatus o) {
         super(o, KafkaServiceStatusAssert.class,
@@ -22,6 +30,12 @@ public class KafkaServiceStatusAssert extends AbstractStatusAssert<KafkaServiceS
                 KafkaServiceStatus::getConditions);
     }
 
+    /**
+     * Creates an assertion on the given status.
+     *
+     * @param actual the status to assert on
+     * @return a new assertion
+     */
     public static KafkaServiceStatusAssert assertThat(KafkaServiceStatus actual) {
         return new KafkaServiceStatusAssert(actual);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/MetadataAssert.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/MetadataAssert.java
@@ -13,33 +13,72 @@ import org.assertj.core.api.MapAssert;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 
+/**
+ * Assertions on the metadata of a Kubernetes resource.
+ *
+ * @param <T> the resource type
+ */
 @SuppressWarnings("UnusedReturnValue")
 public class MetadataAssert<T extends HasMetadata> extends AbstractObjectAssert<MetadataAssert<T>, T> {
     private MetadataAssert(T actual) {
         super(actual, MetadataAssert.class);
     }
 
+    /**
+     * Creates an assertion on the metadata of the given resource.
+     *
+     * @param <T> the resource type
+     * @param actual the resource to assert on
+     * @return a new assertion
+     */
     public static <T extends HasMetadata> MetadataAssert<T> assertThat(T actual) {
         return new MetadataAssert<>(actual);
     }
 
+    /**
+     * Asserts that the resource has an annotation with the given name whose value satisfies the
+     * given requirements.
+     *
+     * @param annotationName the annotation name
+     * @param expectedValueConsumer the requirements the annotation value must satisfy
+     * @return a map assertion on the resource's annotations
+     */
     public MapAssert<String, String> hasAnnotationSatisfying(String annotationName, Consumer<String> expectedValueConsumer) {
         return assertHasObjectMeta().hasAnnotationSatisfying(annotationName, expectedValueConsumer);
     }
 
+    /**
+     * Asserts that the resource has at least one annotation.
+     *
+     * @return a map assertion on the resource's annotations
+     */
     public MapAssert<String, String> hasAnnotations() {
         return assertHasObjectMeta().hasAnnotations();
     }
 
+    /**
+     * Asserts that the resource has no annotations.
+     */
     public void hasNoAnnotations() {
         assertHasObjectMeta().hasNoAnnotations();
     }
 
+    /**
+     * Asserts that the resource has non-null metadata and returns an assertion on it.
+     *
+     * @return an assertion on the resource's metadata
+     */
     public ObjectMetaAssert assertHasObjectMeta() {
         assertThat(actual).isNotNull();
         return ObjectMetaAssert.assertThat(actual.getMetadata()).isNotNull();
     }
 
+    /**
+     * Asserts that the resource does not have an annotation with the given name.
+     *
+     * @param annotationName the annotation name
+     * @return a map assertion on the resource's annotations
+     */
     public MapAssert<String, String> doesNotHaveAnnotation(String annotationName) {
         return assertHasObjectMeta().doesNotHaveAnnotation(annotationName);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/ObjectMetaAssert.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/ObjectMetaAssert.java
@@ -14,25 +14,50 @@ import org.assertj.core.api.MapAssert;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 
+/**
+ * Assertions on an {@link ObjectMeta}.
+ */
 @SuppressWarnings("UnusedReturnValue")
 public class ObjectMetaAssert extends AbstractObjectAssert<ObjectMetaAssert, ObjectMeta> {
     private ObjectMetaAssert(ObjectMeta actual) {
         super(actual, ObjectMetaAssert.class);
     }
 
+    /**
+     * Creates an assertion on the given metadata.
+     *
+     * @param actual the metadata to assert on
+     * @return a new assertion
+     */
     public static ObjectMetaAssert assertThat(ObjectMeta actual) {
         return new ObjectMetaAssert(actual);
     }
 
+    /**
+     * Asserts that the metadata has an annotation with the given name whose value satisfies the
+     * given requirements.
+     *
+     * @param annotationName the annotation name
+     * @param expectedValueConsumer the requirements the annotation value must satisfy
+     * @return a map assertion on the annotations
+     */
     public MapAssert<String, String> hasAnnotationSatisfying(String annotationName, Consumer<String> expectedValueConsumer) {
         return hasAnnotations()
                 .hasEntrySatisfying(annotationName, expectedValueConsumer);
     }
 
+    /**
+     * Asserts that the metadata has at least one annotation.
+     *
+     * @return a map assertion on the annotations
+     */
     public MapAssert<String, String> hasAnnotations() {
         return getAnnotationsAssert().isNotEmpty();
     }
 
+    /**
+     * Asserts that the metadata has no annotations.
+     */
     public void hasNoAnnotations() {
         getAnnotationsAssert().isEmpty();
     }
@@ -44,6 +69,12 @@ public class ObjectMetaAssert extends AbstractObjectAssert<ObjectMetaAssert, Obj
                 .asInstanceOf(InstanceOfAssertFactories.map(String.class, String.class));
     }
 
+    /**
+     * Asserts that the metadata does not have an annotation with the given name.
+     *
+     * @param annotationName the annotation name
+     * @return a map assertion on the annotations
+     */
     public MapAssert<String, String> doesNotHaveAnnotation(String annotationName) {
         return getAnnotationsAssert().doesNotContainKey(annotationName);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/OperatorAssertions.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/OperatorAssertions.java
@@ -17,39 +17,89 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceStatus;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Clusters;
 import io.kroxylicious.proxy.config.Configuration;
 
+/**
+ * Entry point for the custom assertions in this package, following the AssertJ
+ * {@code assertThat} naming convention.
+ */
 public class OperatorAssertions {
 
     // Static factory should not be instantiated.
     private OperatorAssertions() {
     }
 
+    /**
+     * Factory producing {@link ProxyConfigAssert}, for use with AssertJ's {@code asInstanceOf}.
+     */
     public static final InstanceOfAssertFactory<?, ? extends ProxyConfigAssert> CONFIGURATION = new InstanceOfAssertFactory<>(Configuration.class,
             OperatorAssertions::assertThat);
 
+    /**
+     * Creates an assertion on the given {@code KafkaProxy} status.
+     *
+     * @param actual the status to assert on
+     * @return a new assertion
+     */
     public static KafkaProxyStatusAssert assertThat(KafkaProxyStatus actual) {
         return KafkaProxyStatusAssert.assertThat(actual);
     }
 
+    /**
+     * Creates an assertion on the given {@code KafkaService} status.
+     *
+     * @param actual the status to assert on
+     * @return a new assertion
+     */
     public static KafkaServiceStatusAssert assertThat(KafkaServiceStatus actual) {
         return KafkaServiceStatusAssert.assertThat(actual);
     }
 
+    /**
+     * Creates an assertion on the given cluster entry of a {@code KafkaProxy} status.
+     *
+     * @param actual the cluster to assert on
+     * @return a new assertion
+     */
     public static ClusterAssert assertThat(Clusters actual) {
         return ClusterAssert.assertThat(actual);
     }
 
+    /**
+     * Creates an assertion on the given condition.
+     *
+     * @param actual the condition to assert on
+     * @return a new assertion
+     */
     public static ConditionAssert assertThat(Condition actual) {
         return ConditionAssert.assertThat(actual);
     }
 
+    /**
+     * Creates an assertion on the given proxy configuration.
+     *
+     * @param actual the configuration to assert on
+     * @return a new assertion
+     */
     public static ProxyConfigAssert assertThat(Configuration actual) {
         return ProxyConfigAssert.assertThat(actual);
     }
 
+    /**
+     * Creates an assertion on the metadata of the given resource.
+     *
+     * @param <T> the resource type
+     * @param actual the resource to assert on
+     * @return a new assertion
+     */
     public static <T extends HasMetadata> MetadataAssert<T> assertThat(T actual) {
         return MetadataAssert.assertThat(actual);
     }
 
+    /**
+     * Creates an assertion on the given metadata.
+     *
+     * @param actual the metadata to assert on
+     * @return a new assertion
+     */
     public static ObjectMetaAssert assertThat(ObjectMeta actual) {
         return ObjectMetaAssert.assertThat(actual);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/ProxyConfigAssert.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/ProxyConfigAssert.java
@@ -23,15 +23,37 @@ import io.kroxylicious.proxy.service.HostPort;
 
 import static java.util.stream.Collectors.toSet;
 
+/**
+ * Assertions on a proxy {@link Configuration}, allowing navigation into its virtual clusters,
+ * gateways and node identification strategies.
+ */
 public class ProxyConfigAssert extends AbstractObjectAssert<ProxyConfigAssert, Configuration> {
+    /**
+     * Creates an assertion on the given configuration.
+     *
+     * @param config the configuration to assert on
+     */
     public ProxyConfigAssert(Configuration config) {
         super(config, ProxyConfigAssert.class);
     }
 
+    /**
+     * Creates an assertion on the given configuration.
+     *
+     * @param actual the configuration to assert on
+     * @return a new assertion
+     */
     public static ProxyConfigAssert assertThat(Configuration actual) {
         return new ProxyConfigAssert(actual);
     }
 
+    /**
+     * Asserts that the configuration contains a virtual cluster with the given name and
+     * returns an assertion on it.
+     *
+     * @param clusterName the virtual cluster name
+     * @return an assertion on the named virtual cluster
+     */
     public ProxyConfigClusterAssert cluster(String clusterName) {
         Set<String> names = Optional.ofNullable(this.actual.virtualClusters()).orElse(List.of()).stream().map(VirtualCluster::name).collect(toSet());
         Assertions.assertThat(names).withFailMessage("proxy config contains no virtual clusters").isNotEmpty()
@@ -42,11 +64,26 @@ public class ProxyConfigAssert extends AbstractObjectAssert<ProxyConfigAssert, C
         return new ProxyConfigClusterAssert(virtualCluster);
     }
 
+    /**
+     * Assertions on a {@link VirtualCluster} within a proxy configuration.
+     */
     public static class ProxyConfigClusterAssert extends AbstractObjectAssert<ProxyConfigClusterAssert, VirtualCluster> {
+        /**
+         * Creates an assertion on the given virtual cluster.
+         *
+         * @param virtualCluster the virtual cluster to assert on
+         */
         public ProxyConfigClusterAssert(VirtualCluster virtualCluster) {
             super(virtualCluster, ProxyConfigClusterAssert.class);
         }
 
+        /**
+         * Asserts that the virtual cluster contains a gateway with the given name and
+         * returns an assertion on it.
+         *
+         * @param gateway the gateway name
+         * @return an assertion on the named gateway
+         */
         public ProxyConfigGatewayAssert gateway(String gateway) {
             Set<String> names = this.actual.gateways().stream().map(VirtualClusterGateway::name).collect(toSet());
             Assertions.assertThat(names).withFailMessage(
@@ -59,17 +96,37 @@ public class ProxyConfigAssert extends AbstractObjectAssert<ProxyConfigAssert, C
         }
     }
 
+    /**
+     * Assertions on a {@link VirtualClusterGateway} within a proxy configuration.
+     */
     public static class ProxyConfigGatewayAssert extends AbstractObjectAssert<ProxyConfigGatewayAssert, VirtualClusterGateway> {
 
+        /**
+         * Creates an assertion on the given gateway.
+         *
+         * @param virtualClusterGateway the gateway to assert on
+         */
         public ProxyConfigGatewayAssert(VirtualClusterGateway virtualClusterGateway) {
             super(virtualClusterGateway, ProxyConfigGatewayAssert.class);
         }
 
+        /**
+         * Asserts that the gateway uses the port-identifies-node identification strategy and
+         * returns an assertion on it.
+         *
+         * @return an assertion on the port-identifies-node strategy
+         */
         public ProxyConfigPortIdentifiesNodeGatewayAssert portIdentifiesNode() {
             Assertions.assertThat(actual.portIdentifiesNode()).isNotNull();
             return new ProxyConfigPortIdentifiesNodeGatewayAssert(actual.portIdentifiesNode());
         }
 
+        /**
+         * Asserts that the gateway uses the SNI-host-identifies-node identification strategy and
+         * returns an assertion on it.
+         *
+         * @return an assertion on the SNI-host-identifies-node strategy
+         */
         public ProxyConfigSniHostIdentifiesNodeGatewayAssert sniHostIdentifiesNode() {
             Assertions.assertThat(actual.sniHostIdentifiesNode()).isNotNull();
             return new ProxyConfigSniHostIdentifiesNodeGatewayAssert(actual.sniHostIdentifiesNode());
@@ -77,31 +134,66 @@ public class ProxyConfigAssert extends AbstractObjectAssert<ProxyConfigAssert, C
 
     }
 
+    /**
+     * Assertions on a {@link SniHostIdentifiesNodeIdentificationStrategy} within a proxy configuration.
+     */
     public static class ProxyConfigSniHostIdentifiesNodeGatewayAssert
             extends AbstractObjectAssert<ProxyConfigSniHostIdentifiesNodeGatewayAssert, SniHostIdentifiesNodeIdentificationStrategy> {
 
+        /**
+         * Creates an assertion on the given strategy.
+         *
+         * @param sniHostIdentifiesNodeIdentificationStrategy the strategy to assert on
+         */
         public ProxyConfigSniHostIdentifiesNodeGatewayAssert(SniHostIdentifiesNodeIdentificationStrategy sniHostIdentifiesNodeIdentificationStrategy) {
             super(sniHostIdentifiesNodeIdentificationStrategy, ProxyConfigSniHostIdentifiesNodeGatewayAssert.class);
         }
 
+        /**
+         * Asserts that the strategy has the given bootstrap address.
+         *
+         * @param bootstrapAddress the expected bootstrap address
+         * @return this assertion
+         */
         public ProxyConfigSniHostIdentifiesNodeGatewayAssert hasBootstrapAddress(String bootstrapAddress) {
             Assertions.assertThat(actual.getBootstrapAddress()).isEqualTo(bootstrapAddress);
             return this;
         }
 
+        /**
+         * Asserts that the strategy has the given advertised broker address pattern.
+         *
+         * @param advertisedBrokerAddressPattern the expected advertised broker address pattern
+         * @return this assertion
+         */
         public ProxyConfigSniHostIdentifiesNodeGatewayAssert hasAdvertisedBrokerAddressPattern(String advertisedBrokerAddressPattern) {
             Assertions.assertThat(actual.getAdvertisedBrokerAddressPattern()).isEqualTo(advertisedBrokerAddressPattern);
             return this;
         }
     }
 
+    /**
+     * Assertions on a {@link PortIdentifiesNodeIdentificationStrategy} within a proxy configuration.
+     */
     public static class ProxyConfigPortIdentifiesNodeGatewayAssert
             extends AbstractObjectAssert<ProxyConfigPortIdentifiesNodeGatewayAssert, PortIdentifiesNodeIdentificationStrategy> {
 
+        /**
+         * Creates an assertion on the given strategy.
+         *
+         * @param virtualClusterGateway the strategy to assert on
+         */
         public ProxyConfigPortIdentifiesNodeGatewayAssert(PortIdentifiesNodeIdentificationStrategy virtualClusterGateway) {
             super(virtualClusterGateway, ProxyConfigPortIdentifiesNodeGatewayAssert.class);
         }
 
+        /**
+         * Asserts that the strategy contains a node id range with the given name and
+         * returns an assertion on it.
+         *
+         * @param name the node id range name
+         * @return an assertion on the named node id range
+         */
         public NamedRangeAssert namedRange(String name) {
             Set<String> names = Optional.ofNullable(this.actual.getNodeIdRanges()).orElse(List.of()).stream().map(NamedRange::name).collect(toSet());
             Assertions.assertThat(names)
@@ -115,6 +207,12 @@ public class ProxyConfigAssert extends AbstractObjectAssert<ProxyConfigAssert, C
             return new NamedRangeAssert(namedRange);
         }
 
+        /**
+         * Asserts that the strategy has the given bootstrap address.
+         *
+         * @param expected the expected bootstrap address
+         * @return this assertion
+         */
         public ProxyConfigPortIdentifiesNodeGatewayAssert hasBootstrapAddress(HostPort expected) {
             Assertions.assertThat(actual.getBootstrapAddress())
                     .withFailMessage("expected bootstrap address for gateway: '" + expected + "' but was '" + actual.getBootstrapAddress() + "'")
@@ -122,23 +220,48 @@ public class ProxyConfigAssert extends AbstractObjectAssert<ProxyConfigAssert, C
             return this;
         }
 
+        /**
+         * Asserts that the strategy has no node start port configured.
+         *
+         * @return this assertion
+         */
         public ProxyConfigPortIdentifiesNodeGatewayAssert hasNullNodeStartPort() {
             Assertions.assertThat(actual.getNodeStartPort()).describedAs("node start port").isNull();
             return this;
         }
     }
 
+    /**
+     * Assertions on a {@link NamedRange} within a proxy configuration.
+     */
     public static class NamedRangeAssert extends AbstractObjectAssert<NamedRangeAssert, NamedRange> {
 
+        /**
+         * Creates an assertion on the given range.
+         *
+         * @param namedRange the range to assert on
+         */
         public NamedRangeAssert(NamedRange namedRange) {
             super(namedRange, NamedRangeAssert.class);
         }
 
+        /**
+         * Asserts that the range starts at the given node id.
+         *
+         * @param expected the expected range start
+         * @return this assertion
+         */
         public NamedRangeAssert hasStart(int expected) {
             Assertions.assertThat(actual.start()).withFailMessage("expected node id range start to be " + expected + " but was " + actual.start()).isEqualTo(expected);
             return this;
         }
 
+        /**
+         * Asserts that the range ends at the given node id.
+         *
+         * @param expected the expected range end
+         * @return this assertion
+         */
         public NamedRangeAssert hasEnd(int expected) {
             Assertions.assertThat(actual.end()).withFailMessage("expected node id range end to be " + expected + " but was " + actual.end()).isEqualTo(expected);
             return this;

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/VirtualKafkaClusterStatusAssert.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/VirtualKafkaClusterStatusAssert.java
@@ -8,7 +8,15 @@ package io.kroxylicious.testing.operator.assertj;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterStatus;
 
+/**
+ * Assertions on a {@link VirtualKafkaClusterStatus}.
+ */
 public class VirtualKafkaClusterStatusAssert extends AbstractStatusAssert<VirtualKafkaClusterStatus, VirtualKafkaClusterStatusAssert> {
+    /**
+     * Creates an assertion on the given status.
+     *
+     * @param o the status to assert on
+     */
     protected VirtualKafkaClusterStatusAssert(
                                               VirtualKafkaClusterStatus o) {
         super(o, VirtualKafkaClusterStatusAssert.class,
@@ -16,6 +24,12 @@ public class VirtualKafkaClusterStatusAssert extends AbstractStatusAssert<Virtua
                 VirtualKafkaClusterStatus::getConditions);
     }
 
+    /**
+     * Creates an assertion on the given status.
+     *
+     * @param actual the status to assert on
+     * @return a new assertion
+     */
     public static VirtualKafkaClusterStatusAssert assertThat(VirtualKafkaClusterStatus actual) {
         return new VirtualKafkaClusterStatusAssert(actual);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/package-info.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/assertj/package-info.java
@@ -3,6 +3,10 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
+/**
+ * AssertJ custom assertions for Kroxylicious custom resource statuses, conditions,
+ * resource metadata and generated proxy configuration.
+ */
 @ReturnValuesAreNonnullByDefault
 @DefaultAnnotationForParameters(NonNull.class)
 @DefaultAnnotation(NonNull.class)


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_


- Added detailed JavaDoc comments to the AssertFactory, ClusterAssert, ConditionAssert, and other assertion classes to improve code documentation and usability.
- Implemented new assertion methods in ConditionAssert for various condition types, including isAcceptedTrue, isResolvedRefsFalse, and isReadyUnknown, to facilitate more expressive assertions.
- Introduced assertions for KafkaProxyStatus, KafkaServiceStatus, and other related classes, enhancing the ability to validate the status of Kafka resources.
- Improved the ProxyConfigAssert class with additional assertions for virtual clusters and gateways, allowing for more granular testing of proxy configurations.
- Updated package-info.java to provide an overview of the purpose of the assertion package, clarifying its role in testing Kroxylicious custom resources.
### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [X] PR references related GitHub issue(s) so they are closed on merging. Closes: #4575 
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
