### PR TITLE
tactically disable javadoc generation on forked Kafka sources.

### DIFF
--- a/kroxylicious-docs/kroxylicious-api-javadoc/pom.xml
+++ b/kroxylicious-docs/kroxylicious-api-javadoc/pom.xml
@@ -82,11 +82,12 @@
                                 <dependencySourceInclude>io.kroxylicious:kroxylicious-authorizer-api</dependencySourceInclude>
                                 <dependencySourceInclude>io.kroxylicious:kroxylicious-kms</dependencySourceInclude>
                             </dependencySourceIncludes>
-                            <source>17</source>
+                            <source>${java.version}</source>
                             <detectJavaApiLink>true</detectJavaApiLink>
                             <detectLinks>false</detectLinks>
                             <failOnError>false</failOnError>
                             <failOnWarnings>false</failOnWarnings>
+                            <excludePackageNames>io.kroxylicious.kafka:io.kroxylicious.kafka.*</excludePackageNames>
                             <links>
                                 <link>https://javadoc.io/doc/org.apache.kafka/kafka-clients/${kafka.version}/</link>
                             </links>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Exclude forked Kafka sources from javadoc generation.

### Additional Context

Fixes
```
/Users/sbarker/src/kroxylicious/build-wrangling/kroxylicious-api/src/main/java/io/kroxylicious/kafka/common/utils/Utils.java:753: error: malformed HTML
     * @return Destination buffer or null if bytesToRead is < 0
                                                            ^
/Users/sbarker/src/kroxylicious/build-wrangling/kroxylicious-api/src/main/java/io/kroxylicious/kafka/common/compress/ZstdCompression.java:104: error: malformed HTML
     * This size should be <= ZSTD_BLOCKSIZE_MAX
                           ^
```

errors when trying to stage a release.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
