### PR TITLE
use EffectiveLogLevel from logSquelcher 0.3.0

### DIFF
--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/AuthorizationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/AuthorizationFilterTest.java
@@ -42,6 +42,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.reflect.ClassPath;
 
 import io.github.sambarker.logsquelcher.CapturedLogs;
+import io.github.sambarker.logsquelcher.EffectiveLogLevel;
 import io.github.sambarker.logsquelcher.LogSquelcherExtension;
 import io.github.sambarker.logsquelcher.LoggingEventAssert;
 
@@ -150,6 +151,7 @@ class AuthorizationFilterTest {
 
     @ParameterizedTest
     @MethodSource
+    @EffectiveLogLevel(logger = AuthorizationFilter.class, level = Level.DEBUG)
     void authorization(ScenarioDefinition definition, CapturedLogs capturedLogs) {
         SimpleAuthorizer authorizer = new SimpleAuthorizer(definition.given().authorizerRules());
         AuthorizationFilter authorizationFilter = new AuthorizationFilter(authorizer);

--- a/kroxylicious-filters/kroxylicious-protocol-logger/src/test/java/io/kroxylicious/filter/protocollogger/ProtocolLoggerFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-protocol-logger/src/test/java/io/kroxylicious/filter/protocollogger/ProtocolLoggerFilterTest.java
@@ -44,6 +44,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.github.sambarker.logsquelcher.CapturedLogs;
+import io.github.sambarker.logsquelcher.EffectiveLogLevel;
 import io.github.sambarker.logsquelcher.LogSquelcherExtension;
 import io.github.sambarker.logsquelcher.LoggingEventAssert;
 
@@ -59,10 +60,13 @@ import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 class ProtocolLoggerFilterTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String LOGGER_NAME = "filterLogs";
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(LOGGER_NAME);
+    private static final String CUSTOM_LOGGER = "test.custom.logger";
 
     private final ProtocolLoggerFilter filter = new ProtocolLoggerFilter(
             EnumSet.allOf(ApiKeys.class), new MessageFormatter(), Level.DEBUG,
-            LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+            LOGGER);
 
     static Stream<Arguments> credentialBearingRequestsWithSecrets() {
         return Stream.of(
@@ -229,22 +233,24 @@ class ProtocolLoggerFilterTest {
     }
 
     @Test
+    @EffectiveLogLevel(loggerName = LOGGER_NAME, level = Level.DEBUG)
     void shouldHandleRequestReturnsTrueForConfiguredKeyWhenLevelEnabled() {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+                LOGGER);
 
         // When / Then
         assertThat(f.shouldHandleRequest(ApiKeys.METADATA, (short) 12)).isTrue();
     }
 
     @Test
+    @EffectiveLogLevel(loggerName = LOGGER_NAME, level = Level.DEBUG)
     void shouldHandleResponseReturnsTrueForConfiguredKeyWhenLevelEnabled() {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+                LOGGER);
 
         // When / Then
         assertThat(f.shouldHandleResponse(ApiKeys.METADATA, (short) 12)).isTrue();
@@ -255,7 +261,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+                LOGGER);
 
         // When / Then
         assertThat(f.shouldHandleRequest(ApiKeys.PRODUCE, (short) 9)).isFalse();
@@ -266,7 +272,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+                LOGGER);
 
         // When / Then
         assertThat(f.shouldHandleResponse(ApiKeys.PRODUCE, (short) 9)).isFalse();
@@ -334,12 +340,12 @@ class ProtocolLoggerFilterTest {
     }
 
     @Test
+    @EffectiveLogLevel(loggerName = CUSTOM_LOGGER, level = Level.DEBUG)
     void customLoggerNameEmitsUnderThatName(CapturedLogs capturedLogs) {
         // Given
-        String customName = "test.custom.logger";
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(customName));
+                LoggerFactory.getLogger(CUSTOM_LOGGER));
         RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
         MetadataRequestData request = new MetadataRequestData();
         MockFilterContext context = MockFilterContext.builder(header, request).build();
@@ -350,19 +356,20 @@ class ProtocolLoggerFilterTest {
         // Then
         var allEvents = capturedLogs.logged();
         assertThat(allEvents)
-                .filteredOn(e -> customName.equals(e.getLoggerName()))
+                .filteredOn(e -> CUSTOM_LOGGER.equals(e.getLoggerName()))
                 .hasSize(1)
                 .first()
-                .satisfies(e -> assertThat(e.getLoggerName()).isEqualTo(customName));
+                .satisfies(e -> assertThat(e.getLoggerName()).isEqualTo(CUSTOM_LOGGER));
         assertThat(capturedLogs.logged(ProtocolLoggerFilter.class, Level.DEBUG)).isEmpty();
     }
 
     @Test
+    @EffectiveLogLevel(loggerName = LOGGER_NAME, level = Level.DEBUG)
     void onRequestEmitsOneEntryAtConfiguredLevel(CapturedLogs capturedLogs) throws JsonProcessingException {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+                LOGGER);
         RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
         MetadataRequestData request = new MetadataRequestData();
         MockFilterContext context = MockFilterContext.builder(header, request).build();
@@ -371,18 +378,19 @@ class ProtocolLoggerFilterTest {
         f.onRequest(ApiKeys.METADATA, (short) 13, header, request, context).toCompletableFuture().join();
 
         // Then
-        var events = capturedLogs.logged(ProtocolLoggerFilter.class, Level.DEBUG);
+        var events = capturedLogs.logged(LOGGER_NAME, Level.DEBUG);
         LoggingEventAssert.assertThat(events).hasSize(1);
         JsonNode entry = MAPPER.readTree(events.get(0).getMessage());
         assertThat(entry.path("header").path("apiKey").asText()).isEqualTo("METADATA");
     }
 
     @Test
+    @EffectiveLogLevel(loggerName = LOGGER_NAME, level = Level.DEBUG)
     void onResponseEmitsOneEntryAtConfiguredLevel(CapturedLogs capturedLogs) throws JsonProcessingException {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+                LOGGER);
         ResponseHeaderData header = new ResponseHeaderData().setCorrelationId(1);
         MetadataResponseData response = new MetadataResponseData();
         MockFilterContext context = MockFilterContext.builder(header, response).build();
@@ -391,19 +399,20 @@ class ProtocolLoggerFilterTest {
         f.onResponse(ApiKeys.METADATA, (short) 13, header, response, context).toCompletableFuture().join();
 
         // Then
-        var events = capturedLogs.logged(ProtocolLoggerFilter.class, Level.DEBUG);
+        var events = capturedLogs.logged(LOGGER_NAME, Level.DEBUG);
         LoggingEventAssert.assertThat(events).hasSize(1);
         JsonNode entry = MAPPER.readTree(events.get(0).getMessage());
         assertThat(entry.path("header").path("apiKey").asText()).isEqualTo("METADATA");
     }
 
     @Test
+    @EffectiveLogLevel(loggerName = LOGGER_NAME, level = Level.DEBUG)
     void credentialBearingRequestEmitsWithheldEntryWithoutPlantedSecret(CapturedLogs capturedLogs) throws JsonProcessingException {
         // Given
         String plantedSecret = "PLANTED_SASL_SECRET_VALUE";
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+                LOGGER);
         RequestHeaderData header = new RequestHeaderData().setCorrelationId(5).setClientId("c1");
         SaslAuthenticateRequestData request = new SaslAuthenticateRequestData()
                 .setAuthBytes(plantedSecret.getBytes(StandardCharsets.UTF_8));
@@ -413,7 +422,7 @@ class ProtocolLoggerFilterTest {
         f.onRequest(ApiKeys.SASL_AUTHENTICATE, (short) 2, header, request, context).toCompletableFuture().join();
 
         // Then
-        var events = capturedLogs.logged(ProtocolLoggerFilter.class, Level.DEBUG);
+        var events = capturedLogs.logged(LOGGER_NAME, Level.DEBUG);
         LoggingEventAssert.assertThat(events).hasSize(1);
         String message = events.get(0).getMessage();
         assertThat(message).doesNotContain(plantedSecret);
@@ -424,12 +433,13 @@ class ProtocolLoggerFilterTest {
     }
 
     @Test
+    @EffectiveLogLevel(loggerName = LOGGER_NAME, level = Level.DEBUG)
     void credentialBearingResponseEmitsWithheldEntryWithoutPlantedSecret(CapturedLogs capturedLogs) throws JsonProcessingException {
         // Given
         String plantedSecret = "PLANTED_DELEGATION_HMAC_SECRET";
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+                LOGGER);
         ResponseHeaderData header = new ResponseHeaderData().setCorrelationId(7);
         CreateDelegationTokenResponseData response = new CreateDelegationTokenResponseData()
                 .setHmac(plantedSecret.getBytes(StandardCharsets.UTF_8));
@@ -439,7 +449,7 @@ class ProtocolLoggerFilterTest {
         f.onResponse(ApiKeys.CREATE_DELEGATION_TOKEN, (short) 3, header, response, context).toCompletableFuture().join();
 
         // Then
-        var events = capturedLogs.logged(ProtocolLoggerFilter.class, Level.DEBUG);
+        var events = capturedLogs.logged(LOGGER_NAME, Level.DEBUG);
         LoggingEventAssert.assertThat(events).hasSize(1);
         String message = events.get(0).getMessage();
         assertThat(message).doesNotContain(plantedSecret);

--- a/kroxylicious-filters/kroxylicious-protocol-logger/src/test/java/io/kroxylicious/filter/protocollogger/ProtocolLoggerTest.java
+++ b/kroxylicious-filters/kroxylicious-protocol-logger/src/test/java/io/kroxylicious/filter/protocollogger/ProtocolLoggerTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.event.Level;
 
+import io.github.sambarker.logsquelcher.EffectiveLogLevel;
+
 import io.kroxylicious.proxy.filter.RequestFilter;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 
@@ -25,6 +27,7 @@ import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 class ProtocolLoggerTest {
 
+    private static final String DEDICATED_LOGGER = "protocolLogger";
     private final ProtocolLogger factory = new ProtocolLogger();
 
     @Test
@@ -53,9 +56,10 @@ class ProtocolLoggerTest {
     }
 
     @Test
+    @EffectiveLogLevel(loggerName = DEDICATED_LOGGER, level = Level.DEBUG)
     void createFilterWithEmptyApiKeyNamesHandlesAllKeys() {
         // Given
-        ProtocolLogger.Config config = new ProtocolLogger.Config(Set.of(), Level.DEBUG, ProtocolLoggerFilter.class.getName());
+        ProtocolLogger.Config config = new ProtocolLogger.Config(Set.of(), Level.DEBUG, DEDICATED_LOGGER);
 
         // When
         RequestFilter filter = (RequestFilter) factory.createFilter(null, config);
@@ -66,9 +70,10 @@ class ProtocolLoggerTest {
     }
 
     @Test
+    @EffectiveLogLevel(loggerName = DEDICATED_LOGGER, level = Level.DEBUG)
     void createFilterWithPopulatedApiKeyNamesHandlesOnlyThoseKeys() {
         // Given
-        ProtocolLogger.Config config = new ProtocolLogger.Config(Set.of("METADATA"), Level.DEBUG, ProtocolLoggerFilter.class.getName());
+        ProtocolLogger.Config config = new ProtocolLogger.Config(Set.of("METADATA"), Level.DEBUG, DEDICATED_LOGGER);
 
         // When
         RequestFilter filter = (RequestFilter) factory.createFilter(null, config);

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <azure.core.version>1.58.1</azure.core.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
         <apache.httpcore.version>4.4.16</apache.httpcore.version>
-        <logsquelcher.version>0.2.1</logsquelcher.version>
+        <logsquelcher.version>0.3.0-SNAPSHOT</logsquelcher.version>
         <async-profiler.version>4.5</async-profiler.version>
         <json-unit-assertj.version>6.0.1</json-unit-assertj.version>
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Allow tests to control what level loggers are operating at.

### Additional Context

Issues encountered during #4528 meant that logSqueclcher wasn't quite allowing the tests we wanted. This prompted a new annotation in LogSquclcher. 

PR is still in draft as 0.3.0 is not yet released upstream.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
