### PR TITLE
build(release): stop publishing dist artefacts to Maven Central

### DIFF
--- a/changelog/unreleased/04468-stop-publishing-dist-to-central.yaml
+++ b/changelog/unreleased/04468-stop-publishing-dist-to-central.yaml
@@ -1,0 +1,8 @@
+title: "build(release): stop publishing dist artefacts to Maven Central"
+type: changed
+issues:
+  - 4468
+important_notes:
+  - |
+    `kroxylicious-app` (fat jar, `-bin.zip`, `-bin.tar.gz`), `kroxylicious-operator-dist`, and
+    `kroxylicious-admission-dist` (zip, tar.gz) are no longer published to Maven Central. We do not expect these artefacts to be consumed as Maven dependencies, please raise an issue if this affects you. We continue to publish them via GitHub Releases.

--- a/kroxylicious-app/pom.xml
+++ b/kroxylicious-app/pom.xml
@@ -26,8 +26,6 @@
     <properties>
         <!-- derived from snappy's resource-config.json -->
         <native.library.include.patterns>**/*.dylib,**/*.jnilib,**/*.so,**/*.a</native.library.include.patterns>
-
-        <!-- Terminal deployment artefact (fat jar, zip, tar.gz): no Maven consumers, so don't publish to Central -->
         <maven.deploy.skip>true</maven.deploy.skip>
         <central.publishing.skip>true</central.publishing.skip>
     </properties>

--- a/kroxylicious-app/pom.xml
+++ b/kroxylicious-app/pom.xml
@@ -26,6 +26,10 @@
     <properties>
         <!-- derived from snappy's resource-config.json -->
         <native.library.include.patterns>**/*.dylib,**/*.jnilib,**/*.so,**/*.a</native.library.include.patterns>
+
+        <!-- Terminal deployment artefact (fat jar, zip, tar.gz): no Maven consumers, so don't publish to Central -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <central.publishing.skip>true</central.publishing.skip>
     </properties>
 
     <dependencies>

--- a/kroxylicious-kubernetes/kroxylicious-admission-dist/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-admission-dist/pom.xml
@@ -23,8 +23,6 @@
 
     <properties>
         <errorprone.skip>true</errorprone.skip>
-
-        <!-- Terminal deployment artefact (zip, tar.gz): no Maven consumers, so don't publish to Central -->
         <maven.deploy.skip>true</maven.deploy.skip>
         <central.publishing.skip>true</central.publishing.skip>
     </properties>

--- a/kroxylicious-kubernetes/kroxylicious-admission-dist/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-admission-dist/pom.xml
@@ -23,6 +23,10 @@
 
     <properties>
         <errorprone.skip>true</errorprone.skip>
+
+        <!-- Terminal deployment artefact (zip, tar.gz): no Maven consumers, so don't publish to Central -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <central.publishing.skip>true</central.publishing.skip>
     </properties>
 
     <dependencies>

--- a/kroxylicious-kubernetes/kroxylicious-operator-dist/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-operator-dist/pom.xml
@@ -23,8 +23,6 @@
 
     <properties>
         <errorprone.skip>true</errorprone.skip>
-
-        <!-- Terminal deployment artefact (zip, tar.gz): no Maven consumers, so don't publish to Central -->
         <maven.deploy.skip>true</maven.deploy.skip>
         <central.publishing.skip>true</central.publishing.skip>
     </properties>

--- a/kroxylicious-kubernetes/kroxylicious-operator-dist/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-operator-dist/pom.xml
@@ -23,6 +23,10 @@
 
     <properties>
         <errorprone.skip>true</errorprone.skip>
+
+        <!-- Terminal deployment artefact (zip, tar.gz): no Maven consumers, so don't publish to Central -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <central.publishing.skip>true</central.publishing.skip>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,10 @@
         <!-- Error Prone -->
         <errorprone.version>2.50.0</errorprone.version>
         <errorprone.skip>false</errorprone.skip>
+
+        <!-- Maven Central publishing: overridden to true in modules that are terminal
+             deployment artefacts (fat jars, zip/tar.gz) with no Maven consumers -->
+        <central.publishing.skip>false</central.publishing.skip>
     </properties>
 
     <name>Parent POM</name>
@@ -1173,6 +1177,7 @@
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                     <waitMaxTime>3600</waitMaxTime>
+                    <skipPublishing>${central.publishing.skip}</skipPublishing>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

`kroxylicious-app` (fat jar, `-bin.zip`, `-bin.tar.gz`), `kroxylicious-operator-dist`, and `kroxylicious-admission-dist` (zip, tar.gz) currently publish their terminal deployment artefacts to Maven Central. These have no Maven consumers — they're not referenced via the BOM, and we don't expect anyone to depend on them in the Maven sense — so publishing them to Central only inflates release file count and size for no benefit.

This adds a `central.publishing.skip` property (default `false`), wired into the `central-publishing-maven-plugin`'s `skipPublishing` option, and sets it to `true` alongside `maven.deploy.skip` on the three affected modules. The modules remain in the release reactor and are still packaged, so `stage-release.sh` continues to collect their zip/tar.gz for GitHub Releases exactly as before.

### Additional Context

Part of #4467 (reducing our Maven Central publishing footprint ahead of the October 2026 publishing limits). Closes #4468.

Note: #4468's description frames this as a BOM concern ("consumers take these as library dependencies via the BOM, not as distributions"), but that framing is inaccurate — none of these three modules are, or ever were, in the BOM. The real justification is simpler: these are terminal deployment artefacts with no Maven consumers at all, BOM or otherwise.

### Checklist

- [ ] New tests written (where applicable).
- [x] Not a user-facing change requiring new documentation.
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [x] For user facing changes, add a logchange entry YAML file to `changelog/unreleased/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)