### PR TITLE
fix(sasl-termination): use hyphenated SCRAM mechanism names in CLI

### DIFF
--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/cli/KeystoreCredentialTool.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/main/java/io/kroxylicious/scram/credentialstore/keystore/cli/KeystoreCredentialTool.java
@@ -209,7 +209,7 @@ public class KeystoreCredentialTool implements Callable<Integer> {
         String username;
 
         @Option(names = { "-m",
-                "--mechanism" }, description = "Optional SCRAM mechanism: ${COMPLETION-CANDIDATES} (default: ${DEFAULT-VALUE})", defaultValue = "SCRAM_SHA_256")
+                "--mechanism" }, description = "Optional SCRAM mechanism: ${COMPLETION-CANDIDATES} (default: ${DEFAULT-VALUE})", defaultValue = "SCRAM-SHA-256", converter = ScramMechanismType.Converter.class)
         ScramMechanismType mechanism;
 
         @Option(names = { "-i",
@@ -306,7 +306,7 @@ public class KeystoreCredentialTool implements Callable<Integer> {
         String username;
 
         @Option(names = { "-m",
-                "--mechanism" }, description = "Optional SCRAM mechanism: ${COMPLETION-CANDIDATES} (default: ${DEFAULT-VALUE})", defaultValue = "SCRAM_SHA_256")
+                "--mechanism" }, description = "Optional SCRAM mechanism: ${COMPLETION-CANDIDATES} (default: ${DEFAULT-VALUE})", defaultValue = "SCRAM-SHA-256", converter = ScramMechanismType.Converter.class)
         ScramMechanismType mechanism;
 
         @Option(names = { "-i",
@@ -401,6 +401,24 @@ public class KeystoreCredentialTool implements Callable<Integer> {
                 case SCRAM_SHA_256 -> ScramMechanism.SCRAM_SHA_256;
                 case SCRAM_SHA_512 -> ScramMechanism.SCRAM_SHA_512;
             };
+        }
+
+        @Override
+        public String toString() {
+            return toScramMechanism().mechanismName();
+        }
+
+        /** Picocli type converter that accepts the hyphenated IANA mechanism names. */
+        static class Converter implements CommandLine.ITypeConverter<ScramMechanismType> {
+            @Override
+            public ScramMechanismType convert(String value) {
+                ScramMechanism mechanism = ScramMechanism.forMechanismName(value);
+                if (mechanism == null) {
+                    throw new CommandLine.TypeConversionException("expected one of " +
+                            java.util.Arrays.toString(values()) + " but was '" + value + "'");
+                }
+                return valueOf(mechanism.name());
+            }
         }
     }
 

--- a/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/cli/KeystoreCredentialToolIT.java
+++ b/kroxylicious-scram-credential-store-providers/kroxylicious-scram-credential-store-provider-keystore/src/test/java/io/kroxylicious/scram/credentialstore/keystore/cli/KeystoreCredentialToolIT.java
@@ -241,7 +241,7 @@ class KeystoreCredentialToolIT {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "SCRAM_SHA_256", "SCRAM_SHA_512" })
+    @ValueSource(strings = { "SCRAM-SHA-256", "SCRAM-SHA-512" })
     void shouldSupportScramMechanism(String mechanism, @TempDir Path tempDir) {
         Path keystorePath = tempDir.resolve("credentials.p12");
 
@@ -269,7 +269,7 @@ class KeystoreCredentialToolIT {
                 "-p", KEYSTORE_PASSWORD,
                 "-u", "alice",
                 "-w", "alice-secret-password",
-                "-m", "SCRAM_SHA_256",
+                "-m", "SCRAM-SHA-256",
                 "-i", "8192");
 
         executeCommand("--unlock-insecure-options", "add-user",
@@ -277,7 +277,7 @@ class KeystoreCredentialToolIT {
                 "-p", KEYSTORE_PASSWORD,
                 "-u", "bob",
                 "-w", "bob-secret-password",
-                "-m", "SCRAM_SHA_512",
+                "-m", "SCRAM-SHA-512",
                 "-i", "16384");
 
         // When


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

The CLI used `SCRAM_SHA_256` (underscores) while the YAML filter configuration uses `SCRAM-SHA-256` (hyphens). Align the CLI to use the standard hyphenated form for consistency by delegating to `ScramMechanism.mechanismName()` and `forMechanismName()`.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

### Additional Context

Relates to #4391.

