### PR TITLE
build(release): stop publishing benchmark and systemtests modules to Maven Central

### DIFF
--- a/kroxylicious-docs-tests/pom.xml
+++ b/kroxylicious-docs-tests/pom.xml
@@ -26,6 +26,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctorj.version>3.0.1</asciidoctorj.version>
         <snakeyaml.version>2.6</snakeyaml.version>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <central.publishing.skip>true</central.publishing.skip>
     </properties>
 
     <dependencies>

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -22,6 +22,8 @@
 
     <properties>
         <errorprone.skip>true</errorprone.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <central.publishing.skip>true</central.publishing.skip>
     </properties>
 
     <dependencies>

--- a/kroxylicious-microbenchmarks/pom.xml
+++ b/kroxylicious-microbenchmarks/pom.xml
@@ -25,6 +25,8 @@
         <jmh.version>1.37</jmh.version>
         <uberjar.name>microbenchmarks</uberjar.name>
         <sonar.skip>true</sonar.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <central.publishing.skip>true</central.publishing.skip>
     </properties>
 
     <dependencies>

--- a/kroxylicious-openmessaging-benchmarks/pom.xml
+++ b/kroxylicious-openmessaging-benchmarks/pom.xml
@@ -26,6 +26,8 @@
 
     <properties>
         <helm.chart.directory>${project.basedir}/helm/kroxylicious-benchmark</helm.chart.directory>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <central.publishing.skip>true</central.publishing.skip>
     </properties>
 
     <dependencies>

--- a/kroxylicious-systemtests/pom.xml
+++ b/kroxylicious-systemtests/pom.xml
@@ -27,6 +27,8 @@
     <properties>
         <!-- Override for kafka version - used when Apache Kafka is ahead of the Strimzi release  -->
         <!-- <kafka.version>4.1.0</kafka.version> -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <central.publishing.skip>true</central.publishing.skip>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Type of change

- [x] Build/CI change

## Description

Part of #4470. Stops publishing `kroxylicious-microbenchmarks`, `kroxylicious-openmessaging-benchmarks`, `kroxylicious-systemtests`, `kroxylicious-integration-tests`, and `kroxylicious-docs-tests` to Maven Central via the same `maven.deploy.skip`/`central.publishing.skip` pattern used in #4701 for the dist modules. None of these have external Maven consumers today.

`kroxylicious-operator-test-support` (also listed in #4470) is intentionally left out of scope.

## Additional Context

The `kroxylicious-systemtests` change is a throwaway fix for the module as it exists today — see inline comment.

## Checklist

- [x] Tests updated (N/A — build-only change, verified via `mvn help:evaluate` per module)
- [x] Documentation updated (N/A)
- [x] Changelog entry added (N/A — internal-only modules, not user-visible; see rationale in #4470 discussion)