### PR TITLE
fix(aws-kms): remove deprecated longTermCredentials and ec2MetadataCredentials fields

### DIFF
--- a/changelog/unreleased/03784-remove-deprecated-aws-kms-credential-fields.yaml
+++ b/changelog/unreleased/03784-remove-deprecated-aws-kms-credential-fields.yaml
@@ -1,0 +1,8 @@
+title: "fix(aws-kms): remove deprecated top-level credential fields"
+type: removed
+issues:
+  - 3784
+important_notes:
+  - |
+    The deprecated top-level `longTermCredentials` and `ec2MetadataCredentials` fields are removed from AWS KMS configuration.
+    Configure these providers under `credentials.longTerm` or `credentials.ec2Metadata` instead.

--- a/kroxylicious-docs/docs/_modules/record-encryption/aws-kms/snip-aws-kms-service-config-identity-ec2-metadata.adoc
+++ b/kroxylicious-docs/docs/_modules/record-encryption/aws-kms/snip-aws-kms-service-config-identity-ec2-metadata.adoc
@@ -35,5 +35,3 @@ where:
 **** `metadataEndpoint` (Optional) specifies the metadata endpoint used to obtain EC2 metadata. Defaults to `\http://169.254.169.254/`. If using IPv6, use `http://[fd00:ec2::254]` instead.
 **** `credentialLifetimeFactor` (Optional) defines the factor used to determine when to refresh a credential before it expires. Defaults to `0.8`, which means the credential is refreshed once it reaches 80% of its lifetime.
 ** `region` defines the AWS region identifier where KMS resources are located, such as `us-east-1`. This must match the region of the KMS endpoint you're using.
-
-NOTE: The legacy top-level `ec2MetadataCredentials` key is deprecated but continues to work for backward compatibility. New configurations should use `credentials.ec2Metadata` instead.

--- a/kroxylicious-docs/docs/_modules/record-encryption/aws-kms/snip-aws-kms-service-config-identity-long-term.adoc
+++ b/kroxylicious-docs/docs/_modules/record-encryption/aws-kms/snip-aws-kms-service-config-identity-long-term.adoc
@@ -37,5 +37,3 @@ where:
 **** `accessKeyId` references a file containing the AWS access key ID.
 **** `secretAccessKey` references a file containing the AWS secret access key.
 ** `region` defines the AWS region identifier where KMS resources are located, such as `us-east-1`. This must match the region of the KMS endpoint you're using.
-
-NOTE: The legacy top-level `longTermCredentials` key is deprecated but continues to work for backward compatibility. New configurations should use `credentials.longTerm` instead.

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms-test-support/src/main/java/io/kroxylicious/testing/kms/aws/AbstractAwsKmsTestKmsFacade.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms-test-support/src/main/java/io/kroxylicious/testing/kms/aws/AbstractAwsKmsTestKmsFacade.java
@@ -103,7 +103,7 @@ public abstract class AbstractAwsKmsTestKmsFacade implements TestKmsFacade<Confi
     public Config getKmsServiceConfig() {
         var credentialsProviderConfig = new LongTermCredentialsProviderConfig(new InlinePassword(getAccessKey()), new InlinePassword(getSecretKey()));
         var credentials = new CredentialsConfig(credentialsProviderConfig, null, null, null);
-        return new Config(getAwsUrl(), null, null, credentials, getRegion(), null);
+        return new Config(getAwsUrl(), credentials, getRegion(), null);
     }
 
     /**

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/config/Config.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/config/Config.java
@@ -28,6 +28,14 @@ public record Config(@JsonProperty(value = "endpointUrl", required = true) URI e
                      @JsonProperty(value = "region", required = true) String region,
                      @JsonProperty(value = "tls", required = false) @Nullable Tls tls) {
 
+    /**
+     * Creates the AWS KMS configuration.
+     *
+     * @param endpointUrl URL of the AWS KMS endpoint.
+     * @param credentials grouped credential provider configuration.
+     * @param region AWS region.
+     * @param tls TLS settings.
+     */
     public Config {
         Objects.requireNonNull(endpointUrl);
         Objects.requireNonNull(credentials);

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/config/Config.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/config/Config.java
@@ -10,9 +10,7 @@ import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonProperty.Access;
 
-import io.kroxylicious.kms.service.KmsException;
 import io.kroxylicious.proxy.config.tls.Tls;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -21,60 +19,19 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * Configuration for the AWS KMS service.
  *
  * @param endpointUrl URL of the AWS KMS e.g. {@code https://kms.us-east-1.amazonaws.com}
- * @param longTermCredentialsProviderConfig <b>deprecated</b> — use {@code credentials.longTerm} instead.
- *                                          Config for long-term credentials (access key id and secret access key).
- * @param ec2MetadataCredentialsProviderConfig <b>deprecated</b> — use {@code credentials.ec2Metadata} instead.
- *                                             Config obtaining credentials from EC2 metadata.
  * @param credentials grouped credential provider configuration.
  * @param region AWS region
  * @param tls TLS settings
  */
 public record Config(@JsonProperty(value = "endpointUrl", required = true) URI endpointUrl,
-                     @Deprecated(since = "0.21.0", forRemoval = true) @JsonProperty(value = "longTermCredentials", required = false, access = Access.WRITE_ONLY) @Nullable LongTermCredentialsProviderConfig longTermCredentialsProviderConfig,
-                     @Deprecated(since = "0.21.0", forRemoval = true) @JsonProperty(value = "ec2MetadataCredentials", required = false, access = Access.WRITE_ONLY) @Nullable Ec2MetadataCredentialsProviderConfig ec2MetadataCredentialsProviderConfig,
-                     @JsonProperty(value = "credentials", required = false) @Nullable CredentialsConfig credentials,
+                     @JsonProperty(value = "credentials", required = true) CredentialsConfig credentials,
                      @JsonProperty(value = "region", required = true) String region,
                      @JsonProperty(value = "tls", required = false) @Nullable Tls tls) {
 
-    /**
-     * Creates the configuration, migrating any deprecated flat credential fields into the
-     * {@code credentials} node.
-     *
-     * @param endpointUrl URL of the AWS KMS e.g. {@code https://kms.us-east-1.amazonaws.com}
-     * @param longTermCredentialsProviderConfig <b>deprecated</b> — use {@code credentials.longTerm} instead.
-     *                                          Config for long-term credentials (access key id and secret access key).
-     * @param ec2MetadataCredentialsProviderConfig <b>deprecated</b> — use {@code credentials.ec2Metadata} instead.
-     *                                             Config obtaining credentials from EC2 metadata.
-     * @param credentials grouped credential provider configuration.
-     * @param region AWS region
-     * @param tls TLS settings
-     */
     public Config {
         Objects.requireNonNull(endpointUrl);
+        Objects.requireNonNull(credentials);
         Objects.requireNonNull(region);
-
-        // Migrate deprecated flat credential fields into the credentials node.
-        // Old-style YAML (longTermCredentials / ec2MetadataCredentials at the top level)
-        // continues to work but cannot be combined with each other or with the new credentials node.
-        // On serialization these deprecated fields are omitted (JsonProperty.Access.WRITE_ONLY),
-        // so round-trip through YAML always produces the new 'credentials' form.
-        if (longTermCredentialsProviderConfig != null && ec2MetadataCredentialsProviderConfig != null) {
-            throw new KmsException(
-                    "Cannot specify both deprecated 'longTermCredentials' and 'ec2MetadataCredentials' — use the 'credentials' node with a single provider instead");
-        }
-        if (credentials != null && (longTermCredentialsProviderConfig != null || ec2MetadataCredentialsProviderConfig != null)) {
-            var deprecatedField = longTermCredentialsProviderConfig != null ? "longTermCredentials" : "ec2MetadataCredentials";
-            throw new KmsException(
-                    "Cannot specify both 'credentials' and deprecated '" + deprecatedField + "' — use the 'credentials' node only");
-        }
-        if (credentials == null) {
-            if (longTermCredentialsProviderConfig != null) {
-                credentials = new CredentialsConfig(longTermCredentialsProviderConfig, null, null, null);
-            }
-            else if (ec2MetadataCredentialsProviderConfig != null) {
-                credentials = new CredentialsConfig(null, ec2MetadataCredentialsProviderConfig, null, null);
-            }
-        }
     }
 
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsServiceTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsServiceTest.java
@@ -22,7 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.kroxylicious.kms.provider.aws.kms.config.Config;
-import io.kroxylicious.kms.provider.aws.kms.config.LongTermCredentialsProviderConfig;
+import io.kroxylicious.kms.provider.aws.kms.config.CredentialsConfig;
 import io.kroxylicious.kms.provider.aws.kms.credentials.CredentialsProvider;
 import io.kroxylicious.kms.provider.aws.kms.credentials.CredentialsProviderFactory;
 import io.kroxylicious.proxy.config.tls.AllowDeny;
@@ -41,7 +41,7 @@ class AwsKmsServiceTest {
     private CredentialsProviderFactory factory;
 
     @Mock
-    private LongTermCredentialsProviderConfig longTermCredentialsProviderConfig;
+    private CredentialsConfig credentialsConfig;
 
     @Mock
     private CredentialsProvider credentialsProvider;
@@ -63,7 +63,7 @@ class AwsKmsServiceTest {
     @SuppressWarnings("resource")
     void initializeCreatesCredentialsProvider() {
         // Given
-        var config = new Config(URI.create("https://host.invalid"), longTermCredentialsProviderConfig, null, null, "us-east-1", null);
+        var config = new Config(URI.create("https://host.invalid"), credentialsConfig, "us-east-1", null);
 
         // When
         awsKmsService.initialize(config);
@@ -81,7 +81,7 @@ class AwsKmsServiceTest {
     @Test
     void credentialsProviderLifecycle() {
         // Given
-        var config = new Config(URI.create("https://host.invalid"), longTermCredentialsProviderConfig, null, null, "us-east-1", null);
+        var config = new Config(URI.create("https://host.invalid"), credentialsConfig, "us-east-1", null);
         awsKmsService.initialize(config);
 
         // When
@@ -95,7 +95,7 @@ class AwsKmsServiceTest {
     void applesTlsConfiguration() {
         var validButUnusualCipherSuite = "TLS_EMPTY_RENEGOTIATION_INFO_SCSV"; // Valid suite, but not a true cipher
         var config = new Config(URI.create("https://host.invalid"),
-                longTermCredentialsProviderConfig, null, null, "us-east1", new Tls(null, null, new AllowDeny<>(
+                credentialsConfig, "us-east1", new Tls(null, null, new AllowDeny<>(
                         List.of(validButUnusualCipherSuite), null), null, null));
         awsKmsService.initialize(
                 config);

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import com.github.tomakehurst.wiremock.WireMockServer;
 
 import io.kroxylicious.kms.provider.aws.kms.config.Config;
+import io.kroxylicious.kms.provider.aws.kms.config.CredentialsConfig;
 import io.kroxylicious.kms.provider.aws.kms.config.LongTermCredentialsProviderConfig;
 import io.kroxylicious.kms.provider.aws.kms.model.DescribeKeyRequest;
 import io.kroxylicious.kms.service.DekPair;
@@ -64,7 +65,8 @@ class AwsKmsTest {
     @BeforeEach
     void beforeEach() {
         var longTermCredentialsProviderConfig = new LongTermCredentialsProviderConfig(new InlinePassword("access"), new InlinePassword("secret"));
-        var config = new Config(URI.create(server.baseUrl()), longTermCredentialsProviderConfig, null, null, "us-west-2", null);
+        var credentials = new CredentialsConfig(longTermCredentialsProviderConfig, null, null, null);
+        var config = new Config(URI.create(server.baseUrl()), credentials, "us-west-2", null);
         awsKmsService = new AwsKmsService();
         awsKmsService.initialize(config);
         kms = awsKmsService.buildKms();

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/credentials/CredentialsProviderFactoryTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/credentials/CredentialsProviderFactoryTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import io.kroxylicious.kms.provider.aws.kms.config.Config;
@@ -30,8 +31,6 @@ class CredentialsProviderFactoryTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(YAMLFactory.builder().build());
     private static final CredentialsProviderFactory FACTORY = CredentialsProviderFactory.DEFAULT;
-
-    // --- New-style credentials node ---
 
     @Test
     void longTermCredentialsNewStyle() {
@@ -117,54 +116,6 @@ class CredentialsProviderFactoryTest {
         cp.close();
     }
 
-    // --- Backward-compat: deprecated flat fields ---
-
-    @Test
-    void longTermCredentialsBackwardCompat() {
-        var config = buildConfig("""
-                endpointUrl: https://unused.invalid
-                region: unused
-                longTermCredentials:
-                    accessKeyId:
-                        password: accessKeyId
-                    secretAccessKey:
-                        password: secretAccessKey
-                """);
-
-        var cp = FACTORY.createCredentialsProvider(config);
-
-        assertThat(cp)
-                .asInstanceOf(InstanceOfAssertFactories.type(LongTermCredentialsProvider.class))
-                .satisfies(ltcp -> {
-                    assertThat(ltcp.getCredentials())
-                            .succeedsWithin(Duration.ofSeconds(1))
-                            .satisfies(c -> {
-                                assertThat(c.accessKeyId()).isEqualTo("accessKeyId");
-                                assertThat(c.secretAccessKey()).isEqualTo("secretAccessKey");
-                            });
-                });
-        cp.close();
-    }
-
-    @Test
-    void ec2MetadataCredentialsBackwardCompat() {
-        var config = buildConfig("""
-                endpointUrl: https://unused.invalid
-                region: unused
-                ec2MetadataCredentials:
-                    iamRole: foo
-                """);
-
-        var cp = FACTORY.createCredentialsProvider(config);
-
-        assertThat(cp)
-                .isInstanceOf(Ec2MetadataCredentialsProvider.class)
-                .isNotNull();
-        cp.close();
-    }
-
-    // --- Invalid configs ---
-
     public static Stream<Arguments> invalidConfig() {
         return Stream.of(
                 Arguments.argumentSet("no credential provider", """
@@ -193,30 +144,6 @@ class CredentialsProviderFactoryTest {
                                 podIdentity:
                                     credentialsFullUri: http://169.254.170.23/v1/credentials
                                     authorizationTokenFile: /tmp/agent-token
-                        """),
-                Arguments.argumentSet("deprecated longTerm and ec2Metadata conflict", """
-                            endpointUrl: https://unused.invalid
-                            region: unused
-                            longTermCredentials:
-                                accessKeyId:
-                                    password: accessKeyId
-                                secretAccessKey:
-                                    password: secretAccessKey
-                            ec2MetadataCredentials:
-                                iamRole: foo
-                        """),
-                Arguments.argumentSet("deprecated flat field with credentials node conflict", """
-                            endpointUrl: https://unused.invalid
-                            region: us-east-1
-                            longTermCredentials:
-                                accessKeyId:
-                                    password: accessKeyId
-                                secretAccessKey:
-                                    password: secretAccessKey
-                            credentials:
-                                webIdentity:
-                                    roleArn: arn:aws:iam::123456789012:role/r
-                                    webIdentityTokenFile: /tmp/token
                         """));
     }
 
@@ -224,15 +151,10 @@ class CredentialsProviderFactoryTest {
     @MethodSource("invalidConfig")
     @SuppressWarnings("resource")
     void rejectsInvalidConfig(String yaml) {
-        // KmsException may be thrown directly (factory-time) or wrapped in
-        // ValueInstantiationException (deserialization-time, e.g. when the
-        // compact constructor rejects conflicting deprecated + new-style fields).
-        assertThatThrownBy(() -> {
-            var config = buildConfig(yaml);
-            FACTORY.createCredentialsProvider(config);
-        }).satisfiesAnyOf(
-                t -> assertThat(t).isInstanceOf(KmsException.class),
-                t -> assertThat(t).rootCause().isInstanceOf(KmsException.class));
+        assertThatThrownBy(() -> FACTORY.createCredentialsProvider(buildConfig(yaml)))
+                .satisfiesAnyOf(
+                        t -> assertThat(t).isInstanceOf(KmsException.class),
+                        t -> assertThat(t).rootCause().isInstanceOf(MismatchedInputException.class));
     }
 
     private Config buildConfig(String content) {

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/kms/aws/KubeAwsKmsCloudTestKmsFacade.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/kms/aws/KubeAwsKmsCloudTestKmsFacade.java
@@ -62,7 +62,7 @@ public class KubeAwsKmsCloudTestKmsFacade extends AbstractAwsKmsTestKmsFacade {
         var longTermCredentialsProviderConfig = new LongTermCredentialsProviderConfig(new InlinePassword(getKroxyliciousAccessKey()),
                 new InlinePassword(getKroxyliciousSecretKey()));
         var credentials = new CredentialsConfig(longTermCredentialsProviderConfig, null, null, null);
-        return new Config(getAwsUrl(), null, null, credentials, getRegion(), null);
+        return new Config(getAwsUrl(), credentials, getRegion(), null);
     }
 
     @Override


### PR DESCRIPTION
### Type of change

- Refactoring
- Documentation

### Description

Remove the deprecated top-level `longTermCredentials` and
`ec2MetadataCredentials` fields from the AWS KMS `Config` record.

The `credentials` node is now the sole configuration path for AWS
credential providers and is required. Existing call sites, tests, test
support, system tests, and user-facing configuration snippets now use
the nested provider forms:

- `credentials.longTerm`
- `credentials.ec2Metadata`
- `credentials.webIdentity`
- `credentials.podIdentity`

### Additional Context

The two top-level fields were deprecated in 0.21.0 and are now eligible
for removal under the project's deprecation policy. This change removes
the migration and conflict-validation code associated with the legacy
fields.

Closes #3784

### Checklist

- [x] New tests updated for the supported nested credential configurations.
- [x] User-facing documentation updated.
- [x] Changelog entry added under `changelog/unreleased/`.
- [x] Related GitHub issue referenced.
- [x] Focused AWS KMS tests pass.
- [ ] Full local test suite: blocked by the existing Windows `mkfifo`
      environment prerequisite in `UtilsTest.testFileAsStringNamedPipe`.
- [x] Commit includes both `Assisted-by:` and `Signed-off-by:` trailers.