### PR TITLE
ci(release): converge image build logic and retire docker.yaml

### DIFF
--- a/.github/workflows/build-kroxylicious-artifacts.yaml
+++ b/.github/workflows/build-kroxylicious-artifacts.yaml
@@ -21,54 +21,9 @@ on:
 
 jobs:
   build_kroxylicious_images:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
-        with:
-          egress-policy: audit
-
-      - name: 'Check out repository'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          fetch-depth: 0
-      - name: Setup Java
-        uses: ./.github/actions/common/setup-java
-      - name: 'Set up Docker Buildx'
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
-      - name: 'Cache Maven packages'
-        uses: ./.github/actions/common/cache-maven-packages
-      - name: 'Build Kroxylicious Operator/Operand Container Images & Operator Zip'
-        run: |
-          mvn --quiet \
-            --batch-mode \
-            --activate-profiles 'dist,!qa' \
-            --also-make \
-            --projects :kroxylicious-app,:kroxylicious-operator,:kroxylicious-operator-dist,:kroxylicious-admission \
-            -Derrorprone.skip=true \
-            -DskipTests \
-            -Dmaven.javadoc.skip=true \
-            -DskipDocs=true \
-            package
-      - name: 'Archive kroxylicious proxy image'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: kroxylicious-proxy
-          path: kroxylicious-app/target/kroxylicious-proxy.img.tar.gz
-          retention-days: 1
-      - name: 'Archive kroxylicious operator image'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: kroxylicious-operator
-          path: kroxylicious-kubernetes/kroxylicious-operator/target/kroxylicious-operator.img.tar.gz
-          retention-days: 1
-      - name: 'Archive kroxylicious admission webhook image'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: kroxylicious-admission-webhook
-          path: kroxylicious-kubernetes/kroxylicious-admission/target/kroxylicious-webhook.img.tar.gz
-          retention-days: 1
+    uses: ./.github/workflows/build-kroxylicious-container-images.yaml
+    with:
+      output-tarballs: true
 
   build_artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-kroxylicious-container-images.yaml
+++ b/.github/workflows/build-kroxylicious-container-images.yaml
@@ -1,16 +1,21 @@
-# docker.yaml - builds and pushes Kroxylicious container images.
 #
-# Requires repository variables:
-# - REGISTRY_SERVER - the server of the container registry service e.g. `quay.io` or `docker.io`
-# - REGISTRY_USERNAME - your username on the service (or username of your robot account)
-# - PROXY_IMAGE_NAME - the proxy image name (without tag)
-# - OPERATOR_IMAGE_NAME - the operator image name (without tag)
-# - ADMISSION_IMAGE_NAME - the admission webhook image name (without tag)
-# and a repository secret
-# - REGISTRY_TOKEN - the access token that corresponds to `REGISTRY_USERNAME`
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License. You may obtain a copy of the License at
 #
-# If the required repository variables aren't set the workflow will be skipped. This means the workflow won't fail
-# on the forks of developers who haven't configured the variables/secrets.
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# build-kroxylicious-container-images.yaml — the single canonical place for building
+# Kroxylicious container images.
 #
 # Multi-arch proxy images are built as a 4-phase process:
 #   1. mvn install  — compile and install all module JARs into ~/.m2 once
@@ -18,26 +23,66 @@
 #   3. mvn + docker — dist packaging (with -Paarch64) and image build for linux/arm64
 #   4. manifest     — merge per-arch images into a multi-arch manifest list
 #
-# The operator has no architecture-specific native JARs, so a single multi-arch
-# Docker Buildx build covers both platforms without a paired Maven run.
+# The operator and admission webhook have no architecture-specific native JARs,
+# so a single multi-arch Docker Buildx build covers both platforms.
 #
-# PR builds validate only linux/amd64 for speed.
+# Callers:
+#   - maven.yaml          — CI validation (PR) and snapshot image pushes (main/release branches)
+#   - build-kroxylicious-artifacts.yaml — produce tarballs for system tests
+#   - stage_release.yaml  — dispatch on release branch to build and push staged images
+#
+# Required repository variables (when push-images=true):
+#   REGISTRY_SERVER       — container registry server, e.g. quay.io
+#   REGISTRY_ORGANISATION — organisation/namespace within the registry
+#   REGISTRY_USERNAME     — registry username or robot-account username
+#   PROXY_IMAGE_NAME      — proxy image name (without tag)
+#   OPERATOR_IMAGE_NAME   — operator image name (without tag)
+#   ADMISSION_IMAGE_NAME  — admission webhook image name (without tag)
+# Required repository secret (when push-images=true):
+#   REGISTRY_TOKEN        — access token for REGISTRY_USERNAME
 
-name: Docker Build
+name: Build Kroxylicious Container Images
 
 on:
+  workflow_call:
+    inputs:
+      push-images:
+        description: 'Push images to the container registry'
+        type: boolean
+        default: false
+      multi-arch:
+        description: 'Build linux/amd64 and linux/arm64 images (proxy only; operator and admission are always multi-arch)'
+        type: boolean
+        default: false
+      additional-tags:
+        description: 'Extra comma-separated image tags alongside the commit-SHA tag (e.g. "0.23.0-SNAPSHOT"). Leave empty for SHA-only.'
+        type: string
+        default: ''
+      output-tarballs:
+        description: 'Export amd64 images as Docker-format gzip tarballs and upload them as GitHub Actions artifacts for use by system tests. Mutually exclusive with push-images.'
+        type: boolean
+        default: false
+      tag-pom-version:
+        description: 'Also tag pushed images with the project POM version (e.g. "0.24.0-SNAPSHOT"). Only meaningful when push-images=true.'
+        type: boolean
+        default: false
+    secrets:
+      REGISTRY_TOKEN:
+        required: false
   workflow_dispatch:
     inputs:
+      push-images:
+        description: 'Push images to the container registry'
+        type: boolean
+        default: false
+      multi-arch:
+        description: 'Build linux/amd64 and linux/arm64 images'
+        type: boolean
+        default: false
       additional-tags:
-        description: 'Extra comma-separated image tags to apply alongside the commit SHA tag (e.g. "0.23.0-SNAPSHOT"). Leave empty for SHA-only (used by staging).'
+        description: 'Extra comma-separated image tags alongside the commit-SHA tag (e.g. "0.23.0-SNAPSHOT"). Leave empty for SHA-only.'
         required: false
         default: ''
-  push:
-    branches:
-      - 'main'
-      - 'release/**'
-  pull_request:
-    types: [ opened, synchronize, reopened ]
 
 jobs:
   build:
@@ -47,12 +92,6 @@ jobs:
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
-
-      - name: 'Test for Slack secret'
-        env:
-          KROXYLICIOUS_SLACK_WEBHOOK: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
-        run: |
-          echo "SLACK_WEBHOOK_SET=$(test ${KROXYLICIOUS_SLACK_WEBHOOK} && echo true)" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -67,7 +106,7 @@ jobs:
       - name: Setup Java
         uses: ./.github/actions/common/setup-java
 
-      - name: 'Cache Maven packages'
+      - name: Cache Maven packages
         uses: ./.github/actions/common/cache-maven-packages
 
       - name: Determine Build Configuration
@@ -80,8 +119,20 @@ jobs:
           echo "image_created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
           SHA_TAG="commit-$(git rev-parse --short "${GITHUB_SHA}")"
 
-          if [[ "${{ github.event_name }}" == "pull_request" || "${{ vars.REGISTRY_SERVER }}" == "" ]]; then
-            # PR / no-registry builds: amd64 only for speed, no push, no manifest needed.
+          if [[ "${{ inputs.output-tarballs }}" == "true" ]]; then
+            # Tarball mode: amd64-only, no push, use Maven image names for compatibility
+            # with system-test tooling that verifies image names via Maven properties.
+            echo "push_images=false" >> $GITHUB_OUTPUT
+            echo "multi_arch=false" >> $GITHUB_OUTPUT
+            echo "proxy_amd64_tag=quay.io/kroxylicious/proxy:${POMS_VERSION}" >> $GITHUB_OUTPUT
+            echo "proxy_arm64_tag=" >> $GITHUB_OUTPUT
+            echo "proxy_final_tags=" >> $GITHUB_OUTPUT
+            echo "operator_platforms=linux/amd64" >> $GITHUB_OUTPUT
+            echo "operator_tags=quay.io/kroxylicious/operator:${POMS_VERSION}" >> $GITHUB_OUTPUT
+            echo "admission_platforms=linux/amd64" >> $GITHUB_OUTPUT
+            echo "admission_tags=quay.io/kroxylicious/webhook:${POMS_VERSION}" >> $GITHUB_OUTPUT
+          elif [[ "${{ inputs.push-images }}" != "true" || "${{ vars.REGISTRY_SERVER }}" == "" ]]; then
+            # No-push mode: amd64-only validation build (CI PRs or forks without registry vars).
             echo "push_images=false" >> $GITHUB_OUTPUT
             echo "multi_arch=false" >> $GITHUB_OUTPUT
             echo "proxy_amd64_tag=kroxylicious-proxy:${SHA_TAG}" >> $GITHUB_OUTPUT
@@ -100,15 +151,15 @@ jobs:
             # Per-arch intermediate tags are pushed individually then merged into the
             # final manifest list (which also covers the legacy kroxylicious image name).
             echo "push_images=true" >> $GITHUB_OUTPUT
-            echo "multi_arch=true" >> $GITHUB_OUTPUT
+            echo "multi_arch=${{ inputs.multi-arch }}" >> $GITHUB_OUTPUT
             echo "proxy_amd64_tag=${PROXY_IMAGE}:${SHA_TAG}-amd64" >> $GITHUB_OUTPUT
             echo "proxy_arm64_tag=${PROXY_IMAGE}:${SHA_TAG}-arm64" >> $GITHUB_OUTPUT
 
-            # All builds get a commit SHA tag. Branch pushes also get the pom version
-            # (will be x.y.z-SNAPSHOT). Dispatched builds get any caller-supplied tags
-            # (empty for staging; promote_release.yaml owns the release version tag).
+            # All builds get a commit SHA tag. Branch-push CI builds also add
+            # the POM version (x.y.z-SNAPSHOT); staging dispatches do not.
+            # Callers may also pass arbitrary additional-tags.
             TAG_SUFFIXES=("${SHA_TAG}")
-            if [[ "${{ github.event_name }}" == "push" ]]; then
+            if [[ "${{ inputs.tag-pom-version }}" == "true" ]]; then
               TAG_SUFFIXES+=("${POMS_VERSION}")
             fi
             if [[ -n "${ADDITIONAL_TAGS}" ]]; then
@@ -173,6 +224,7 @@ jobs:
             package
 
       - name: Build and maybe push amd64 proxy image
+        if: ${{ inputs.output-tarballs != true }}
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./kroxylicious-app
@@ -190,7 +242,28 @@ jobs:
           cache-from: type=gha,scope=proxy-amd64
           cache-to: type=gha,mode=max,compression=zstd,scope=proxy-amd64
 
+      - name: Export amd64 proxy image as tarball
+        if: ${{ inputs.output-tarballs == true }}
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        with:
+          context: ./kroxylicious-app
+          file: ./kroxylicious-app/src/main/docker/proxy.dockerfile
+          platforms: linux/amd64
+          push: false
+          outputs: type=docker,dest=/tmp/kroxylicious-proxy.img.tar
+          build-args: |
+            KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.build_configuration.outputs.image_created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/kroxylicious/kroxylicious
+            org.opencontainers.image.version=${{ steps.build_configuration.outputs.release_version }}
+          tags: ${{ steps.build_configuration.outputs.proxy_amd64_tag }}
+          cache-from: type=gha,scope=proxy-amd64
+          cache-to: type=gha,mode=max,compression=zstd,scope=proxy-amd64
+
       - name: Build and maybe push operator image
+        if: ${{ inputs.output-tarballs != true }}
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./kroxylicious-kubernetes/kroxylicious-operator
@@ -208,7 +281,28 @@ jobs:
           cache-from: type=gha,scope=operator
           cache-to: type=gha,mode=max,compression=zstd,scope=operator
 
+      - name: Export operator image as tarball
+        if: ${{ inputs.output-tarballs == true }}
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        with:
+          context: ./kroxylicious-kubernetes/kroxylicious-operator
+          file: ./kroxylicious-kubernetes/kroxylicious-operator/src/main/docker/operator.dockerfile
+          platforms: linux/amd64
+          push: false
+          outputs: type=docker,dest=/tmp/kroxylicious-operator.img.tar
+          build-args: |
+            KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.build_configuration.outputs.image_created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/kroxylicious/kroxylicious
+            org.opencontainers.image.version=${{ steps.build_configuration.outputs.release_version }}
+          tags: ${{ steps.build_configuration.outputs.operator_tags }}
+          cache-from: type=gha,scope=operator
+          cache-to: type=gha,mode=max,compression=zstd,scope=operator
+
       - name: Build and maybe push Admission webhook image
+        if: ${{ inputs.output-tarballs != true }}
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./kroxylicious-kubernetes/kroxylicious-admission
@@ -225,6 +319,33 @@ jobs:
           tags: ${{ steps.build_configuration.outputs.admission_tags }}
           cache-from: type=gha,scope=admission
           cache-to: type=gha,mode=max,compression=zstd,scope=admission
+
+      - name: Export Admission webhook image as tarball
+        if: ${{ inputs.output-tarballs == true }}
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        with:
+          context: ./kroxylicious-kubernetes/kroxylicious-admission
+          file: ./kroxylicious-kubernetes/kroxylicious-admission/src/main/docker/webhook.dockerfile
+          platforms: linux/amd64
+          push: false
+          outputs: type=docker,dest=/tmp/kroxylicious-webhook.img.tar
+          build-args: |
+            KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.build_configuration.outputs.image_created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/kroxylicious/kroxylicious
+            org.opencontainers.image.version=${{ steps.build_configuration.outputs.release_version }}
+          tags: ${{ steps.build_configuration.outputs.admission_tags }}
+          cache-from: type=gha,scope=admission
+          cache-to: type=gha,mode=max,compression=zstd,scope=admission
+
+      - name: Gzip image tarballs
+        if: ${{ inputs.output-tarballs == true }}
+        run: |
+          gzip /tmp/kroxylicious-proxy.img.tar
+          gzip /tmp/kroxylicious-operator.img.tar
+          gzip /tmp/kroxylicious-webhook.img.tar
 
       # `clean package` on runtime+app wipes their target/ directories so the
       # aarch64 assembly contains only linux-aarch_64 Netty native binaries (no
@@ -297,13 +418,26 @@ jobs:
               "${{ steps.build_configuration.outputs.proxy_arm64_tag }}"
           done
 
-      - name: Slack Notification on Failure
-        if: failure() && env.SLACK_WEBHOOK_SET == 'true' && github.event_name == 'push'
-        uses: ./.github/actions/common/slack-notification
+      - name: Archive proxy image tarball
+        if: ${{ inputs.output-tarballs == true }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
-          slackTitle: 'Failure Alert: ${{ github.repository }}'
-          slackMessage: 'The docker build workflow failed on branch ${{ github.ref_name }}.'
-          serverUrl: ${{ github.server_url }}
-          repository: ${{ github.repository }}
-          runId: ${{ github.run_id }}
+          name: kroxylicious-proxy
+          path: /tmp/kroxylicious-proxy.img.tar.gz
+          retention-days: 1
+
+      - name: Archive operator image tarball
+        if: ${{ inputs.output-tarballs == true }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: kroxylicious-operator
+          path: /tmp/kroxylicious-operator.img.tar.gz
+          retention-days: 1
+
+      - name: Archive admission webhook image tarball
+        if: ${{ inputs.output-tarballs == true }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: kroxylicious-admission-webhook
+          path: /tmp/kroxylicious-webhook.img.tar.gz
+          retention-days: 1

--- a/.github/workflows/build-kroxylicious-container-images.yaml
+++ b/.github/workflows/build-kroxylicious-container-images.yaml
@@ -118,6 +118,7 @@ jobs:
           POMS_VERSION=$(mvn help:evaluate -Dexpression=project.version --quiet -DforceStdout)
           echo "release_version=${POMS_VERSION}" >> $GITHUB_OUTPUT
           echo "image_created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+          echo "output_tarballs=${{ inputs.output-tarballs }}" >> $GITHUB_OUTPUT
           SHA_TAG="commit-$(git rev-parse --short "${GITHUB_SHA}")"
 
           if [[ "${{ inputs.output-tarballs }}" == "true" ]]; then
@@ -222,7 +223,7 @@ jobs:
             package
 
       - name: Build and maybe push amd64 proxy image
-        if: ${{ inputs.output-tarballs != true }}
+        if: steps.build_configuration.outputs.output_tarballs != 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./kroxylicious-app
@@ -241,7 +242,7 @@ jobs:
           cache-to: type=gha,mode=max,compression=zstd,scope=proxy-amd64
 
       - name: Export amd64 proxy image as tarball
-        if: ${{ inputs.output-tarballs == true }}
+        if: steps.build_configuration.outputs.output_tarballs == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./kroxylicious-app
@@ -261,7 +262,7 @@ jobs:
           cache-to: type=gha,mode=max,compression=zstd,scope=proxy-amd64
 
       - name: Build and maybe push operator image
-        if: ${{ inputs.output-tarballs != true }}
+        if: steps.build_configuration.outputs.output_tarballs != 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./kroxylicious-kubernetes/kroxylicious-operator
@@ -280,7 +281,7 @@ jobs:
           cache-to: type=gha,mode=max,compression=zstd,scope=operator
 
       - name: Export operator image as tarball
-        if: ${{ inputs.output-tarballs == true }}
+        if: steps.build_configuration.outputs.output_tarballs == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./kroxylicious-kubernetes/kroxylicious-operator
@@ -300,7 +301,7 @@ jobs:
           cache-to: type=gha,mode=max,compression=zstd,scope=operator
 
       - name: Build and maybe push Admission webhook image
-        if: ${{ inputs.output-tarballs != true }}
+        if: steps.build_configuration.outputs.output_tarballs != 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./kroxylicious-kubernetes/kroxylicious-admission
@@ -319,7 +320,7 @@ jobs:
           cache-to: type=gha,mode=max,compression=zstd,scope=admission
 
       - name: Export Admission webhook image as tarball
-        if: ${{ inputs.output-tarballs == true }}
+        if: steps.build_configuration.outputs.output_tarballs == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./kroxylicious-kubernetes/kroxylicious-admission
@@ -339,7 +340,7 @@ jobs:
           cache-to: type=gha,mode=max,compression=zstd,scope=admission
 
       - name: Gzip image tarballs
-        if: ${{ inputs.output-tarballs == true }}
+        if: steps.build_configuration.outputs.output_tarballs == 'true'
         run: |
           gzip /tmp/kroxylicious-proxy.img.tar
           gzip /tmp/kroxylicious-operator.img.tar
@@ -417,7 +418,7 @@ jobs:
           done
 
       - name: Archive proxy image tarball
-        if: ${{ inputs.output-tarballs == true }}
+        if: steps.build_configuration.outputs.output_tarballs == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: kroxylicious-proxy
@@ -425,7 +426,7 @@ jobs:
           retention-days: 1
 
       - name: Archive operator image tarball
-        if: ${{ inputs.output-tarballs == true }}
+        if: steps.build_configuration.outputs.output_tarballs == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: kroxylicious-operator
@@ -433,7 +434,7 @@ jobs:
           retention-days: 1
 
       - name: Archive admission webhook image tarball
-        if: ${{ inputs.output-tarballs == true }}
+        if: steps.build_configuration.outputs.output_tarballs == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: kroxylicious-admission-webhook

--- a/.github/workflows/build-kroxylicious-container-images.yaml
+++ b/.github/workflows/build-kroxylicious-container-images.yaml
@@ -62,10 +62,6 @@ on:
         description: 'Export amd64 images as Docker-format gzip tarballs and upload them as GitHub Actions artifacts for use by system tests. Mutually exclusive with push-images.'
         type: boolean
         default: false
-      tag-pom-version:
-        description: 'Also tag pushed images with the project POM version (e.g. "0.24.0-SNAPSHOT"). Only meaningful when push-images=true.'
-        type: boolean
-        default: false
     secrets:
       REGISTRY_TOKEN:
         required: false
@@ -155,13 +151,10 @@ jobs:
             echo "proxy_amd64_tag=${PROXY_IMAGE}:${SHA_TAG}-amd64" >> $GITHUB_OUTPUT
             echo "proxy_arm64_tag=${PROXY_IMAGE}:${SHA_TAG}-arm64" >> $GITHUB_OUTPUT
 
-            # All builds get a commit SHA tag. Branch-push CI builds also add
-            # the POM version (x.y.z-SNAPSHOT); staging dispatches do not.
-            # Callers may also pass arbitrary additional-tags.
+            # All builds get a commit SHA tag. Callers may also pass arbitrary
+            # additional-tags (e.g. maven.yaml adds the POM version on pushes
+            # to main/release; staging dispatches pass none).
             TAG_SUFFIXES=("${SHA_TAG}")
-            if [[ "${{ inputs.tag-pom-version }}" == "true" ]]; then
-              TAG_SUFFIXES+=("${POMS_VERSION}")
-            fi
             if [[ -n "${ADDITIONAL_TAGS}" ]]; then
               IFS=',' read -ra EXTRA_TAGS <<< "${ADDITIONAL_TAGS}"
               for extra_tag in "${EXTRA_TAGS[@]}"; do

--- a/.github/workflows/build-kroxylicious-container-images.yaml
+++ b/.github/workflows/build-kroxylicious-container-images.yaml
@@ -110,6 +110,11 @@ jobs:
         env:
           ADDITIONAL_TAGS: ${{ inputs.additional-tags }}
         run: |
+          if [[ "${{ inputs.output-tarballs }}" == "true" && "${{ inputs.push-images }}" == "true" ]]; then
+            echo "::error::output-tarballs and push-images are mutually exclusive; set at most one to true." >&2
+            exit 1
+          fi
+
           POMS_VERSION=$(mvn help:evaluate -Dexpression=project.version --quiet -DforceStdout)
           echo "release_version=${POMS_VERSION}" >> $GITHUB_OUTPUT
           echo "image_created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-kroxylicious-container-images.yaml
+++ b/.github/workflows/build-kroxylicious-container-images.yaml
@@ -79,6 +79,10 @@ on:
         description: 'Extra comma-separated image tags alongside the commit-SHA tag (e.g. "0.23.0-SNAPSHOT"). Leave empty for SHA-only.'
         required: false
         default: ''
+      output-tarballs:
+        description: 'Export amd64 images as Docker-format gzip tarballs and upload them as GitHub Actions artifacts for use by system tests. Mutually exclusive with push-images.'
+        type: boolean
+        default: false
 
 jobs:
   build:

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -119,11 +119,31 @@ jobs:
           repository: ${{ github.repository }}
           runId: ${{ github.run_id }}
 
+  compute_pom_version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+      - name: 'Check out repository'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: Setup Java
+        uses: ./.github/actions/common/setup-java
+      - name: 'Cache Maven packages'
+        uses: ./.github/actions/common/cache-maven-packages
+      - name: 'Determine project version'
+        id: version
+        run: echo "version=$(mvn --quiet help:evaluate -Dexpression=project.version -DforceStdout)" >> "$GITHUB_OUTPUT"
+
   build_container_images:
+    needs: compute_pom_version
     uses: ./.github/workflows/build-kroxylicious-container-images.yaml
     with:
       push-images: ${{ github.event_name == 'push' }}
       multi-arch: ${{ github.event_name == 'push' }}
-      tag-pom-version: ${{ github.event_name == 'push' }}
+      additional-tags: ${{ github.event_name == 'push' && needs.compute_pom_version.outputs.version || '' }}
     secrets:
       REGISTRY_TOKEN: ${{ secrets.REGISTRY_TOKEN }}

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -147,3 +147,30 @@ jobs:
       additional-tags: ${{ github.event_name == 'push' && needs.compute_pom_version.outputs.version || '' }}
     secrets:
       REGISTRY_TOKEN: ${{ secrets.REGISTRY_TOKEN }}
+
+  container_images_slack_notification:
+    runs-on: ubuntu-latest
+    needs: build_container_images
+    if: failure() && github.event_name == 'push'
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+      - name: 'Check out repository'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: 'Test for Slack secret'
+        env:
+          KROXYLICIOUS_SLACK_WEBHOOK: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
+        run: |
+          echo "SLACK_WEBHOOK_SET=$(test ${KROXYLICIOUS_SLACK_WEBHOOK} && echo true)" >> $GITHUB_ENV
+      - name: Slack Notification on Failure
+        if: env.SLACK_WEBHOOK_SET == 'true'
+        uses: ./.github/actions/common/slack-notification
+        with:
+          slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
+          slackTitle: 'Failure Alert: ${{ github.repository }}'
+          slackMessage: 'The container image build failed on branch ${{ github.ref_name }}.'
+          serverUrl: ${{ github.server_url }}
+          repository: ${{ github.repository }}
+          runId: ${{ github.run_id }}

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -118,3 +118,12 @@ jobs:
           serverUrl: ${{ github.server_url }}
           repository: ${{ github.repository }}
           runId: ${{ github.run_id }}
+
+  build_container_images:
+    uses: ./.github/workflows/build-kroxylicious-container-images.yaml
+    with:
+      push-images: ${{ github.event_name == 'push' }}
+      multi-arch: ${{ github.event_name == 'push' }}
+      tag-pom-version: ${{ github.event_name == 'push' }}
+    secrets:
+      REGISTRY_TOKEN: ${{ secrets.REGISTRY_TOKEN }}

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -110,7 +110,7 @@ jobs:
             -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED}
       - name: Slack Notification on Failure
         if: failure() && env.SLACK_WEBHOOK_SET == 'true' && github.event_name == 'push'
-        uses: ./.github/actions/common/slack-notification
+        uses: $/.github/actions/common/slack-notification
         with:
           slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
@@ -157,8 +157,6 @@ jobs:
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
-      - name: 'Check out repository'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: 'Test for Slack secret'
         env:
           KROXYLICIOUS_SLACK_WEBHOOK: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
@@ -166,7 +164,7 @@ jobs:
           echo "SLACK_WEBHOOK_SET=$(test ${KROXYLICIOUS_SLACK_WEBHOOK} && echo true)" >> $GITHUB_ENV
       - name: Slack Notification on Failure
         if: env.SLACK_WEBHOOK_SET == 'true'
-        uses: ./.github/actions/common/slack-notification
+        uses: $/.github/actions/common/slack-notification
         with:
           slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'

--- a/.github/workflows/publish-snapshot-docs-to-website.yaml
+++ b/.github/workflows/publish-snapshot-docs-to-website.yaml
@@ -148,6 +148,12 @@ jobs:
           KROXYLICIOUS_SLACK_WEBHOOK: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
         run: |
           echo "SLACK_WEBHOOK_SET=$(test ${KROXYLICIOUS_SLACK_WEBHOOK} && echo true)" >> $GITHUB_ENV
+      # We need to call common action from kroxylicious path as it is the path used in the checkout below
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          path: kroxylicious
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.ref_name }}
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/publish-snapshot-docs-to-website.yaml
+++ b/.github/workflows/publish-snapshot-docs-to-website.yaml
@@ -121,7 +121,7 @@ jobs:
           retention-days: 14
       - name: Slack Notification on Failure
         if: failure() && env.SLACK_WEBHOOK_SET == 'true' && github.event_name == 'push'
-        uses: ./kroxylicious/.github/actions/common/slack-notification
+        uses: $/.github/actions/common/slack-notification
         with:
           slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
@@ -148,18 +148,12 @@ jobs:
           KROXYLICIOUS_SLACK_WEBHOOK: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
         run: |
           echo "SLACK_WEBHOOK_SET=$(test ${KROXYLICIOUS_SLACK_WEBHOOK} && echo true)" >> $GITHUB_ENV
-      # We need to call common action from kroxylicious path as it is the path used in the checkout below
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          path: kroxylicious
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.ref_name }}
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
       - name: Slack Notification on Failure
         if: failure() && env.SLACK_WEBHOOK_SET == 'true' && github.event_name == 'push'
-        uses: ./kroxylicious/.github/actions/common/slack-notification
+        uses: $/.github/actions/common/slack-notification
         with:
           slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -143,25 +143,29 @@ jobs:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
           # The release branch (rel) was pushed by stage-release.sh and carries exactly the
-          # release commit.  We use it as the docker.yaml trigger ref (a branch name is required)
-          # and as the anchor for the commit-<sha> image tags built by that workflow.
+          # release commit.  We dispatch build-kroxylicious-container-images.yaml on this branch
+          # so images are built from the release version and tagged commit-<sha> (no version tag
+          # until promote).
           RELEASE_SHA=$(git rev-parse "origin/${WORK_BRANCH}-rel")
 
           # Capture time before dispatch so the poll can ignore runs from prior staging attempts
           DISPATCH_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          gh workflow run docker.yaml --ref "${WORK_BRANCH}-rel"
+          gh workflow run build-kroxylicious-container-images.yaml \
+            --ref "${WORK_BRANCH}-rel" \
+            --field push-images=true \
+            --field multi-arch=true
 
           # Poll until the triggered run appears (dispatch registration can take a few seconds)
           RUN_ID=""
           for i in $(seq 1 12); do
             sleep 10
             RUN_ID=$(DISPATCH_SINCE="${DISPATCH_TIME}" gh api \
-              "/repos/${{ github.repository }}/actions/workflows/docker.yaml/runs?head_sha=${RELEASE_SHA}&event=workflow_dispatch" \
+              "/repos/${{ github.repository }}/actions/workflows/build-kroxylicious-container-images.yaml/runs?head_sha=${RELEASE_SHA}&event=workflow_dispatch" \
               --jq '[.workflow_runs[] | select(.created_at >= env.DISPATCH_SINCE)] | .[0].id // empty')
             [[ -n "${RUN_ID}" ]] && break
           done
           if [[ -z "${RUN_ID}" ]]; then
-            echo "Timed out waiting for docker workflow run to appear for ${RELEASE_SHA}"
+            echo "Timed out waiting for build-kroxylicious-container-images workflow run to appear for ${RELEASE_SHA}"
             exit 1
           fi
           gh run watch "${RUN_ID}" --exit-status
@@ -171,7 +175,7 @@ jobs:
       - name: 'Build release state'
         run: |
           VERSION="${{ github.event.inputs.release-version }}"
-          # RELEASE_SHA is the pre-merge release commit; it is also what docker.yaml tagged
+          # RELEASE_SHA is the pre-merge release commit; it is also what build-kroxylicious-container-images.yaml tagged
           # images with (GITHUB_SHA on the release branch == this commit).
           SHA_TAG="commit-$(git rev-parse --short "${RELEASE_SHA}")"
           REGISTRY="${{ vars.REGISTRY_SERVER }}"

--- a/.github/workflows/system-tests-merge.yaml
+++ b/.github/workflows/system-tests-merge.yaml
@@ -92,6 +92,13 @@ jobs:
     steps:
       # StepSecurity harden-runner cannot be used here because of the limitation of running it on containers
       # https://github.com/step-security/harden-runner/blob/main/docs/limitations.md
+      - name: 'Test for Slack secret'
+        env:
+          KROXYLICIOUS_SLACK_WEBHOOK: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
+        run: |
+          echo "SLACK_WEBHOOK_SET=$(test ${KROXYLICIOUS_SLACK_WEBHOOK} && echo true)" >> $GITHUB_ENV
+      - name: 'Check out repository'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: 'Check all matrix builds'
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/system-tests-merge.yaml
+++ b/.github/workflows/system-tests-merge.yaml
@@ -97,8 +97,6 @@ jobs:
           KROXYLICIOUS_SLACK_WEBHOOK: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
         run: |
           echo "SLACK_WEBHOOK_SET=$(test ${KROXYLICIOUS_SLACK_WEBHOOK} && echo true)" >> $GITHUB_ENV
-      - name: 'Check out repository'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: 'Check all matrix builds'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -117,7 +115,7 @@ jobs:
           exit 1
       - name: Slack Notification on Failure
         if: failure() && env.SLACK_WEBHOOK_SET == 'true' && github.event_name == 'push'
-        uses: ./.github/actions/common/slack-notification
+        uses: $/.github/actions/common/slack-notification
         with:
           slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Creates `build-kroxylicious-container-images.yaml` as the single canonical workflow for building Kroxylicious container images, replacing `docker.yaml`.

`docker.yaml` and `build-kroxylicious-artifacts.yaml` both built container images but in different ways (#2336). This PR consolidates the logic into one reusable workflow and wires all callers up to it.

**New workflow: `build-kroxylicious-container-images.yaml`**

Supports three operational modes via boolean inputs:

| Mode | Inputs | Used by |
|------|--------|---------|
| Validation only | (defaults) | `maven.yaml` on PRs — amd64 build, no push |
| Registry push | `push-images=true`, `multi-arch=true` | `maven.yaml` on branch merge; `stage_release.yaml` dispatch |
| Tarball export | `output-tarballs=true` | `build-kroxylicious-artifacts.yaml` — Docker-format gzip tarballs for system tests |

The tarball mode tags images with Maven image names (`quay.io/kroxylicious/proxy:${version}`) so `minikube image load` and image-name verification in `run-system-tests.yaml` continue to work unchanged.

**Callers updated:**
- `maven.yaml`: new `build_container_images` job replaces `docker.yaml`'s CI role. PRs get validation-only amd64 builds; branch merges get multi-arch push with commit-SHA + POM-version tags.
- `build-kroxylicious-artifacts.yaml`: `build_kroxylicious_images` job now calls the reusable workflow with `output-tarballs: true` (51 lines → 3 lines).
- `stage_release.yaml`: dispatches `build-kroxylicious-container-images.yaml` instead of `docker.yaml`, passing `push-images=true` and `multi-arch=true` explicitly.

`docker.yaml` is deleted. There is now exactly one place that defines how to build each container image.

### Additional Context

Part of the release process redesign (#4278). Closes #4287.

Depends on #4285 (images built at stage, re-tagged at promote) which was resolved by #4406.

### Checklist

- [ ] New tests written (where applicable).
- [x] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [x] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.