### PR TITLE
refactor(record-validation): remove deprecated `WireFormatVersion.V2`  and update documentation

### DIFF
--- a/changelog/unreleased/03785-remove-wireformatversion-v2.yaml
+++ b/changelog/unreleased/03785-remove-wireformatversion-v2.yaml
@@ -1,0 +1,11 @@
+title: "feat(record-validation): remove deprecated `WireFormatVersion.V2` enum value."
+type: removed
+issues:
+  - 3785
+important_notes:
+  - |
+    The deprecated `V2` value of the record validation filter's `wireFormatVersion` configuration option is removed.
+    The filter now supports only the Apicurio Registry v3 wire format (`V3`, the default), which uses Confluent-compatible 4-byte content IDs.
+    Users still using `V2` must update the `apicurioId` in their configuration to refer to the schema's `contentId` (instead of `globalId`),
+    and ensure Kafka clients embed the 4-byte `contentId` in record headers/magic bytes.
+    See the Apicurio Registry v2 to v3 migration guide for details.

--- a/kroxylicious-docs/docs/_modules/record-validation/proc-configuring-record-validation-filter.adoc
+++ b/kroxylicious-docs/docs/_modules/record-validation/proc-configuring-record-validation-filter.adoc
@@ -72,7 +72,7 @@ allowNulls: true
 allowEmpty: true
 ----
 
-* `apicurioId` identifies the schema that the filter enforces. By default, this ID refers to the Apicurio Registry's `contentId`.
+* `apicurioId` identifies the schema that the filter enforces. This ID refers to the Apicurio Registry's `contentId`.
   If the record key or value does not conform to the schema identified by this ID, the record is rejected.
   If a Kafka producer embeds a schema ID in the record (either in a header or _magic_ bytes at the start of the record's key or value), the filter validates it against this value. The record is rejected if the IDs do not match.
 * `apicurioRegistryUrl` specifies the endpoint URL for the Apicurio Registry.
@@ -84,10 +84,8 @@ allowEmpty: true
 ** `storeFile` path to the truststore file that contains the trust anchors used to validate the server connection.
 ** `storePassword` (Optional) password used to protect the truststore.
 ** `storeType` truststore type. Supported values include `PKCS12`, `JKS`, and `PEM`.
-* `wireFormatVersion` controls whether the Apicurio client operates in `V3` (default) or `V2` (deprecated).
-   In `V3` mode, the `apicurioId` property identifies schema by content ID, and the filter expects the Kafka producer to use content IDs to identify schema.
-   In `V2` mode, the `apicurioId` property identifies schema by global ID, and the filter expects the Kafka producer to use global IDs to identify schema.
-   `V2` mode exists only for compatibility with older Apicurio configurations and is deprecated. For new applications, use `V3`.
+* `wireFormatVersion` specifies the Apicurio wire format version. `V3` is the default and only supported value.
+   The `apicurioId` property identifies schema by content ID, and the filter expects the Kafka producer to use content IDs to identify schema.
 * `allowNulls` specifies whether the validator allows record keys or values to be `null`. The default is `false`.
 * `allowEmpty` specifies whether the validator allows record keys or values to be empty. The default is `false`.
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/ProduceRequestValidatorBuilder.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/ProduceRequestValidatorBuilder.java
@@ -79,9 +79,9 @@ class ProduceRequestValidatorBuilder {
     private static BytebufValidator buildSchemaValidator(SchemaValidationConfig config) {
         var schemaResolverConfig = buildSchemaResolverConfig(config);
         return switch (config.schemaType()) {
-            case JSON_SCHEMA -> BytebufValidators.jsonSchemaValidator(schemaResolverConfig, config.apicurioId(), config.wireFormatVersion());
-            case AVRO -> BytebufValidators.avroSchemaValidator(schemaResolverConfig, config.apicurioId(), config.wireFormatVersion());
-            case PROTOBUF -> BytebufValidators.protobufSchemaValidator(schemaResolverConfig, config.apicurioId(), config.wireFormatVersion());
+            case JSON_SCHEMA -> BytebufValidators.jsonSchemaValidator(schemaResolverConfig, config.apicurioId());
+            case AVRO -> BytebufValidators.avroSchemaValidator(schemaResolverConfig, config.apicurioId());
+            case PROTOBUF -> BytebufValidators.protobufSchemaValidator(schemaResolverConfig, config.apicurioId());
         };
     }
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/config/SchemaValidationConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/config/SchemaValidationConfig.java
@@ -18,7 +18,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 /**
  * Configuration for validating a component ByteBuffer of a {@link org.apache.kafka.common.record.Record} is valid using the schema in Apicurio Registry.
  * @param apicurioRegistryUrl apicurio registry url
- * @param apicurioId schema identifier - interpreted as contentId for V3 (default) or globalId for V2
+ * @param apicurioId schema identifier - interpreted as contentId
  * @param wireFormatVersion wire format version (defaults to V3 if null)
  * @param tls optional TLS configuration for connecting to a schema registry protected by TLS
  * @param schemaType the type of schema to validate against (defaults to JSON_SCHEMA if null)
@@ -52,18 +52,10 @@ public record SchemaValidationConfig(URL apicurioRegistryUrl,
     /**
      * Wire format versions for Apicurio Registry schema identifiers.
      * <p>
-     * V3 uses 4-byte content IDs (Confluent-compatible format) and is the default.
-     * V2 uses 8-byte global IDs and is deprecated.
+     * V3 uses 4-byte content IDs (Confluent-compatible format) and is the default and only supported format.
      * </p>
      */
     public enum WireFormatVersion {
-        /**
-         * Apicurio Registry v2 wire format using 8-byte global IDs.
-         * @deprecated Use {@link #V3} instead for Confluent compatibility. This option will be removed in a future release.
-         */
-        @Deprecated(since = "0.19.0", forRemoval = true)
-        V2,
-
         /**
          * Apicurio Registry v3 wire format using 4-byte content IDs (Confluent-compatible).
          * This is the recommended and default format.
@@ -74,7 +66,7 @@ public record SchemaValidationConfig(URL apicurioRegistryUrl,
     /**
      * Construct SchemaValidationConfig with explicit wire format version, TLS configuration, and schema type
      * @param apicurioRegistryUrl Apicurio Registry instance url
-     * @param apicurioId schema identifier - interpreted as contentId for V3 (default) or globalId for V2
+     * @param apicurioId schema identifier - interpreted as contentId
      * @param wireFormatVersion wire format version (defaults to V3 if null)
      * @param tls optional TLS configuration for connecting to a schema registry protected by TLS with a custom trust store
      * @param schemaType the type of schema to validate against (defaults to JSON_SCHEMA if null)

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AbstractSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AbstractSchemaBytebufValidator.java
@@ -18,12 +18,10 @@ import org.apache.kafka.common.record.Record;
 import io.apicurio.registry.serde.BaseSerde;
 import io.apicurio.registry.serde.Default4ByteIdHandler;
 import io.apicurio.registry.serde.IdHandler;
-import io.apicurio.registry.serde.Legacy8ByteIdHandler;
 import io.apicurio.registry.serde.kafka.headers.DefaultHeadersHandler;
 import io.apicurio.registry.serde.kafka.headers.HeadersHandler;
 import io.apicurio.schema.validation.ValidationResult;
 
-import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
 import io.kroxylicious.filter.validation.validators.Result;
 
 /**
@@ -46,19 +44,17 @@ import io.kroxylicious.filter.validation.validators.Result;
  */
 abstract class AbstractSchemaBytebufValidator implements BytebufValidator {
     private final Long schemaId;
-    private final WireFormatVersion wireFormatVersion;
     private final HeadersHandler keyHeaderHandler;
     private final HeadersHandler valueHeaderHandler;
     private final IdHandler keyIdHandler;
     private final IdHandler valueIdHandler;
 
-    protected AbstractSchemaBytebufValidator(Long schemaId, WireFormatVersion wireFormatVersion) {
+    protected AbstractSchemaBytebufValidator(Long schemaId) {
         this.schemaId = schemaId;
-        this.wireFormatVersion = wireFormatVersion;
         this.keyHeaderHandler = buildHeaderHandler(true);
-        this.keyIdHandler = buildIdHandler(true, wireFormatVersion);
+        this.keyIdHandler = buildIdHandler(true);
         this.valueHeaderHandler = buildHeaderHandler(false);
-        this.valueIdHandler = buildIdHandler(false, wireFormatVersion);
+        this.valueIdHandler = buildIdHandler(false);
     }
 
     @Override
@@ -112,7 +108,6 @@ abstract class AbstractSchemaBytebufValidator implements BytebufValidator {
                 : CompletableFuture.completedFuture(new Result(false, validationResult.toString()));
     }
 
-    @SuppressWarnings("removal")
     private Optional<Long> extractSchemaIdFromRecord(ByteBuffer buffer, Record kafkaRecord, boolean isKey) {
         // Try headers first
         var headerId = extractSchemaIdFromHeaders(kafkaRecord, isKey);
@@ -126,26 +121,18 @@ abstract class AbstractSchemaBytebufValidator implements BytebufValidator {
         if (buffer.remaining() > minBytes && buffer.get(buffer.position()) == BaseSerde.MAGIC_BYTE) {
             buffer.get(); // ignore magic
             var ref = idHandler.readId(buffer);
-            Long id = switch (wireFormatVersion) {
-                case V2 -> ref.getGlobalId();
-                case V3 -> ref.getContentId();
-            };
-            return Optional.ofNullable(id);
+            return Optional.ofNullable(ref.getContentId());
         }
         return Optional.empty();
     }
 
-    @SuppressWarnings("removal")
     private Optional<Long> extractSchemaIdFromHeaders(Record kafkaRecord, boolean isKey) {
         if (kafkaRecord.headers().length > 0) {
             var recordHeaders = new RecordHeaders(kafkaRecord.headers());
             var headerHandler = isKey ? keyHeaderHandler : valueHeaderHandler;
             var ref = headerHandler.readHeaders(recordHeaders);
 
-            Long id = switch (wireFormatVersion) {
-                case V2 -> ref.getGlobalId();
-                case V3 -> ref.getContentId();
-            };
+            Long id = ref.getContentId();
             if (id != null) {
                 return Optional.of(id);
             }
@@ -159,12 +146,8 @@ abstract class AbstractSchemaBytebufValidator implements BytebufValidator {
         return handler;
     }
 
-    @SuppressWarnings("removal")
-    private static IdHandler buildIdHandler(boolean isKey, WireFormatVersion wireFormatVersion) {
-        IdHandler handler = switch (wireFormatVersion) {
-            case V2 -> new Legacy8ByteIdHandler();
-            case V3 -> new Default4ByteIdHandler();
-        };
+    private static IdHandler buildIdHandler(boolean isKey) {
+        IdHandler handler = new Default4ByteIdHandler();
         handler.configure(Map.of(), isKey);
         return handler;
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidator.java
@@ -25,7 +25,6 @@ import io.apicurio.registry.resolver.strategy.ArtifactReference;
 import io.apicurio.schema.validation.avro.AvroSchemaParser;
 import io.apicurio.schema.validation.avro.AvroValidator;
 
-import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
 import io.kroxylicious.filter.validation.validators.Result;
 
 /**
@@ -41,8 +40,8 @@ class AvroSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
     private final AvroValidator avroValidator;
     private final Schema avroSchema;
 
-    AvroSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long schemaId, WireFormatVersion wireFormatVersion) {
-        super(schemaId, wireFormatVersion);
+    AvroSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long schemaId) {
+        super(schemaId);
         this.avroValidator = new AvroValidator(schemaResolverConfig, Optional.of(ArtifactReference.fromContentId(schemaId)));
         this.avroSchema = resolveAvroSchema(schemaResolverConfig, schemaId);
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/BytebufValidators.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/BytebufValidators.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 
 import org.jose4j.jwk.JsonWebKeySet;
 
-import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
 import io.kroxylicious.proxy.config.tls.AllowDeny;
 
 /**
@@ -59,33 +58,30 @@ public class BytebufValidators {
      * get validator that validates if a non-null/non-empty buffer contains data that matches a JSONSchema registered in the Schema Registry
      * @param schemaResolverConfig schema resolver configuration
      * @param contentId content ID to validate against
-     * @param wireFormatVersion wire format version (V2 or V3)
      * @return validator
      */
-    public static BytebufValidator jsonSchemaValidator(Map<String, Object> schemaResolverConfig, Long contentId, WireFormatVersion wireFormatVersion) {
-        return new JsonSchemaBytebufValidator(schemaResolverConfig, contentId, wireFormatVersion);
+    public static BytebufValidator jsonSchemaValidator(Map<String, Object> schemaResolverConfig, Long contentId) {
+        return new JsonSchemaBytebufValidator(schemaResolverConfig, contentId);
     }
 
     /**
      * get validator that validates if a non-null/non-empty buffer contains data that matches an Avro schema registered in the Schema Registry
      * @param schemaResolverConfig schema resolver configuration
      * @param contentId content ID to validate against
-     * @param wireFormatVersion wire format version (V2 or V3)
      * @return validator
      */
-    public static BytebufValidator avroSchemaValidator(Map<String, Object> schemaResolverConfig, Long contentId, WireFormatVersion wireFormatVersion) {
-        return new AvroSchemaBytebufValidator(schemaResolverConfig, contentId, wireFormatVersion);
+    public static BytebufValidator avroSchemaValidator(Map<String, Object> schemaResolverConfig, Long contentId) {
+        return new AvroSchemaBytebufValidator(schemaResolverConfig, contentId);
     }
 
     /**
      * get validator that validates if a non-null/non-empty buffer contains data that matches a Protobuf schema registered in the Schema Registry
      * @param schemaResolverConfig schema resolver configuration
      * @param contentId content ID to validate against
-     * @param wireFormatVersion wire format version (V2 or V3)
      * @return validator
      */
-    public static BytebufValidator protobufSchemaValidator(Map<String, Object> schemaResolverConfig, Long contentId, WireFormatVersion wireFormatVersion) {
-        return new ProtobufSchemaBytebufValidator(schemaResolverConfig, contentId, wireFormatVersion);
+    public static BytebufValidator protobufSchemaValidator(Map<String, Object> schemaResolverConfig, Long contentId) {
+        return new ProtobufSchemaBytebufValidator(schemaResolverConfig, contentId);
     }
 
     /**

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/JsonSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/JsonSchemaBytebufValidator.java
@@ -14,7 +14,6 @@ import java.util.concurrent.CompletionStage;
 import io.apicurio.registry.resolver.strategy.ArtifactReference;
 import io.apicurio.schema.validation.json.JsonValidator;
 
-import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
 import io.kroxylicious.filter.validation.validators.Result;
 
 /**
@@ -28,8 +27,8 @@ import io.kroxylicious.filter.validation.validators.Result;
 class JsonSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
     private final JsonValidator jsonValidator;
 
-    JsonSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long schemaId, WireFormatVersion wireFormatVersion) {
-        super(schemaId, wireFormatVersion);
+    JsonSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long schemaId) {
+        super(schemaId);
         this.jsonValidator = new JsonValidator(schemaResolverConfig, Optional.of(ArtifactReference.fromContentId(schemaId)));
     }
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
@@ -26,7 +26,6 @@ import io.apicurio.registry.utils.protobuf.schema.ProtobufSchema;
 import io.apicurio.schema.validation.protobuf.ProtobufSchemaParser;
 import io.apicurio.schema.validation.protobuf.ProtobufValidator;
 
-import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
 import io.kroxylicious.filter.validation.validators.Result;
 
 /**
@@ -50,8 +49,8 @@ class ProtobufSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
     private final ProtobufValidator protobufValidator;
     private final Descriptors.Descriptor messageDescriptor;
 
-    ProtobufSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long schemaId, WireFormatVersion wireFormatVersion) {
-        super(schemaId, wireFormatVersion);
+    ProtobufSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long schemaId) {
+        super(schemaId);
         this.protobufValidator = new ProtobufValidator(schemaResolverConfig, Optional.of(ArtifactReference.fromContentId(schemaId)));
         this.messageDescriptor = resolveProtobufDescriptor(schemaResolverConfig, schemaId);
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidatorTest.java
@@ -31,7 +31,6 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import io.apicurio.registry.serde.BaseSerde;
 import io.apicurio.registry.serde.kafka.headers.KafkaSerdeHeaders;
 
-import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
 import io.kroxylicious.filter.validation.validators.Result;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -104,7 +103,7 @@ class AvroSchemaBytebufValidatorTest {
     @Test
     void valuePassesSchemaValidation() {
         Record record = record(RECORD_KEY, validAvroBytes);
-        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
@@ -115,7 +114,7 @@ class AvroSchemaBytebufValidatorTest {
     @Test
     void nonAvroValueFailsDeserialization() {
         Record record = record(RECORD_KEY, "not avro data".getBytes(StandardCharsets.UTF_8));
-        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
@@ -130,7 +129,7 @@ class AvroSchemaBytebufValidatorTest {
     void valueWithCorrectSchemaIdInHeaderPassesValidation() {
         Header[] headers = new Header[]{ new RecordHeader(KafkaSerdeHeaders.HEADER_VALUE_CONTENT_ID, toByteArray(CONTENT_ID)) };
         Record record = record(RECORD_KEY, validAvroBytes, headers);
-        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
@@ -142,7 +141,7 @@ class AvroSchemaBytebufValidatorTest {
     void valueWithWrongSchemaIdInHeaderRejected() {
         Header[] headers = new Header[]{ new RecordHeader(KafkaSerdeHeaders.HEADER_VALUE_CONTENT_ID, toByteArray(CONTENT_ID + 1)) };
         Record record = record(RECORD_KEY, validAvroBytes, headers);
-        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
@@ -154,7 +153,7 @@ class AvroSchemaBytebufValidatorTest {
     void valueWithCorrectSchemaIdInBodyPassesValidation() {
         var value = asV3SchemaIdPrefixBuf(CONTENT_ID, validAvroBytes);
         Record record = record(RECORD_KEY, value);
-        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
@@ -166,7 +165,7 @@ class AvroSchemaBytebufValidatorTest {
     void valueWithUnexpectedSchemaIdInBodyRejected() {
         var value = asV3SchemaIdPrefixBuf(CONTENT_ID + 1, validAvroBytes);
         Record record = record(RECORD_KEY, value);
-        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
@@ -197,7 +196,7 @@ class AvroSchemaBytebufValidatorTest {
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("{\"message\":\"No artifact with ID '999' was found.\",\"error_code\":404}")));
 
-        assertThatThrownBy(() -> BytebufValidators.avroSchemaValidator(apicurioConfig, nonExistentContentId, WireFormatVersion.V3))
+        assertThatThrownBy(() -> BytebufValidators.avroSchemaValidator(apicurioConfig, nonExistentContentId))
                 .isInstanceOf(RuntimeException.class);
     }
 
@@ -205,7 +204,7 @@ class AvroSchemaBytebufValidatorTest {
     void bufferTooSmallForSchemaIdHandledGracefully() {
         byte[] tinyBuffer = new byte[]{ BaseSerde.MAGIC_BYTE, 0x01 };
         Record record = record(RECORD_KEY, tinyBuffer);
-        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/bytebuf/JsonSchemaBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/bytebuf/JsonSchemaBytebufValidatorTest.java
@@ -24,7 +24,6 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import io.apicurio.registry.serde.BaseSerde;
 import io.apicurio.registry.serde.kafka.headers.KafkaSerdeHeaders;
 
-import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
 import io.kroxylicious.filter.validation.validators.Result;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -102,7 +101,7 @@ class JsonSchemaBytebufValidatorTest {
     @Test
     void valuePassesSchemaValidation() {
         Record record = record(RECORD_KEY, VALID_JSON);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
@@ -113,7 +112,7 @@ class JsonSchemaBytebufValidatorTest {
     @Test
     void jsonValueFailsSchemaValidation() {
         Record record = record(RECORD_KEY, INVALID_JSON);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
@@ -124,7 +123,7 @@ class JsonSchemaBytebufValidatorTest {
     @Test
     void nonJsonValueFailsToParse() {
         Record record = record(RECORD_KEY, "not a json value".getBytes(StandardCharsets.UTF_8));
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
         assertThat(future)
                 .succeedsWithin(Duration.ofSeconds(1))
@@ -135,7 +134,7 @@ class JsonSchemaBytebufValidatorTest {
     void valueWithCorrectSchemaIdInHeaderPassesValidation() {
         Header[] headers = new Header[]{ new RecordHeader(KafkaSerdeHeaders.HEADER_VALUE_CONTENT_ID, toByteArray(CONTENT_ID)) };
         Record record = record(RECORD_KEY, VALID_JSON, headers);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
         assertThat(future)
                 .succeedsWithin(Duration.ofSeconds(1))
@@ -146,7 +145,7 @@ class JsonSchemaBytebufValidatorTest {
     void valueWithCorrectSchemaIdInBodyPassesValidation() {
         var value = asSchemaIdPrefixBuf(CONTENT_ID, VALID_JSON);
         Record record = record(RECORD_KEY, value);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
         assertThat(future)
                 .succeedsWithin(Duration.ofSeconds(1))
@@ -157,7 +156,7 @@ class JsonSchemaBytebufValidatorTest {
     void valueWithWrongSchemaIdInHeaderRejected() {
         Header[] headers = new Header[]{ new RecordHeader(KafkaSerdeHeaders.HEADER_VALUE_CONTENT_ID, toByteArray(CONTENT_ID + 1)) };
         Record record = record(RECORD_KEY, VALID_JSON, headers);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
         assertThat(future)
                 .succeedsWithin(Duration.ofSeconds(1))
@@ -168,7 +167,7 @@ class JsonSchemaBytebufValidatorTest {
     void valueWithUnexpectedSchemaIdInBodyRejected() {
         var value = asSchemaIdPrefixBuf(CONTENT_ID + 1, VALID_JSON);
         Record record = record(RECORD_KEY, value);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
         assertThat(future)
                 .succeedsWithin(Duration.ofSeconds(1))
@@ -179,7 +178,7 @@ class JsonSchemaBytebufValidatorTest {
     void keyWithCorrectSchemaIdInHeaderPassesValidation() {
         Header[] headers = new Header[]{ new RecordHeader(KafkaSerdeHeaders.HEADER_VALUE_CONTENT_ID, toByteArray(CONTENT_ID)) };
         Record record = record(VALID_JSON, null, headers);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.key(), record, true);
         assertThat(future)
                 .succeedsWithin(Duration.ofSeconds(1))
@@ -190,7 +189,7 @@ class JsonSchemaBytebufValidatorTest {
     void keyWithUnexpectedSchemaIdInBodyRejected() {
         var key = asSchemaIdPrefixBuf(CONTENT_ID + 1, VALID_JSON);
         Record record = record(key, null, new Header[]{});
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.key(), record, true);
         assertThat(future)
                 .succeedsWithin(Duration.ofSeconds(1))
@@ -216,7 +215,7 @@ class JsonSchemaBytebufValidatorTest {
                                 .withBody("{\"message\":\"No artifact with ID '999' was found.\",\"error_code\":404}")));
 
         Record record = record(RECORD_KEY, VALID_JSON);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, nonExistentContentId, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, nonExistentContentId);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
@@ -229,7 +228,7 @@ class JsonSchemaBytebufValidatorTest {
         // Create a buffer that's too small to contain a schema ID (less than 1 + 4 bytes)
         byte[] tinyBuffer = new byte[]{ BaseSerde.MAGIC_BYTE, 0x01 }; // Only 2 bytes
         Record record = record(RECORD_KEY, tinyBuffer);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
@@ -243,66 +242,12 @@ class JsonSchemaBytebufValidatorTest {
         byte[] bufferWithoutMagic = new byte[20]; // Large enough but no magic byte
         bufferWithoutMagic[0] = 0x00; // Not the magic byte
         Record record = record(RECORD_KEY, bufferWithoutMagic);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
                 .succeedsWithin(Duration.ofSeconds(1))
                 .returns(false, Result::valid);
-    }
-
-    @Test
-    @SuppressWarnings("removal")
-    void v2WireFormatUsesLegacy8ByteIdHandler() {
-        // V2 wire format uses 8-byte global IDs
-        var value = asV2SchemaIdPrefixBuf(CONTENT_ID, VALID_JSON);
-        Record record = record(RECORD_KEY, value);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V2);
-        var future = validator.validate(record.value(), record, false);
-        assertThat(future)
-                .succeedsWithin(Duration.ofSeconds(1))
-                .returns(true, Result::valid);
-    }
-
-    @Test
-    @SuppressWarnings("removal")
-    void v2ValueWithCorrectGlobalIdInHeaderPassesValidation() {
-        // V2 mode should read globalId from headers (not contentId)
-        Header[] headers = new Header[]{ new RecordHeader(KafkaSerdeHeaders.HEADER_VALUE_GLOBAL_ID, toByteArray(CONTENT_ID)) };
-        Record record = record(RECORD_KEY, VALID_JSON, headers);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V2);
-        var future = validator.validate(record.value(), record, false);
-        assertThat(future)
-                .succeedsWithin(Duration.ofSeconds(1))
-                .returns(true, Result::valid);
-    }
-
-    @Test
-    @SuppressWarnings("removal")
-    void v2ValueWithWrongGlobalIdInHeaderRejected() {
-        // V2 mode should reject wrong globalId in headers
-        Header[] headers = new Header[]{ new RecordHeader(KafkaSerdeHeaders.HEADER_VALUE_GLOBAL_ID, toByteArray(CONTENT_ID + 1)) };
-        Record record = record(RECORD_KEY, VALID_JSON, headers);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V2);
-        var future = validator.validate(record.value(), record, false);
-        assertThat(future)
-                .succeedsWithin(Duration.ofSeconds(1))
-                .isEqualTo(new Result(false, "Unexpected schema id in record (2), expecting 1"));
-    }
-
-    @Test
-    @SuppressWarnings("removal")
-    void v2ValueWithContentIdInHeaderFallsBackToMagicByte() {
-        // V2 mode should ignore contentId header (only reads globalId)
-        // If contentId header is present but no globalId, it should fall back to magic byte detection
-        Header[] headers = new Header[]{ new RecordHeader(KafkaSerdeHeaders.HEADER_VALUE_CONTENT_ID, toByteArray(CONTENT_ID)) };
-        var value = asV2SchemaIdPrefixBuf(CONTENT_ID, VALID_JSON);
-        Record record = record(RECORD_KEY, value, headers);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V2);
-        var future = validator.validate(record.value(), record, false);
-        assertThat(future)
-                .succeedsWithin(Duration.ofSeconds(1))
-                .returns(true, Result::valid);
     }
 
     @Test
@@ -310,7 +255,7 @@ class JsonSchemaBytebufValidatorTest {
         // V3 wire format uses 4-byte content IDs (Confluent-compatible)
         var value = asV3SchemaIdPrefixBuf(CONTENT_ID, VALID_JSON);
         Record record = record(RECORD_KEY, value);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
         assertThat(future)
                 .succeedsWithin(Duration.ofSeconds(1))
@@ -318,25 +263,11 @@ class JsonSchemaBytebufValidatorTest {
     }
 
     @Test
-    @SuppressWarnings("removal")
-    void v2ValidatorRejectsV3WireFormat() {
-        // V2 validator should reject V3 format (4-byte content ID)
-        var value = asV3SchemaIdPrefixBuf(CONTENT_ID, VALID_JSON);
-        Record record = record(RECORD_KEY, value);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V2);
-        var future = validator.validate(record.value(), record, false);
-        assertThat(future)
-                .succeedsWithin(Duration.ofSeconds(1))
-                .returns(false, Result::valid);
-    }
-
-    @Test
-    @SuppressWarnings("removal")
     void v3ValidatorRejectsV2WireFormat() {
         // V3 validator should reject V2 format (8-byte global ID)
         var value = asV2SchemaIdPrefixBuf(CONTENT_ID, VALID_JSON);
         Record record = record(RECORD_KEY, value);
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
         assertThat(future)
                 .succeedsWithin(Duration.ofSeconds(1))

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidatorTest.java
@@ -24,7 +24,6 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import io.apicurio.registry.serde.BaseSerde;
 import io.apicurio.registry.serde.kafka.headers.KafkaSerdeHeaders;
 
-import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
 import io.kroxylicious.filter.validation.validators.Result;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -91,7 +90,7 @@ class ProtobufSchemaBytebufValidatorTest {
     @Test
     void valuePassesSchemaValidation() {
         Record record = record(RECORD_KEY, VALID_PROTOBUF);
-        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
@@ -103,7 +102,7 @@ class ProtobufSchemaBytebufValidatorTest {
     void emptyMessagePassesValidation() {
         // In proto3, all fields are optional, so an empty message is valid
         Record record = record(RECORD_KEY, new byte[0]);
-        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
@@ -116,7 +115,7 @@ class ProtobufSchemaBytebufValidatorTest {
         // Length-delimited field claims length 16 but only 1 byte follows
         byte[] corruptData = new byte[]{ 0x0A, 0x10, 0x01 };
         Record record = record(RECORD_KEY, corruptData);
-        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
@@ -133,7 +132,7 @@ class ProtobufSchemaBytebufValidatorTest {
         // When schema ID is in headers, the Apicurio ProtobufSerde writes a Ref delimited message
         // before the protobuf payload in the body.
         Record record = record(RECORD_KEY, withRefPrefix("Person", VALID_PROTOBUF), headers);
-        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
@@ -145,7 +144,7 @@ class ProtobufSchemaBytebufValidatorTest {
     void valueWithWrongSchemaIdInHeaderRejected() {
         Header[] headers = new Header[]{ new RecordHeader(KafkaSerdeHeaders.HEADER_VALUE_CONTENT_ID, toByteArray(CONTENT_ID + 1)) };
         Record record = record(RECORD_KEY, VALID_PROTOBUF, headers);
-        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
@@ -158,7 +157,7 @@ class ProtobufSchemaBytebufValidatorTest {
         // Apicurio protobuf body wire format: magic + contentId + Ref + protobuf
         var value = asV3SchemaIdPrefixBuf(CONTENT_ID, withRefPrefix("Person", VALID_PROTOBUF));
         Record record = record(RECORD_KEY, value);
-        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
@@ -170,7 +169,7 @@ class ProtobufSchemaBytebufValidatorTest {
     void valueWithUnexpectedSchemaIdInBodyRejected() {
         var value = asV3SchemaIdPrefixBuf(CONTENT_ID + 1, withRefPrefix("Person", VALID_PROTOBUF));
         Record record = record(RECORD_KEY, value);
-        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID);
         var future = validator.validate(record.value(), record, false);
 
         assertThat(future)
@@ -201,7 +200,7 @@ class ProtobufSchemaBytebufValidatorTest {
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("{\"message\":\"No artifact with ID '999' was found.\",\"error_code\":404}")));
 
-        assertThatThrownBy(() -> BytebufValidators.protobufSchemaValidator(apicurioConfig, nonExistentContentId, WireFormatVersion.V3))
+        assertThatThrownBy(() -> BytebufValidators.protobufSchemaValidator(apicurioConfig, nonExistentContentId))
                 .isInstanceOf(RuntimeException.class);
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/JsonSchemaRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/JsonSchemaRecordValidationIT.java
@@ -342,29 +342,6 @@ class JsonSchemaRecordValidationIT extends RecordSchemaValidationBaseIT {
     }
 
     @Test
-    void v2WireFormatValidationWorks(KafkaCluster cluster, Topic topic) {
-        // Configure V2 wire format (8-byte global IDs) - deprecated but should still work
-        var config = createContentIdRecordValidationConfigWithWireFormat(cluster, topic, "valueRule", firstContentId, "V2");
-
-        var keySerde = new Serdes.StringSerde();
-        // Create a V2-compatible producer (8-byte IDs)
-        var producerValueSerde = createJsonSchemaProducerSerdeV2(false);
-        var consumerValueSerde = createJsonSchemaConsumerSerdeV2(false);
-
-        try (var tester = kroxyliciousTester(config);
-                var producer = tester.producer(keySerde, producerValueSerde, Map.of());
-                var consumer = consumeFromEarliestOffsets(tester, keySerde, consumerValueSerde)) {
-            // Should accept valid data with V2 wire format
-            assertThat(producer.send(new ProducerRecord<>(topic.name(), "my-key", PERSON_BEAN)))
-                    .succeedsWithin(Duration.ofSeconds(10));
-            consumer.subscribe(Set.of(topic.name()));
-
-            var records = consumer.poll(Duration.ofSeconds(10));
-            assertSingleRecordInTopicHasProperty(records, topic, ConsumerRecord::value, OBJECT_MAPPER.valueToTree(PERSON_BEAN));
-        }
-    }
-
-    @Test
     void v3ValidatorRejectsV2WireFormatData(KafkaCluster cluster, Topic topic) {
         // Configure V3 wire format validator
         var config = createContentIdRecordValidationConfigWithWireFormat(cluster, topic, "valueRule", firstContentId, "V3");
@@ -438,18 +415,6 @@ class JsonSchemaRecordValidationIT extends RecordSchemaValidationBaseIT {
                 KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader,
                 SerdeConfig.ID_HANDLER, "io.apicurio.registry.serde.Legacy8ByteIdHandler"), false);
         return producerSerde;
-    }
-
-    private static @NonNull JsonSchemaSerde<Object> createJsonSchemaConsumerSerdeV2(boolean schemaIdInHeader) {
-        // V2 wire format uses Legacy8ByteIdHandler
-        var consumerSerde = new JsonSchemaSerde<>();
-        consumerSerde.configure(Map.of(
-                SerdeConfig.EXPLICIT_ARTIFACT_ID, firstArtifactId,
-                SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
-                KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader,
-                SerdeConfig.REGISTRY_URL, apicurioRegistryUrl,
-                SerdeConfig.ID_HANDLER, "io.apicurio.registry.serde.Legacy8ByteIdHandler"), false);
-        return consumerSerde;
     }
 
     private static <T, S> org.apache.kafka.clients.consumer.Consumer<T, S> consumeFromEarliestOffsets(KroxyliciousTester tester, Serde<T> keySerde,


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring
- Documentation

### Description

_Please describe your pull request_


- Removed the deprecated `WireFormatVersion.V2` from the record validation filter.
- Updated the `apicurioId` configuration to only refer to the schema's `contentId`.
- Adjusted the documentation to reflect the removal of `V2` and the exclusive support for `V3`.
- Refactored related code to eliminate references to `V2`, including in validators and tests.
- Updated integration tests to remove validation for `V2` wire format.

### Additional Context

_Why are you making this pull request?_

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [X] PR references related GitHub issue(s) so they are closed on merging. Closes: #3785 
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
