### PR TITLE
fix(filters): made ProtocolLogger filter resilient to formatting exceptions

### DIFF
--- a/changelog/unreleased/04669-protocol-logger-failsafe.yaml
+++ b/changelog/unreleased/04669-protocol-logger-failsafe.yaml
@@ -1,0 +1,4 @@
+title: "fix(filters): make ProtocolLogger filter resilient to formatting exceptions"
+type: fixed
+issues:
+  - 4669

--- a/kroxylicious-filters/kroxylicious-protocol-logger/README.md
+++ b/kroxylicious-filters/kroxylicious-protocol-logger/README.md
@@ -253,6 +253,12 @@ Depending on chain position this filter may observe them and cannot reliably tel
 
 Latency can be derived from the log timestamps of matched request/response pairs.
 
+## Failure resilience
+
+The filter is a passive observer — it never modifies messages and never interferes with forwarding.
+If an exception occurs while building or emitting a log entry, the filter catches it, emits a rate-limited warning, and forwards the message unchanged.
+Warnings are keyed by API key: the first failure logs immediately, subsequent failures for the same key are suppressed for five minutes, and the next warning after the interval reports how many were suppressed.
+
 ## Caveats
 
 - **Idle consumers produce verbose output.** On an idle consumer the output is dominated by `HEARTBEAT` and `FETCH` responses. Use `apiKeyNames` to filter these out.

--- a/kroxylicious-filters/kroxylicious-protocol-logger/README.md
+++ b/kroxylicious-filters/kroxylicious-protocol-logger/README.md
@@ -257,6 +257,8 @@ Latency can be derived from the log timestamps of matched request/response pairs
 
 The filter is a passive observer — it never modifies messages and never interferes with forwarding.
 If an exception occurs while building or emitting a log entry, the filter catches it, emits a rate-limited warning, and forwards the message unchanged.
+Warnings are emitted on the filter module's own logger (`io.kroxylicious.filter.protocollogger.LogWarningThrottle`), not the configured protocol logger, so they remain visible even when protocol trace output is routed to a dedicated appender.
+Each warning includes a `targetLogger` key-value identifying the configured logger instance that failed.
 Warnings are keyed by API key: the first failure logs immediately, subsequent failures for the same key are suppressed for five minutes, and the next warning after the interval reports how many were suppressed.
 
 ## Caveats

--- a/kroxylicious-filters/kroxylicious-protocol-logger/src/main/java/io/kroxylicious/filter/protocollogger/LogWarningThrottle.java
+++ b/kroxylicious-filters/kroxylicious-protocol-logger/src/main/java/io/kroxylicious/filter/protocollogger/LogWarningThrottle.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.protocollogger;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+/**
+ * Rate-limits warning emissions per {@link ApiKeys}, so a recurring formatting
+ * failure does not flood the log.
+ *
+ * <p>Not thread-safe — intended for use on a single Netty event-loop thread.
+ */
+class LogWarningThrottle {
+
+    static final Duration SUPPRESSION_INTERVAL = Duration.ofMinutes(5);
+
+    private final Clock clock;
+    private final Map<ApiKeys, FailureState> states = new EnumMap<>(ApiKeys.class);
+
+    LogWarningThrottle(Clock clock) {
+        this.clock = clock;
+    }
+
+    void onFailure(ApiKeys apiKey, short apiVersion, Exception exception, Logger logger) {
+        FailureState state = states.get(apiKey);
+        long now = clock.millis();
+        if (state == null) {
+            states.put(apiKey, new FailureState(now));
+            warnFirst(logger, apiKey, apiVersion, exception);
+        }
+        else if (now - state.lastWarnedMillis >= SUPPRESSION_INTERVAL.toMillis()) {
+            long suppressed = state.suppressedCount;
+            state.lastWarnedMillis = now;
+            state.suppressedCount = 0;
+            warnRecurring(logger, apiKey, apiVersion, exception, suppressed);
+        }
+        else {
+            state.suppressedCount++;
+        }
+    }
+
+    private static void warnFirst(Logger logger, ApiKeys apiKey, short apiVersion, Exception exception) {
+        logger.atLevel(Level.WARN)
+                .addKeyValue("apiKey", apiKey)
+                .addKeyValue("apiVersion", apiVersion)
+                .addKeyValue("error", exception.getMessage())
+                .setCause(logger.isDebugEnabled() ? exception : null)
+                .log(logger.isDebugEnabled()
+                        ? "failed to log protocol entry"
+                        : "failed to log protocol entry, increase log level to DEBUG for stacktrace");
+    }
+
+    private static void warnRecurring(Logger logger, ApiKeys apiKey, short apiVersion, Exception exception, long suppressedCount) {
+        logger.atLevel(Level.WARN)
+                .addKeyValue("apiKey", apiKey)
+                .addKeyValue("apiVersion", apiVersion)
+                .addKeyValue("error", exception.getMessage())
+                .addKeyValue("suppressedCount", suppressedCount)
+                .setCause(logger.isDebugEnabled() ? exception : null)
+                .log(logger.isDebugEnabled()
+                        ? "failed to log protocol entry"
+                        : "failed to log protocol entry, increase log level to DEBUG for stacktrace");
+    }
+
+    private static class FailureState {
+        long lastWarnedMillis;
+        long suppressedCount;
+
+        FailureState(long lastWarnedMillis) {
+            this.lastWarnedMillis = lastWarnedMillis;
+            this.suppressedCount = 0;
+        }
+    }
+}

--- a/kroxylicious-filters/kroxylicious-protocol-logger/src/main/java/io/kroxylicious/filter/protocollogger/LogWarningThrottle.java
+++ b/kroxylicious-filters/kroxylicious-protocol-logger/src/main/java/io/kroxylicious/filter/protocollogger/LogWarningThrottle.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 /**
@@ -23,52 +24,58 @@ import org.slf4j.event.Level;
  */
 class LogWarningThrottle {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogWarningThrottle.class);
+
     static final Duration SUPPRESSION_INTERVAL = Duration.ofMinutes(5);
 
     private final Clock clock;
+    private final String targetLoggerName;
     private final Map<ApiKeys, FailureState> states = new EnumMap<>(ApiKeys.class);
 
-    LogWarningThrottle(Clock clock) {
+    LogWarningThrottle(Clock clock, String targetLoggerName) {
         this.clock = clock;
+        this.targetLoggerName = targetLoggerName;
     }
 
-    void onFailure(ApiKeys apiKey, short apiVersion, Exception exception, Logger logger) {
+    void onFailure(ApiKeys apiKey, short apiVersion, Exception exception) {
         FailureState state = states.get(apiKey);
         long now = clock.millis();
         if (state == null) {
             states.put(apiKey, new FailureState(now));
-            warnFirst(logger, apiKey, apiVersion, exception);
+            warnFirst(apiKey, apiVersion, exception);
         }
         else if (now - state.lastWarnedMillis >= SUPPRESSION_INTERVAL.toMillis()) {
             long suppressed = state.suppressedCount;
             state.lastWarnedMillis = now;
             state.suppressedCount = 0;
-            warnRecurring(logger, apiKey, apiVersion, exception, suppressed);
+            warnRecurring(apiKey, apiVersion, exception, suppressed);
         }
         else {
             state.suppressedCount++;
         }
     }
 
-    private static void warnFirst(Logger logger, ApiKeys apiKey, short apiVersion, Exception exception) {
-        logger.atLevel(Level.WARN)
+    private void warnFirst(ApiKeys apiKey, short apiVersion, Exception exception) {
+        LOGGER.atLevel(Level.WARN)
                 .addKeyValue("apiKey", apiKey)
                 .addKeyValue("apiVersion", apiVersion)
+                .addKeyValue("targetLogger", targetLoggerName)
                 .addKeyValue("error", exception.getMessage())
-                .setCause(logger.isDebugEnabled() ? exception : null)
-                .log(logger.isDebugEnabled()
+                .setCause(LOGGER.isDebugEnabled() ? exception : null)
+                .log(LOGGER.isDebugEnabled()
                         ? "failed to log protocol entry"
                         : "failed to log protocol entry, increase log level to DEBUG for stacktrace");
     }
 
-    private static void warnRecurring(Logger logger, ApiKeys apiKey, short apiVersion, Exception exception, long suppressedCount) {
-        logger.atLevel(Level.WARN)
+    private void warnRecurring(ApiKeys apiKey, short apiVersion, Exception exception, long suppressedCount) {
+        LOGGER.atLevel(Level.WARN)
                 .addKeyValue("apiKey", apiKey)
                 .addKeyValue("apiVersion", apiVersion)
+                .addKeyValue("targetLogger", targetLoggerName)
                 .addKeyValue("error", exception.getMessage())
                 .addKeyValue("suppressedCount", suppressedCount)
-                .setCause(logger.isDebugEnabled() ? exception : null)
-                .log(logger.isDebugEnabled()
+                .setCause(LOGGER.isDebugEnabled() ? exception : null)
+                .log(LOGGER.isDebugEnabled()
                         ? "failed to log protocol entry"
                         : "failed to log protocol entry, increase log level to DEBUG for stacktrace");
     }

--- a/kroxylicious-filters/kroxylicious-protocol-logger/src/main/java/io/kroxylicious/filter/protocollogger/ProtocolLogger.java
+++ b/kroxylicious-filters/kroxylicious-protocol-logger/src/main/java/io/kroxylicious/filter/protocollogger/ProtocolLogger.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.filter.protocollogger;
 
+import java.time.Clock;
 import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Map;
@@ -109,7 +110,7 @@ public class ProtocolLogger implements FilterFactory<ProtocolLogger.Config, Prot
                     .collect(Collectors.toCollection(() -> EnumSet.noneOf(ApiKeys.class)));
         }
         Logger logger = LoggerFactory.getLogger(config.loggerName());
-        return new ProtocolLoggerFilter(keys, new MessageFormatter(), config.logLevel(), logger);
+        return new ProtocolLoggerFilter(keys, new MessageFormatter(), config.logLevel(), logger, new LogWarningThrottle(Clock.systemUTC()));
     }
 
 }

--- a/kroxylicious-filters/kroxylicious-protocol-logger/src/main/java/io/kroxylicious/filter/protocollogger/ProtocolLogger.java
+++ b/kroxylicious-filters/kroxylicious-protocol-logger/src/main/java/io/kroxylicious/filter/protocollogger/ProtocolLogger.java
@@ -110,7 +110,7 @@ public class ProtocolLogger implements FilterFactory<ProtocolLogger.Config, Prot
                     .collect(Collectors.toCollection(() -> EnumSet.noneOf(ApiKeys.class)));
         }
         Logger logger = LoggerFactory.getLogger(config.loggerName());
-        return new ProtocolLoggerFilter(keys, new MessageFormatter(), config.logLevel(), logger, new LogWarningThrottle(Clock.systemUTC()));
+        return new ProtocolLoggerFilter(keys, new MessageFormatter(), config.logLevel(), logger, new LogWarningThrottle(Clock.systemUTC(), config.loggerName()));
     }
 
 }

--- a/kroxylicious-filters/kroxylicious-protocol-logger/src/main/java/io/kroxylicious/filter/protocollogger/ProtocolLoggerFilter.java
+++ b/kroxylicious-filters/kroxylicious-protocol-logger/src/main/java/io/kroxylicious/filter/protocollogger/ProtocolLoggerFilter.java
@@ -50,6 +50,7 @@ class ProtocolLoggerFilter implements RequestFilter, ResponseFilter {
         return logger.isEnabledForLevel(logLevel) && apiKeys.contains(apiKey);
     }
 
+    @SuppressWarnings("Finally") // deliberate: the forward must execute even if warningThrottle throws
     @Override
     public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey,
                                                           short apiVersion,
@@ -69,9 +70,12 @@ class ProtocolLoggerFilter implements RequestFilter, ResponseFilter {
         catch (Exception e) {
             warningThrottle.onFailure(apiKey, apiVersion, e, logger);
         }
-        return context.forwardRequest(header, request);
+        finally {
+            return context.forwardRequest(header, request); // the forward must execute even if warningThrottle throws
+        }
     }
 
+    @SuppressWarnings("Finally") // deliberate: the forward must execute even if warningThrottle throws
     @Override
     public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey,
                                                             short apiVersion,
@@ -90,7 +94,9 @@ class ProtocolLoggerFilter implements RequestFilter, ResponseFilter {
         catch (Exception e) {
             warningThrottle.onFailure(apiKey, apiVersion, e, logger);
         }
-        return context.forwardResponse(header, response);
+        finally {
+            return context.forwardResponse(header, response); // the forward must execute even if warningThrottle throws
+        }
     }
 
     String buildRequestLogMessage(ApiKeys apiKey, short apiVersion, RequestHeaderData header, ApiMessage request) {

--- a/kroxylicious-filters/kroxylicious-protocol-logger/src/main/java/io/kroxylicious/filter/protocollogger/ProtocolLoggerFilter.java
+++ b/kroxylicious-filters/kroxylicious-protocol-logger/src/main/java/io/kroxylicious/filter/protocollogger/ProtocolLoggerFilter.java
@@ -30,12 +30,14 @@ class ProtocolLoggerFilter implements RequestFilter, ResponseFilter {
     private final MessageFormatter formatter;
     private final Level logLevel;
     private final Logger logger;
+    private final LogWarningThrottle warningThrottle;
 
-    ProtocolLoggerFilter(Set<ApiKeys> apiKeys, MessageFormatter formatter, Level logLevel, Logger logger) {
+    ProtocolLoggerFilter(Set<ApiKeys> apiKeys, MessageFormatter formatter, Level logLevel, Logger logger, LogWarningThrottle warningThrottle) {
         this.apiKeys = apiKeys;
         this.formatter = formatter;
         this.logLevel = logLevel;
         this.logger = logger;
+        this.warningThrottle = warningThrottle;
     }
 
     @Override
@@ -54,14 +56,19 @@ class ProtocolLoggerFilter implements RequestFilter, ResponseFilter {
                                                           RequestHeaderData header,
                                                           ApiMessage request,
                                                           FilterContext context) {
-        logger.atLevel(logLevel)
-                .addKeyValue("direction", "request")
-                .addKeyValue("apiKey", apiKey)
-                .addKeyValue("apiVersion", apiVersion)
-                .addKeyValue("clientCorrelationId", header.correlationId())
-                .addKeyValue("clientId", header.clientId())
-                .addKeyValue("sessionId", context.sessionId())
-                .log(() -> buildRequestLogMessage(apiKey, apiVersion, header, request));
+        try {
+            logger.atLevel(logLevel)
+                    .addKeyValue("direction", "request")
+                    .addKeyValue("apiKey", apiKey)
+                    .addKeyValue("apiVersion", apiVersion)
+                    .addKeyValue("clientCorrelationId", header.correlationId())
+                    .addKeyValue("clientId", header.clientId())
+                    .addKeyValue("sessionId", context.sessionId())
+                    .log(() -> buildRequestLogMessage(apiKey, apiVersion, header, request));
+        }
+        catch (Exception e) {
+            warningThrottle.onFailure(apiKey, apiVersion, e, logger);
+        }
         return context.forwardRequest(header, request);
     }
 
@@ -71,13 +78,18 @@ class ProtocolLoggerFilter implements RequestFilter, ResponseFilter {
                                                             ResponseHeaderData header,
                                                             ApiMessage response,
                                                             FilterContext context) {
-        logger.atLevel(logLevel)
-                .addKeyValue("direction", "response")
-                .addKeyValue("apiKey", apiKey)
-                .addKeyValue("apiVersion", apiVersion)
-                .addKeyValue("clientCorrelationId", header.correlationId())
-                .addKeyValue("sessionId", context.sessionId())
-                .log(() -> buildResponseLogMessage(apiKey, apiVersion, header, response));
+        try {
+            logger.atLevel(logLevel)
+                    .addKeyValue("direction", "response")
+                    .addKeyValue("apiKey", apiKey)
+                    .addKeyValue("apiVersion", apiVersion)
+                    .addKeyValue("clientCorrelationId", header.correlationId())
+                    .addKeyValue("sessionId", context.sessionId())
+                    .log(() -> buildResponseLogMessage(apiKey, apiVersion, header, response));
+        }
+        catch (Exception e) {
+            warningThrottle.onFailure(apiKey, apiVersion, e, logger);
+        }
         return context.forwardResponse(header, response);
     }
 

--- a/kroxylicious-filters/kroxylicious-protocol-logger/src/main/java/io/kroxylicious/filter/protocollogger/ProtocolLoggerFilter.java
+++ b/kroxylicious-filters/kroxylicious-protocol-logger/src/main/java/io/kroxylicious/filter/protocollogger/ProtocolLoggerFilter.java
@@ -50,7 +50,6 @@ class ProtocolLoggerFilter implements RequestFilter, ResponseFilter {
         return logger.isEnabledForLevel(logLevel) && apiKeys.contains(apiKey);
     }
 
-    @SuppressWarnings("Finally") // deliberate: the forward must execute even if warningThrottle throws
     @Override
     public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey,
                                                           short apiVersion,
@@ -68,14 +67,16 @@ class ProtocolLoggerFilter implements RequestFilter, ResponseFilter {
                     .log(() -> buildRequestLogMessage(apiKey, apiVersion, header, request));
         }
         catch (Exception e) {
-            warningThrottle.onFailure(apiKey, apiVersion, e, logger);
+            try {
+                warningThrottle.onFailure(apiKey, apiVersion, e);
+            }
+            catch (Exception ignored) {
+                // the throttle itself failed; nothing more we can safely do here
+            }
         }
-        finally {
-            return context.forwardRequest(header, request); // the forward must execute even if warningThrottle throws
-        }
+        return context.forwardRequest(header, request);
     }
 
-    @SuppressWarnings("Finally") // deliberate: the forward must execute even if warningThrottle throws
     @Override
     public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey,
                                                             short apiVersion,
@@ -92,11 +93,14 @@ class ProtocolLoggerFilter implements RequestFilter, ResponseFilter {
                     .log(() -> buildResponseLogMessage(apiKey, apiVersion, header, response));
         }
         catch (Exception e) {
-            warningThrottle.onFailure(apiKey, apiVersion, e, logger);
+            try {
+                warningThrottle.onFailure(apiKey, apiVersion, e);
+            }
+            catch (Exception ignored) {
+                // the throttle itself failed; nothing more we can safely do here
+            }
         }
-        finally {
-            return context.forwardResponse(header, response); // the forward must execute even if warningThrottle throws
-        }
+        return context.forwardResponse(header, response);
     }
 
     String buildRequestLogMessage(ApiKeys apiKey, short apiVersion, RequestHeaderData header, ApiMessage request) {

--- a/kroxylicious-filters/kroxylicious-protocol-logger/src/test/java/io/kroxylicious/filter/protocollogger/ProtocolLoggerFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-protocol-logger/src/test/java/io/kroxylicious/filter/protocollogger/ProtocolLoggerFilterTest.java
@@ -467,6 +467,15 @@ class ProtocolLoggerFilterTest {
         };
     }
 
+    private static LogWarningThrottle throwingThrottle() {
+        return new LogWarningThrottle(Clock.systemUTC()) {
+            @Override
+            void onFailure(ApiKeys apiKey, short apiVersion, Exception exception, org.slf4j.Logger logger) {
+                throw new RuntimeException("throttle boom");
+            }
+        };
+    }
+
     @Test
     void requestWhoseFormattingThrowsIsStillForwardedUnchanged() {
         // Given
@@ -658,6 +667,48 @@ class ProtocolLoggerFilterTest {
                 .anyMatch(kv -> "apiKey".equals(kv.key) && ApiKeys.METADATA.equals(kv.value));
         assertThat(warnings.get(1).getKeyValuePairs())
                 .anyMatch(kv -> "apiKey".equals(kv.key) && ApiKeys.PRODUCE.equals(kv.value));
+    }
+
+    @Test
+    void requestForwardedEvenWhenBothFormatterAndThrottleThrow() {
+        // Given
+        ProtocolLoggerFilter f = new ProtocolLoggerFilter(
+                EnumSet.allOf(ApiKeys.class), throwingFormatter(), Level.DEBUG,
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), throwingThrottle());
+        RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
+        MetadataRequestData request = new MetadataRequestData();
+        MockFilterContext context = MockFilterContext.builder(header, request).build();
+
+        // When
+        RequestFilterResult result = f.onRequest(ApiKeys.METADATA, (short) 13, header, request, context)
+                .toCompletableFuture().join();
+
+        // Then
+        MockFilterContextAssert.assertThat(result)
+                .isForwardRequest()
+                .hasHeaderEqualTo(header)
+                .hasMessageEqualTo(request);
+    }
+
+    @Test
+    void responseForwardedEvenWhenBothFormatterAndThrottleThrow() {
+        // Given
+        ProtocolLoggerFilter f = new ProtocolLoggerFilter(
+                EnumSet.allOf(ApiKeys.class), throwingFormatter(), Level.DEBUG,
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), throwingThrottle());
+        ResponseHeaderData header = new ResponseHeaderData().setCorrelationId(1);
+        MetadataResponseData response = new MetadataResponseData();
+        MockFilterContext context = MockFilterContext.builder(header, response).build();
+
+        // When
+        ResponseFilterResult result = f.onResponse(ApiKeys.METADATA, (short) 13, header, response, context)
+                .toCompletableFuture().join();
+
+        // Then
+        MockFilterContextAssert.assertThat(result)
+                .isForwardResponse()
+                .hasHeaderEqualTo(header)
+                .hasMessageEqualTo(response);
     }
 
 }

--- a/kroxylicious-filters/kroxylicious-protocol-logger/src/test/java/io/kroxylicious/filter/protocollogger/ProtocolLoggerFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-protocol-logger/src/test/java/io/kroxylicious/filter/protocollogger/ProtocolLoggerFilterTest.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.filter.protocollogger;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +43,7 @@ import org.slf4j.helpers.NOPLogger;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.github.sambarker.logsquelcher.CapturedLogs;
 import io.github.sambarker.logsquelcher.LogSquelcherExtension;
@@ -62,7 +64,7 @@ class ProtocolLoggerFilterTest {
 
     private final ProtocolLoggerFilter filter = new ProtocolLoggerFilter(
             EnumSet.allOf(ApiKeys.class), new MessageFormatter(), Level.DEBUG,
-            LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+            LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
 
     static Stream<Arguments> credentialBearingRequestsWithSecrets() {
         return Stream.of(
@@ -233,7 +235,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
 
         // When / Then
         assertThat(f.shouldHandleRequest(ApiKeys.METADATA, (short) 12)).isTrue();
@@ -244,7 +246,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
 
         // When / Then
         assertThat(f.shouldHandleResponse(ApiKeys.METADATA, (short) 12)).isTrue();
@@ -255,7 +257,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
 
         // When / Then
         assertThat(f.shouldHandleRequest(ApiKeys.PRODUCE, (short) 9)).isFalse();
@@ -266,7 +268,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
 
         // When / Then
         assertThat(f.shouldHandleResponse(ApiKeys.PRODUCE, (short) 9)).isFalse();
@@ -277,7 +279,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), new MessageFormatter(), Level.DEBUG,
-                NOPLogger.NOP_LOGGER);
+                NOPLogger.NOP_LOGGER, new LogWarningThrottle(Clock.systemUTC()));
 
         // When / Then
         assertThat(f.shouldHandleRequest(ApiKeys.METADATA, (short) 12)).isFalse();
@@ -288,7 +290,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), new MessageFormatter(), Level.DEBUG,
-                NOPLogger.NOP_LOGGER);
+                NOPLogger.NOP_LOGGER, new LogWarningThrottle(Clock.systemUTC()));
 
         // When / Then
         assertThat(f.shouldHandleResponse(ApiKeys.METADATA, (short) 12)).isFalse();
@@ -339,7 +341,7 @@ class ProtocolLoggerFilterTest {
         String customName = "test.custom.logger";
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(customName));
+                LoggerFactory.getLogger(customName), new LogWarningThrottle(Clock.systemUTC()));
         RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
         MetadataRequestData request = new MetadataRequestData();
         MockFilterContext context = MockFilterContext.builder(header, request).build();
@@ -362,7 +364,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
         RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
         MetadataRequestData request = new MetadataRequestData();
         MockFilterContext context = MockFilterContext.builder(header, request).build();
@@ -382,7 +384,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
         ResponseHeaderData header = new ResponseHeaderData().setCorrelationId(1);
         MetadataResponseData response = new MetadataResponseData();
         MockFilterContext context = MockFilterContext.builder(header, response).build();
@@ -403,7 +405,7 @@ class ProtocolLoggerFilterTest {
         String plantedSecret = "PLANTED_SASL_SECRET_VALUE";
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
         RequestHeaderData header = new RequestHeaderData().setCorrelationId(5).setClientId("c1");
         SaslAuthenticateRequestData request = new SaslAuthenticateRequestData()
                 .setAuthBytes(plantedSecret.getBytes(StandardCharsets.UTF_8));
@@ -429,7 +431,7 @@ class ProtocolLoggerFilterTest {
         String plantedSecret = "PLANTED_DELEGATION_HMAC_SECRET";
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
         ResponseHeaderData header = new ResponseHeaderData().setCorrelationId(7);
         CreateDelegationTokenResponseData response = new CreateDelegationTokenResponseData()
                 .setHmac(plantedSecret.getBytes(StandardCharsets.UTF_8));
@@ -447,6 +449,215 @@ class ProtocolLoggerFilterTest {
         assertThat(entry.path("header").path("apiKey").asText()).isEqualTo("CREATE_DELEGATION_TOKEN");
         assertThat(entry.path("payload").isNull()).isTrue();
         assertThat(entry.path("payloadWithheld").asText()).isEqualTo(MessageFormatter.PAYLOAD_WITHHELD_REASON);
+    }
+
+    // --- Exception handling and suppression tests ---
+
+    private static MessageFormatter throwingFormatter() {
+        return new MessageFormatter() {
+            @Override
+            ObjectNode formatRequest(ApiKeys apiKey, short apiVersion, RequestHeaderData header, ApiMessage message) {
+                throw new RuntimeException("converter boom");
+            }
+
+            @Override
+            ObjectNode formatResponse(ApiKeys apiKey, short apiVersion, ResponseHeaderData header, ApiMessage message) {
+                throw new RuntimeException("converter boom");
+            }
+        };
+    }
+
+    @Test
+    void requestWhoseFormattingThrowsIsStillForwardedUnchanged() {
+        // Given
+        ProtocolLoggerFilter f = new ProtocolLoggerFilter(
+                EnumSet.allOf(ApiKeys.class), throwingFormatter(), Level.DEBUG,
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+        RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
+        MetadataRequestData request = new MetadataRequestData();
+        MockFilterContext context = MockFilterContext.builder(header, request).build();
+
+        // When
+        RequestFilterResult result = f.onRequest(ApiKeys.METADATA, (short) 13, header, request, context)
+                .toCompletableFuture().join();
+
+        // Then
+        MockFilterContextAssert.assertThat(result)
+                .isForwardRequest()
+                .hasHeaderEqualTo(header)
+                .hasMessageEqualTo(request);
+    }
+
+    @Test
+    void responseWhoseFormattingThrowsIsStillForwardedUnchanged() {
+        // Given
+        ProtocolLoggerFilter f = new ProtocolLoggerFilter(
+                EnumSet.allOf(ApiKeys.class), throwingFormatter(), Level.DEBUG,
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+        ResponseHeaderData header = new ResponseHeaderData().setCorrelationId(1);
+        MetadataResponseData response = new MetadataResponseData();
+        MockFilterContext context = MockFilterContext.builder(header, response).build();
+
+        // When
+        ResponseFilterResult result = f.onResponse(ApiKeys.METADATA, (short) 13, header, response, context)
+                .toCompletableFuture().join();
+
+        // Then
+        MockFilterContextAssert.assertThat(result)
+                .isForwardResponse()
+                .hasHeaderEqualTo(header)
+                .hasMessageEqualTo(response);
+    }
+
+    @Test
+    void formattingFailureEmitsWarningNamingApiKey(CapturedLogs capturedLogs) {
+        // Given
+        ProtocolLoggerFilter f = new ProtocolLoggerFilter(
+                EnumSet.allOf(ApiKeys.class), throwingFormatter(), Level.DEBUG,
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+        RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
+        MetadataRequestData request = new MetadataRequestData();
+        MockFilterContext context = MockFilterContext.builder(header, request).build();
+
+        // When
+        f.onRequest(ApiKeys.METADATA, (short) 13, header, request, context).toCompletableFuture().join();
+
+        // Then
+        var warnings = capturedLogs.logged(ProtocolLoggerFilter.class, Level.WARN);
+        LoggingEventAssert.assertThat(warnings).hasSize(1);
+        assertThat(warnings.get(0).getKeyValuePairs())
+                .anyMatch(kv -> "apiKey".equals(kv.key) && ApiKeys.METADATA.equals(kv.value));
+    }
+
+    @Test
+    void formattingFailureWarningDoesNotAppearAsProtocolEntry(CapturedLogs capturedLogs) {
+        // Given
+        ProtocolLoggerFilter f = new ProtocolLoggerFilter(
+                EnumSet.allOf(ApiKeys.class), throwingFormatter(), Level.DEBUG,
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+        RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
+        MetadataRequestData request = new MetadataRequestData();
+        MockFilterContext context = MockFilterContext.builder(header, request).build();
+
+        // When
+        f.onRequest(ApiKeys.METADATA, (short) 13, header, request, context).toCompletableFuture().join();
+
+        // Then
+        var debugEntries = capturedLogs.logged(ProtocolLoggerFilter.class, Level.DEBUG);
+        LoggingEventAssert.assertThat(debugEntries).isEmpty();
+    }
+
+    @Test
+    void normalMessageEmitsEntryWithNoWarning(CapturedLogs capturedLogs) {
+        // Given
+        ProtocolLoggerFilter f = new ProtocolLoggerFilter(
+                EnumSet.allOf(ApiKeys.class), new MessageFormatter(), Level.DEBUG,
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+        RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
+        MetadataRequestData request = new MetadataRequestData();
+        MockFilterContext context = MockFilterContext.builder(header, request).build();
+
+        // When
+        f.onRequest(ApiKeys.METADATA, (short) 13, header, request, context).toCompletableFuture().join();
+
+        // Then
+        var debugEntries = capturedLogs.logged(ProtocolLoggerFilter.class, Level.DEBUG);
+        LoggingEventAssert.assertThat(debugEntries).hasSize(1);
+        var warnings = capturedLogs.logged(ProtocolLoggerFilter.class, Level.WARN);
+        LoggingEventAssert.assertThat(warnings).isEmpty();
+    }
+
+    @Test
+    void firstFailureWarnsButImmediateSecondIsSuppressed(CapturedLogs capturedLogs) {
+        // Given
+        Clock fixedClock = Clock.fixed(java.time.Instant.ofEpochMilli(1000), java.time.ZoneOffset.UTC);
+        ProtocolLoggerFilter f = new ProtocolLoggerFilter(
+                EnumSet.allOf(ApiKeys.class), throwingFormatter(), Level.DEBUG,
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(fixedClock));
+        RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
+        MetadataRequestData request = new MetadataRequestData();
+
+        // When
+        f.onRequest(ApiKeys.METADATA, (short) 13, header, request, MockFilterContext.builder(header, request).build())
+                .toCompletableFuture().join();
+        f.onRequest(ApiKeys.METADATA, (short) 13, header, request, MockFilterContext.builder(header, request).build())
+                .toCompletableFuture().join();
+
+        // Then
+        var warnings = capturedLogs.logged(ProtocolLoggerFilter.class, Level.WARN);
+        LoggingEventAssert.assertThat(warnings).hasSize(1);
+    }
+
+    @Test
+    void failureAfterIntervalWarnsAgainWithSuppressedCount(CapturedLogs capturedLogs) {
+        // Given
+        java.time.Instant start = java.time.Instant.ofEpochMilli(1000);
+        java.util.concurrent.atomic.AtomicReference<java.time.Instant> now = new java.util.concurrent.atomic.AtomicReference<>(start);
+        Clock advanceableClock = new Clock() {
+            @Override
+            public java.time.ZoneId getZone() {
+                return java.time.ZoneOffset.UTC;
+            }
+
+            @Override
+            public Clock withZone(java.time.ZoneId zone) {
+                return this;
+            }
+
+            @Override
+            public java.time.Instant instant() {
+                return now.get();
+            }
+        };
+        ProtocolLoggerFilter f = new ProtocolLoggerFilter(
+                EnumSet.allOf(ApiKeys.class), throwingFormatter(), Level.DEBUG,
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(advanceableClock));
+        RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
+        MetadataRequestData request = new MetadataRequestData();
+
+        // When
+        f.onRequest(ApiKeys.METADATA, (short) 13, header, request, MockFilterContext.builder(header, request).build())
+                .toCompletableFuture().join();
+        f.onRequest(ApiKeys.METADATA, (short) 13, header, request, MockFilterContext.builder(header, request).build())
+                .toCompletableFuture().join();
+        f.onRequest(ApiKeys.METADATA, (short) 13, header, request, MockFilterContext.builder(header, request).build())
+                .toCompletableFuture().join();
+        now.set(start.plus(LogWarningThrottle.SUPPRESSION_INTERVAL));
+        f.onRequest(ApiKeys.METADATA, (short) 13, header, request, MockFilterContext.builder(header, request).build())
+                .toCompletableFuture().join();
+
+        // Then
+        var warnings = capturedLogs.logged(ProtocolLoggerFilter.class, Level.WARN);
+        LoggingEventAssert.assertThat(warnings).hasSize(2);
+        assertThat(warnings.get(1).getKeyValuePairs())
+                .anyMatch(kv -> "suppressedCount".equals(kv.key) && Long.valueOf(2).equals(kv.value));
+    }
+
+    @Test
+    void failuresForDifferentApiKeysWarnIndependently(CapturedLogs capturedLogs) {
+        // Given
+        Clock fixedClock = Clock.fixed(java.time.Instant.ofEpochMilli(1000), java.time.ZoneOffset.UTC);
+        ProtocolLoggerFilter f = new ProtocolLoggerFilter(
+                EnumSet.allOf(ApiKeys.class), throwingFormatter(), Level.DEBUG,
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(fixedClock));
+
+        RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
+        MetadataRequestData metadataRequest = new MetadataRequestData();
+        org.apache.kafka.common.message.ProduceRequestData produceRequest = new org.apache.kafka.common.message.ProduceRequestData();
+
+        // When
+        f.onRequest(ApiKeys.METADATA, (short) 13, header, metadataRequest, MockFilterContext.builder(header, metadataRequest).build())
+                .toCompletableFuture().join();
+        f.onRequest(ApiKeys.PRODUCE, (short) 9, header, produceRequest, MockFilterContext.builder(header, produceRequest).build())
+                .toCompletableFuture().join();
+
+        // Then
+        var warnings = capturedLogs.logged(ProtocolLoggerFilter.class, Level.WARN);
+        LoggingEventAssert.assertThat(warnings).hasSize(2);
+        assertThat(warnings.get(0).getKeyValuePairs())
+                .anyMatch(kv -> "apiKey".equals(kv.key) && ApiKeys.METADATA.equals(kv.value));
+        assertThat(warnings.get(1).getKeyValuePairs())
+                .anyMatch(kv -> "apiKey".equals(kv.key) && ApiKeys.PRODUCE.equals(kv.value));
     }
 
 }

--- a/kroxylicious-filters/kroxylicious-protocol-logger/src/test/java/io/kroxylicious/filter/protocollogger/ProtocolLoggerFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-protocol-logger/src/test/java/io/kroxylicious/filter/protocollogger/ProtocolLoggerFilterTest.java
@@ -64,7 +64,7 @@ class ProtocolLoggerFilterTest {
 
     private final ProtocolLoggerFilter filter = new ProtocolLoggerFilter(
             EnumSet.allOf(ApiKeys.class), new MessageFormatter(), Level.DEBUG,
-            LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+            LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC(), ProtocolLoggerFilter.class.getName()));
 
     static Stream<Arguments> credentialBearingRequestsWithSecrets() {
         return Stream.of(
@@ -235,7 +235,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC(), ProtocolLoggerFilter.class.getName()));
 
         // When / Then
         assertThat(f.shouldHandleRequest(ApiKeys.METADATA, (short) 12)).isTrue();
@@ -246,7 +246,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC(), ProtocolLoggerFilter.class.getName()));
 
         // When / Then
         assertThat(f.shouldHandleResponse(ApiKeys.METADATA, (short) 12)).isTrue();
@@ -257,7 +257,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC(), ProtocolLoggerFilter.class.getName()));
 
         // When / Then
         assertThat(f.shouldHandleRequest(ApiKeys.PRODUCE, (short) 9)).isFalse();
@@ -268,7 +268,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC(), ProtocolLoggerFilter.class.getName()));
 
         // When / Then
         assertThat(f.shouldHandleResponse(ApiKeys.PRODUCE, (short) 9)).isFalse();
@@ -279,7 +279,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), new MessageFormatter(), Level.DEBUG,
-                NOPLogger.NOP_LOGGER, new LogWarningThrottle(Clock.systemUTC()));
+                NOPLogger.NOP_LOGGER, new LogWarningThrottle(Clock.systemUTC(), ProtocolLoggerFilter.class.getName()));
 
         // When / Then
         assertThat(f.shouldHandleRequest(ApiKeys.METADATA, (short) 12)).isFalse();
@@ -290,7 +290,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), new MessageFormatter(), Level.DEBUG,
-                NOPLogger.NOP_LOGGER, new LogWarningThrottle(Clock.systemUTC()));
+                NOPLogger.NOP_LOGGER, new LogWarningThrottle(Clock.systemUTC(), ProtocolLoggerFilter.class.getName()));
 
         // When / Then
         assertThat(f.shouldHandleResponse(ApiKeys.METADATA, (short) 12)).isFalse();
@@ -341,7 +341,7 @@ class ProtocolLoggerFilterTest {
         String customName = "test.custom.logger";
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(customName), new LogWarningThrottle(Clock.systemUTC()));
+                LoggerFactory.getLogger(customName), new LogWarningThrottle(Clock.systemUTC(), customName));
         RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
         MetadataRequestData request = new MetadataRequestData();
         MockFilterContext context = MockFilterContext.builder(header, request).build();
@@ -364,7 +364,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC(), ProtocolLoggerFilter.class.getName()));
         RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
         MetadataRequestData request = new MetadataRequestData();
         MockFilterContext context = MockFilterContext.builder(header, request).build();
@@ -384,7 +384,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.of(ApiKeys.METADATA), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC(), ProtocolLoggerFilter.class.getName()));
         ResponseHeaderData header = new ResponseHeaderData().setCorrelationId(1);
         MetadataResponseData response = new MetadataResponseData();
         MockFilterContext context = MockFilterContext.builder(header, response).build();
@@ -405,7 +405,7 @@ class ProtocolLoggerFilterTest {
         String plantedSecret = "PLANTED_SASL_SECRET_VALUE";
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC(), ProtocolLoggerFilter.class.getName()));
         RequestHeaderData header = new RequestHeaderData().setCorrelationId(5).setClientId("c1");
         SaslAuthenticateRequestData request = new SaslAuthenticateRequestData()
                 .setAuthBytes(plantedSecret.getBytes(StandardCharsets.UTF_8));
@@ -431,7 +431,7 @@ class ProtocolLoggerFilterTest {
         String plantedSecret = "PLANTED_DELEGATION_HMAC_SECRET";
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC(), ProtocolLoggerFilter.class.getName()));
         ResponseHeaderData header = new ResponseHeaderData().setCorrelationId(7);
         CreateDelegationTokenResponseData response = new CreateDelegationTokenResponseData()
                 .setHmac(plantedSecret.getBytes(StandardCharsets.UTF_8));
@@ -468,9 +468,9 @@ class ProtocolLoggerFilterTest {
     }
 
     private static LogWarningThrottle throwingThrottle() {
-        return new LogWarningThrottle(Clock.systemUTC()) {
+        return new LogWarningThrottle(Clock.systemUTC(), ProtocolLoggerFilter.class.getName()) {
             @Override
-            void onFailure(ApiKeys apiKey, short apiVersion, Exception exception, org.slf4j.Logger logger) {
+            void onFailure(ApiKeys apiKey, short apiVersion, Exception exception) {
                 throw new RuntimeException("throttle boom");
             }
         };
@@ -481,7 +481,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), throwingFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC(), ProtocolLoggerFilter.class.getName()));
         RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
         MetadataRequestData request = new MetadataRequestData();
         MockFilterContext context = MockFilterContext.builder(header, request).build();
@@ -502,7 +502,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), throwingFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC(), ProtocolLoggerFilter.class.getName()));
         ResponseHeaderData header = new ResponseHeaderData().setCorrelationId(1);
         MetadataResponseData response = new MetadataResponseData();
         MockFilterContext context = MockFilterContext.builder(header, response).build();
@@ -523,7 +523,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), throwingFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC(), ProtocolLoggerFilter.class.getName()));
         RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
         MetadataRequestData request = new MetadataRequestData();
         MockFilterContext context = MockFilterContext.builder(header, request).build();
@@ -532,10 +532,12 @@ class ProtocolLoggerFilterTest {
         f.onRequest(ApiKeys.METADATA, (short) 13, header, request, context).toCompletableFuture().join();
 
         // Then
-        var warnings = capturedLogs.logged(ProtocolLoggerFilter.class, Level.WARN);
+        var warnings = capturedLogs.logged(LogWarningThrottle.class, Level.WARN);
         LoggingEventAssert.assertThat(warnings).hasSize(1);
         assertThat(warnings.get(0).getKeyValuePairs())
                 .anyMatch(kv -> "apiKey".equals(kv.key) && ApiKeys.METADATA.equals(kv.value));
+        assertThat(warnings.get(0).getKeyValuePairs())
+                .anyMatch(kv -> "targetLogger".equals(kv.key) && ProtocolLoggerFilter.class.getName().equals(kv.value));
     }
 
     @Test
@@ -543,7 +545,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), throwingFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC(), ProtocolLoggerFilter.class.getName()));
         RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
         MetadataRequestData request = new MetadataRequestData();
         MockFilterContext context = MockFilterContext.builder(header, request).build();
@@ -561,7 +563,7 @@ class ProtocolLoggerFilterTest {
         // Given
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), new MessageFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC()));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(Clock.systemUTC(), ProtocolLoggerFilter.class.getName()));
         RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
         MetadataRequestData request = new MetadataRequestData();
         MockFilterContext context = MockFilterContext.builder(header, request).build();
@@ -572,7 +574,7 @@ class ProtocolLoggerFilterTest {
         // Then
         var debugEntries = capturedLogs.logged(ProtocolLoggerFilter.class, Level.DEBUG);
         LoggingEventAssert.assertThat(debugEntries).hasSize(1);
-        var warnings = capturedLogs.logged(ProtocolLoggerFilter.class, Level.WARN);
+        var warnings = capturedLogs.logged(LogWarningThrottle.class, Level.WARN);
         LoggingEventAssert.assertThat(warnings).isEmpty();
     }
 
@@ -582,7 +584,7 @@ class ProtocolLoggerFilterTest {
         Clock fixedClock = Clock.fixed(java.time.Instant.ofEpochMilli(1000), java.time.ZoneOffset.UTC);
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), throwingFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(fixedClock));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(fixedClock, ProtocolLoggerFilter.class.getName()));
         RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
         MetadataRequestData request = new MetadataRequestData();
 
@@ -593,7 +595,7 @@ class ProtocolLoggerFilterTest {
                 .toCompletableFuture().join();
 
         // Then
-        var warnings = capturedLogs.logged(ProtocolLoggerFilter.class, Level.WARN);
+        var warnings = capturedLogs.logged(LogWarningThrottle.class, Level.WARN);
         LoggingEventAssert.assertThat(warnings).hasSize(1);
     }
 
@@ -620,7 +622,7 @@ class ProtocolLoggerFilterTest {
         };
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), throwingFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(advanceableClock));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(advanceableClock, ProtocolLoggerFilter.class.getName()));
         RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
         MetadataRequestData request = new MetadataRequestData();
 
@@ -636,10 +638,14 @@ class ProtocolLoggerFilterTest {
                 .toCompletableFuture().join();
 
         // Then
-        var warnings = capturedLogs.logged(ProtocolLoggerFilter.class, Level.WARN);
+        var warnings = capturedLogs.logged(LogWarningThrottle.class, Level.WARN);
         LoggingEventAssert.assertThat(warnings).hasSize(2);
+        assertThat(warnings.get(0).getKeyValuePairs())
+                .anyMatch(kv -> "targetLogger".equals(kv.key) && ProtocolLoggerFilter.class.getName().equals(kv.value));
         assertThat(warnings.get(1).getKeyValuePairs())
                 .anyMatch(kv -> "suppressedCount".equals(kv.key) && Long.valueOf(2).equals(kv.value));
+        assertThat(warnings.get(1).getKeyValuePairs())
+                .anyMatch(kv -> "targetLogger".equals(kv.key) && ProtocolLoggerFilter.class.getName().equals(kv.value));
     }
 
     @Test
@@ -648,7 +654,7 @@ class ProtocolLoggerFilterTest {
         Clock fixedClock = Clock.fixed(java.time.Instant.ofEpochMilli(1000), java.time.ZoneOffset.UTC);
         ProtocolLoggerFilter f = new ProtocolLoggerFilter(
                 EnumSet.allOf(ApiKeys.class), throwingFormatter(), Level.DEBUG,
-                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(fixedClock));
+                LoggerFactory.getLogger(ProtocolLoggerFilter.class), new LogWarningThrottle(fixedClock, ProtocolLoggerFilter.class.getName()));
 
         RequestHeaderData header = new RequestHeaderData().setCorrelationId(1).setClientId("c1");
         MetadataRequestData metadataRequest = new MetadataRequestData();
@@ -661,7 +667,7 @@ class ProtocolLoggerFilterTest {
                 .toCompletableFuture().join();
 
         // Then
-        var warnings = capturedLogs.logged(ProtocolLoggerFilter.class, Level.WARN);
+        var warnings = capturedLogs.logged(LogWarningThrottle.class, Level.WARN);
         LoggingEventAssert.assertThat(warnings).hasSize(2);
         assertThat(warnings.get(0).getKeyValuePairs())
                 .anyMatch(kv -> "apiKey".equals(kv.key) && ApiKeys.METADATA.equals(kv.value));


### PR DESCRIPTION
Fixes #4669
 
Makes the `ProtocolLogger` filter failsafe: exceptions raised while building or emitting a log entry are caught and reported, and never affect message forwarding.
 
## The catch boundary
 
What the try block covers:
 
- **inside** — the converter lookup through to the emit call
- **outside** — `context.forwardRequest` / `context.forwardResponse`
Failures in *observing* a message are swallowed, because the filter is a passive observer and shouldn't be able to stop traffic. A failure in *forwarding* is the proxy's actual job failing — the message genuinely didn't reach its destination — so it propagates as before.
 
The entry is built inside a supplier passed to `.log(() -> ...)`, so the exception surfaces when the logging backend evaluates the supplier rather than where the supplier is created. There's a test asserting a message whose formatting throws is still forwarded, so the catch is verified to cover that point rather than assumed to.
 
Catches `Exception` rather than `Throwable`, so an `OutOfMemoryError` isn't swallowed. The throttle call is itself wrapped in a nested catch, so a failure in reporting the failure can't prevent forwarding either.
 
## Rate-limited warnings
 
Failures aren't swallowed silently — a visualisation filter that quietly drops entries is worse than one that fails visibly, since you'd be debugging with an incomplete picture and no indication anything was missing.
 
But a warning per failure would be a problem, because the filter runs the same code path for every message of a given API key. Which scenarios repeat, and how often:
 
| Cause | Repeats? |
|---|---|
| Missing converter entry for an API key | Every message of that key, indefinitely — the lookup depends only on the API key |
| Version-handling bug | Every message on that connection — a client negotiates its API versions once at setup and uses them for the connection's life |
| Data-dependent failure (unexpected null, unhandled field combination) | Intermittently, but Kafka traffic is repetitive — a consumer polling the same topics gets structurally identical responses |
 
`Fetch` is one of the highest-volume APIs because consumers poll continuously whether or not there is data, so the worst case is a warning per message indefinitely — enough to fill a disk and bury every other log the proxy writes. Even the intermittent case is hundreds per second on a busy cluster. A filter added to help with debugging would end up making debugging harder.
 
**How it's handled.** Warnings are throttled per API key:
 
- the first failure for a key warns immediately, with the exception
- subsequent failures for that key are counted silently
- after 5 minutes, the next failure warns again and reports how many were suppressed in between, so the scale stays visible
Throttling per key rather than globally means a second, unrelated failure isn't hidden behind the first. The interval is a constant rather than a config key.
 
Throttle state is per connection, matching the filter's own lifecycle — so a single misbehaving client is distinguishable from a systematically broken converter.
 
## Where warnings go
 
Warnings are emitted on `LogWarningThrottle`'s own logger, not the configured `loggerName`.
 
This matters because the protocol logger is often routed somewhere of its own — a separate file, an async appender, or off entirely when not investigating. Sending warnings there too would mean an operator watching the main proxy log never learns that formatting is failing, which is exactly when they need to know the trace is incomplete.
 
Protocol entries are unaffected and still go to the configured logger. The configured name is carried on the warning as a `targetLogger` key-value, so with several instances configured differently it's clear which one failed.
 
## Changes
 
**New — `LogWarningThrottle`**
Rate-limiting helper keyed by `ApiKeys`, tracking last-warned time and suppressed count per key. Takes a `Clock` for testability and the target logger name at construction, since it's fixed per filter instance. Emits on its own logger. Warnings carry structured key-values for `apiKey`, `apiVersion`, `targetLogger`, `error` and `suppressedCount`, with the full stacktrace only when DEBUG is enabled. Not thread-safe by design — filter instances are per-connection and confined to a single event loop thread.
 
**`ProtocolLoggerFilter`**
Takes a `LogWarningThrottle`. The logging path in `onRequest`/`onResponse` is wrapped in `try/catch(Exception)`, with a nested catch around the throttle call, then falls through to forwarding.
 
**`ProtocolLogger`**
Constructs the throttle with `Clock.systemUTC()` and the configured logger name.
 
**`README.md`**
New "Failure resilience" section covering the catch, the rate-limited warnings, where warnings are emitted, and that forwarding is never affected.
 
**Changelog**
`changelog/unreleased/04669-protocol-logger-failsafe.yaml`.
 
## Testing
 
80 tests in the module. New coverage:
 
- a message whose formatting throws is still forwarded unchanged, both directions
- a throttle that throws from `onFailure` also doesn't prevent forwarding
- the warning names the API key, carries `targetLogger`, and doesn't appear as a normal protocol entry
- warnings land on the throttle's logger while protocol entries still go to the configured one
- normal messages are unaffected — entry emitted, no warning
- first failure warns, an immediate second is suppressed
- a failure after the interval warns again with the correct suppressed count
- different API keys throttle independently
Interval behaviour is tested with `Clock.fixed` and an advanceable clock rather than sleeping.
 
Verified the tests aren't passing trivially: with the interval set to zero, `firstFailureWarnsButImmediateSecondIsSuppressed` fails with 2 warnings instead of 1, confirming both calls genuinely fail and the single-warning result is real suppression. Removing the nested catch makes the throttle-throws test fail, confirming that guard is load-bearing too.
 
🤖 Assisted by Claude Opus