### PR TITLE
ci(cache): use week-based key and restrict cache writes to maven.yaml

### DIFF
--- a/.github/actions/common/cache-maven-packages/action.yml
+++ b/.github/actions/common/cache-maven-packages/action.yml
@@ -38,7 +38,6 @@ runs:
           ~/.m2
           !~/.m2/repository/io/kroxylicious
         key: ${{ runner.os }}-m2-week-${{ steps.week.outputs.week }}
-        restore-keys: ${{ runner.os }}-m2-week-
     - name: 'Cache Maven packages (read-write)'
       if: ${{ inputs.read-only == 'false' }}
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -47,4 +46,3 @@ runs:
           ~/.m2
           !~/.m2/repository/io/kroxylicious
         key: ${{ runner.os }}-m2-week-${{ steps.week.outputs.week }}
-        restore-keys: ${{ runner.os }}-m2-week-

--- a/.github/actions/common/cache-maven-packages/action.yml
+++ b/.github/actions/common/cache-maven-packages/action.yml
@@ -18,14 +18,33 @@
 name: "Cache Maven Packages"
 description: "Cache Maven Packages"
 
+inputs:
+  read-only:
+    description: 'If true, only restore the cache (never save). Set to false in maven.yaml to allow writing.'
+    default: 'true'
+
 runs:
   using: "composite"
   steps:
-    - name: 'Cache Maven packages'
+    - name: 'Compute week cache key'
+      id: week
+      shell: bash
+      run: echo "week=$(date -u +%G-W%V)" >> $GITHUB_OUTPUT
+    - name: 'Restore Maven packages (read-only)'
+      if: ${{ inputs.read-only == 'true' }}
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      with:
+        path: |
+          ~/.m2
+          !~/.m2/repository/io/kroxylicious
+        key: ${{ runner.os }}-m2-week-${{ steps.week.outputs.week }}
+        restore-keys: ${{ runner.os }}-m2-week-
+    - name: 'Cache Maven packages (read-write)'
+      if: ${{ inputs.read-only == 'false' }}
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
       with:
         path: |
           ~/.m2
           !~/.m2/repository/io/kroxylicious
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+        key: ${{ runner.os }}-m2-week-${{ steps.week.outputs.week }}
+        restore-keys: ${{ runner.os }}-m2-week-

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -73,6 +73,8 @@ jobs:
           echo "REFERENCE_RELEASE_UNPUBLISHED=$(mvn --quiet dependency:get -Dartifact=io.kroxylicious:kroxylicious-parent:${REFERENCE_RELEASE}:pom 1>/dev/null && echo false || echo true)" >> $GITHUB_ENV
       - name: 'Cache Maven packages'
         uses: $/.github/actions/common/cache-maven-packages
+        with:
+          read-only: 'false'
       - name: 'Unit test all modules'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -132,8 +134,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Setup Java
         uses: $/.github/actions/common/setup-java
-      - name: 'Cache Maven packages'
-        uses: $/.github/actions/common/cache-maven-packages
       - name: 'Determine project version'
         id: version
         run: echo "version=$(mvn --quiet help:evaluate -Dexpression=project.version -DforceStdout)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -134,6 +134,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Setup Java
         uses: $/.github/actions/common/setup-java
+      - name: 'Cache Maven packages'
+        uses: $/.github/actions/common/cache-maven-packages
       - name: 'Determine project version'
         id: version
         run: echo "version=$(mvn --quiet help:evaluate -Dexpression=project.version -DforceStdout)" >> "$GITHUB_OUTPUT"

--- a/pom.xml
+++ b/pom.xml
@@ -856,9 +856,18 @@
                                 junit.jupiter.extensions.autodetection.enabled=true
                             </configurationParameters>
                         </properties>
-                        <additionalClasspathElements>
-                            <additionalClasspathElement>${settings.localRepository}/io/github/sambarker/logsquelcher/${logsquelcher.version}/logsquelcher-${logsquelcher.version}.jar</additionalClasspathElement>
-                        </additionalClasspathElements>
+                        <additionalClasspathDependencies>
+                            <dependency>
+                                <groupId>io.github.sambarker</groupId>
+                                <artifactId>logsquelcher</artifactId>
+                                <version>${logsquelcher.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.mockito</groupId>
+                                <artifactId>mockito-core</artifactId>
+                                <version>${mockito.version}</version>
+                            </dependency>
+                        </additionalClasspathDependencies>
                         <systemPropertyVariables>
                             <io.netty.leakDetection.level>paranoid</io.netty.leakDetection.level>
                             <container.logs.dir>${project.build.directory}/container-logs/</container.logs.dir>
@@ -933,9 +942,18 @@
                                 junit.jupiter.extensions.autodetection.enabled=true
                             </configurationParameters>
                         </properties>
-                        <additionalClasspathElements>
-                            <additionalClasspathElement>${settings.localRepository}/io/github/sambarker/logsquelcher/${logsquelcher.version}/logsquelcher-${logsquelcher.version}.jar</additionalClasspathElement>
-                        </additionalClasspathElements>
+                        <additionalClasspathDependencies>
+                            <dependency>
+                                <groupId>io.github.sambarker</groupId>
+                                <artifactId>logsquelcher</artifactId>
+                                <version>${logsquelcher.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.mockito</groupId>
+                                <artifactId>mockito-core</artifactId>
+                                <version>${mockito.version}</version>
+                            </dependency>
+                        </additionalClasspathDependencies>
                         <systemPropertyVariables>
                             <slf4j.provider>io.github.sambarker.logsquelcher.LogSquelcherSLF4JProvider</slf4j.provider>
                         </systemPropertyVariables>


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Every job that used `cache-maven-packages` could write a new cache entry, causing uncontrolled churn: whichever job happened to finish first on a given run set the cache for all subsequent runs, with no consistent dependency set behind it.

`cache-maven-packages` now defaults to read-only mode, using `actions/cache/restore` so jobs restore the cache but never save it. Only the `unittest_all` job in `maven.yaml` sets `read-only: false`, making it the sole writer. That job runs on every PR and push to main and performs the broadest Maven build, so it downloads the most complete dependency set.

The cache key switches from a `pom.xml` hash to a UTC ISO week number (`YYYY-Www`). All jobs in a given week share one key, and the cache rotates weekly to pick up new dependencies. A `restore-keys` prefix allows fallback to the previous week's cache on the first run of a new week.

Also closes #4742 by adding mockito to failsafe classpaths, this isn't ideal but prevents tests failing when run with no maven cache. We use an argLine to add mockito-core to the classpath but nothing told maven it needed to download the dependency first.

### Checklist

- [x] Existing unit/integration/system tests passing.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.