### PR TITLE
ci(release): remove legacy kroxylicious image references from workflows

### DIFF
--- a/.github/workflows/build-kroxylicious-container-images.yaml
+++ b/.github/workflows/build-kroxylicious-container-images.yaml
@@ -150,12 +150,11 @@ jobs:
             echo "admission_tags=kroxylicious-admission:${SHA_TAG}" >> $GITHUB_OUTPUT
           else
             PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.PROXY_IMAGE_NAME }}"
-            LEGACY_PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/kroxylicious"
             OPERATOR_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.OPERATOR_IMAGE_NAME }}"
             ADMISSION_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.ADMISSION_IMAGE_NAME }}"
 
             # Per-arch intermediate tags are pushed individually then merged into the
-            # final manifest list (which also covers the legacy kroxylicious image name).
+            # final manifest list.
             echo "push_images=true" >> $GITHUB_OUTPUT
             echo "multi_arch=${{ inputs.multi-arch }}" >> $GITHUB_OUTPUT
             echo "proxy_amd64_tag=${PROXY_IMAGE}:${SHA_TAG}-amd64" >> $GITHUB_OUTPUT
@@ -176,7 +175,7 @@ jobs:
             OPERATOR_TAGS=""
             ADMISSION_TAGS=""
             for suffix in "${TAG_SUFFIXES[@]}"; do
-              PROXY_FINAL_TAGS="${PROXY_FINAL_TAGS:+${PROXY_FINAL_TAGS},}${PROXY_IMAGE}:${suffix},${LEGACY_PROXY_IMAGE}:${suffix}"
+              PROXY_FINAL_TAGS="${PROXY_FINAL_TAGS:+${PROXY_FINAL_TAGS},}${PROXY_IMAGE}:${suffix}"
               OPERATOR_TAGS="${OPERATOR_TAGS:+${OPERATOR_TAGS},}${OPERATOR_IMAGE}:${suffix}"
               ADMISSION_TAGS="${ADMISSION_TAGS:+${ADMISSION_TAGS},}${ADMISSION_IMAGE}:${suffix}"
             done

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -195,7 +195,6 @@ jobs:
             --arg proxyAmd64Ref "${PROXY}:${SHA_TAG}-amd64" \
             --arg proxyArm64Ref "${PROXY}:${SHA_TAG}-arm64" \
             --arg proxyManifest "${PROXY}:${SHA_TAG}" \
-            --arg legacyProxyManifest "${REGISTRY}/${ORG}/kroxylicious:${SHA_TAG}" \
             --arg operatorManifest "${OPERATOR}:${SHA_TAG}" \
             --arg admissionManifest "${ADMISSION}:${SHA_TAG}" \
             '{
@@ -212,11 +211,6 @@ jobs:
                     manifestImage: { ref: $proxyManifest },
                     amd64: { ref: $proxyAmd64Ref, builtFrom: { pom: ("io.kroxylicious:kroxylicious-app:" + $releaseVersion + ":pom"), profiles: ["dist"] } },
                     arm64: { ref: $proxyArm64Ref, builtFrom: { pom: ("io.kroxylicious:kroxylicious-app:" + $releaseVersion + ":pom"), profiles: ["dist", "aarch64"] } }
-                  }
-                },
-                legacyProxy: {
-                  images: {
-                    manifestImage: { ref: $legacyProxyManifest }
                   }
                 },
                 operator: {

--- a/changelog/unreleased/03895-remove-legacy-kroxylicious-image-push.yaml
+++ b/changelog/unreleased/03895-remove-legacy-kroxylicious-image-push.yaml
@@ -1,0 +1,8 @@
+title: "ci(release): remove legacy `quay.io/kroxylicious/kroxylicious` image push"
+type: removed
+issues:
+  - 3895
+important_notes:
+  - |
+    The deprecated `quay.io/kroxylicious/kroxylicious` proxy container image is no longer published.
+    Use `quay.io/kroxylicious/proxy` instead.


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring
- Documentation

### Description

_Please describe your pull request_

 Remove variable `LEGACY_PROXY_IMAGE`
### Additional Context

_Why are you making this pull request?_

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [X] PR references related GitHub issue(s) so they are closed on merging. Closes: #3895 
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
