### PR TITLE
test(operator): isolate IT resource names with per-invocation suffix

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/OperatorTestUtils.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/OperatorTestUtils.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.testing.operator;
 
 import java.util.Objects;
+import java.util.UUID;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
@@ -64,6 +65,20 @@ public class OperatorTestUtils {
      */
     public static boolean isKubeClientAvailable() {
         return isKubeClientAvailable(PRESENCE_PROBING_KUBE_CLIENT_BUILD);
+    }
+
+    /**
+     * A unique, hyphen-prefixed suffix (e.g. {@code "-a1b2c3d4"}), used to isolate resource names
+     * per test invocation so that stale reconciler events from a completed test cannot race
+     * resources created by the next test with the same name. See #4527 / #4533.
+     * <p>
+     * The leading hyphen means callers can append it directly to a base name without adding their
+     * own separator, e.g. {@code "proxy-a" + uniqueSuffix()}.
+     *
+     * @return a unique, hyphen-prefixed suffix
+     */
+    public static String uniqueSuffix() {
+        return "-" + UUID.randomUUID().toString().substring(0, 8);
     }
 
     @VisibleForTesting

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/OperatorTestUtilsTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/OperatorTestUtilsTest.java
@@ -59,4 +59,23 @@ class OperatorTestUtilsTest {
         when(builder.build()).thenReturn(null);
         assertThat(OperatorTestUtils.isKubeClientAvailable(builder)).isFalse();
     }
+
+    @Test
+    void uniqueSuffixShouldBeHyphenPrefixed() {
+        // When
+        var suffix = OperatorTestUtils.uniqueSuffix();
+
+        // Then
+        assertThat(suffix).startsWith("-");
+    }
+
+    @Test
+    void uniqueSuffixShouldBeUniquePerInvocation() {
+        // When
+        var first = OperatorTestUtils.uniqueSuffix();
+        var second = OperatorTestUtils.uniqueSuffix();
+
+        // Then
+        assertThat(first).isNotEqualTo(second);
+    }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
@@ -77,6 +76,7 @@ import io.kroxylicious.testing.operator.OperatorTestUtils;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.STRIMZI_CLUSTER_CA_BUNDLE;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.STRIMZI_CLUSTER_CA_CERT_SECRET_SUFFIX;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
+import static io.kroxylicious.testing.operator.OperatorTestUtils.uniqueSuffix;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -135,17 +135,11 @@ class AllReconcilersIT {
         externalOperator = operator.externalOperator();
     }
 
-    // unique per-test suffix to avoid stale reconciler events from a previous test
-    // racing against resources created by the next test with the same name
-    private static String uniqueSuffix() {
-        return UUID.randomUUID().toString().substring(0, 8);
-    }
-
     @Test
     void emptyProxyIsAllowed() {
         // Given
         var suffix = uniqueSuffix();
-        var myProxy = editableProxy(PROXY_A + "-" + suffix).build();
+        var myProxy = editableProxy(PROXY_A + suffix).build();
 
         // When
         createAll(myProxy);
@@ -160,7 +154,7 @@ class AllReconcilersIT {
                         (BiFunction<ClusterUser, String, KafkaProtocolFilter>) ((actor, suffix) -> null)),
                 argumentSet("filter with simple config", uniqueSuffix(),
                         (BiFunction<ClusterUser, String, KafkaProtocolFilter>) ((actor, suffix) -> {
-                            var filter = editableFilter(CLUSTER_FOO_FILTER + "-" + suffix).build();
+                            var filter = editableFilter(CLUSTER_FOO_FILTER + suffix).build();
                             actor.create(filter);
                             return filter;
                         })),
@@ -169,13 +163,13 @@ class AllReconcilersIT {
                         // @formatter:off
                             var filterConfigMap = new ConfigMapBuilder()
                                     .withNewMetadata()
-                                    .withName("filter-configmap-" + suffix)
+                                    .withName("filter-configmap" + suffix)
                                     .endMetadata()
                                     .addToData("key", "value")
                                     .build();
-                            var filter = editableFilter(CLUSTER_FOO_FILTER + "-" + suffix)
+                            var filter = editableFilter(CLUSTER_FOO_FILTER + suffix)
                                     .editOrNewSpec()
-                                        .withConfigTemplate(Map.of("configMapProp", "${configmap:filter-configmap-" + suffix + ":key}"))
+                                        .withConfigTemplate(Map.of("configMapProp", "${configmap:filter-configmap" + suffix + ":key}"))
                                     .endSpec()
                                     .build();
                             // @formatter:on
@@ -189,9 +183,9 @@ class AllReconcilersIT {
     @MethodSource("filterScenarios")
     void singleVirtualCluster(String suffix, BiFunction<ClusterUser, String, KafkaProtocolFilter> filterFunc) {
         // Given
-        var myProxy = editableProxy(PROXY_A + "-" + suffix).build();
+        var myProxy = editableProxy(PROXY_A + suffix).build();
         // @formatter:off
-        var myIngress = editableIngress(CLUSTER_FOO_CLUSTER_IP_INGRESS + "-" + suffix, myProxy)
+        var myIngress = editableIngress(CLUSTER_FOO_CLUSTER_IP_INGRESS + suffix, myProxy)
                 .editOrNewSpec()
                     .withNewClusterIP()
                         .withProtocol(Protocol.TCP)
@@ -199,11 +193,11 @@ class AllReconcilersIT {
                 .endSpec()
                 .build();
         // @formatter:on
-        var myService = editableService(CLUSTER_FOO_SERVICE + "-" + suffix).build();
+        var myService = editableService(CLUSTER_FOO_SERVICE + suffix).build();
 
         var myFilter = filterFunc.apply(clusterUser, suffix);
 
-        var myCluster = editableVirtualCluster(CLUSTER_FOO + "-" + suffix, myProxy, myService, List.of(myIngress), Optional.ofNullable(myFilter).stream().toList())
+        var myCluster = editableVirtualCluster(CLUSTER_FOO + suffix, myProxy, myService, List.of(myIngress), Optional.ofNullable(myFilter).stream().toList())
                 .build();
 
         // When
@@ -219,8 +213,8 @@ class AllReconcilersIT {
         // The accepted condition and ingresses may be set in separate reconciliation cycles,
         // so we wait explicitly for the ingresses to be populated rather than checking the
         // snapshot returned when the accepted condition first became true.
-        AWAIT.alias("cluster %s has ingresses with bootstrap servers".formatted(CLUSTER_FOO + "-" + suffix))
-                .untilAsserted(() -> assertThat(clusterUser.get(VirtualKafkaCluster.class, CLUSTER_FOO + "-" + suffix))
+        AWAIT.alias("cluster %s has ingresses with bootstrap servers".formatted(CLUSTER_FOO + suffix))
+                .untilAsserted(() -> assertThat(clusterUser.get(VirtualKafkaCluster.class, CLUSTER_FOO + suffix))
                         .isNotNull()
                         .extracting(VirtualKafkaCluster::getStatus)
                         .satisfies(vcs -> assertThat(vcs)
@@ -239,10 +233,10 @@ class AllReconcilersIT {
         // Given
         var suffix = uniqueSuffix();
         var domain = OpenShiftUtils.getDefaultIngressControllerDomain();
-        var myProxy = editableProxy(PROXY_A + "-" + suffix).build();
-        var myService = editableService(CLUSTER_FOO_SERVICE + "-" + suffix).build();
+        var myProxy = editableProxy(PROXY_A + suffix).build();
+        var myService = editableService(CLUSTER_FOO_SERVICE + suffix).build();
         // @formatter:off
-        var myIngress = editableIngress(CLUSTER_FOO_CLUSTER_IP_INGRESS + "-" + suffix, myProxy)
+        var myIngress = editableIngress(CLUSTER_FOO_CLUSTER_IP_INGRESS + suffix, myProxy)
                 .editOrNewSpec()
                     .withNewOpenShiftRoute()
                     .endOpenShiftRoute()
@@ -251,7 +245,7 @@ class AllReconcilersIT {
                 .build();
         var tlsCert = new SecretBuilder()
                 .withNewMetadata()
-                    .withName("downstream-tls-certificate-" + suffix)
+                    .withName("downstream-tls-certificate" + suffix)
                 .endMetadata()
                 .withType("kubernetes.io/tls")
                 .addToStringData("tls.crt", TestKeyMaterial.TEST_CERT_PEM)
@@ -267,7 +261,7 @@ class AllReconcilersIT {
                 .build();
         var myCluster = new VirtualKafkaClusterBuilder()
                 .withNewMetadata()
-                    .withName(CLUSTER_FOO + "-" + suffix)
+                    .withName(CLUSTER_FOO + suffix)
                 .endMetadata()
                 .withNewSpec()
                     .withNewProxyRef()
@@ -284,8 +278,8 @@ class AllReconcilersIT {
 
         // Then
         assertResourceAttainsCondition(AllReconcilersIT::resourceAccepted, myCluster);
-        AWAIT.alias("cluster %s has route-based bootstrap server".formatted(CLUSTER_FOO + "-" + suffix))
-                .untilAsserted(() -> assertThat(clusterUser.get(VirtualKafkaCluster.class, CLUSTER_FOO + "-" + suffix))
+        AWAIT.alias("cluster %s has route-based bootstrap server".formatted(CLUSTER_FOO + suffix))
+                .untilAsserted(() -> assertThat(clusterUser.get(VirtualKafkaCluster.class, CLUSTER_FOO + suffix))
                         .isNotNull()
                         .extracting(VirtualKafkaCluster::getStatus)
                         .satisfies(vcs -> assertThat(vcs)
@@ -304,7 +298,7 @@ class AllReconcilersIT {
                         // @formatter:off
                             var trust = new SecretBuilder()
                                     .withNewMetadata()
-                                        .withName("upstream-trust-" + suffix)
+                                        .withName("upstream-trust" + suffix)
                                     .endMetadata()
                                     .addToStringData("trust.pem", TestKeyMaterial.TEST_CERT_PEM)
                                     .build();
@@ -326,7 +320,7 @@ class AllReconcilersIT {
                         // @formatter:off
                             var trust = new SecretBuilder()
                                     .withNewMetadata()
-                                        .withName("upstream-trust-" + suffix)
+                                        .withName("upstream-trust" + suffix)
                                     .endMetadata()
                                     .addToStringData("trust.crt", TestKeyMaterial.TEST_CERT_PEM)
                                     .build();
@@ -352,9 +346,9 @@ class AllReconcilersIT {
         // Given
         var tlsScenario = tlsFunc.apply(clusterUser, suffix);
 
-        var myProxy = editableProxy(PROXY_A + "-" + suffix).build();
+        var myProxy = editableProxy(PROXY_A + suffix).build();
         // @formatter:off
-        var myIngress = editableIngress(CLUSTER_FOO_CLUSTER_IP_INGRESS + "-" + suffix, myProxy)
+        var myIngress = editableIngress(CLUSTER_FOO_CLUSTER_IP_INGRESS + suffix, myProxy)
                 .editOrNewSpec()
                     .withNewClusterIP()
                         .withProtocol(Protocol.TCP)
@@ -362,14 +356,14 @@ class AllReconcilersIT {
                 .endSpec()
                 .build();
 
-        var myService = editableService(CLUSTER_FOO_SERVICE + "-" + suffix)
+        var myService = editableService(CLUSTER_FOO_SERVICE + suffix)
                 .editOrNewSpec()
                     .withTls(tlsScenario)
                 .endSpec()
                 .build();
         // @formatter:on
 
-        var myCluster = editableVirtualCluster(CLUSTER_FOO + "-" + suffix, myProxy, myService, List.of(myIngress), List.of()).build();
+        var myCluster = editableVirtualCluster(CLUSTER_FOO + suffix, myProxy, myService, List.of(myIngress), List.of()).build();
 
         // When
         createAll(myProxy, myCluster, myIngress, myService);
@@ -386,7 +380,7 @@ class AllReconcilersIT {
                         // @formatter:off
                             var downstreamCert = new SecretBuilder()
                                     .withNewMetadata()
-                                        .withName("downstream-cert-" + suffix)
+                                        .withName("downstream-cert" + suffix)
                                     .endMetadata()
                                     .withType("kubernetes.io/tls")
                                     .addToStringData("tls.crt", TestKeyMaterial.TEST_CERT_PEM)
@@ -405,7 +399,7 @@ class AllReconcilersIT {
                         // @formatter:off
                             var downstreamCert = new SecretBuilder()
                                     .withNewMetadata()
-                                        .withName("downstream-cert-" + suffix)
+                                        .withName("downstream-cert" + suffix)
                                     .endMetadata()
                                     .withType("kubernetes.io/tls")
                                     .addToStringData("tls.crt", TestKeyMaterial.TEST_CERT_PEM)
@@ -413,7 +407,7 @@ class AllReconcilersIT {
                                     .build();
                             var downstreamTrust = new ConfigMapBuilder()
                                     .withNewMetadata()
-                                        .withName("downstream-trust-configmap-" + suffix)
+                                        .withName("downstream-trust-configmap" + suffix)
                                     .endMetadata()
                                     .addToData("trust.pem", TestKeyMaterial.TEST_CERT_PEM)
                                     .build();
@@ -438,7 +432,7 @@ class AllReconcilersIT {
                         // @formatter:off
                             var downstreamCert = new SecretBuilder()
                                     .withNewMetadata()
-                                        .withName("downstream-cert-" + suffix)
+                                        .withName("downstream-cert" + suffix)
                                     .endMetadata()
                                     .withType("kubernetes.io/tls")
                                     .addToStringData("tls.crt", TestKeyMaterial.TEST_CERT_PEM)
@@ -446,7 +440,7 @@ class AllReconcilersIT {
                                     .build();
                             var downstreamTrust = new SecretBuilder()
                                     .withNewMetadata()
-                                        .withName("downstream-trust-secret-" + suffix)
+                                        .withName("downstream-trust-secret" + suffix)
                                     .endMetadata()
                                     .addToStringData("trust.pem", TestKeyMaterial.TEST_CERT_PEM)
                                     .build();
@@ -472,7 +466,7 @@ class AllReconcilersIT {
                         // @formatter:off
                             var downstreamCert = new SecretBuilder()
                                     .withNewMetadata()
-                                        .withName("downstream-cert-" + suffix)
+                                        .withName("downstream-cert" + suffix)
                                     .endMetadata()
                                     .withType("kubernetes.io/tls")
                                     .addToStringData("tls.crt", TestKeyMaterial.TEST_CERT_PEM)
@@ -480,7 +474,7 @@ class AllReconcilersIT {
                                     .build();
                             var downstreamTrust = new ConfigMapBuilder()
                                     .withNewMetadata()
-                                        .withName("downstream-trust-configmap-" + suffix)
+                                        .withName("downstream-trust-configmap" + suffix)
                                     .endMetadata()
                                     .addToData("trust.crt", TestKeyMaterial.TEST_CERT_PEM)
                                     .build();
@@ -509,9 +503,9 @@ class AllReconcilersIT {
         // Given
         var tlsScenario = tlsFunc.apply(clusterUser, suffix);
 
-        var myProxy = editableProxy(PROXY_A + "-" + suffix).build();
+        var myProxy = editableProxy(PROXY_A + suffix).build();
         // @formatter:off
-        var myIngress = editableIngress(CLUSTER_FOO_CLUSTER_IP_INGRESS + "-" + suffix, myProxy)
+        var myIngress = editableIngress(CLUSTER_FOO_CLUSTER_IP_INGRESS + suffix, myProxy)
                 .editOrNewSpec()
                     .withNewClusterIP()
                         .withProtocol(Protocol.TLS)
@@ -519,9 +513,9 @@ class AllReconcilersIT {
                 .endSpec()
                 .build();
 
-        var myService = editableService(CLUSTER_FOO_SERVICE + "-" + suffix).build();
+        var myService = editableService(CLUSTER_FOO_SERVICE + suffix).build();
 
-        var myCluster = editableVirtualCluster(CLUSTER_FOO + "-" + suffix, myProxy, myService, List.of(myIngress), List.of())
+        var myCluster = editableVirtualCluster(CLUSTER_FOO + suffix, myProxy, myService, List.of(myIngress), List.of())
                 .editOrNewSpec()
                     .editIngress(0)
                         .withTls(tlsScenario)
@@ -542,9 +536,9 @@ class AllReconcilersIT {
     void infrastructureAnnotationsAppliedToServices() {
         // Given
         var suffix = uniqueSuffix();
-        var myProxy = editableProxy(PROXY_A + "-" + suffix).build();
+        var myProxy = editableProxy(PROXY_A + suffix).build();
         // @formatter:off
-        var myIngress = editableIngress(CLUSTER_FOO_CLUSTER_IP_INGRESS + "-" + suffix, myProxy)
+        var myIngress = editableIngress(CLUSTER_FOO_CLUSTER_IP_INGRESS + suffix, myProxy)
                 .editOrNewSpec()
                     .withNewInfrastructure()
                         .addToAnnotations("example.com/custom-annotation", "test-value")
@@ -557,8 +551,8 @@ class AllReconcilersIT {
                 .build();
         // @formatter:on
 
-        var myService = editableService(CLUSTER_FOO_SERVICE + "-" + suffix).build();
-        var myCluster = editableVirtualCluster(CLUSTER_FOO + "-" + suffix, myProxy, myService, List.of(myIngress), List.of()).build();
+        var myService = editableService(CLUSTER_FOO_SERVICE + suffix).build();
+        var myCluster = editableVirtualCluster(CLUSTER_FOO + suffix, myProxy, myService, List.of(myIngress), List.of()).build();
 
         // When
         createAll(myProxy, myIngress, myService, myCluster);
@@ -569,9 +563,9 @@ class AllReconcilersIT {
         assertResourceAttainsCondition(AllReconcilersIT::resourceAccepted, myCluster);
 
         // Verify Service has infrastructure annotations
-        AWAIT.alias("Service for cluster %s has infrastructure annotations".formatted(CLUSTER_FOO + "-" + suffix))
+        AWAIT.alias("Service for cluster %s has infrastructure annotations".formatted(CLUSTER_FOO + suffix))
                 .untilAsserted(() -> {
-                    String serviceName = CLUSTER_FOO + "-" + suffix + "-" + CLUSTER_FOO_CLUSTER_IP_INGRESS + "-" + suffix + "-bootstrap";
+                    String serviceName = CLUSTER_FOO + suffix + "-" + CLUSTER_FOO_CLUSTER_IP_INGRESS + suffix + "-bootstrap";
                     var service = clusterUser.get(Service.class, serviceName);
                     assertThat(service)
                             .isNotNull()
@@ -587,7 +581,7 @@ class AllReconcilersIT {
     void upstreamTlsFromStrimziKafkaRef() {
         // Given
         var suffix = uniqueSuffix();
-        String kafkaName = "my-cluster-" + suffix;
+        String kafkaName = "my-cluster" + suffix;
         // @formatter:off
         clusterUser.create(new KafkaBuilder()
                 .withNewMetadata()
@@ -628,9 +622,9 @@ class AllReconcilersIT {
                 .addToData(STRIMZI_CLUSTER_CA_BUNDLE, "dGVzdC1jYQ==")
                 .build());
 
-        var myService = editableStrimziService(CLUSTER_FOO_SERVICE + "-" + suffix, kafkaName, STRIMZI_TLS_LISTENER).build();
-        var myProxy = editableProxy(PROXY_A + "-" + suffix).build();
-        var myIngress = editableIngress(CLUSTER_FOO_CLUSTER_IP_INGRESS + "-" + suffix, myProxy)
+        var myService = editableStrimziService(CLUSTER_FOO_SERVICE + suffix, kafkaName, STRIMZI_TLS_LISTENER).build();
+        var myProxy = editableProxy(PROXY_A + suffix).build();
+        var myIngress = editableIngress(CLUSTER_FOO_CLUSTER_IP_INGRESS + suffix, myProxy)
                 .editOrNewSpec()
                     .withNewClusterIP()
                         .withProtocol(Protocol.TCP)
@@ -639,7 +633,7 @@ class AllReconcilersIT {
                 .build();
         // @formatter:on
 
-        var myCluster = editableVirtualCluster(CLUSTER_FOO + "-" + suffix, myProxy, myService, List.of(myIngress), List.of()).build();
+        var myCluster = editableVirtualCluster(CLUSTER_FOO + suffix, myProxy, myService, List.of(myIngress), List.of()).build();
 
         // When
         createAll(myProxy, myCluster, myIngress, myService);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
@@ -37,6 +37,7 @@ import io.kroxylicious.testing.operator.OperatorTestUtils;
 import io.kroxylicious.testing.operator.assertj.KafkaProtocolFilterStatusAssert;
 
 import static io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED;
+import static io.kroxylicious.testing.operator.OperatorTestUtils.uniqueSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -68,38 +69,41 @@ class KafkaProtocolFilterReconcilerIT {
 
     @Test
     void shouldEventuallyResolveWhenFilterCreatedFirst() {
-        createFilterFirst();
+        var suffix = uniqueSuffix();
+        createFilterFirst(suffix);
     }
 
-    private KafkaProtocolFilter createFilterFirst() {
-        KafkaProtocolFilter filterOne = clusterUser.create(filter(FILTER_ONE,
-                "${secret:" + A + ":foo}", "${configmap:" + B + ":foo}"));
-        assertResolvedRefsFalse(filterOne, "Referenced Secrets [a] ConfigMaps [b] not found");
-        clusterUser.create(secret(A));
-        assertResolvedRefsFalse(filterOne, "Referenced ConfigMaps [b] not found");
-        clusterUser.create(cm(B));
+    private KafkaProtocolFilter createFilterFirst(String suffix) {
+        KafkaProtocolFilter filterOne = clusterUser.create(filter(FILTER_ONE + suffix,
+                "${secret:" + (A + suffix) + ":foo}", "${configmap:" + (B + suffix) + ":foo}"));
+        assertResolvedRefsFalse(filterOne, "Referenced Secrets [" + (A + suffix) + "] ConfigMaps [" + (B + suffix) + "] not found");
+        clusterUser.create(secret(A + suffix));
+        assertResolvedRefsFalse(filterOne, "Referenced ConfigMaps [" + (B + suffix) + "] not found");
+        clusterUser.create(cm(B + suffix));
         assertAllConditionsTrue(filterOne);
         return filterOne;
     }
 
     @Test
     void shouldEventuallyResolveWhenASecretCreatedFirst() {
-        clusterUser.create(secret(A));
-        KafkaProtocolFilter filterOne = clusterUser.create(filter(FILTER_ONE,
-                "${secret:" + A + ":foo}", "${secret:" + B + ":foo}"));
-        assertResolvedRefsFalse(filterOne, "Referenced Secrets [b] not found");
-        clusterUser.create(secret(B));
+        var suffix = uniqueSuffix();
+        clusterUser.create(secret(A + suffix));
+        KafkaProtocolFilter filterOne = clusterUser.create(filter(FILTER_ONE + suffix,
+                "${secret:" + (A + suffix) + ":foo}", "${secret:" + (B + suffix) + ":foo}"));
+        assertResolvedRefsFalse(filterOne, "Referenced Secrets [" + (B + suffix) + "] not found");
+        clusterUser.create(secret(B + suffix));
         assertAllConditionsTrue(filterOne);
     }
 
     @Test
     void shouldEventuallyResolveWhenAllSecretsCreatedFirst() {
-        clusterUser.create(secret(A));
-        clusterUser.create(secret(B));
-        clusterUser.create(secret(C));
-        KafkaProtocolFilter filterOne = clusterUser.create(filter(FILTER_ONE,
-                "${secret:" + A + ":foo}",
-                "${secret:" + B + ":foo}"));
+        var suffix = uniqueSuffix();
+        clusterUser.create(secret(A + suffix));
+        clusterUser.create(secret(B + suffix));
+        clusterUser.create(secret(C + suffix));
+        KafkaProtocolFilter filterOne = clusterUser.create(filter(FILTER_ONE + suffix,
+                "${secret:" + (A + suffix) + ":foo}",
+                "${secret:" + (B + suffix) + ":foo}"));
         assertAllConditionsTrue(filterOne);
     }
 
@@ -122,32 +126,35 @@ class KafkaProtocolFilterReconcilerIT {
 
     @Test
     void shouldEventuallyResolveWhenSecretsAndConfigMapsFirst() {
-        clusterUser.create(secret(A));
-        clusterUser.create(cm(B));
-        clusterUser.create(secret(C));
-        KafkaProtocolFilter filterOne = clusterUser.create(filter(FILTER_ONE,
-                "${secret:" + A + ":foo}",
-                "${configmap:" + B + ":foo}"));
+        var suffix = uniqueSuffix();
+        clusterUser.create(secret(A + suffix));
+        clusterUser.create(cm(B + suffix));
+        clusterUser.create(secret(C + suffix));
+        KafkaProtocolFilter filterOne = clusterUser.create(filter(FILTER_ONE + suffix,
+                "${secret:" + (A + suffix) + ":foo}",
+                "${configmap:" + (B + suffix) + ":foo}"));
         assertAllConditionsTrue(filterOne);
     }
 
     @Test
     void shouldUpdateStatusOnFilterModify() {
-        shouldEventuallyResolveWhenFilterCreatedFirst();
+        var suffix = uniqueSuffix();
+        createFilterFirst(suffix);
 
-        KafkaProtocolFilter filterOne = clusterUser.replace(filter(FILTER_ONE,
-                "${secret:" + C + ":foo}", "${configmap:" + B + ":foo}"));
-        assertResolvedRefsFalse(filterOne, "Referenced Secrets [c] not found");
+        KafkaProtocolFilter filterOne = clusterUser.replace(filter(FILTER_ONE + suffix,
+                "${secret:" + (C + suffix) + ":foo}", "${configmap:" + (B + suffix) + ":foo}"));
+        assertResolvedRefsFalse(filterOne, "Referenced Secrets [" + (C + suffix) + "] not found");
 
-        clusterUser.create(secret(C));
+        clusterUser.create(secret(C + suffix));
         assertAllConditionsTrue(filterOne);
     }
 
     @Test
     void shouldUpdateStatusOnSecretModify() {
-        var filterOne = createFilterFirst();
+        var suffix = uniqueSuffix();
+        var filterOne = createFilterFirst(suffix);
 
-        clusterUser.resources(Secret.class).withName(A).edit(secret -> secret.edit()
+        clusterUser.resources(Secret.class).withName(A + suffix).edit(secret -> secret.edit()
                 .addToData("baz", Base64.getEncoder().encodeToString("".getBytes(StandardCharsets.UTF_8)))
                 .build());
         assertAllConditionsTrue(filterOne);
@@ -156,12 +163,13 @@ class KafkaProtocolFilterReconcilerIT {
     @Test
     void shouldUpdateReferentAnnotationOnSecretModify() {
         // given
-        var filterOne = createFilterFirst();
+        var suffix = uniqueSuffix();
+        var filterOne = createFilterFirst(suffix);
         String checksum = clusterUser.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
                 .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
 
         // when
-        clusterUser.resources(Secret.class).withName(A).edit(secret -> secret.edit()
+        clusterUser.resources(Secret.class).withName(A + suffix).edit(secret -> secret.edit()
                 .addToData("baz", Base64.getEncoder().encodeToString("".getBytes(StandardCharsets.UTF_8)))
                 .build());
 
@@ -187,12 +195,13 @@ class KafkaProtocolFilterReconcilerIT {
     @Test
     void shouldUpdateReferentAnnotationOnConfigMapModify() {
         // given
-        var filterOne = createFilterFirst();
+        var suffix = uniqueSuffix();
+        var filterOne = createFilterFirst(suffix);
         String checksum = clusterUser.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
                 .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
 
         // when
-        clusterUser.resources(ConfigMap.class).withName(B).edit(configMap -> configMap.edit()
+        clusterUser.resources(ConfigMap.class).withName(B + suffix).edit(configMap -> configMap.edit()
                 .addToData("baz", Base64.getEncoder().encodeToString("".getBytes(StandardCharsets.UTF_8)))
                 .build());
 
@@ -217,18 +226,20 @@ class KafkaProtocolFilterReconcilerIT {
 
     @Test
     void shouldUpdateStatusOnSecretDelete() {
-        var filterOne = createFilterFirst();
+        var suffix = uniqueSuffix();
+        var filterOne = createFilterFirst(suffix);
 
-        clusterUser.delete(secret(A));
-        assertResolvedRefsFalse(filterOne, "Referenced Secrets [a] not found");
+        clusterUser.delete(secret(A + suffix));
+        assertResolvedRefsFalse(filterOne, "Referenced Secrets [" + (A + suffix) + "] not found");
     }
 
     @Test
     void shouldUpdateStatusOnConfigMapDelete() {
-        var filterOne = createFilterFirst();
+        var suffix = uniqueSuffix();
+        var filterOne = createFilterFirst(suffix);
 
-        clusterUser.delete(cm(B));
-        assertResolvedRefsFalse(filterOne, "Referenced ConfigMaps [b] not found");
+        clusterUser.delete(cm(B + suffix));
+        assertResolvedRefsFalse(filterOne, "Referenced ConfigMaps [" + (B + suffix) + "] not found");
     }
 
     private KafkaProtocolFilter filter(String filterName, String refA, String refB) {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
@@ -115,6 +115,7 @@ import static io.kroxylicious.kubernetes.api.common.Protocol.TCP;
 import static io.kroxylicious.kubernetes.api.common.Protocol.TLS;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.generation;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
+import static io.kroxylicious.testing.operator.OperatorTestUtils.uniqueSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
@@ -164,13 +165,15 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void testCreate() {
-        doCreate();
+        var suffix = uniqueSuffix();
+        doCreate(suffix);
     }
 
     @Test
     void shouldConfigureResourcesOnProxyContainer() {
         // given
-        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP);
+        var suffix = uniqueSuffix();
+        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP);
 
         // when
         // @formatter:off
@@ -179,7 +182,7 @@ public class KafkaProxyReconcilerIT {
                 .build();
         KafkaProxy kafkaProxy = new KafkaProxyBuilder()
                 .withNewMetadata()
-                    .withName(PROXY_A)
+                    .withName(PROXY_A + suffix)
                 .endMetadata()
                 .withNewSpec()
                     .withNewInfrastructure()
@@ -190,7 +193,7 @@ public class KafkaProxyReconcilerIT {
                 .endSpec()
                 .build();
         // @formatter:on
-        var created = doCreate(kafkaService, kafkaProxy);
+        var created = doCreate(suffix, kafkaService, kafkaProxy);
 
         // then
         assertDeploymentResourcesEqual(created.proxy(), requirements);
@@ -199,10 +202,11 @@ public class KafkaProxyReconcilerIT {
     @Test
     void shouldConfigureReplicaCountOnDeployment() {
         // given
-        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP);
+        var suffix = uniqueSuffix();
+        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP);
 
         // when
-        var created = doCreate(kafkaService, kafkaProxy(PROXY_A, 3));
+        var created = doCreate(suffix, kafkaService, kafkaProxy(PROXY_A + suffix, 3));
 
         // then
         assertDeploymentReplicaCount(created.proxy(), 3);
@@ -211,12 +215,13 @@ public class KafkaProxyReconcilerIT {
     @Test
     void shouldPropagateNetworkSettingsToProxyConfig() {
         // given
-        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP);
+        var suffix = uniqueSuffix();
+        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP);
 
         // @formatter:off
         KafkaProxy kafkaProxy = new KafkaProxyBuilder()
                 .withNewMetadata()
-                    .withName(PROXY_A)
+                    .withName(PROXY_A + suffix)
                 .endMetadata()
                 .withNewSpec()
                     .withNewNetwork()
@@ -249,7 +254,7 @@ public class KafkaProxyReconcilerIT {
         var expectedNetwork = new NetworkDefinition(expectedManagementNettySettings, expectedProxyNettySettings);
 
         // when
-        var created = doCreate(kafkaService, kafkaProxy);
+        var created = doCreate(suffix, kafkaService, kafkaProxy);
 
         // then
         AWAIT.untilAsserted(() -> assertProxyConfigInConfigMap(created.proxy())
@@ -260,12 +265,13 @@ public class KafkaProxyReconcilerIT {
     @Test
     void shouldPropagateProxyOnlyNetworkSettingsToProxyConfig() {
         // given
-        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP);
+        var suffix = uniqueSuffix();
+        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP);
 
         // @formatter:off
         KafkaProxy kafkaProxy = new KafkaProxyBuilder()
                 .withNewMetadata()
-                    .withName(PROXY_A)
+                    .withName(PROXY_A + suffix)
                 .endMetadata()
                 .withNewSpec()
                     .withNewNetwork()
@@ -287,7 +293,7 @@ public class KafkaProxyReconcilerIT {
         var expectedNetwork = new NetworkDefinition(null, expectedProxyNettySettings);
 
         // when
-        var created = doCreate(kafkaService, kafkaProxy);
+        var created = doCreate(suffix, kafkaService, kafkaProxy);
 
         // then
         AWAIT.untilAsserted(() -> assertProxyConfigInConfigMap(created.proxy())
@@ -298,12 +304,13 @@ public class KafkaProxyReconcilerIT {
     @Test
     void shouldPropagateManagementOnlyNetworkSettingsToProxyConfig() {
         // given
-        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP);
+        var suffix = uniqueSuffix();
+        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP);
 
         // @formatter:off
         KafkaProxy kafkaProxy = new KafkaProxyBuilder()
                 .withNewMetadata()
-                    .withName(PROXY_A)
+                    .withName(PROXY_A + suffix)
                 .endMetadata()
                 .withNewSpec()
                     .withNewNetwork()
@@ -325,7 +332,7 @@ public class KafkaProxyReconcilerIT {
         var expectedNetwork = new NetworkDefinition(expectedManagementNettySettings, null);
 
         // when
-        var created = doCreate(kafkaService, kafkaProxy);
+        var created = doCreate(suffix, kafkaService, kafkaProxy);
 
         // then
         AWAIT.untilAsserted(() -> assertProxyConfigInConfigMap(created.proxy())
@@ -336,14 +343,15 @@ public class KafkaProxyReconcilerIT {
     @ParameterizedTest
     @MethodSource("dependentResourceSsaTestCases")
     void externalSsaPatchSurvivesOperatorReconcile(
+                                                   String suffix,
                                                    Class<? extends HasMetadata> resourceClass,
-                                                   Function<KafkaProxy, String> resourceNameFn,
+                                                   BiFunction<KafkaProxy, String, String> resourceNameFn,
                                                    BiFunction<String, String, HasMetadata> patchFn) {
         // given — create a proxy with 1 replica and wait for the target resource to exist
-        var created = doCreate(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP), kafkaProxy(PROXY_A, 1));
+        var created = doCreate(suffix, kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP), kafkaProxy(PROXY_A + suffix, 1));
         KafkaProxy proxy = created.proxy();
         String namespace = operator.getNamespace();
-        String resourceName = resourceNameFn.apply(proxy);
+        String resourceName = resourceNameFn.apply(proxy, suffix);
 
         AWAIT.alias(resourceName + " to exist").untilAsserted(() -> assertThat(clusterUser.get(resourceClass, resourceName)).isNotNull());
 
@@ -374,29 +382,34 @@ public class KafkaProxyReconcilerIT {
     static Stream<Arguments> dependentResourceSsaTestCases() {
         return Stream.of(
                 Arguments.argumentSet("Deployment",
+                        uniqueSuffix(),
                         Deployment.class,
-                        (Function<KafkaProxy, String>) ProxyDeploymentDependentResource::deploymentName,
+                        (BiFunction<KafkaProxy, String, String>) (proxy, suffix) -> ProxyDeploymentDependentResource.deploymentName(proxy),
                         (BiFunction<String, String, HasMetadata>) (name, ns) -> new DeploymentBuilder()
                                 .withNewMetadata().withName(name).withNamespace(ns)
                                 .addToAnnotations("test.kroxylicious.io/external", "present")
                                 .endMetadata().build()),
                 Arguments.argumentSet("proxy-config ConfigMap",
+                        uniqueSuffix(),
                         ConfigMap.class,
-                        (Function<KafkaProxy, String>) ProxyConfigDependentResource::configMapName,
+                        (BiFunction<KafkaProxy, String, String>) (proxy, suffix) -> ProxyConfigDependentResource.configMapName(proxy),
                         (BiFunction<String, String, HasMetadata>) (name, ns) -> new ConfigMapBuilder()
                                 .withNewMetadata().withName(name).withNamespace(ns)
                                 .addToAnnotations("test.kroxylicious.io/external", "present")
                                 .endMetadata().build()),
                 Arguments.argumentSet("config-state ConfigMap",
+                        uniqueSuffix(),
                         ConfigMap.class,
-                        (Function<KafkaProxy, String>) ProxyConfigStateDependentResource::configMapName,
+                        (BiFunction<KafkaProxy, String, String>) (proxy, suffix) -> ProxyConfigStateDependentResource.configMapName(proxy),
                         (BiFunction<String, String, HasMetadata>) (name, ns) -> new ConfigMapBuilder()
                                 .withNewMetadata().withName(name).withNamespace(ns)
                                 .addToAnnotations("test.kroxylicious.io/external", "present")
                                 .endMetadata().build()),
                 Arguments.argumentSet("cluster Service",
+                        uniqueSuffix(),
                         Service.class,
-                        (Function<KafkaProxy, String>) proxy -> CLUSTER_BAR + "-" + CLUSTER_BAR_CLUSTERIP_INGRESS + "-bootstrap",
+                        (BiFunction<KafkaProxy, String, String>) (proxy, suffix) -> CLUSTER_BAR + suffix + "-" + CLUSTER_BAR_CLUSTERIP_INGRESS + suffix
+                                + "-bootstrap",
                         (BiFunction<String, String, HasMetadata>) (name, ns) -> new ServiceBuilder()
                                 .withNewMetadata().withName(name).withNamespace(ns)
                                 .addToAnnotations("test.kroxylicious.io/external", "present")
@@ -406,11 +419,12 @@ public class KafkaProxyReconcilerIT {
     @Test
     void shouldIncludeReplicaCountInKafkaProxyStatus() {
         // given
+        var suffix = uniqueSuffix();
         int desiredReplicaCount = 3;
-        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP);
+        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP);
 
         // when
-        var created = doCreate(kafkaService, kafkaProxy(PROXY_A, desiredReplicaCount));
+        var created = doCreate(suffix, kafkaService, kafkaProxy(PROXY_A + suffix, desiredReplicaCount));
         assertDeploymentReplicaCount(created.proxy(), desiredReplicaCount);
 
         // then
@@ -420,11 +434,12 @@ public class KafkaProxyReconcilerIT {
     @Test
     void shouldNotIncludeDeprecationWarningInKafkaProxyStatus() {
         // given
+        var suffix = uniqueSuffix();
         int desiredReplicaCount = 3;
-        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP);
+        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP);
 
         // when
-        var created = doCreate(kafkaService, kafkaProxy(PROXY_A, desiredReplicaCount));
+        var created = doCreate(suffix, kafkaService, kafkaProxy(PROXY_A + suffix, desiredReplicaCount));
         assertDeploymentReplicaCount(created.proxy(), desiredReplicaCount);
 
         // then
@@ -436,10 +451,11 @@ public class KafkaProxyReconcilerIT {
     @Test
     void shouldIncludeDeprecationWarningInKafkaProxyStatus() {
         // given
-        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP);
+        var suffix = uniqueSuffix();
+        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP);
 
         // when
-        var created = doCreate(kafkaService, kafkaProxyNoSpec(PROXY_A));
+        var created = doCreate(suffix, kafkaService, kafkaProxyNoSpec(PROXY_A + suffix));
 
         // then
         AWAIT.alias("DeprecationWarning condition present").untilAsserted(() -> {
@@ -450,59 +466,63 @@ public class KafkaProxyReconcilerIT {
     @Test
     void testCreateWithKafkaServiceTls() {
         // given
-        clusterUser.create(tlsKeyAndCertSecret(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME));
-        clusterUser.create(trustAnchorConfigMap(CA_BUNDLE_CONFIG_MAP_NAME));
-        KafkaService kafkaService = kafkaServiceWithTls();
+        var suffix = uniqueSuffix();
+        clusterUser.create(tlsKeyAndCertSecret(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME + suffix));
+        clusterUser.create(trustAnchorConfigMap(CA_BUNDLE_CONFIG_MAP_NAME + suffix));
+        KafkaService kafkaService = kafkaServiceWithTls(suffix);
 
         // when
-        var created = doCreate(kafkaService);
+        var created = doCreate(suffix, kafkaService);
 
         // then
         assertProxyConfigContents(created.proxy(), Set
                 .of(
-                        UPSTREAM_TLS_CERTIFICATE_SECRET_NAME,
+                        UPSTREAM_TLS_CERTIFICATE_SECRET_NAME + suffix,
                         TRUSTED_CAS_PEM,
                         PROTOCOL_TLS_V1_3,
                         TLS_CIPHER_SUITE_AES256GCM_SHA384),
                 Set.of());
-        assertDeploymentMountsConfigMap(created.proxy(), CA_BUNDLE_CONFIG_MAP_NAME);
-        assertDeploymentMountsSecret(created.proxy(), UPSTREAM_TLS_CERTIFICATE_SECRET_NAME);
+        assertDeploymentMountsConfigMap(created.proxy(), CA_BUNDLE_CONFIG_MAP_NAME + suffix);
+        assertDeploymentMountsSecret(created.proxy(), UPSTREAM_TLS_CERTIFICATE_SECRET_NAME + suffix);
     }
 
     @Test
     void testCreateWithKafkaServiceTlsUsingTrustAnchorFromSecret() {
         // given
-        clusterUser.create(tlsKeyAndCertSecret(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME));
-        clusterUser.create(trustAnchorSecret(CA_CERT_SECRET_NAME));
-        KafkaService kafkaService = kafkaServiceWithTlsWithTrustAnchorRefAsSecret();
+        var suffix = uniqueSuffix();
+        clusterUser.create(tlsKeyAndCertSecret(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME + suffix));
+        clusterUser.create(trustAnchorSecret(CA_CERT_SECRET_NAME + suffix));
+        KafkaService kafkaService = kafkaServiceWithTlsWithTrustAnchorRefAsSecret(suffix);
 
         // when
-        var created = doCreate(kafkaService);
+        var created = doCreate(suffix, kafkaService);
 
         // then
         assertProxyConfigContents(created.proxy(), Set
                 .of(
-                        UPSTREAM_TLS_CERTIFICATE_SECRET_NAME,
+                        UPSTREAM_TLS_CERTIFICATE_SECRET_NAME + suffix,
                         TRUSTED_CAS_PEM),
                 Set.of());
-        assertDeploymentMountsSecret(created.proxy(), CA_CERT_SECRET_NAME);
-        assertDeploymentMountsSecret(created.proxy(), UPSTREAM_TLS_CERTIFICATE_SECRET_NAME);
+        assertDeploymentMountsSecret(created.proxy(), CA_CERT_SECRET_NAME + suffix);
+        assertDeploymentMountsSecret(created.proxy(), UPSTREAM_TLS_CERTIFICATE_SECRET_NAME + suffix);
     }
 
     @Test
     void virtualClusterWithClusterIpIngress() {
         // Given
-        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
+        var suffix = uniqueSuffix();
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A + suffix));
 
-        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP)),
+                CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress ingress = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
+        KafkaProxyIngress ingress = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS + suffix, proxy, TLS)));
 
-        String downstreamCertSecretName = "downstream-tls-certificate";
+        String downstreamCertSecretName = "downstream-tls-certificate" + suffix;
         Secret tlsCert = clusterUser.create(tlsKeyAndCertSecret(downstreamCertSecretName));
 
         Ingresses build = createIngressForCluster(ingress, tlsCert);
-        VirtualKafkaCluster resource = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(build), Optional.empty());
+        VirtualKafkaCluster resource = virtualKafkaCluster(CLUSTER_BAR + suffix, proxy, kafkaService, List.of(build), Optional.empty());
 
         // When
         updateStatusObservedGeneration(clusterUser.create(resource));
@@ -515,14 +535,16 @@ public class KafkaProxyReconcilerIT {
     @Test
     void virtualClusterWithClusterIpIngressWithTrustAnchor() {
         // Given
-        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
+        var suffix = uniqueSuffix();
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A + suffix));
 
-        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP)),
+                CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress ingress = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
+        KafkaProxyIngress ingress = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS + suffix, proxy, TLS)));
 
-        Secret tlsServerCert = clusterUser.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
-        String downstreamTrustAnchorName = "downstream-tls-trust-anchor";
+        Secret tlsServerCert = clusterUser.create(tlsKeyAndCertSecret("downstream-tls-certificate" + suffix));
+        String downstreamTrustAnchorName = "downstream-tls-trust-anchor" + suffix;
         ConfigMap trustAnchor = clusterUser.create(trustAnchorConfigMap(downstreamTrustAnchorName));
 
         Ingresses clusterIngress = new IngressesBuilder()
@@ -533,7 +555,7 @@ public class KafkaProxyReconcilerIT {
                 .endTls()
                 .build();
 
-        VirtualKafkaCluster resource = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(clusterIngress), Optional.empty());
+        VirtualKafkaCluster resource = virtualKafkaCluster(CLUSTER_BAR + suffix, proxy, kafkaService, List.of(clusterIngress), Optional.empty());
 
         // When
         updateStatusObservedGeneration(clusterUser.create(resource));
@@ -566,15 +588,17 @@ public class KafkaProxyReconcilerIT {
     @Test
     void virtualClusterWithMultipleClusterIpIngressWithTrustAnchor() {
         // Given
-        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
+        var suffix = uniqueSuffix();
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A + suffix));
 
-        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP)),
+                CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress ingress = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
-        KafkaProxyIngress ingress2 = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress("another-cluster-ip", proxy, TLS)));
+        KafkaProxyIngress ingress = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS + suffix, proxy, TLS)));
+        KafkaProxyIngress ingress2 = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress("another-cluster-ip" + suffix, proxy, TLS)));
 
-        Secret tlsServerCert = clusterUser.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
-        String downstreamTrustAnchorName = "downstream-tls-trust-anchor";
+        Secret tlsServerCert = clusterUser.create(tlsKeyAndCertSecret("downstream-tls-certificate" + suffix));
+        String downstreamTrustAnchorName = "downstream-tls-trust-anchor" + suffix;
         ConfigMap trustAnchor = clusterUser.create(trustAnchorConfigMap(downstreamTrustAnchorName));
 
         Ingresses clusterIngress = new IngressesBuilder()
@@ -593,7 +617,7 @@ public class KafkaProxyReconcilerIT {
                 .endTls()
                 .build();
 
-        VirtualKafkaCluster resource = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(clusterIngress, clusterIngress2), Optional.empty());
+        VirtualKafkaCluster resource = virtualKafkaCluster(CLUSTER_BAR + suffix, proxy, kafkaService, List.of(clusterIngress, clusterIngress2), Optional.empty());
 
         // When
         updateStatusObservedGeneration(clusterUser.create(resource));
@@ -652,17 +676,19 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void virtualClusterWithLoadBalancerIngressWithTrustAnchor() {
-        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
-        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        var suffix = uniqueSuffix();
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP)),
+                CLUSTER_BAR_BOOTSTRAP);
 
         String loadbalancerBootstrap = "bootstrap.kafka";
         String loadbalancerBrokerAddressPattern = "broker-$(nodeId).kafka";
         KafkaProxyIngress loadBalancerIngress = updateStatusObservedGeneration(
-                clusterUser.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy, loadbalancerBootstrap,
+                clusterUser.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS + suffix, proxy, loadbalancerBootstrap,
                         loadbalancerBrokerAddressPattern)));
 
-        Secret tlsServerCert = clusterUser.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
-        String downstreamTrustAnchorName = "downstream-tls-trust-anchor";
+        Secret tlsServerCert = clusterUser.create(tlsKeyAndCertSecret("downstream-tls-certificate" + suffix));
+        String downstreamTrustAnchorName = "downstream-tls-trust-anchor" + suffix;
         ConfigMap trustAnchor = clusterUser.create(trustAnchorConfigMap(downstreamTrustAnchorName));
 
         Ingresses clusterIngress = new IngressesBuilder()
@@ -672,7 +698,7 @@ public class KafkaProxyReconcilerIT {
                 .withTrustAnchorRef(toTrustAnchorRef(trustAnchor))
                 .endTls()
                 .build();
-        VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(clusterIngress), Optional.empty());
+        VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR + suffix, proxy, kafkaService, List.of(clusterIngress), Optional.empty());
 
         // when
         updateStatusObservedGeneration(clusterUser.create(cluster));
@@ -729,24 +755,26 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void virtualClusterWithLoadBalancerAndClusterIpIngress() {
-        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
-        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        var suffix = uniqueSuffix();
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP)),
+                CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress loadBalancerIngress = updateStatusObservedGeneration(clusterUser.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy,
+        KafkaProxyIngress loadBalancerIngress = updateStatusObservedGeneration(clusterUser.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS + suffix, proxy,
                 "bootstrap.kafka",
                 "broker-$(nodeId).kafka")));
 
-        Secret loadBalancerTlsServerCert = clusterUser.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate"));
+        Secret loadBalancerTlsServerCert = clusterUser.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate" + suffix));
 
         Ingresses lbIngress = createIngressForCluster(loadBalancerIngress, loadBalancerTlsServerCert);
 
-        Secret clusterIpTlsServerCert = clusterUser.create(tlsKeyAndCertSecret("clusterip-tls-certificate"));
+        Secret clusterIpTlsServerCert = clusterUser.create(tlsKeyAndCertSecret("clusterip-tls-certificate" + suffix));
 
-        KafkaProxyIngress clusterIpIngress = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
+        KafkaProxyIngress clusterIpIngress = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS + suffix, proxy, TLS)));
 
         Ingresses cipIngress = createIngressForCluster(clusterIpIngress, clusterIpTlsServerCert);
 
-        VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(lbIngress, cipIngress), Optional.empty());
+        VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR + suffix, proxy, kafkaService, List.of(lbIngress, cipIngress), Optional.empty());
 
         // when
         updateStatusObservedGeneration(clusterUser.create(cluster));
@@ -754,7 +782,7 @@ public class KafkaProxyReconcilerIT {
         // then
         AWAIT.alias("services manifested").untilAsserted(() -> {
             String sharedSniServiceName = name(proxy) + "-sni";
-            String clusterIpServiceName = CLUSTER_BAR + "-" + clusterIpIngress.getMetadata().getName() + "-bootstrap";
+            String clusterIpServiceName = CLUSTER_BAR + suffix + "-" + clusterIpIngress.getMetadata().getName() + "-bootstrap";
             var services = clusterUser.resources(Service.class).list().getItems();
             assertThat(services)
                     .extracting(service -> service.getMetadata().getName())
@@ -770,26 +798,28 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void twoVirtualClusterUsingLoadBalancer() {
-        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
-        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        var suffix = uniqueSuffix();
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP)),
+                CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress loadBalancerIngressFoo = updateStatusObservedGeneration(clusterUser.create(loadBalancerIngress(CLUSTER_FOO_LOADBALANCER_INGRESS, proxy,
+        KafkaProxyIngress loadBalancerIngressFoo = updateStatusObservedGeneration(clusterUser.create(loadBalancerIngress(CLUSTER_FOO_LOADBALANCER_INGRESS + suffix, proxy,
                 "bootstrap.foo.kafka",
                 "broker-$(nodeId).foo.kafka")));
 
-        KafkaProxyIngress loadBalancerIngressBar = updateStatusObservedGeneration(clusterUser.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy,
+        KafkaProxyIngress loadBalancerIngressBar = updateStatusObservedGeneration(clusterUser.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS + suffix, proxy,
                 "bootstrap.bar.kafka",
                 "broker-$(nodeId).bar.kafka")));
 
-        Secret loadBalancerTlsServerCertFoo = clusterUser.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate-foo"));
-        Secret loadBalancerTlsServerCertBar = clusterUser.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate-bar"));
+        Secret loadBalancerTlsServerCertFoo = clusterUser.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate-foo" + suffix));
+        Secret loadBalancerTlsServerCertBar = clusterUser.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate-bar" + suffix));
 
         Ingresses lbIngressFoo = createIngressForCluster(loadBalancerIngressFoo, loadBalancerTlsServerCertFoo);
 
         Ingresses lbIngressBar = createIngressForCluster(loadBalancerIngressBar, loadBalancerTlsServerCertBar);
 
-        VirtualKafkaCluster fooCluster = clusterUser.create(virtualKafkaCluster(CLUSTER_FOO, proxy, kafkaService, List.of(lbIngressFoo), Optional.empty()));
-        VirtualKafkaCluster barCluster = clusterUser.create(virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(lbIngressBar), Optional.empty()));
+        VirtualKafkaCluster fooCluster = clusterUser.create(virtualKafkaCluster(CLUSTER_FOO + suffix, proxy, kafkaService, List.of(lbIngressFoo), Optional.empty()));
+        VirtualKafkaCluster barCluster = clusterUser.create(virtualKafkaCluster(CLUSTER_BAR + suffix, proxy, kafkaService, List.of(lbIngressBar), Optional.empty()));
 
         // when
         List.of(fooCluster, barCluster).forEach(this::updateStatusObservedGeneration);
@@ -820,17 +850,18 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void clusterIpIngressUsesDeclaredNodeIdsOfService() {
-        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
-        KafkaProtocolFilter filter = clusterUser.create(filter(FILTER_NAME));
+        var suffix = uniqueSuffix();
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        KafkaProtocolFilter filter = clusterUser.create(filter(FILTER_NAME + suffix));
         filter = updateStatusObservedGeneration(filter);
-        KafkaService barService = clusterUser.create(new KafkaServiceBuilder().withNewMetadata().withName(CLUSTER_BAR_REF).endMetadata()
+        KafkaService barService = clusterUser.create(new KafkaServiceBuilder().withNewMetadata().withName(CLUSTER_BAR_REF + suffix).endMetadata()
                 .withNewSpec()
                 .withBootstrapServers(CLUSTER_BAR_BOOTSTRAP)
                 .withNodeIdRanges(createNodeIdRanges("brokers", 3L, 4L), createNodeIdRanges("more-brokers", 10L, 10L))
                 .endSpec().build());
         barService = updateStatusObservedGeneration(barService, CLUSTER_BAR_BOOTSTRAP);
-        KafkaProxyIngress ingressBar = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TCP)));
-        VirtualKafkaCluster clusterBar = clusterUser.create(virtualKafkaCluster(CLUSTER_BAR, proxy, barService,
+        KafkaProxyIngress ingressBar = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS + suffix, proxy, TCP)));
+        VirtualKafkaCluster clusterBar = clusterUser.create(virtualKafkaCluster(CLUSTER_BAR + suffix, proxy, barService,
                 List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressBar)).build()), Optional.of(filter)));
         updateStatusObservedGeneration(clusterBar);
         clusterBar.setStatus(new VirtualKafkaClusterStatusBuilder().withObservedGeneration(generation(clusterBar)).build());
@@ -847,10 +878,10 @@ public class KafkaProxyReconcilerIT {
                     .extracting(svc -> svc.getSpec().getSelector())
                     .describedAs("Service's selector should select proxy pods")
                     .isEqualTo(ProxyDeploymentDependentResource.podLabels(proxy));
-            ServicePort bootstrapServicePort = clusterIpServicePort(expectedBootstrapPort);
-            ServicePort node0ServicePort = clusterIpServicePort(expectedBootstrapPort + 1);
-            ServicePort node1ServicePort = clusterIpServicePort(expectedBootstrapPort + 2);
-            ServicePort node2ServicePort = clusterIpServicePort(expectedBootstrapPort + 3);
+            ServicePort bootstrapServicePort = clusterIpServicePort(expectedBootstrapPort, suffix);
+            ServicePort node0ServicePort = clusterIpServicePort(expectedBootstrapPort + 1, suffix);
+            ServicePort node1ServicePort = clusterIpServicePort(expectedBootstrapPort + 2, suffix);
+            ServicePort node2ServicePort = clusterIpServicePort(expectedBootstrapPort + 3, suffix);
             assertThat(service.getSpec().getPorts()).containsExactly(bootstrapServicePort, node0ServicePort, node1ServicePort, node2ServicePort);
         });
 
@@ -898,23 +929,25 @@ public class KafkaProxyReconcilerIT {
         assumeThat(OpenShiftUtils.supportsRoute()).withFailMessage("kubernetes server is missing support for resource kind Route").isTrue();
 
         // Given
+        var suffix = uniqueSuffix();
         var domain = OpenShiftUtils.getDefaultIngressControllerDomain();
-        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
-        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP)),
+                CLUSTER_BAR_BOOTSTRAP);
 
         int proxyListenPort = ProxyDeploymentDependentResource.SHARED_SNI_PORT;
 
-        String ingressName = "openshiftroute";
+        String ingressName = "openshiftroute" + suffix;
         String routeBootstrap = "$(virtualClusterName)-bootstrap." + domain;
         String routeBrokerAddressPattern = "$(virtualClusterName)-$(nodeId)." + domain;
         KafkaProxyIngress openshiftRouteIngress = updateStatusObservedGeneration(
                 clusterUser.create(openshiftRouteIngress(ingressName, proxy)));
 
-        String downstreamCertSecretName = "downstream-tls-certificate";
+        String downstreamCertSecretName = "downstream-tls-certificate" + suffix;
         Secret tlsCert = clusterUser.create(tlsKeyAndCertSecret(downstreamCertSecretName));
 
         Ingresses clusterIngress = createIngressForCluster(openshiftRouteIngress, tlsCert);
-        VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(clusterIngress), Optional.empty());
+        VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR + suffix, proxy, kafkaService, List.of(clusterIngress), Optional.empty());
 
         // When
         updateStatusObservedGeneration(clusterUser.create(cluster));
@@ -989,8 +1022,8 @@ public class KafkaProxyReconcilerIT {
         return createContainerPort(bootstrapPort, bootstrapPort + "-bootstrap");
     }
 
-    private static @NonNull ServicePort clusterIpServicePort(int port) {
-        return createServicePort(KafkaProxyReconcilerIT.CLUSTER_BAR + "-" + port, port, port);
+    private static @NonNull ServicePort clusterIpServicePort(int port, String suffix) {
+        return createServicePort(KafkaProxyReconcilerIT.CLUSTER_BAR + suffix + "-" + port, port, port);
     }
 
     private static ContainerPort createContainerPort(int port, String name) {
@@ -1005,41 +1038,41 @@ public class KafkaProxyReconcilerIT {
         return new ServicePortBuilder().withName(name).withPort(port).withProtocol("TCP").withTargetPort(new IntOrString(targetPort)).build();
     }
 
-    private record CreatedResources(KafkaProxy proxy, Set<VirtualKafkaCluster> clusters, Set<KafkaService> services, Set<KafkaProxyIngress> ingresses) {
+    private record CreatedResources(String suffix, KafkaProxy proxy, Set<VirtualKafkaCluster> clusters, Set<KafkaService> services, Set<KafkaProxyIngress> ingresses) {
 
         VirtualKafkaCluster cluster() {
-            return clusters.stream().filter(r -> CLUSTER_BAR.equals(r.getMetadata().getName())).findFirst().orElseThrow();
+            return clusters.stream().filter(r -> (CLUSTER_BAR + suffix).equals(r.getMetadata().getName())).findFirst().orElseThrow();
         }
 
         KafkaService kafkaService() {
-            return services.stream().filter(r -> CLUSTER_BAR_REF.equals(r.getMetadata().getName())).findFirst().orElseThrow();
+            return services.stream().filter(r -> (CLUSTER_BAR_REF + suffix).equals(r.getMetadata().getName())).findFirst().orElseThrow();
         }
 
         KafkaProxyIngress ingress() {
-            return ingresses.stream().filter(r -> CLUSTER_BAR_CLUSTERIP_INGRESS.equals(r.getMetadata().getName())).findFirst().orElseThrow();
+            return ingresses.stream().filter(r -> (CLUSTER_BAR_CLUSTERIP_INGRESS + suffix).equals(r.getMetadata().getName())).findFirst().orElseThrow();
         }
 
     }
 
-    CreatedResources doCreate() {
-        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP);
-        return doCreate(kafkaService);
+    CreatedResources doCreate(String suffix) {
+        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP);
+        return doCreate(suffix, kafkaService);
     }
 
-    CreatedResources doCreate(KafkaService kafkaService) {
-        return doCreate(kafkaService, kafkaProxy(PROXY_A));
+    CreatedResources doCreate(String suffix, KafkaService kafkaService) {
+        return doCreate(suffix, kafkaService, kafkaProxy(PROXY_A + suffix));
     }
 
-    CreatedResources doCreate(KafkaService kafkaService, KafkaProxy kafkaProxy) {
+    CreatedResources doCreate(String suffix, KafkaService kafkaService, KafkaProxy kafkaProxy) {
         KafkaProxy proxy = clusterUser.create(kafkaProxy);
-        KafkaProtocolFilter filter = clusterUser.create(filter(FILTER_NAME));
+        KafkaProtocolFilter filter = clusterUser.create(filter(FILTER_NAME + suffix));
         filter = updateStatusObservedGeneration(filter);
         KafkaService barService = clusterUser.create(kafkaService);
         barService = updateStatusObservedGeneration(barService, CLUSTER_BAR_BOOTSTRAP);
-        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TCP));
+        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS + suffix, proxy, TCP));
         ingressBar = updateStatusObservedGeneration(ingressBar);
         Set<KafkaService> kafkaServices = Set.of(barService);
-        VirtualKafkaCluster clusterBar = clusterUser.create(virtualKafkaCluster(CLUSTER_BAR, proxy, barService,
+        VirtualKafkaCluster clusterBar = clusterUser.create(virtualKafkaCluster(CLUSTER_BAR + suffix, proxy, barService,
                 List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressBar)).build()), Optional.of(filter)));
         clusterBar = updateStatusObservedGeneration(clusterBar);
         Set<VirtualKafkaCluster> clusters = Set.of(clusterBar);
@@ -1048,7 +1081,7 @@ public class KafkaProxyReconcilerIT {
         assertDeploymentMountsConfigMap(proxy, ProxyConfigDependentResource.configMapName(proxy));
         assertDeploymentBecomesReady(proxy);
         assertServiceTargetsProxyInstances(proxy, clusterBar, ingressBar);
-        return new CreatedResources(proxy, clusters, kafkaServices, Set.of(ingressBar));
+        return new CreatedResources(suffix, proxy, clusters, kafkaServices, Set.of(ingressBar));
     }
 
     private void assertDefaultVirtualClusterGatewayConfigured(KafkaProxy proxy, KafkaProxyIngress ingressBar, VirtualKafkaCluster clusterBar) {
@@ -1259,7 +1292,8 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void testDelete() {
-        var createdResources = doCreate();
+        var suffix = uniqueSuffix();
+        var createdResources = doCreate(suffix);
         KafkaProxy proxy = createdResources.proxy;
         clusterUser.delete(proxy);
 
@@ -1281,7 +1315,8 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void testUpdateVirtualClusterTargetBootstrap() {
-        final var createdResources = doCreate();
+        var suffix = uniqueSuffix();
+        final var createdResources = doCreate(suffix);
         KafkaProxy proxy = createdResources.proxy;
         var kafkaService = createdResources.kafkaService().edit().editSpec().withBootstrapServers(NEW_BOOTSTRAP).endSpec().build();
         kafkaService = clusterUser.replace(kafkaService);
@@ -1298,10 +1333,11 @@ public class KafkaProxyReconcilerIT {
     @Test
     void testUpdateVirtualClusterClusterRef() {
         // given
-        final var createdResources = doCreate();
+        var suffix = uniqueSuffix();
+        final var createdResources = doCreate(suffix);
         KafkaProxy proxy = createdResources.proxy;
 
-        String newClusterRefName = "new-cluster-ref";
+        String newClusterRefName = "new-cluster-ref" + suffix;
         updateStatusObservedGeneration(clusterUser.create(kafkaService(newClusterRefName, NEW_BOOTSTRAP)), NEW_BOOTSTRAP);
 
         KafkaServiceRef newClusterRef = new KafkaServiceRefBuilder().withName(newClusterRefName).build();
@@ -1322,7 +1358,8 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void testDeleteVirtualCluster() {
-        final var createdResources = doCreate();
+        var suffix = uniqueSuffix();
+        final var createdResources = doCreate(suffix);
         KafkaProxy proxy = createdResources.proxy;
         clusterUser.delete(createdResources.cluster());
 
@@ -1332,7 +1369,7 @@ public class KafkaProxyReconcilerIT {
                     .describedAs("Expect ConfigMap for cluster 'bar' to have been deleted")
                     .isNull();
 
-            var service = clusterUser.get(Service.class, CLUSTER_BAR);
+            var service = clusterUser.get(Service.class, CLUSTER_BAR + suffix);
             assertThat(service)
                     .describedAs("Expect Service for cluster 'bar' to have been deleted")
                     .isNull();
@@ -1342,19 +1379,22 @@ public class KafkaProxyReconcilerIT {
     @Test
     void moveVirtualKafkaClusterToAnotherKafkaProxy() {
         // given
-        KafkaProxy proxyA = clusterUser.create(kafkaProxy(PROXY_A));
-        KafkaProxy proxyB = clusterUser.create(kafkaProxy(PROXY_B));
-        KafkaProxyIngress ingressFoo = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyA, TCP)));
-        KafkaProxyIngress ingressBar = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxyB, TCP)));
+        var suffix = uniqueSuffix();
+        KafkaProxy proxyA = clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        KafkaProxy proxyB = clusterUser.create(kafkaProxy(PROXY_B + suffix));
+        KafkaProxyIngress ingressFoo = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS + suffix, proxyA, TCP)));
+        KafkaProxyIngress ingressBar = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS + suffix, proxyB, TCP)));
 
-        KafkaService fooService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP)), CLUSTER_FOO_BOOTSTRAP);
-        KafkaService barService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
-        KafkaProtocolFilter filter = updateStatusObservedGeneration(clusterUser.create(filter(FILTER_NAME)));
+        KafkaService fooService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_FOO_REF + suffix, CLUSTER_FOO_BOOTSTRAP)),
+                CLUSTER_FOO_BOOTSTRAP);
+        KafkaService barService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF + suffix, CLUSTER_BAR_BOOTSTRAP)),
+                CLUSTER_BAR_BOOTSTRAP);
+        KafkaProtocolFilter filter = updateStatusObservedGeneration(clusterUser.create(filter(FILTER_NAME + suffix)));
 
-        VirtualKafkaCluster fooCluster = clusterUser.create(virtualKafkaCluster(CLUSTER_FOO, proxyA, fooService,
+        VirtualKafkaCluster fooCluster = clusterUser.create(virtualKafkaCluster(CLUSTER_FOO + suffix, proxyA, fooService,
                 List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressFoo)).build()), Optional.of(filter)));
         updateStatusObservedGeneration(fooCluster);
-        VirtualKafkaCluster barCluster = clusterUser.create(virtualKafkaCluster(CLUSTER_BAR, proxyB, barService,
+        VirtualKafkaCluster barCluster = clusterUser.create(virtualKafkaCluster(CLUSTER_BAR + suffix, proxyB, barService,
                 List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressBar)).build()), Optional.of(filter)));
         updateStatusObservedGeneration(barCluster);
 
@@ -1364,14 +1404,16 @@ public class KafkaProxyReconcilerIT {
         assertServiceTargetsProxyInstances(proxyB, barCluster, ingressBar);
 
         // must swap ingresses so both proxy instances have a single port-per-broker ingress
-        updateStatusObservedGeneration(clusterUser.replace(clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyB, TCP)));
-        updateStatusObservedGeneration(clusterUser.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxyA, TCP)));
-        var updatedFooCluster = new VirtualKafkaClusterBuilder(clusterUser.get(VirtualKafkaCluster.class, CLUSTER_FOO)).editSpec().editProxyRef().withName(name(proxyB))
+        updateStatusObservedGeneration(clusterUser.replace(clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS + suffix, proxyB, TCP)));
+        updateStatusObservedGeneration(clusterUser.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS + suffix, proxyA, TCP)));
+        var updatedFooCluster = new VirtualKafkaClusterBuilder(clusterUser.get(VirtualKafkaCluster.class, CLUSTER_FOO + suffix)).editSpec().editProxyRef()
+                .withName(name(proxyB))
                 .endProxyRef().endSpec()
                 .build();
         updatedFooCluster = clusterUser.replace(updatedFooCluster);
         updateStatusObservedGeneration(updatedFooCluster);
-        var updatedBarCluster = new VirtualKafkaClusterBuilder(clusterUser.get(VirtualKafkaCluster.class, CLUSTER_BAR)).editSpec().editProxyRef().withName(name(proxyA))
+        var updatedBarCluster = new VirtualKafkaClusterBuilder(clusterUser.get(VirtualKafkaCluster.class, CLUSTER_BAR + suffix)).editSpec().editProxyRef()
+                .withName(name(proxyA))
                 .endProxyRef().endSpec()
                 .build();
         updatedBarCluster = clusterUser.replace(updatedBarCluster);
@@ -1391,16 +1433,19 @@ public class KafkaProxyReconcilerIT {
     @Test
     void deleteAndRestoreADependency() {
         // given
-        KafkaProxy proxyA = clusterUser.create(kafkaProxy(PROXY_A));
+        var suffix = uniqueSuffix();
+        KafkaProxy proxyA = clusterUser.create(kafkaProxy(PROXY_A + suffix));
 
-        KafkaProxyIngress ingress = clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyA, TCP);
+        KafkaProxyIngress ingress = clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS + suffix, proxyA, TCP);
         KafkaProxyIngress ingressFoo = updateStatusObservedGeneration(clusterUser.create(ingress.edit().build()));
 
-        KafkaService fooService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP)), CLUSTER_FOO_BOOTSTRAP);
-        KafkaProtocolFilter filter = updateStatusObservedGeneration(clusterUser.create(filter(FILTER_NAME)));
+        KafkaService fooService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_FOO_REF + suffix, CLUSTER_FOO_BOOTSTRAP)),
+                CLUSTER_FOO_BOOTSTRAP);
+        KafkaProtocolFilter filter = updateStatusObservedGeneration(clusterUser.create(filter(FILTER_NAME + suffix)));
 
         VirtualKafkaCluster fooCluster = updateStatusObservedGeneration(
-                clusterUser.create(virtualKafkaCluster(CLUSTER_FOO, proxyA, fooService, List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressFoo)).build()),
+                clusterUser.create(virtualKafkaCluster(CLUSTER_FOO + suffix, proxyA, fooService,
+                        List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressFoo)).build()),
                         Optional.of(filter))));
 
         assertProxyConfigContents(proxyA, Set.of(CLUSTER_FOO_BOOTSTRAP), Set.of());
@@ -1497,17 +1542,17 @@ public class KafkaProxyReconcilerIT {
         // @formatter:on
     }
 
-    private static KafkaService kafkaServiceWithTls() {
+    private static KafkaService kafkaServiceWithTls(String suffix) {
         // @formatter:off
-        return new KafkaServiceBuilder(kafkaService(KafkaProxyReconcilerIT.CLUSTER_BAR_REF, KafkaProxyReconcilerIT.CLUSTER_BAR_BOOTSTRAP))
+        return new KafkaServiceBuilder(kafkaService(KafkaProxyReconcilerIT.CLUSTER_BAR_REF + suffix, KafkaProxyReconcilerIT.CLUSTER_BAR_BOOTSTRAP))
                 .editSpec()
                     .withNewTls()
                         .withNewCertificateRef()
-                            .withName(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME)
+                            .withName(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME + suffix)
                         .endCertificateRef()
                         .withNewTrustAnchorRef()
                             .withNewRef()
-                                .withName(CA_BUNDLE_CONFIG_MAP_NAME)
+                                .withName(CA_BUNDLE_CONFIG_MAP_NAME + suffix)
                             .endRef()
                             .withKey(TRUSTED_CAS_PEM)
                         .endTrustAnchorRef()
@@ -1523,17 +1568,17 @@ public class KafkaProxyReconcilerIT {
         // @formatter:on
     }
 
-    private static KafkaService kafkaServiceWithTlsWithTrustAnchorRefAsSecret() {
+    private static KafkaService kafkaServiceWithTlsWithTrustAnchorRefAsSecret(String suffix) {
         // @formatter:off
-        return new KafkaServiceBuilder(kafkaService(KafkaProxyReconcilerIT.CLUSTER_BAR_REF, KafkaProxyReconcilerIT.CLUSTER_BAR_BOOTSTRAP))
+        return new KafkaServiceBuilder(kafkaService(KafkaProxyReconcilerIT.CLUSTER_BAR_REF + suffix, KafkaProxyReconcilerIT.CLUSTER_BAR_BOOTSTRAP))
                 .editSpec()
                     .withNewTls()
                         .withNewCertificateRef()
-                            .withName(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME)
+                            .withName(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME + suffix)
                         .endCertificateRef()
                         .withNewTrustAnchorRef()
                             .withNewRef()
-                                .withName(CA_CERT_SECRET_NAME)
+                                .withName(CA_CERT_SECRET_NAME + suffix)
                                 .withKind("Secret")
                             .endRef()
                             .withKey(TRUSTED_CAS_PEM)

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconcilerIT.java
@@ -26,6 +26,7 @@ import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.testing.operator.assertj.KafkaProxyIngressStatusAssert;
 
 import static io.kroxylicious.kubernetes.api.common.Protocol.TCP;
+import static io.kroxylicious.testing.operator.OperatorTestUtils.uniqueSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -54,23 +55,26 @@ class KafkaProxyIngressReconcilerIT {
 
     @Test
     void testCreateIngressFirst() {
-        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        var suffix = uniqueSuffix();
+        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS + suffix, PROXY_A + suffix));
         assertResolvedRefsFalse(ingressBar);
-        clusterUser.create(kafkaProxy(PROXY_A));
+        clusterUser.create(kafkaProxy(PROXY_A + suffix));
         assertAllConditionsTrue(ingressBar);
     }
 
     @Test
     void testCreateProxyFirst() {
-        clusterUser.create(kafkaProxy(PROXY_A));
-        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        var suffix = uniqueSuffix();
+        clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS + suffix, PROXY_A + suffix));
         assertAllConditionsTrue(ingressBar);
     }
 
     @Test
     void testDeleteProxy() {
-        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
-        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        var suffix = uniqueSuffix();
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS + suffix, ResourcesUtil.name(proxy)));
         assertAllConditionsTrue(ingressBar);
 
         clusterUser.delete(proxy);
@@ -79,12 +83,13 @@ class KafkaProxyIngressReconcilerIT {
 
     @Test
     void testSwitchProxy() {
-        clusterUser.create(kafkaProxy(PROXY_A));
-        clusterUser.create(kafkaProxy(PROXY_B));
-        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        var suffix = uniqueSuffix();
+        clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        clusterUser.create(kafkaProxy(PROXY_B + suffix));
+        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS + suffix, PROXY_A + suffix));
         assertAllConditionsTrue(ingressBar);
 
-        clusterUser.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_B));
+        clusterUser.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS + suffix, PROXY_B + suffix));
         assertAllConditionsTrue(ingressBar);
     }
 

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
@@ -36,6 +36,7 @@ import io.kroxylicious.testing.operator.assertj.OperatorAssertions;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED;
+import static io.kroxylicious.testing.operator.OperatorTestUtils.uniqueSuffix;
 import static io.kroxylicious.testing.operator.assertj.OperatorAssertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -70,7 +71,8 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldImmediatelyResolveWhenNoReferents() {
         // Given
-        KafkaService resource = kafkaService(SERVICE_A, null, null, null);
+        var suffix = uniqueSuffix();
+        KafkaService resource = kafkaService(SERVICE_A + suffix, null, null, null);
 
         // When
         clusterUser.create(resource);
@@ -82,12 +84,14 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldResolveUpdateToKafkaService() {
         // Given
+        var suffix = uniqueSuffix();
         var kafkaService = clusterUser.create(
-                new KafkaServiceBuilder().withNewMetadata().withName(SERVICE_A).endMetadata().withNewSpec().withBootstrapServers(FOO_BOOTSTRAP_9090).endSpec().build());
+                new KafkaServiceBuilder().withNewMetadata().withName(SERVICE_A + suffix).endMetadata().withNewSpec().withBootstrapServers(FOO_BOOTSTRAP_9090)
+                        .endSpec().build());
         assertResolvedRefsTrue(kafkaService, FOO_BOOTSTRAP_9090, false);
 
         // When
-        clusterUser.resources(KafkaService.class).withName(SERVICE_A)
+        clusterUser.resources(KafkaService.class).withName(SERVICE_A + suffix)
                 .edit(current -> new KafkaServiceBuilder(current).editSpec().withBootstrapServers(BAR_BOOTSTRAP_9090).endSpec().build());
 
         // Then
@@ -97,7 +101,8 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldEventuallyResolveOnceCertSecretCreated() {
         // Given
-        KafkaService resource = kafkaService(SERVICE_A, SECRET_X, null, null);
+        var suffix = uniqueSuffix();
+        KafkaService resource = kafkaService(SERVICE_A + suffix, SECRET_X + suffix, null, null);
 
         // When
         final KafkaService kafkaService = clusterUser.create(resource);
@@ -106,7 +111,7 @@ class KafkaServiceBootstrapReconcilerIT {
         assertResolvedRefsFalse(kafkaService, Condition.REASON_REFS_NOT_FOUND, "spec.tls.certificateRef: referenced secret not found");
 
         // And When
-        clusterUser.create(tlsCertificateSecret(SECRET_X));
+        clusterUser.create(tlsCertificateSecret(SECRET_X + suffix));
 
         // Then
         assertResolvedRefsTrue(kafkaService, FOO_BOOTSTRAP_9090, true);
@@ -116,8 +121,9 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldUpdateStatusOnceTlsCertificateSecretDeleted() {
         // Given
-        var tlsCertSecret = clusterUser.create(tlsCertificateSecret(SECRET_X));
-        KafkaService resource = clusterUser.create(kafkaService(SERVICE_A, SECRET_X, null, null));
+        var suffix = uniqueSuffix();
+        var tlsCertSecret = clusterUser.create(tlsCertificateSecret(SECRET_X + suffix));
+        KafkaService resource = clusterUser.create(kafkaService(SERVICE_A + suffix, SECRET_X + suffix, null, null));
         assertResolvedRefsTrue(resource, FOO_BOOTSTRAP_9090, true);
 
         // When
@@ -130,7 +136,8 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldEventuallyResolveOnceTrustAnchorConfigMapCreated() {
         // Given
-        KafkaService resource = kafkaService(SERVICE_A, null, CONFIG_MAP_T, null);
+        var suffix = uniqueSuffix();
+        KafkaService resource = kafkaService(SERVICE_A + suffix, null, CONFIG_MAP_T + suffix, null);
 
         // When
         final KafkaService kafkaService = clusterUser.create(resource);
@@ -139,7 +146,7 @@ class KafkaServiceBootstrapReconcilerIT {
         assertResolvedRefsFalse(kafkaService, Condition.REASON_REFS_NOT_FOUND, "spec.tls.trustAnchorRef: referenced configmap not found");
 
         // And When
-        clusterUser.create(trustAnchorConfigMap(CONFIG_MAP_T));
+        clusterUser.create(trustAnchorConfigMap(CONFIG_MAP_T + suffix));
 
         // Then
         assertResolvedRefsTrue(kafkaService, FOO_BOOTSTRAP_9090, true);
@@ -149,7 +156,8 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldEventuallyResolveOnceTrustAnchorSecretCreated() {
         // Given
-        KafkaService resource = kafkaService(SERVICE_A, null, SECRET_T, "Secret");
+        var suffix = uniqueSuffix();
+        KafkaService resource = kafkaService(SERVICE_A + suffix, null, SECRET_T + suffix, "Secret");
 
         // When
         final KafkaService kafkaService = clusterUser.create(resource);
@@ -158,7 +166,7 @@ class KafkaServiceBootstrapReconcilerIT {
         assertResolvedRefsFalse(kafkaService, Condition.REASON_REFS_NOT_FOUND, "spec.tls.trustAnchorRef: referenced secret not found");
 
         // And When
-        clusterUser.create(trustAnchorSecret(SECRET_T));
+        clusterUser.create(trustAnchorSecret(SECRET_T + suffix));
 
         // Then
         assertResolvedRefsTrue(kafkaService, FOO_BOOTSTRAP_9090, true);
@@ -168,13 +176,14 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldUpdateReferentAnnotationWhenTrustAnchorConfigMapModified() {
         // Given
-        clusterUser.create(trustAnchorConfigMap(CONFIG_MAP_T));
-        KafkaService resource = kafkaService(SERVICE_A, null, CONFIG_MAP_T, null);
+        var suffix = uniqueSuffix();
+        clusterUser.create(trustAnchorConfigMap(CONFIG_MAP_T + suffix));
+        KafkaService resource = kafkaService(SERVICE_A + suffix, null, CONFIG_MAP_T + suffix, null);
         final KafkaService kafkaService = clusterUser.create(resource);
         String checksum = awaitReferentsChecksumSpecified(resource);
 
         // When
-        clusterUser.replace(trustAnchorConfigMap(CONFIG_MAP_T).edit().addToData("arbitrary", "arbitrary").build());
+        clusterUser.replace(trustAnchorConfigMap(CONFIG_MAP_T + suffix).edit().addToData("arbitrary", "arbitrary").build());
 
         // Then
         assertReferentsChecksumNotEqual(kafkaService, checksum);
@@ -183,12 +192,13 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldUpdateReferentAnnotationWhenCertificateSecretModified() {
         // Given
-        clusterUser.create(tlsCertificateSecret(SECRET_X));
-        KafkaService resource = clusterUser.create(kafkaService(SERVICE_A, SECRET_X, null, null));
+        var suffix = uniqueSuffix();
+        clusterUser.create(tlsCertificateSecret(SECRET_X + suffix));
+        KafkaService resource = clusterUser.create(kafkaService(SERVICE_A + suffix, SECRET_X + suffix, null, null));
         String checksum = awaitReferentsChecksumSpecified(resource);
 
         // When
-        clusterUser.replace(tlsCertificateSecret(SECRET_X).edit().addToData("arbitrary", "whatever").build());
+        clusterUser.replace(tlsCertificateSecret(SECRET_X + suffix).edit().addToData("arbitrary", "whatever").build());
 
         // Then
         assertReferentsChecksumNotEqual(resource, checksum);
@@ -197,8 +207,9 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldUpdateStatusOnceTrustAnchorConfigMapDeleted() {
         // Given
-        var trustedCaCerts = clusterUser.create(trustAnchorConfigMap(CONFIG_MAP_T));
-        KafkaService resource = clusterUser.create(kafkaService(SERVICE_A, null, CONFIG_MAP_T, null));
+        var suffix = uniqueSuffix();
+        var trustedCaCerts = clusterUser.create(trustAnchorConfigMap(CONFIG_MAP_T + suffix));
+        KafkaService resource = clusterUser.create(kafkaService(SERVICE_A + suffix, null, CONFIG_MAP_T + suffix, null));
         assertResolvedRefsTrue(resource, FOO_BOOTSTRAP_9090, true);
 
         // When

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
@@ -53,6 +53,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.STRIMZI_CLUSTER_CA_BUNDLE;
 import static io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED;
+import static io.kroxylicious.testing.operator.OperatorTestUtils.uniqueSuffix;
 import static io.kroxylicious.testing.operator.assertj.OperatorAssertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -102,11 +103,12 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @Test
     void shouldResolveStrimziKafkaWithPlainListener() {
         // Given
-        var kafka = clusterUser.create(kafkaResource(KAFKA_RESOURCE_NAME));
+        var suffix = uniqueSuffix();
+        var kafka = clusterUser.create(kafkaResource(KAFKA_RESOURCE_NAME + suffix));
         reconcileStrimziResource(kafka);
 
         // When
-        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
+        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A + suffix, "plain", KAFKA_RESOURCE_NAME + suffix));
 
         // Then
         assertResolvedRefsTrue(service, FOO_BOOTSTRAP_9090, true);
@@ -115,11 +117,12 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @Test
     void shouldResolveStrimziKafkaWithTlsListener() {
         // Given
-        var kafka = clusterUser.create(kafkaResourceWithTls(KAFKA_RESOURCE_NAME));
+        var suffix = uniqueSuffix();
+        var kafka = clusterUser.create(kafkaResourceWithTls(KAFKA_RESOURCE_NAME + suffix));
         reconcileStrimziResource(kafka);
 
         // When
-        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "tls", KAFKA_RESOURCE_NAME));
+        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A + suffix, "tls", KAFKA_RESOURCE_NAME + suffix));
 
         // Then
         assertResolvedRefsTrue(service, FOO_BOOTSTRAP_9090, true);
@@ -127,15 +130,17 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
 
     @Test
     void shouldResolveStrimziKafkaInDifferentNamespace() {
+        var suffix = uniqueSuffix();
         String strimziNamespace = "strimzi-" + UUID.randomUUID();
 
         try (KubernetesClient client = OperatorTestUtils.kubeClient()) {
             client.namespaces().resource(new NamespaceBuilder().withNewMetadata().withName(strimziNamespace).endMetadata().build()).create();
             try {
-                var kafka = client.resources(Kafka.class).inNamespace(strimziNamespace).resource(kafkaResource(KAFKA_RESOURCE_NAME)).create();
+                var kafka = client.resources(Kafka.class).inNamespace(strimziNamespace).resource(kafkaResource(KAFKA_RESOURCE_NAME + suffix)).create();
                 reconcileStrimziResource(kafka, strimziNamespace);
 
-                KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME, strimziNamespace));
+                KafkaService service = clusterUser
+                        .create(kafkaServiceWithStrimziKafkaRef(SERVICE_A + suffix, "plain", KAFKA_RESOURCE_NAME + suffix, strimziNamespace));
 
                 assertResolvedRefsTrue(service, FOO_BOOTSTRAP_9090, true);
             }
@@ -148,20 +153,23 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
 
     @Test
     void shouldResolveStrimziCaSecretInReferencedKafkaNamespace() {
+        var suffix = uniqueSuffix();
+        String kafkaResourceName = KAFKA_RESOURCE_NAME + suffix;
         String strimziNamespace = "strimzi-" + UUID.randomUUID();
 
         try (KubernetesClient client = OperatorTestUtils.kubeClient()) {
             client.namespaces().resource(new NamespaceBuilder().withNewMetadata().withName(strimziNamespace).endMetadata().build()).create();
             try {
-                var kafka = client.resources(Kafka.class).inNamespace(strimziNamespace).resource(kafkaResourceWithTls(KAFKA_RESOURCE_NAME)).create();
+                var kafka = client.resources(Kafka.class).inNamespace(strimziNamespace).resource(kafkaResourceWithTls(kafkaResourceName)).create();
                 reconcileStrimziResource(kafka, strimziNamespace);
-                String clusterCaSecretName = KAFKA_RESOURCE_NAME + ResourcesUtil.STRIMZI_CLUSTER_CA_CERT_SECRET_SUFFIX;
+                String clusterCaSecretName = kafkaResourceName + ResourcesUtil.STRIMZI_CLUSTER_CA_CERT_SECRET_SUFFIX;
                 client.secrets().inNamespace(strimziNamespace).resource(strimziTrustAnchorSecret(clusterCaSecretName)).create();
 
-                KafkaService service = clusterUser.create(kafkaServiceWithCrossNamespaceStrimziCa("service-cross-namespace-strimzi-ca", "tls", strimziNamespace));
+                KafkaService service = clusterUser
+                        .create(kafkaServiceWithCrossNamespaceStrimziCa("service-cross-namespace-strimzi-ca" + suffix, "tls", strimziNamespace, kafkaResourceName));
 
                 assertResolvedRefsTrue(service, FOO_BOOTSTRAP_9090, true);
-                assertKafkaService("service-cross-namespace-strimzi-ca", clusterCaSecretName, "Secret");
+                assertKafkaService("service-cross-namespace-strimzi-ca" + suffix, clusterCaSecretName, "Secret");
             }
             finally {
                 client.namespaces().withName(strimziNamespace).delete();
@@ -172,14 +180,15 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @Test
     void shouldHandleStrimziKafkaWithNoReconciledListeners() {
         // Given
-        clusterUser.create(kafkaResource(KAFKA_RESOURCE_NAME));
-        externalOperator.updateStatus(Kafka.class, KAFKA_RESOURCE_NAME, fresh -> new KafkaBuilder(fresh)
+        var suffix = uniqueSuffix();
+        clusterUser.create(kafkaResource(KAFKA_RESOURCE_NAME + suffix));
+        externalOperator.updateStatus(Kafka.class, KAFKA_RESOURCE_NAME + suffix, fresh -> new KafkaBuilder(fresh)
                 .withNewStatus()
                 .endStatus()
                 .build());
 
         // When
-        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
+        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A + suffix, "plain", KAFKA_RESOURCE_NAME + suffix));
 
         // Then
         assertResolvedRefsFalse(service, Condition.REASON_REFERENCED_RESOURCE_NOT_RECONCILED, "Referenced resource has not yet reconciled listener name: plain");
@@ -188,10 +197,11 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @Test
     void shouldHandleStrimziKafkaWithNoStatus() {
         // Given
-        clusterUser.create(kafkaResource(KAFKA_RESOURCE_NAME));
+        var suffix = uniqueSuffix();
+        clusterUser.create(kafkaResource(KAFKA_RESOURCE_NAME + suffix));
 
         // When
-        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
+        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A + suffix, "plain", KAFKA_RESOURCE_NAME + suffix));
 
         // Then
         assertResolvedRefsFalse(service, Condition.REASON_REFERENCED_RESOURCE_NOT_RECONCILED, "Referenced resource has not yet reconciled listener name: plain");
@@ -200,11 +210,12 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @Test
     void shouldUpdateStatusOnceStrimziKafkaResourceDeleted() {
         // Given
-        var kafka = clusterUser.create(kafkaResource(KAFKA_RESOURCE_NAME));
+        var suffix = uniqueSuffix();
+        var kafka = clusterUser.create(kafkaResource(KAFKA_RESOURCE_NAME + suffix));
         reconcileStrimziResource(kafka);
 
         // When
-        KafkaService updated = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
+        KafkaService updated = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A + suffix, "plain", KAFKA_RESOURCE_NAME + suffix));
         assertResolvedRefsTrue(updated, FOO_BOOTSTRAP_9090, true);
 
         // When
@@ -221,18 +232,21 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @Test
     void trustAnchorRefAlwaysTakesPrecedenceWhenPresent() {
         // Given
-        var kafka = clusterUser.create(kafkaResourceWithTls(KAFKA_RESOURCE_NAME));
+        var suffix = uniqueSuffix();
+        String kafkaResourceName = KAFKA_RESOURCE_NAME + suffix;
+        var kafka = clusterUser.create(kafkaResourceWithTls(kafkaResourceName));
         reconcileStrimziResource(kafka);
-        createTrustAnchorSecret("explicit-trust", "ca-bundle.pem");
+        createTrustAnchorSecret("explicit-trust" + suffix, "ca-bundle.pem");
 
-        var tar = createTrustAnchorRef("explicit-trust", "Secret");
+        var tar = createTrustAnchorRef("explicit-trust" + suffix, "Secret");
 
         // When - Create KafkaService with trustAnchorRef AND trustStrimziCaCertificate=true
-        var service = clusterUser.create(kafkaServiceWithStrimziKafkaRefAndOptionalTrustAnchor("service-with-both-refs", "tls", true, tar));
+        var service = clusterUser
+                .create(kafkaServiceWithStrimziKafkaRefAndOptionalTrustAnchor("service-with-both-refs" + suffix, "tls", true, tar, kafkaResourceName));
 
         // Then - Explicit trustAnchorRef should be used (not Strimzi CA)
         assertResolvedRefsTrue(service, FOO_BOOTSTRAP_9090, true);
-        assertKafkaService("service-with-both-refs", "explicit-trust", "Secret");
+        assertKafkaService("service-with-both-refs" + suffix, "explicit-trust" + suffix, "Secret");
     }
 
     /**
@@ -241,18 +255,21 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @Test
     void trustAnchorRefUsedWhenTrustStrimziCaDisabled() {
         // Given
-        var kafka = clusterUser.create(kafkaResourceWithTls(KAFKA_RESOURCE_NAME));
+        var suffix = uniqueSuffix();
+        String kafkaResourceName = KAFKA_RESOURCE_NAME + suffix;
+        var kafka = clusterUser.create(kafkaResourceWithTls(kafkaResourceName));
         reconcileStrimziResource(kafka);
-        createTrustAnchorConfigMap("explicit-trust");
+        createTrustAnchorConfigMap("explicit-trust" + suffix);
 
-        var tar = createTrustAnchorRef("explicit-trust", "ConfigMap");
+        var tar = createTrustAnchorRef("explicit-trust" + suffix, "ConfigMap");
 
         // When - Create KafkaService with trustAnchorRef AND trustStrimziCaCertificate=false
-        var service = clusterUser.create(kafkaServiceWithStrimziKafkaRefAndOptionalTrustAnchor("service-trust-anchor-only", "tls", false, tar));
+        var service = clusterUser
+                .create(kafkaServiceWithStrimziKafkaRefAndOptionalTrustAnchor("service-trust-anchor-only" + suffix, "tls", false, tar, kafkaResourceName));
 
         // Then - Explicit trustAnchorRef should be used
         assertResolvedRefsTrue(service, FOO_BOOTSTRAP_9090, true);
-        assertKafkaService("service-trust-anchor-only", "explicit-trust", "ConfigMap");
+        assertKafkaService("service-trust-anchor-only" + suffix, "explicit-trust" + suffix, "ConfigMap");
     }
 
     /**
@@ -262,17 +279,20 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @Test
     void strimziCaUsedWhenTrustAnchorRefNotPresent() {
         // Given
-        var kafka = clusterUser.create(kafkaResourceWithTls(KAFKA_RESOURCE_NAME));
+        var suffix = uniqueSuffix();
+        String kafkaResourceName = KAFKA_RESOURCE_NAME + suffix;
+        var kafka = clusterUser.create(kafkaResourceWithTls(kafkaResourceName));
         reconcileStrimziResource(kafka);
-        String clusterCaSecretName = KAFKA_RESOURCE_NAME + ResourcesUtil.STRIMZI_CLUSTER_CA_CERT_SECRET_SUFFIX;
+        String clusterCaSecretName = kafkaResourceName + ResourcesUtil.STRIMZI_CLUSTER_CA_CERT_SECRET_SUFFIX;
         createStrimziTrustAnchorSecret(clusterCaSecretName);
 
         // When - Create KafkaService with trustStrimziCaCertificate=true but NO trustAnchorRef
-        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRefAndOptionalTrustAnchor("service-strimzi-only", "tls", true, null));
+        KafkaService service = clusterUser
+                .create(kafkaServiceWithStrimziKafkaRefAndOptionalTrustAnchor("service-strimzi-only" + suffix, "tls", true, null, kafkaResourceName));
 
         // Then - Strimzi CA should be used
         assertResolvedRefsTrue(service, FOO_BOOTSTRAP_9090, true);
-        assertKafkaService("service-strimzi-only", clusterCaSecretName, "Secret");
+        assertKafkaService("service-strimzi-only" + suffix, clusterCaSecretName, "Secret");
     }
 
     /**
@@ -283,18 +303,20 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @Test
     void shouldBuildStatusTlsWhenSpecTlsIsNullButTrustAnchorRefDiscovered() {
         // Given
-        var kafka = clusterUser.create(kafkaResourceWithTls(KAFKA_RESOURCE_NAME));
+        var suffix = uniqueSuffix();
+        String kafkaResourceName = KAFKA_RESOURCE_NAME + suffix;
+        var kafka = clusterUser.create(kafkaResourceWithTls(kafkaResourceName));
         reconcileStrimziResource(kafka);
-        String clusterCaSecretName = KAFKA_RESOURCE_NAME + ResourcesUtil.STRIMZI_CLUSTER_CA_CERT_SECRET_SUFFIX;
+        String clusterCaSecretName = kafkaResourceName + ResourcesUtil.STRIMZI_CLUSTER_CA_CERT_SECRET_SUFFIX;
         createStrimziTrustAnchorSecret(clusterCaSecretName);
 
         // When - Create KafkaService with spec.tls=null and trustStrimziCaCertificate=true
-        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRefAndNullTls("service-null-tls", "tls"));
+        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRefAndNullTls("service-null-tls" + suffix, "tls", kafkaResourceName));
 
         // Then - status.tls should be built with Strimzi CA as trust anchor
         assertResolvedRefsTrue(service, FOO_BOOTSTRAP_9090, true);
         AWAIT.untilAsserted(() -> {
-            var kafkaService = clusterUser.get(KafkaService.class, "service-null-tls");
+            var kafkaService = clusterUser.get(KafkaService.class, "service-null-tls" + suffix);
             assertThat(kafkaService)
                     .isNotNull()
                     .extracting(KafkaService::getStatus)
@@ -354,7 +376,8 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     private KafkaService kafkaServiceWithStrimziKafkaRefAndOptionalTrustAnchor(String serviceName,
                                                                                String listenerName,
                                                                                boolean trustStrimziCa,
-                                                                               @Nullable TrustAnchorRef explictTrust) {
+                                                                               @Nullable TrustAnchorRef explictTrust,
+                                                                               String kafkaResourceName) {
         // @formatter:off
         var builder = new KafkaServiceBuilder()
                 .withNewMetadata()
@@ -365,7 +388,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
                         .withListenerName(listenerName)
                         .withTrustStrimziCaCertificate(trustStrimziCa)
                         .withNewRef()
-                            .withName(KAFKA_RESOURCE_NAME)
+                            .withName(kafkaResourceName)
                         .endRef()
                     .endStrimziKafkaRef();
 
@@ -456,7 +479,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
         // @formatter:on
     }
 
-    private static KafkaService kafkaServiceWithCrossNamespaceStrimziCa(String resourceName, String listenerName, String clusterNamespace) {
+    private static KafkaService kafkaServiceWithCrossNamespaceStrimziCa(String resourceName, String listenerName, String clusterNamespace, String kafkaResourceName) {
         // @formatter:off
         return new KafkaServiceBuilder()
                 .withNewMetadata()
@@ -468,7 +491,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
                 .withTrustStrimziCaCertificate(true)
                 .withNamespace(clusterNamespace)
                 .withNewRef()
-                .withName(KAFKA_RESOURCE_NAME)
+                .withName(kafkaResourceName)
                 .endRef()
                 .endStrimziKafkaRef()
                 .endSpec()
@@ -476,7 +499,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
         // @formatter:on
     }
 
-    private static KafkaService kafkaServiceWithStrimziKafkaRefAndNullTls(String resourceName, String listenerName) {
+    private static KafkaService kafkaServiceWithStrimziKafkaRefAndNullTls(String resourceName, String listenerName, String kafkaResourceName) {
         // @formatter:off
         return new KafkaServiceBuilder()
                 .withNewMetadata()
@@ -487,7 +510,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
                         .withListenerName(listenerName)
                         .withTrustStrimziCaCertificate(true)
                         .withNewRef()
-                            .withName(KAFKA_RESOURCE_NAME)
+                            .withName(kafkaResourceName)
                         .endRef()
                     .endStrimziKafkaRef()
                     .withTls(null)

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
@@ -60,6 +60,7 @@ import static io.kroxylicious.kubernetes.api.common.Protocol.TCP;
 import static io.kroxylicious.kubernetes.api.common.Protocol.TLS;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.generation;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
+import static io.kroxylicious.testing.operator.OperatorTestUtils.uniqueSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -101,13 +102,15 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldResolveWhenClusterCreatedAfterReferents() {
         // Given
-        clusterUser.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        updateStatusObservedGeneration(clusterUser.create(filter(FILTER_K)));
+        var suffix = uniqueSuffix();
+        clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D + suffix, PROXY_A + suffix, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H + suffix)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(clusterUser.create(filter(FILTER_K + suffix)));
 
         // When
-        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
+        VirtualKafkaCluster clusterBar = clusterUser
+                .create(cluster(CLUSTER_BAR + suffix, PROXY_A + suffix, INGRESS_D + suffix, SERVICE_H + suffix, FILTER_K + suffix));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -116,17 +119,19 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileProxyInitiallyAbsent() {
         // Given
-        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        var suffix = uniqueSuffix();
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D + suffix, PROXY_A + suffix, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H + suffix)), BOOTSTRAP_SERVERS);
 
         // When
-        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null));
+        VirtualKafkaCluster clusterBar = clusterUser
+                .create(cluster(CLUSTER_BAR + suffix, PROXY_A + suffix, INGRESS_D + suffix, SERVICE_H + suffix, null));
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
 
         // And When
-        clusterUser.create(kafkaProxy(PROXY_A));
+        clusterUser.create(kafkaProxy(PROXY_A + suffix));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -135,17 +140,19 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileServiceInitiallyAbsent() {
         // Given
-        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        clusterUser.create(kafkaProxy(PROXY_A));
+        var suffix = uniqueSuffix();
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D + suffix, PROXY_A + suffix, TCP)));
+        clusterUser.create(kafkaProxy(PROXY_A + suffix));
 
         // When
-        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null));
+        VirtualKafkaCluster clusterBar = clusterUser
+                .create(cluster(CLUSTER_BAR + suffix, PROXY_A + suffix, INGRESS_D + suffix, SERVICE_H + suffix, null));
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
 
         // And When
-        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H + suffix)), BOOTSTRAP_SERVERS);
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -154,18 +161,19 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileIngressInitiallyAbsent() {
         // Given
-        clusterUser.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        var suffix = uniqueSuffix();
+        clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H + suffix)), BOOTSTRAP_SERVERS);
 
         // When
-        VirtualKafkaCluster resource = cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null);
+        VirtualKafkaCluster resource = cluster(CLUSTER_BAR + suffix, PROXY_A + suffix, INGRESS_D + suffix, SERVICE_H + suffix, null);
         VirtualKafkaCluster clusterBar = clusterUser.create(resource);
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
 
         // And When
-        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D + suffix, PROXY_A + suffix, TCP)));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -174,18 +182,20 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileFilterInitiallyAbsent() {
         // Given
-        clusterUser.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        var suffix = uniqueSuffix();
+        clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D + suffix, PROXY_A + suffix, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H + suffix)), BOOTSTRAP_SERVERS);
 
         // When
-        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
+        VirtualKafkaCluster clusterBar = clusterUser
+                .create(cluster(CLUSTER_BAR + suffix, PROXY_A + suffix, INGRESS_D + suffix, SERVICE_H + suffix, FILTER_K + suffix));
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
 
         // And When
-        updateStatusObservedGeneration(clusterUser.create(filter(FILTER_K)));
+        updateStatusObservedGeneration(clusterUser.create(filter(FILTER_K + suffix)));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -194,11 +204,13 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhenProxyDeleted() {
         // Given
-        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        updateStatusObservedGeneration(clusterUser.create(filter(FILTER_K)));
-        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
+        var suffix = uniqueSuffix();
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D + suffix, PROXY_A + suffix, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H + suffix)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(clusterUser.create(filter(FILTER_K + suffix)));
+        VirtualKafkaCluster clusterBar = clusterUser
+                .create(cluster(CLUSTER_BAR + suffix, PROXY_A + suffix, INGRESS_D + suffix, SERVICE_H + suffix, FILTER_K + suffix));
         assertAllConditionsTrue(clusterBar);
 
         // When
@@ -211,11 +223,13 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhenFilterDeleted() {
         // Given
-        clusterUser.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        var filter = updateStatusObservedGeneration(clusterUser.create(filter(FILTER_K)));
-        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
+        var suffix = uniqueSuffix();
+        clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D + suffix, PROXY_A + suffix, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H + suffix)), BOOTSTRAP_SERVERS);
+        var filter = updateStatusObservedGeneration(clusterUser.create(filter(FILTER_K + suffix)));
+        VirtualKafkaCluster clusterBar = clusterUser
+                .create(cluster(CLUSTER_BAR + suffix, PROXY_A + suffix, INGRESS_D + suffix, SERVICE_H + suffix, FILTER_K + suffix));
         assertAllConditionsTrue(clusterBar);
 
         // When
@@ -228,20 +242,21 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileIngressRefersToOtherProxy() {
         // Given
-        clusterUser.create(kafkaProxy(PROXY_A));
-        clusterUser.create(kafkaProxy(PROXY_B));
-        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_B, TCP))); // not A, which is what the VKC references
+        var suffix = uniqueSuffix();
+        clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        clusterUser.create(kafkaProxy(PROXY_B + suffix));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H + suffix)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D + suffix, PROXY_B + suffix, TCP))); // not A, which is what the VKC references
 
         // When
-        VirtualKafkaCluster resource = cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null);
+        VirtualKafkaCluster resource = cluster(CLUSTER_BAR + suffix, PROXY_A + suffix, INGRESS_D + suffix, SERVICE_H + suffix, null);
         VirtualKafkaCluster clusterBar = clusterUser.create(resource);
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_TRANSITIVE_REFS_NOT_FOUND);
 
         // And when
-        updateStatusObservedGeneration(clusterUser.replace(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.replace(clusterIpIngress(INGRESS_D + suffix, PROXY_A + suffix, TCP)));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -250,20 +265,22 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileTwoIpIngresses() {
         // Given
-        clusterUser.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_E, PROXY_A, TCP)));
+        var suffix = uniqueSuffix();
+        clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H + suffix)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D + suffix, PROXY_A + suffix, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_E + suffix, PROXY_A + suffix, TCP)));
 
         // When
-        VirtualKafkaCluster resource = cluster(CLUSTER_BAR, PROXY_A, List.of(INGRESS_D, INGRESS_E), SERVICE_H, null);
+        VirtualKafkaCluster resource = cluster(CLUSTER_BAR + suffix, PROXY_A + suffix, List.of(INGRESS_D + suffix, INGRESS_E + suffix),
+                SERVICE_H + suffix, null);
         VirtualKafkaCluster clusterBar = clusterUser.create(resource);
 
         // Then
         assertClusterAcceptedFalse(clusterBar, ProxyConfigDependentResource.REASON_INVALID);
 
         // And when
-        clusterUser.replace(cluster(CLUSTER_BAR, PROXY_A, List.of(INGRESS_D), SERVICE_H, null));
+        clusterUser.replace(cluster(CLUSTER_BAR + suffix, PROXY_A + suffix, List.of(INGRESS_D + suffix), SERVICE_H + suffix, null));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -272,37 +289,40 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldReportIngressClusterIpBootstrap() {
         // Given
-        clusterUser.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        var cluster = cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null);
-        var ingress = clusterIpIngress(INGRESS_D, PROXY_A, TCP);
+        var suffix = uniqueSuffix();
+        clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H + suffix)), BOOTSTRAP_SERVERS);
+        var cluster = cluster(CLUSTER_BAR + suffix, PROXY_A + suffix, INGRESS_D + suffix, SERVICE_H + suffix, null);
+        var ingress = clusterIpIngress(INGRESS_D + suffix, PROXY_A + suffix, TCP);
         updateStatusObservedGeneration(clusterUser.create(ingress));
 
         // When
         VirtualKafkaCluster clusterBar = clusterUser.create(cluster);
 
         // Then
-        assertClusterIngressStatusPopulated(clusterBar, ingress, "bar-cluster-ingress-d-bootstrap.%s.svc.cluster.local:9292", Protocol.TCP);
+        assertClusterIngressStatusPopulated(clusterBar, ingress,
+                CLUSTER_BAR + suffix + "-" + INGRESS_D + suffix + "-bootstrap.%s.svc.cluster.local:9292", Protocol.TCP);
     }
 
     @Test
     void shouldResolveWithSecretTrustAnchorRef() {
         // Given
-        clusterUser.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        var suffix = uniqueSuffix();
+        clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H + suffix)), BOOTSTRAP_SERVERS);
         // @formatter:off
         var ingresses = List.of(new IngressesBuilder()
                 .withNewIngressRef()
-                    .withName(INGRESS_D)
+                    .withName(INGRESS_D + suffix)
                 .endIngressRef()
                 .withNewTls()
                     .withNewCertificateRef()
-                        .withName(SECRET_NAME)
+                        .withName(SECRET_NAME + suffix)
                     .endCertificateRef()
                 .withNewTrustAnchorRef()
                     .withNewRef()
                         .withKind("Secret")
-                        .withName(SECRET_TRUST_ANCHOR_REF_NAME)
+                        .withName(SECRET_TRUST_ANCHOR_REF_NAME + suffix)
                     .endRef()
                     .withKey("cert.pem")
                 .endTrustAnchorRef()
@@ -311,21 +331,21 @@ class VirtualKafkaClusterReconcilerIT {
 
         var specBuilder = new VirtualKafkaClusterBuilder()
                 .withNewMetadata()
-                    .withName(CLUSTER_BAR)
+                    .withName(CLUSTER_BAR + suffix)
                 .endMetadata()
                 .withNewSpec()
                 .withNewProxyRef()
-                    .withName(PROXY_A)
+                    .withName(PROXY_A + suffix)
                 .endProxyRef()
                 .withIngresses(ingresses)
                 .withNewTargetKafkaServiceRef()
-                    .withName(SERVICE_H)
+                    .withName(SERVICE_H + suffix)
                 .endTargetKafkaServiceRef();
         // @formatter:on
         var cluster = specBuilder.endSpec().build();
-        var ingress = clusterIpIngress(INGRESS_D, PROXY_A, TLS);
-        clusterUser.create(tlsKeyAndCertSecret(SECRET_NAME));
-        clusterUser.create(secretTrustAnchorRef(SECRET_TRUST_ANCHOR_REF_NAME));
+        var ingress = clusterIpIngress(INGRESS_D + suffix, PROXY_A + suffix, TLS);
+        clusterUser.create(tlsKeyAndCertSecret(SECRET_NAME + suffix));
+        clusterUser.create(secretTrustAnchorRef(SECRET_TRUST_ANCHOR_REF_NAME + suffix));
 
         updateStatusObservedGeneration(clusterUser.create(ingress));
 
@@ -334,82 +354,86 @@ class VirtualKafkaClusterReconcilerIT {
 
         // Then
         assertAllConditionsTrue(clusterBar);
-        assertClusterIngressStatusPopulated(clusterBar, ingress, "bar-cluster-ingress-d-bootstrap.%s.svc.cluster.local:9292", Protocol.TLS);
+        assertClusterIngressStatusPopulated(clusterBar, ingress,
+                CLUSTER_BAR + suffix + "-" + INGRESS_D + suffix + "-bootstrap.%s.svc.cluster.local:9292", Protocol.TLS);
     }
 
     @Test
     void shouldReportIngressTlsClusterIpBootstrap() {
         // Given
-        clusterUser.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        var suffix = uniqueSuffix();
+        clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H + suffix)), BOOTSTRAP_SERVERS);
         // @formatter:off
         var ingresses = List.of(new IngressesBuilder()
                         .withNewIngressRef()
-                            .withName(INGRESS_D)
+                            .withName(INGRESS_D + suffix)
                         .endIngressRef()
                         .withNewTls()
                             .withNewCertificateRef()
-                                .withName(SECRET_NAME)
+                                .withName(SECRET_NAME + suffix)
                             .endCertificateRef()
                         .endTls()
                         .build());
         var specBuilder = new VirtualKafkaClusterBuilder()
                 .withNewMetadata()
-                    .withName(CLUSTER_BAR)
+                    .withName(CLUSTER_BAR + suffix)
                 .endMetadata()
                 .withNewSpec()
                 .withNewProxyRef()
-                    .withName(PROXY_A)
+                    .withName(PROXY_A + suffix)
                 .endProxyRef()
                 .withIngresses(ingresses)
                 .withNewTargetKafkaServiceRef()
-                    .withName(SERVICE_H)
+                    .withName(SERVICE_H + suffix)
                 .endTargetKafkaServiceRef();
         // @formatter:on
         var cluster = specBuilder.endSpec().build();
-        var ingress = clusterIpIngress(INGRESS_D, PROXY_A, TLS);
-        clusterUser.create(tlsKeyAndCertSecret(SECRET_NAME));
+        var ingress = clusterIpIngress(INGRESS_D + suffix, PROXY_A + suffix, TLS);
+        clusterUser.create(tlsKeyAndCertSecret(SECRET_NAME + suffix));
         updateStatusObservedGeneration(clusterUser.create(ingress));
 
         // When
         VirtualKafkaCluster clusterBar = clusterUser.create(cluster);
 
         // Then
-        assertClusterIngressStatusPopulated(clusterBar, ingress, "bar-cluster-ingress-d-bootstrap.%s.svc.cluster.local:9292", Protocol.TLS);
+        assertClusterIngressStatusPopulated(clusterBar, ingress,
+                CLUSTER_BAR + suffix + "-" + INGRESS_D + suffix + "-bootstrap.%s.svc.cluster.local:9292", Protocol.TLS);
     }
 
     @Test
     void shouldReportIngressLoadBalancerBootstrap() {
         // Given
-        clusterUser.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        clusterUser.create(tlsKeyAndCertSecret(SECRET_NAME));
+        var suffix = uniqueSuffix();
+        clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H + suffix)), BOOTSTRAP_SERVERS);
+        clusterUser.create(tlsKeyAndCertSecret(SECRET_NAME + suffix));
         // @formatter:off
         var ingresses = new IngressesBuilder()
                 .withNewIngressRef()
-                    .withName(INGRESS_D)
+                    .withName(INGRESS_D + suffix)
                 .endIngressRef()
                 .withNewTls()
                     .withNewCertificateRef()
-                        .withName(SECRET_NAME)
+                        .withName(SECRET_NAME + suffix)
                     .endCertificateRef()
                 .endTls()
                 .build();
         var specBuilder = new VirtualKafkaClusterBuilder()
                 .withNewMetadata()
-                    .withName(CLUSTER_BAR)
+                    .withName(CLUSTER_BAR + suffix)
                 .endMetadata()
                 .withNewSpec()
                 .withNewProxyRef()
-                    .withName(PROXY_A)
+                    .withName(PROXY_A + suffix)
                 .endProxyRef()
                 .withIngresses(List.of(ingresses))
                 .withNewTargetKafkaServiceRef()
-                    .withName(SERVICE_H)
+                    .withName(SERVICE_H + suffix)
                 .endTargetKafkaServiceRef();
         // @formatter:on
         var cluster = specBuilder.endSpec().build();
-        var ingress = loadBalancerIngress(INGRESS_D, PROXY_A);
+        var ingress = loadBalancerIngress(INGRESS_D + suffix, PROXY_A + suffix);
         updateStatusObservedGeneration(clusterUser.create(ingress));
 
         // When
@@ -422,10 +446,11 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldReportIngressClusterIpBootstrapWhenIngressInitiallyAbsent() {
         // Given
-        clusterUser.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        var cluster = cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null);
-        var ingress = clusterIpIngress(INGRESS_D, PROXY_A, TCP);
+        var suffix = uniqueSuffix();
+        clusterUser.create(kafkaProxy(PROXY_A + suffix));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H + suffix)), BOOTSTRAP_SERVERS);
+        var cluster = cluster(CLUSTER_BAR + suffix, PROXY_A + suffix, INGRESS_D + suffix, SERVICE_H + suffix, null);
+        var ingress = clusterIpIngress(INGRESS_D + suffix, PROXY_A + suffix, TCP);
 
         VirtualKafkaCluster clusterBar = clusterUser.create(cluster);
 
@@ -443,7 +468,8 @@ class VirtualKafkaClusterReconcilerIT {
         updateStatusObservedGeneration(clusterUser.create(ingress));
 
         // Then
-        assertClusterIngressStatusPopulated(clusterBar, ingress, "bar-cluster-ingress-d-bootstrap.%s.svc.cluster.local:9292", Protocol.TCP);
+        assertClusterIngressStatusPopulated(clusterBar, ingress,
+                CLUSTER_BAR + suffix + "-" + INGRESS_D + suffix + "-bootstrap.%s.svc.cluster.local:9292", Protocol.TCP);
     }
 
     private VirtualKafkaCluster cluster(String clusterName, String proxyName, String ingressName, String serviceName, @Nullable String filterName) {


### PR DESCRIPTION
### Type of change

- Refactoring (test-only)

### Description

Applies the unique per-invocation suffix pattern (introduced for `AllReconcilersIT` in #4533) **uniformly** across the operator reconciler integration tests.

These ITs share **one namespace per test class** (`LocalKroxyliciousOperatorExtension`), and `afterEach` fires a non-blocking `deleteAll(...)` between methods. Because every test reused **fixed** resource names (`proxy-a`, `bar-cluster`, …), a deleted resource was immediately recreated with the same name but a new UID, so stale reconciler/informer events for the old UID could race the new resource — producing `kafkaproxies.kroxylicious.io "proxy-a" not found` (stale-UID 404), a reconcile storm, and status that never converged. This is the root cause behind the flaky failures tracked in #4746 / #4527.

Each created/looked-up resource name now carries a unique per-invocation suffix, so a stale event for an old name can never collide with a freshly created resource.

Changes:
- Move `uniqueSuffix()` into the shared `OperatorTestUtils` (DRY) and make it **hyphen-prefixed** (e.g. `-a1b2c3d4`) so call sites read `base + suffix` rather than `base + "-" + suffix`.
- Thread the suffix through all resource names, cross-references, factories and expected assertion strings in the 6 reconciler ITs.
- Refactor `AllReconcilersIT` to use the shared helper (no behaviour change).

Namespace-per-test was considered and rejected — it would slow the suite.

### Additional Context

Fixes recurring operator IT flakiness (#4746, #4527).

Verification:
- `mvn test-compile` for `kroxylicious-operator` + `kroxylicious-operator-test-support`.
- All modified ITs pass locally against minikube: VirtualKafkaClusterReconcilerIT (14), KafkaProxyReconcilerIT (29), KafkaProxyIngressReconcilerIT (4), KafkaProtocolFilterReconcilerIT (10), KafkaServiceBootstrapReconcilerIT (9), KafkaServiceStrimziKafkaRefReconcilerIT (11), AllReconcilersIT (14).

### Checklist

- [x] New tests written (where applicable) — n/a, this hardens existing tests.
- [ ] If making a user-facing change, documentation is provided — n/a, test-only.
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed.
- [x] PR references related GitHub issue(s).
- [x] If AI tools assisted with code changes, commit messages include `Assisted-by:` trailer.
- [ ] Logchange entry — n/a, test-only change with no user-facing effect.

Relates-to: #4746
Relates-to: #4527