### PR TITLE
test(routing): ignore exceptions in topic description assertions

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingPassThroughIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingPassThroughIT.java
@@ -423,10 +423,11 @@ class RoutingPassThroughIT {
 
             // When / Then
             await().atMost(Duration.ofSeconds(30)).untilAsserted(() -> {
-                var descriptions = admin.describeTopics(List.of(topicName)).allTopicNames().get(10, TimeUnit.SECONDS);
-                assertThat(descriptions.get(topicName).partitions())
-                        .singleElement()
-                        .satisfies(p -> assertThat(p.leader().id()).isEqualTo(1));
+                assertThat(admin.describeTopics(List.of(topicName)).allTopicNames().toCompletionStage().toCompletableFuture())
+                        .succeedsWithin(10, TimeUnit.SECONDS)
+                        .satisfies(descriptions -> assertThat(descriptions.get(topicName).partitions())
+                                .singleElement()
+                                .satisfies(p -> assertThat(p.leader().id()).isEqualTo(1)));
             });
         }
     }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/AuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/AuthzIT.java
@@ -426,9 +426,10 @@ public abstract class AuthzIT extends BaseIT {
                 .untilAsserted(() -> {
                     producer.initTransactions();
                     producer.beginTransaction();
-                    producer.send(new ProducerRecord<>("top", "", "")).get();
-                    var coordId = admin.describeTransactions(List.of(transactionalId)).all().toCompletionStage().toCompletableFuture()
-                            .join().get(transactionalId).coordinatorId();
+                    assertThat(producer.send(new ProducerRecord<>("top", "", ""))).succeedsWithin(Duration.ofSeconds(10));
+                    var describedTransactions = admin.describeTransactions(List.of(transactionalId)).all().toCompletionStage().toCompletableFuture();
+                    assertThat(describedTransactions).succeedsWithin(Duration.ofSeconds(10));
+                    var coordId = describedTransactions.join().get(transactionalId).coordinatorId();
                     producer.abortTransaction();
                     assertThat(coordId).isNotEqualTo(-1);
                 });

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/encryption/RecordEncryptionFilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/encryption/RecordEncryptionFilterIT.java
@@ -395,7 +395,7 @@ class RecordEncryptionFilterIT {
                     .atMost(Duration.ofSeconds(30))
                     .untilAsserted(() -> {
                         // async edek refresh will be trigger by the arrival of a message after edekExpiry
-                        producer.send(new ProducerRecord<>(topic.name(), message)).get(5, TimeUnit.SECONDS);
+                        assertThat(producer.send(new ProducerRecord<>(topic.name(), message))).succeedsWithin(5, TimeUnit.SECONDS);
                         assertMoreThanOneEdekUsed(topic, directConsumer);
                     });
         }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/multitenant/MultiTenantIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/multitenant/MultiTenantIT.java
@@ -337,9 +337,10 @@ class MultiTenantIT extends BaseMultiTenantIT {
                         Optional.of(transactionalId));
                 Awaitility.await().untilAsserted(() -> {
                     var describeTransactionsResult = admin.describeTransactions(List.of(transactionalId));
-                    var transactionMap = describeTransactionsResult.all().get();
-                    assertThat(transactionMap).hasEntrySatisfying(transactionalId,
-                            allOf(matches(TransactionDescription::state, TransactionState.COMPLETE_COMMIT)));
+                    assertThat(describeTransactionsResult.all().toCompletionStage().toCompletableFuture())
+                            .succeedsWithin(10, TimeUnit.SECONDS)
+                            .satisfies(transactionMap -> assertThat(transactionMap).hasEntrySatisfying(transactionalId,
+                                    allOf(matches(TransactionDescription::state, TransactionState.COMPLETE_COMMIT))));
                 });
             }
         }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

The test creates a topic and immediately calls `admin.describeTopics(...)` within an
`await().atMost(Duration.ofSeconds(30)).untilAsserted(...)` block.

- `admin.createTopics(...)` completes as soon as the controller accepts the creation request—this **does not**
guarantee that the topic metadata has already propagated to the broker that will handle the
subsequent `DescribeTopics` call.
- When `describeTopics` arrives before metadata propagation (a common race condition
in slower CI runners), `KafkaFuture.get()` throws an
`ExecutionException` caused by an `UnknownTopicOrPartitionException`.
- By default, Awaitility only retries when the lambda throws an `AssertionError`. Any other
exception (such as the `ExecutionException` mentioned above) escapes the retry mechanism
and causes the test to fail **immediately**, even if the 30-second window has not yet elapsed.
_Please describe your pull request_

In other words: the waiting window existed precisely to absorb this asynchronous propagation,
but the transient exception bypassed the retry.

### Additional Context

_Why are you making this pull request?_

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [X] PR references related GitHub issue(s) so they are closed on merging. Fixes: #4709 
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
