### PR TITLE
Don't enable tests-suites module when installing

### DIFF
--- a/.github/workflows/kubernetes-modules-maven.yaml
+++ b/.github/workflows/kubernetes-modules-maven.yaml
@@ -67,7 +67,7 @@ jobs:
         run: |
           source scripts/ci-build-functions.sh
           mvn --batch-mode \
-            --activate-profiles "!build-the-world,!qa" \
+            --activate-profiles "!build-the-world,!qa,!test-suites" \
             --activate-profiles "${PROXY_PROFILES}" \
             -DskipTests \
             -Derrorprone.skip=true \
@@ -79,7 +79,7 @@ jobs:
         run: |
           source scripts/ci-build-functions.sh
           mvn --batch-mode \
-            --activate-profiles "!build-the-world,!qa" \
+            --activate-profiles "!build-the-world,!qa,!test-suites" \
             --activate-profiles "${KUBERNETES_PROFILES},ci" \
             -Derrorprone.skip=true \
             -Djapicmp.skip=true \


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Prevent the system tests being built when installing proxy dependencies.

### Additional Context

Maven cache miss (https://github.com/kroxylicious/kroxylicious/actions/runs/32680658639/job/97296667426) highlighted the error.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
