### PR TITLE
build(release): publish only required checksums to Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1202,6 +1202,7 @@
                     <publishingServerId>central</publishingServerId>
                     <waitMaxTime>3600</waitMaxTime>
                     <skipPublishing>${central.publishing.skip}</skipPublishing>
+                    <checksums>required</checksums>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The `central-publishing-maven-plugin` defaults `checksums` to `all`, publishing `.md5`, `.sha1`, `.sha256`, and `.sha512` companion files for every artifact. This sets `<checksums>required</checksums>` in the parent POM so only the checksums Maven Central actually requires are published, reducing file count per release without removing any content consumers need.

### Additional Context

Part of #4467. Fixes #4471.

### Checklist

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.