### PR TITLE
docs(authn): add SCRAM-SHA-256/512 documentation to Authentication guide

### DIFF
--- a/.claude/rules/documentation-requirements.md
+++ b/.claude/rules/documentation-requirements.md
@@ -81,6 +81,7 @@ Each filter guide must cover:
 - Follow IBM documentation style guide
 - Be comprehensive
 - Avoid contractions. For example instead of "Here's", use "Here is"
+- Phrase cross-references as "For <reason>, see <reference>", not "See <reference> for <reason>". Do not italicize or otherwise mark up the referenced section's title.
 
 ## Compiling the documentation
 

--- a/kroxylicious-docs/docs/_assemblies/assembly-configuring-authentication-sasl-termination.adoc
+++ b/kroxylicious-docs/docs/_assemblies/assembly-configuring-authentication-sasl-termination.adoc
@@ -24,7 +24,8 @@ ifndef::OpenShiftOnly[]
 For information on deploying Kroxylicious, see the {ProxyGuide} or {OperatorGuide}.
 endif::OpenShiftOnly[]
 * For the `OAUTHBEARER` mechanism, a reachable JWKS endpoint that publishes the public keys used to verify JWT signatures.
-* For the `SCRAM-SHA-256` or `SCRAM-SHA-512` mechanism, a PKCS#12 KeyStore file populated with SCRAM credentials using the SCRAM credential tool.
+* For the `SCRAM-SHA-256` or `SCRAM-SHA-512` mechanism, a credential store containing the SCRAM credentials for your users.
+The built-in `KeystoreScramCredentialStoreService` uses a proxy SCRAM credential file populated using the SCRAM credential tool.
 
 .Procedure
 

--- a/kroxylicious-docs/docs/_assemblies/assembly-configuring-authentication-sasl-termination.adoc
+++ b/kroxylicious-docs/docs/_assemblies/assembly-configuring-authentication-sasl-termination.adoc
@@ -24,6 +24,7 @@ ifndef::OpenShiftOnly[]
 For information on deploying Kroxylicious, see the {ProxyGuide} or {OperatorGuide}.
 endif::OpenShiftOnly[]
 * For the `OAUTHBEARER` mechanism, a reachable JWKS endpoint that publishes the public keys used to verify JWT signatures.
+* For the `SCRAM-SHA-256` or `SCRAM-SHA-512` mechanism, a PKCS#12 KeyStore file populated with SCRAM credentials using the SCRAM credential tool.
 
 .Procedure
 
@@ -42,3 +43,7 @@ endif::[]
 ifdef::include-platform-kubernetes[]
 include::../_modules/sasl-termination/con-example-kafkaprotocolfilter-resource.adoc[leveloffset=+1]
 endif::[]
+
+include::../_modules/sasl-termination/proc-managing-scram-credentials.adoc[leveloffset=+1]
+
+include::../_modules/sasl-termination/con-scram-security.adoc[leveloffset=+1]

--- a/kroxylicious-docs/docs/_modules/authentication/con-choosing-authentication-approach.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/con-choosing-authentication-approach.adoc
@@ -89,7 +89,7 @@ Consider the following:
   SCRAM credentials must be managed using the SCRAM credential tool instead.
 * Unlike SASL Passthrough Inspection, SASL Termination enforces authentication at the proxy: clients that fail authentication are rejected before their application requests are forwarded to the broker.
 
-Infrastructure requirements depend on the mechanism: `OAUTHBEARER` requires a reachable JWKS endpoint that provides the public keys used to verify JWT signatures; `SCRAM-SHA-256` and `SCRAM-SHA-512` require a credential store such as a PKCS#12 KeyStore.
+Infrastructure requirements depend on the mechanism: `OAUTHBEARER` requires a reachable JWKS endpoint that provides the public keys used to verify JWT signatures; `SCRAM-SHA-256` and `SCRAM-SHA-512` require a credential store containing SCRAM credentials for your users.
 
 == Combining approaches
 
@@ -133,5 +133,5 @@ This can be useful when you want transport-level identity as a baseline and appl
 |Yes (from SASL exchange)
 |Yes (proxy validates directly)
 |Yes (`SaslTermination` filter)
-|JWKS endpoint (OAUTHBEARER) or credential store (SCRAM)
+|JWKS endpoint (OAUTHBEARER) or SCRAM credential store (SCRAM)
 |===

--- a/kroxylicious-docs/docs/_modules/authentication/con-choosing-authentication-approach.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/con-choosing-authentication-approach.adoc
@@ -69,7 +69,7 @@ Use SASL Termination when:
 
 * You want the proxy to be the sole authority for client authentication, fully decoupling it from the broker.
 * You need to ensure that only authenticated clients' application requests are forwarded to the broker.
-* Your Kafka clients authenticate using OAuth 2.0 bearer tokens (the `OAUTHBEARER` SASL mechanism), which is the only mechanism currently supported.
+* Your Kafka clients authenticate using the `OAUTHBEARER`, `SCRAM-SHA-256`, or `SCRAM-SHA-512` SASL mechanism.
 
 Authenticating clients at the proxy means that every broker feature which depends on client identity needs to be reconsidered:
 
@@ -85,9 +85,11 @@ Consider the following:
 * The proxy validates credentials directly and does not forward SASL exchanges to the broker.
   The broker does not need to be configured for SASL authentication at all, or it can use a different authentication mechanism for other clients.
 * Delegation Token APIs (`CreateDelegationToken`, `RenewDelegationToken`, `ExpireDelegationToken`, `DescribeDelegationToken`) are not available to clients when SASL is terminated at the proxy, because these APIs depend on a broker-side SASL session.
+* SCRAM credential management APIs (`AlterUserScramCredentials`, `DescribeUserScramCredentials`) are not available to clients when SCRAM is terminated at the proxy.
+  SCRAM credentials must be managed using the SCRAM credential tool instead.
 * Unlike SASL Passthrough Inspection, SASL Termination enforces authentication at the proxy: clients that fail authentication are rejected before their application requests are forwarded to the broker.
 
-This mode requires a reachable JWKS endpoint that provides the public keys used to verify JWT signatures.
+Infrastructure requirements depend on the mechanism: `OAUTHBEARER` requires a reachable JWKS endpoint that provides the public keys used to verify JWT signatures; `SCRAM-SHA-256` and `SCRAM-SHA-512` require a credential store such as a PKCS#12 KeyStore.
 
 == Combining approaches
 
@@ -131,5 +133,5 @@ This can be useful when you want transport-level identity as a baseline and appl
 |Yes (from SASL exchange)
 |Yes (proxy validates directly)
 |Yes (`SaslTermination` filter)
-|JWKS endpoint (for OAUTHBEARER)
+|JWKS endpoint (OAUTHBEARER) or credential store (SCRAM)
 |===

--- a/kroxylicious-docs/docs/_modules/authentication/con-choosing-sasl-mechanism.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/con-choosing-sasl-mechanism.adoc
@@ -15,7 +15,7 @@ This section compares the PLAIN, SCRAM, and OAUTHBEARER mechanisms across severa
 
 The choice of SASL mechanism is independent of the choice of xref:con-choosing-authentication-approach-{context}[authentication approach] (Passthrough, Inspection, Termination, or OAuthBearer Validation).
 However, some authentication approaches constrain the available mechanisms.
-For example, SASL Termination currently supports only the `OAUTHBEARER` mechanism.
+See xref:con-choosing-authentication-approach-{context}[] for which mechanisms each authentication approach supports.
 
 This section uses _server_ to refer to whichever component performs SASL authentication — either the Kafka broker or the Kroxylicious proxy, depending on your authentication approach.
 Where a point applies specifically to Apache Kafka brokers or to the proxy, the more specific term is used.

--- a/kroxylicious-docs/docs/_modules/authentication/con-choosing-sasl-mechanism.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/con-choosing-sasl-mechanism.adoc
@@ -15,7 +15,7 @@ This section compares the PLAIN, SCRAM, and OAUTHBEARER mechanisms across severa
 
 The choice of SASL mechanism is independent of the choice of xref:con-choosing-authentication-approach-{context}[authentication approach] (Passthrough, Inspection, Termination, or OAuthBearer Validation).
 However, some authentication approaches constrain the available mechanisms.
-See xref:con-choosing-authentication-approach-{context}[] for which mechanisms each authentication approach supports.
+For information about the mechanisms supported by each authentication approach, see xref:con-choosing-authentication-approach-{context}[]
 
 This section uses _server_ to refer to whichever component performs SASL authentication — either the Kafka broker or the Kroxylicious proxy, depending on your authentication approach.
 Where a point applies specifically to Apache Kafka brokers or to the proxy, the more specific term is used.

--- a/kroxylicious-docs/docs/_modules/authentication/con-sasl-authentication-modes.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/con-sasl-authentication-modes.adoc
@@ -81,6 +81,7 @@ It fully decouples client authentication from broker authentication, which can b
 The `SaslTermination` filter supports the `OAUTHBEARER`, `SCRAM-SHA-256`, and `SCRAM-SHA-512` SASL mechanisms.
 If a client attempts to use a mechanism that is not configured, the proxy rejects the handshake with an unsupported mechanism error and closes the connection.
 For `OAUTHBEARER`, the filter validates JWT tokens against a JSON Web Key Set (JWKS) retrieved from a configurable endpoint, checking the token signature, audience, issuer, and expiry.
+For `SCRAM-SHA-256` and `SCRAM-SHA-512`, the filter validates client credentials against a pluggable credential store that provides the SCRAM derived keys for each user.
 
 The filter supports session expiry and reauthentication (https://cwiki.apache.org/confluence/display/KAFKA/KIP-368%3A+Allow+SASL+Connections+to+Periodically+Re-Authenticate[KIP-368]).
 When a token's expiry is reached, the client must reauthenticate or the connection is closed.

--- a/kroxylicious-docs/docs/_modules/authentication/ref-authentication-glossary.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/ref-authentication-glossary.adoc
@@ -20,8 +20,8 @@ mTLS:: Mutual TLS. A TLS configuration in which both the server and the client p
 Principal:: A named identifier that represents one aspect of an authenticated client's identity, such as a user name or a group membership.
 PBKDF2:: Password-Based Key Derivation Function 2 is a key derivation function used by SCRAM to derive stored keys from passwords. Defined in https://datatracker.ietf.org/doc/html/rfc2898[RFC 2898].
 SASL:: Simple Authentication and Security Layer is an https://datatracker.ietf.org/doc/html/rfc4422[IETF framework] for handling authentication.
-SCRAM:: Salted Challenge Response Authentication Mechanism is a family of SASL mechanisms that authenticate clients using a challenge-response protocol. The password is never transmitted. Defined in https://datatracker.ietf.org/doc/html/rfc5802[RFC 5802].
 SASL Passthrough:: A mode in which the proxy forwards SASL authentication exchanges between client and broker without inspecting or modifying them. This is the default behavior.
 SASL Passthrough Inspection:: A mode in which the proxy observes SASL authentication exchanges to infer the client's identity without altering the exchange. The broker remains the authority for authentication decisions.
 SASL Termination:: A mode in which the proxy handles SASL authentication itself, without forwarding to the broker. The proxy validates credentials directly and constructs an authenticated subject on success.
+SCRAM:: Salted Challenge Response Authentication Mechanism is a family of SASL mechanisms that authenticate clients using a challenge-response protocol. The password is never transmitted. Defined in https://datatracker.ietf.org/doc/html/rfc5802[RFC 5802].
 Subject:: The authenticated identity of a client, composed of one or more principals. Used by filters to make identity-aware decisions.

--- a/kroxylicious-docs/docs/_modules/authentication/ref-authentication-glossary.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/ref-authentication-glossary.adoc
@@ -18,7 +18,9 @@ JWS:: JSON Web Signature is an https://datatracker.ietf.org/doc/html/rfc7515[IET
 JWT:: JSON Web Token is an https://datatracker.ietf.org/doc/html/rfc7519[IETF standard] for securely transmitting information between parties as a JSON object.
 mTLS:: Mutual TLS. A TLS configuration in which both the server and the client present certificates to each other, providing mutual authentication.
 Principal:: A named identifier that represents one aspect of an authenticated client's identity, such as a user name or a group membership.
+PBKDF2:: Password-Based Key Derivation Function 2 is a key derivation function used by SCRAM to derive stored keys from passwords. Defined in https://datatracker.ietf.org/doc/html/rfc2898[RFC 2898].
 SASL:: Simple Authentication and Security Layer is an https://datatracker.ietf.org/doc/html/rfc4422[IETF framework] for handling authentication.
+SCRAM:: Salted Challenge Response Authentication Mechanism is a family of SASL mechanisms that authenticate clients using a challenge-response protocol. The password is never transmitted. Defined in https://datatracker.ietf.org/doc/html/rfc5802[RFC 5802].
 SASL Passthrough:: A mode in which the proxy forwards SASL authentication exchanges between client and broker without inspecting or modifying them. This is the default behavior.
 SASL Passthrough Inspection:: A mode in which the proxy observes SASL authentication exchanges to infer the client's identity without altering the exchange. The broker remains the authority for authentication decisions.
 SASL Termination:: A mode in which the proxy handles SASL authentication itself, without forwarding to the broker. The proxy validates credentials directly and constructs an authenticated subject on success.

--- a/kroxylicious-docs/docs/_modules/sasl-termination/con-example-kafkaprotocolfilter-resource.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/con-example-kafkaprotocolfilter-resource.adoc
@@ -32,7 +32,7 @@ spec:
         expectedAudience: kafka
         expectedIssuer: https://idp.example.com
       - mechanism: SCRAM-SHA-256
-        credentialStore: KeystoreScramCredentialStore
+        credentialStore: KeystoreScramCredentialStoreService
         credentialStoreConfig:
           file: /etc/kroxylicious/scram-credentials.p12
           storePassword:

--- a/kroxylicious-docs/docs/_modules/sasl-termination/con-example-kafkaprotocolfilter-resource.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/con-example-kafkaprotocolfilter-resource.adoc
@@ -34,7 +34,7 @@ spec:
       - mechanism: SCRAM-SHA-256
         credentialStore: KeystoreScramCredentialStoreService
         credentialStoreConfig:
-          file: /etc/kroxylicious/scram-credentials.p12
+          file: ${secret:scram-credentials:credentials.p12}
           storePassword:
             passwordFile: ${secret:scram-credentials:store-password}
     maxTimeBeforeReauth: 1h
@@ -60,7 +60,7 @@ If omitted, a default subject builder creates a principal with name matching the
 For `OAUTHBEARER` mechanism configuration, see the bare-metal configuration example for a full description of the mechanism-specific fields (`jwksEndpointUrl`, `expectedAudience`, `expectedIssuer`, and others).
 
 For `SCRAM-SHA-256` and `SCRAM-SHA-512` mechanism configuration, see the bare-metal configuration example for a full description of the mechanism-specific fields (`credentialStore`, `credentialStoreConfig`).
-The `${secret:scram-credentials:store-password}` syntax interpolates the `store-password` key from the Kubernetes Secret named `scram-credentials`.
-The KeyStore file itself must also be available to the proxy container, for example by mounting the Secret as a volume.
+The `${secret:scram-credentials:credentials.p12}` and `${secret:scram-credentials:store-password}` syntax references entries from the Kubernetes Secret named `scram-credentials`.
+The operator automatically mounts the referenced Secret entries as files in the proxy container and replaces the interpolation expressions with the corresponding file paths.
 
 For more information about configuration on Kubernetes, see the {OperatorGuide}.

--- a/kroxylicious-docs/docs/_modules/sasl-termination/con-example-kafkaprotocolfilter-resource.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/con-example-kafkaprotocolfilter-resource.adoc
@@ -16,7 +16,7 @@
 [role="_abstract"]
 If your instance of Kroxylicious runs on Kubernetes, you must use a `KafkaProtocolFilter` resource to contain the filter configuration.
 
-Here is a complete example of a `KafkaProtocolFilter` resource configured for SASL Termination:
+Here is a complete example of a `KafkaProtocolFilter` resource configured for SASL Termination with both `OAUTHBEARER` and `SCRAM-SHA-256` mechanisms:
 
 [source,yaml]
 ----
@@ -31,6 +31,12 @@ spec:
         jwksEndpointUrl: https://idp.example.com/.well-known/jwks.json
         expectedAudience: kafka
         expectedIssuer: https://idp.example.com
+      - mechanism: SCRAM-SHA-256
+        credentialStore: KeystoreScramCredentialStore
+        credentialStoreConfig:
+          file: /etc/kroxylicious/scram-credentials.p12
+          storePassword:
+            passwordFile: ${secret:scram-credentials:store-password}
     maxTimeBeforeReauth: 1h
     fixedAuthDelay: 200ms
     subjectBuilder: <class name>
@@ -38,7 +44,7 @@ spec:
 ----
 where:
 
-* `mechanisms` (required) configures the list of SASL mechanisms that the filter supports.
+* `mechanisms` (required) configures the enabled SASL mechanisms that the filter supports.
 Each entry specifies a `mechanism` name and mechanism-specific configuration.
 `OAUTHBEARER`, `SCRAM-SHA-256`, and `SCRAM-SHA-512` are supported.
 * `maxTimeBeforeReauth` specifies the maximum session lifetime before the client must reauthenticate (https://cwiki.apache.org/confluence/display/KAFKA/KIP-368%3A+Allow+SASL+Connections+to+Periodically+Re-Authenticate[KIP-368]).
@@ -52,5 +58,9 @@ If omitted, a default subject builder creates a principal with name matching the
 * `subjectBuilderConfig` provides subject builder configuration.
 
 For `OAUTHBEARER` mechanism configuration, see the bare-metal configuration example for a full description of the mechanism-specific fields (`jwksEndpointUrl`, `expectedAudience`, `expectedIssuer`, and others).
+
+For `SCRAM-SHA-256` and `SCRAM-SHA-512` mechanism configuration, see the bare-metal configuration example for a full description of the mechanism-specific fields (`credentialStore`, `credentialStoreConfig`).
+The `${secret:scram-credentials:store-password}` syntax interpolates the `store-password` key from the Kubernetes Secret named `scram-credentials`.
+The KeyStore file itself must also be available to the proxy container, for example by mounting the Secret as a volume.
 
 For more information about configuration on Kubernetes, see the {OperatorGuide}.

--- a/kroxylicious-docs/docs/_modules/sasl-termination/con-example-proxy-config.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/con-example-proxy-config.adoc
@@ -16,7 +16,7 @@
 [role="_abstract"]
 If your instance of the Kroxylicious Proxy runs directly on an operating system, provide the filter configuration in the `filterDefinitions` list of your proxy configuration.
 
-Here is a complete example of a `filterDefinitions` entry configured for SASL Termination:
+Here is a complete example of a `filterDefinitions` entry configured for SASL Termination with both `OAUTHBEARER` and `SCRAM-SHA-256` mechanisms:
 
 [source, yaml]
 ----
@@ -29,6 +29,12 @@ filterDefinitions:
           jwksEndpointUrl: https://idp.example.com/.well-known/jwks.json
           expectedAudience: kafka
           expectedIssuer: https://idp.example.com
+        - mechanism: SCRAM-SHA-256
+          credentialStore: KeystoreScramCredentialStore
+          credentialStoreConfig:
+            file: /etc/kroxylicious/scram-credentials.p12
+            storePassword:
+              passwordFile: /etc/kroxylicious/keystore-password.txt
       maxTimeBeforeReauth: 1h
       fixedAuthDelay: 200ms
       subjectBuilder: <class name>
@@ -36,7 +42,7 @@ filterDefinitions:
 ----
 where:
 
-* `mechanisms` (required) configures the list of SASL mechanisms that the filter supports.
+* `mechanisms` (required) configures the enabled SASL mechanisms that the filter supports.
 Each entry specifies a `mechanism` name and mechanism-specific configuration.
 `OAUTHBEARER`, `SCRAM-SHA-256`, and `SCRAM-SHA-512` are supported.
 * `maxTimeBeforeReauth` specifies the maximum session lifetime before the client must reauthenticate (https://cwiki.apache.org/confluence/display/KAFKA/KIP-368%3A+Allow+SASL+Connections+to+Periodically+Re-Authenticate[KIP-368]).
@@ -65,5 +71,27 @@ The following properties are optional:
 * `jwksEndpointRefresh` specifies the interval between refreshes of the JWKS cache used to verify JWT signatures.
 * `jwksEndpointRetryBackoff` specifies the initial delay between attempts to retrieve the JWKS from the external authentication provider.
 * `jwksEndpointRetryBackoffMax` specifies the maximum delay between JWKS retrieval attempts.
+
+== SCRAM-SHA-256 and SCRAM-SHA-512 mechanism configuration
+
+The `SCRAM-SHA-256` and `SCRAM-SHA-512` mechanisms validate client credentials against a pluggable credential store.
+
+* `credentialStore` (required) specifies the name of a plugin implementing `ScramCredentialStoreService`.
+The built-in KeyStore credential store is named `KeystoreScramCredentialStore`.
+* `credentialStoreConfig` (required) provides configuration for the credential store plugin.
+The structure depends on the credential store implementation.
+
+=== KeyStore credential store configuration
+
+The `KeystoreScramCredentialStore` credential store loads SCRAM credentials from a PKCS#12 KeyStore file.
+Use the SCRAM credential tool to create and populate the KeyStore.
+See <<proc-managing-scram-credentials-{context}>> for instructions.
+
+* `file` (required) specifies the path to the PKCS#12 KeyStore file.
+* `storePassword` (required) specifies the password used to access the KeyStore, using a `PasswordProvider`:
+** `passwordFile` specifies the path to a file containing the password.
+This is the recommended approach for production deployments.
+** `password` specifies the password inline.
+This is not recommended for production use.
 
 For more information about configuring proxy, see the {ProxyGuide}.

--- a/kroxylicious-docs/docs/_modules/sasl-termination/con-example-proxy-config.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/con-example-proxy-config.adoc
@@ -83,11 +83,11 @@ The structure depends on the credential store implementation.
 
 === KeyStore credential store configuration
 
-The `KeystoreScramCredentialStoreService` credential store loads SCRAM credentials from a PKCS#12 KeyStore file.
-Use the SCRAM credential tool to create and populate the KeyStore.
+The `KeystoreScramCredentialStoreService` credential store loads SCRAM credentials from a proxy SCRAM credential file.
+Use the SCRAM credential tool to create and populate this file.
 See <<proc-managing-scram-credentials-{context}>> for instructions.
 
-* `file` (required) specifies the path to the PKCS#12 KeyStore file.
+* `file` (required) specifies the path to the proxy SCRAM credential file.
 * `storePassword` (required) specifies the password used to access the KeyStore, using a `PasswordProvider`:
 ** `passwordFile` specifies the path to a file containing the password.
 This is the recommended approach for production deployments.

--- a/kroxylicious-docs/docs/_modules/sasl-termination/con-example-proxy-config.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/con-example-proxy-config.adoc
@@ -30,7 +30,7 @@ filterDefinitions:
           expectedAudience: kafka
           expectedIssuer: https://idp.example.com
         - mechanism: SCRAM-SHA-256
-          credentialStore: KeystoreScramCredentialStore
+          credentialStore: KeystoreScramCredentialStoreService
           credentialStoreConfig:
             file: /etc/kroxylicious/scram-credentials.p12
             storePassword:
@@ -77,13 +77,13 @@ The following properties are optional:
 The `SCRAM-SHA-256` and `SCRAM-SHA-512` mechanisms validate client credentials against a pluggable credential store.
 
 * `credentialStore` (required) specifies the name of a plugin implementing `ScramCredentialStoreService`.
-The built-in KeyStore credential store is named `KeystoreScramCredentialStore`.
+The built-in KeyStore credential store is named `KeystoreScramCredentialStoreService`.
 * `credentialStoreConfig` (required) provides configuration for the credential store plugin.
 The structure depends on the credential store implementation.
 
 === KeyStore credential store configuration
 
-The `KeystoreScramCredentialStore` credential store loads SCRAM credentials from a PKCS#12 KeyStore file.
+The `KeystoreScramCredentialStoreService` credential store loads SCRAM credentials from a PKCS#12 KeyStore file.
 Use the SCRAM credential tool to create and populate the KeyStore.
 See <<proc-managing-scram-credentials-{context}>> for instructions.
 

--- a/kroxylicious-docs/docs/_modules/sasl-termination/con-scram-security.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/con-scram-security.adoc
@@ -18,12 +18,15 @@ This section describes the security measures that the `SaslTermination` filter a
 
 == Credential storage
 
-The SCRAM credential store does not contain plaintext passwords.
-When a user is added using the SCRAM credential tool, the password is processed through PBKDF2 key derivation to produce two derived keys: `StoredKey` and `ServerKey`.
+The SCRAM credential tool creates a _proxy SCRAM credential file_ — a PKCS#12 file with an internal format specific to Kroxylicious.
+Always use the SCRAM credential tool to create and modify this file; other tools such as the JDK `keytool` are not compatible with the internal format.
+
+The proxy SCRAM credential file does not contain plaintext passwords.
+When a user is added, the password is processed through PBKDF2 key derivation to produce two derived keys: `StoredKey` and `ServerKey`.
 Only these derived keys and the associated salt and iteration count are stored.
 
 The PBKDF2 iteration count controls the computational cost of deriving keys from a password.
-Higher values increase resistance to brute-force attacks against the credential store, but also increase the CPU cost of each authentication.
+Higher values increase resistance to brute-force attacks against the credential file, but also increase the CPU cost of each authentication.
 The default is 10000, and the minimum is 4096.
 
 == Username enumeration protection
@@ -32,7 +35,10 @@ The filter protects against username enumeration attacks by generating synthetic
 These _phantom challenges_ are constructed so that an attacker cannot distinguish between a response for a valid user and a response for a non-existent user.
 
 To maintain this protection, the `phantomIterations` configuration property should match the iteration count used when creating real credentials.
-If the iteration counts differ, an attacker could potentially distinguish real challenges from phantom challenges based on the time taken to compute the server's response.
+The iteration count is sent as a plaintext field in the SCRAM server challenge message, so if phantom challenges use a different iteration count than real credentials, an attacker can simply compare the values across attempts to distinguish real usernames from non-existent ones.
+
+All proxy instances must use the same proxy SCRAM credential file, because it contains a secret key used to derive phantom salts.
+If different instances used different files, phantom challenges for the same username would produce different salts across instances, which could reveal which challenges are phantom.
 
 == Timing side-channel mitigation
 

--- a/kroxylicious-docs/docs/_modules/sasl-termination/con-scram-security.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/con-scram-security.adoc
@@ -1,0 +1,47 @@
+////
+  // Copyright Kroxylicious Authors.
+  //
+  // Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+////
+
+:_mod-docs-content-type: CONCEPT
+
+// file included in the following:
+//
+// assembly-configuring-authentication-sasl-termination.adoc
+
+[id='con-scram-security-{context}']
+= SCRAM security considerations
+
+[role="_abstract"]
+This section describes the security measures that the `SaslTermination` filter applies when handling SCRAM-SHA-256 and SCRAM-SHA-512 authentication.
+
+== Credential storage
+
+The SCRAM credential store does not contain plaintext passwords.
+When a user is added using the SCRAM credential tool, the password is processed through PBKDF2 key derivation to produce two derived keys: `StoredKey` and `ServerKey`.
+Only these derived keys and the associated salt and iteration count are stored.
+
+The PBKDF2 iteration count controls the computational cost of deriving keys from a password.
+Higher values increase resistance to brute-force attacks against the credential store, but also increase the CPU cost of each authentication.
+The default is 10000, and the minimum is 4096.
+
+== Username enumeration protection
+
+The filter protects against username enumeration attacks by generating synthetic SCRAM challenges for unknown usernames.
+These _phantom challenges_ are constructed so that an attacker cannot distinguish between a response for a valid user and a response for a non-existent user.
+
+To maintain this protection, the `phantomIterations` configuration property should match the iteration count used when creating real credentials.
+If the iteration counts differ, an attacker could potentially distinguish real challenges from phantom challenges based on the time taken to compute the server's response.
+
+== Timing side-channel mitigation
+
+The `fixedAuthDelay` property (configured at the `SaslTermination` filter level, not per mechanism) applies a fixed delay to each authentication round.
+This ensures that authentication responses take a consistent amount of time regardless of whether the user exists, the password is correct, or any other condition.
+The default delay is 200 milliseconds.
+
+If connection latency is a higher priority than timing attack mitigation, the delay can be set to `0s` to disable it entirely.
+The value can also be tuned to a lower delay, but if it is configured low enough that authentication processing frequently exceeds the fixed delay, the timing attack mitigation is lost.
+The `kroxylicious_filter_sasl_termination_auth_duration_seconds` metric records the real authentication latency exclusive of the fixed delay, and the filter logs a warning when authentication processing exceeds it.
+Use these to inform any tuning.
+See xref:con-authentication-metrics-{context}[] and xref:con-authentication-logging-{context}[] for details.

--- a/kroxylicious-docs/docs/_modules/sasl-termination/con-scram-security.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/con-scram-security.adoc
@@ -50,4 +50,4 @@ If connection latency is a higher priority than timing attack mitigation, the de
 The value can also be tuned to a lower delay, but if it is configured low enough that authentication processing frequently exceeds the fixed delay, the timing attack mitigation is lost.
 The `kroxylicious_filter_sasl_termination_auth_duration_seconds` metric records the real authentication latency exclusive of the fixed delay, and the filter logs a warning when authentication processing exceeds it.
 Use these to inform any tuning.
-See the _Authentication metrics_ and _Authentication logging_ sections of this guide for details.
+For details, see the Authentication metrics and Authentication logging sections of this guide.

--- a/kroxylicious-docs/docs/_modules/sasl-termination/con-scram-security.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/con-scram-security.adoc
@@ -44,4 +44,4 @@ If connection latency is a higher priority than timing attack mitigation, the de
 The value can also be tuned to a lower delay, but if it is configured low enough that authentication processing frequently exceeds the fixed delay, the timing attack mitigation is lost.
 The `kroxylicious_filter_sasl_termination_auth_duration_seconds` metric records the real authentication latency exclusive of the fixed delay, and the filter logs a warning when authentication processing exceeds it.
 Use these to inform any tuning.
-See xref:con-authentication-metrics-{context}[] and xref:con-authentication-logging-{context}[] for details.
+See the _Authentication metrics_ and _Authentication logging_ sections of this guide for details.

--- a/kroxylicious-docs/docs/_modules/sasl-termination/proc-managing-scram-credentials.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/proc-managing-scram-credentials.adoc
@@ -130,6 +130,9 @@ kubectl create secret generic scram-credentials \
   --from-file=credentials.p12=/etc/kroxylicious/scram-credentials.p12 \
   --from-file=store-password=/etc/kroxylicious/keystore-password.txt
 ----
++
+The key names (`credentials.p12` and `store-password`) must match the keys used in the `${secret:...}` interpolation expressions in the `KafkaProtocolFilter` resource.
 
 . Reference the secret in the `KafkaProtocolFilter` resource using the `${secret:...}` interpolation syntax.
-See the <<con-example-kafkaprotocolfilter-resource-{context}>> for an example.
+The operator automatically mounts the referenced Secret entries as files in the proxy container.
+See <<con-example-kafkaprotocolfilter-resource-{context}>> for an example.

--- a/kroxylicious-docs/docs/_modules/sasl-termination/proc-managing-scram-credentials.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/proc-managing-scram-credentials.adoc
@@ -18,7 +18,7 @@ Use the SCRAM credential tool to create a PKCS#12 KeyStore and manage user crede
 The tool ships in the Kroxylicious distribution at `bin/scram-credential-tool.sh`.
 
 The KeyStore stores SCRAM derived keys (`ServerKey` and `StoredKey`), not plaintext passwords.
-Passwords are prompted interactively by default, with confirmation required when setting a new password.
+The tool prompts for passwords interactively by default and requires confirmation when setting a new password.
 
 IMPORTANT: Although the credential file uses the standard PKCS#12 format, use the Kroxylicious SCRAM credential tool to create and modify it.
 The format of aliases and entries within the file is specific to Kroxylicious, so other tools such as the JDK `keytool` are not compatible.
@@ -47,8 +47,8 @@ bin/scram-credential-tool.sh create \
   -k /etc/kroxylicious/scram-credentials.p12
 ----
 +
-You are prompted for a store password.
-Enter the password you generated in step 1.
+The tool prompts for a store password.
+Enter the password generated in step 1.
 +
 On POSIX filesystems, the tool automatically restricts file permissions on the KeyStore to owner-only access.
 If you create the KeyStore on a non-POSIX filesystem (such as Windows) and later transfer it to a POSIX system, restrict permissions manually:
@@ -69,7 +69,7 @@ bin/scram-credential-tool.sh add-user \
   -i 10000
 ----
 +
-You are prompted for the store password and the user's password.
+The tool prompts for the store password and the user's password.
 Passwords must be at least 12 characters long.
 There is no restriction on which characters may be used, but sticking to ASCII alphabetic characters, digits, and punctuation is advised.
 +
@@ -98,7 +98,7 @@ bin/scram-credential-tool.sh update-password \
   -u alice
 ----
 +
-You are prompted for the store password and the new user password.
+The tool prompts for the store password and the new user password.
 The `-m` and `-i` options are also available if you need to change the mechanism or iteration count.
 
 . Remove a user:

--- a/kroxylicious-docs/docs/_modules/sasl-termination/proc-managing-scram-credentials.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/proc-managing-scram-credentials.adoc
@@ -18,8 +18,8 @@ Use the SCRAM credential tool to create and manage a proxy SCRAM credential file
 The tool ships in the Kroxylicious distribution at `bin/scram-credential-tool.sh`.
 
 The proxy SCRAM credential file stores SCRAM derived keys, not plaintext passwords.
-The tool prompts for passwords interactively by default and requires confirmation when setting a new password.
-See <<con-scram-security-{context}>> for more information about the proxy SCRAM credential file format and security properties.
+By default, the tool prompts you for a password and requires you to confirm it when you set a new password.
+For more information about the proxy SCRAM credential file format and security properties, see <<con-scram-security-{context}>>
 
 .Prerequisites
 
@@ -133,4 +133,4 @@ The key names (`credentials.p12` and `store-password`) must match the keys used 
 
 . Reference the secret in the `KafkaProtocolFilter` resource using the `${secret:...}` interpolation syntax.
 The operator automatically mounts the referenced Secret entries as files in the proxy container.
-See <<con-example-kafkaprotocolfilter-resource-{context}>> for an example.
+For example, see <<con-example-kafkaprotocolfilter-resource-{context}>>

--- a/kroxylicious-docs/docs/_modules/sasl-termination/proc-managing-scram-credentials.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/proc-managing-scram-credentials.adoc
@@ -14,14 +14,12 @@
 = Managing SCRAM credentials
 
 [role="_abstract"]
-Use the SCRAM credential tool to create a PKCS#12 KeyStore and manage user credentials for SCRAM-SHA-256 and SCRAM-SHA-512 authentication.
+Use the SCRAM credential tool to create and manage a proxy SCRAM credential file for SCRAM-SHA-256 and SCRAM-SHA-512 authentication.
 The tool ships in the Kroxylicious distribution at `bin/scram-credential-tool.sh`.
 
-The KeyStore stores SCRAM derived keys (`ServerKey` and `StoredKey`), not plaintext passwords.
+The proxy SCRAM credential file stores SCRAM derived keys, not plaintext passwords.
 The tool prompts for passwords interactively by default and requires confirmation when setting a new password.
-
-IMPORTANT: Although the credential file uses the standard PKCS#12 format, use the Kroxylicious SCRAM credential tool to create and modify it.
-The format of aliases and entries within the file is specific to Kroxylicious, so other tools such as the JDK `keytool` are not compatible.
+See <<con-scram-security-{context}>> for more information about the proxy SCRAM credential file format and security properties.
 
 .Prerequisites
 
@@ -39,7 +37,7 @@ openssl rand -base64 32 > /etc/kroxylicious/keystore-password.txt
 +
 You use this password when prompted by the credential tool commands below.
 
-. Create a new KeyStore:
+. Create a new proxy SCRAM credential file:
 +
 [source,shell]
 ----
@@ -50,8 +48,8 @@ bin/scram-credential-tool.sh create \
 The tool prompts for a store password.
 Enter the password generated in step 1.
 +
-On POSIX filesystems, the tool automatically restricts file permissions on the KeyStore to owner-only access.
-If you create the KeyStore on a non-POSIX filesystem (such as Windows) and later transfer it to a POSIX system, restrict permissions manually:
+On POSIX filesystems, the tool automatically restricts file permissions to owner-only access.
+If you create the file on a non-POSIX filesystem (such as Windows) and later transfer it to a POSIX system, restrict permissions manually:
 +
 [source,shell]
 ----
@@ -79,7 +77,7 @@ Valid values are `SCRAM-SHA-256` (default) and `SCRAM-SHA-512`.
 `-i` sets the PBKDF2 iteration count (default 10000, minimum 4096).
 Higher values increase the cost of brute-force attacks against the credential store but also increase the CPU cost of each authentication.
 
-. List users in the KeyStore:
+. List users in the credential file:
 +
 [source,shell]
 ----
@@ -118,11 +116,11 @@ For automation scenarios, the `--unlock-insecure-options` flag enables the `-p` 
 WARNING: Command-line passwords are visible in process listings, shell history, and system logs.
 Prefer interactive prompts or other secret management approaches for production use.
 
-== Using the credential store on Kubernetes
+== Using the credential file on Kubernetes
 
-To use the KeyStore in a Kubernetes deployment:
+To use the proxy SCRAM credential file in a Kubernetes deployment:
 
-. Create a Kubernetes Secret containing both the KeyStore file and the store password:
+. Create a Kubernetes Secret containing both the credential file and the store password:
 +
 [source,shell]
 ----

--- a/kroxylicious-docs/docs/_modules/sasl-termination/proc-managing-scram-credentials.adoc
+++ b/kroxylicious-docs/docs/_modules/sasl-termination/proc-managing-scram-credentials.adoc
@@ -1,0 +1,135 @@
+////
+  // Copyright Kroxylicious Authors.
+  //
+  // Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+////
+
+:_mod-docs-content-type: PROCEDURE
+
+// file included in the following:
+//
+// assembly-configuring-authentication-sasl-termination.adoc
+
+[id='proc-managing-scram-credentials-{context}']
+= Managing SCRAM credentials
+
+[role="_abstract"]
+Use the SCRAM credential tool to create a PKCS#12 KeyStore and manage user credentials for SCRAM-SHA-256 and SCRAM-SHA-512 authentication.
+The tool ships in the Kroxylicious distribution at `bin/scram-credential-tool.sh`.
+
+The KeyStore stores SCRAM derived keys (`ServerKey` and `StoredKey`), not plaintext passwords.
+Passwords are prompted interactively by default, with confirmation required when setting a new password.
+
+IMPORTANT: Although the credential file uses the standard PKCS#12 format, use the Kroxylicious SCRAM credential tool to create and modify it.
+The format of aliases and entries within the file is specific to Kroxylicious, so other tools such as the JDK `keytool` are not compatible.
+
+.Prerequisites
+
+* A Kroxylicious distribution installed on the system where you run the tool.
+* Java 21 or later.
+
+.Procedure
+
+. Generate a strong store password and save it to a file:
++
+[source,shell]
+----
+openssl rand -base64 32 > /etc/kroxylicious/keystore-password.txt
+----
++
+You use this password when prompted by the credential tool commands below.
+
+. Create a new KeyStore:
++
+[source,shell]
+----
+bin/scram-credential-tool.sh create \
+  -k /etc/kroxylicious/scram-credentials.p12
+----
++
+You are prompted for a store password.
+Enter the password you generated in step 1.
++
+On POSIX filesystems, the tool automatically restricts file permissions on the KeyStore to owner-only access.
+If you create the KeyStore on a non-POSIX filesystem (such as Windows) and later transfer it to a POSIX system, restrict permissions manually:
++
+[source,shell]
+----
+chmod 600 /etc/kroxylicious/scram-credentials.p12
+----
+
+. Add a user with SCRAM-SHA-256 credentials:
++
+[source,shell]
+----
+bin/scram-credential-tool.sh add-user \
+  -k /etc/kroxylicious/scram-credentials.p12 \
+  -u alice \
+  -m SCRAM-SHA-256 \
+  -i 10000
+----
++
+You are prompted for the store password and the user's password.
+Passwords must be at least 12 characters long.
+There is no restriction on which characters may be used, but sticking to ASCII alphabetic characters, digits, and punctuation is advised.
++
+`-m` selects the SCRAM mechanism.
+Valid values are `SCRAM-SHA-256` (default) and `SCRAM-SHA-512`.
++
+`-i` sets the PBKDF2 iteration count (default 10000, minimum 4096).
+Higher values increase the cost of brute-force attacks against the credential store but also increase the CPU cost of each authentication.
+
+. List users in the KeyStore:
++
+[source,shell]
+----
+bin/scram-credential-tool.sh list-users \
+  -k /etc/kroxylicious/scram-credentials.p12
+----
++
+The output shows each user's name, mechanism, and iteration count.
+
+. Update a user's password:
++
+[source,shell]
+----
+bin/scram-credential-tool.sh update-password \
+  -k /etc/kroxylicious/scram-credentials.p12 \
+  -u alice
+----
++
+You are prompted for the store password and the new user password.
+The `-m` and `-i` options are also available if you need to change the mechanism or iteration count.
+
+. Remove a user:
++
+[source,shell]
+----
+bin/scram-credential-tool.sh remove-user \
+  -k /etc/kroxylicious/scram-credentials.p12 \
+  -u alice
+----
+
+== Non-interactive password options
+
+By default, the tool prompts for passwords interactively.
+For automation scenarios, the `--unlock-insecure-options` flag enables the `-p` (store password) and `-w` (user password) command-line options.
+
+WARNING: Command-line passwords are visible in process listings, shell history, and system logs.
+Prefer interactive prompts or other secret management approaches for production use.
+
+== Using the credential store on Kubernetes
+
+To use the KeyStore in a Kubernetes deployment:
+
+. Create a Kubernetes Secret containing both the KeyStore file and the store password:
++
+[source,shell]
+----
+kubectl create secret generic scram-credentials \
+  --from-file=credentials.p12=/etc/kroxylicious/scram-credentials.p12 \
+  --from-file=store-password=/etc/kroxylicious/keystore-password.txt
+----
+
+. Reference the secret in the `KafkaProtocolFilter` resource using the `${secret:...}` interpolation syntax.
+See the <<con-example-kafkaprotocolfilter-resource-{context}>> for an example.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Add user documentation for configuring SCRAM-SHA-256 and SCRAM-SHA-512 SASL mechanisms with the `SaslTermination` filter, including:

- SCRAM mechanism configuration for bare-metal and Kubernetes deployments
- KeyStore credential store configuration reference
- SCRAM credential tool procedure (create, add-user, list-users, update-password, remove-user)
- SCRAM security considerations (credential storage, username enumeration protection, timing side-channel mitigation)
- Updated choosing authentication approach and SASL mechanism guides to reflect SCRAM support
- PBKDF2 and SCRAM glossary entries

Part of #4391.
Fixes #4521.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>


