### PR TITLE
feat(api): introduce owned ApiKeys under io.kroxylicious.kafka

### DIFF
--- a/kroxylicious-api/pom.xml
+++ b/kroxylicious-api/pom.xml
@@ -183,6 +183,33 @@
                             </arguments>
                         </configuration>
                     </execution>
+                    <!-- Generate the owned io.kroxylicious.kafka.common.protocol.ApiKeys enum as a
+                         veneer over the generated ApiMessageType. ApiKeys lives in the protocol
+                         package (mirroring Kafka), which differs from ApiMessageType's message
+                         package, so it needs its own MessageGenerator run with a distinct -p/-o. -->
+                    <execution>
+                        <id>generate-api-keys</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>io.kroxylicious.kafka.message.MessageGenerator</mainClass>
+                            <includePluginDependencies>true</includePluginDependencies>
+                            <arguments>
+                                <argument>-p</argument>
+                                <argument>io.kroxylicious.kafka.common.protocol</argument>
+                                <argument>-i</argument>
+                                <argument>${project.build.directory}/data-class-message-specs/common/message</argument>
+                                <argument>-o</argument>
+                                <argument>
+                                    ${project.build.directory}/generated-sources/kafka-messages/io/kroxylicious/kafka/common/protocol
+                                </argument>
+                                <argument>-t</argument>
+                                <argument>ApiKeysGenerator</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
                 <dependencies>
                     <dependency>

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ApiKeysGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ApiKeysGenerator.java
@@ -198,6 +198,10 @@ public final class ApiKeysGenerator implements TypeClassGenerator {
         headerGenerator.addImport("java.util.List");
         headerGenerator.addImport("java.util.Map");
 
+        buffer.printf("%s%n", "/**");
+        buffer.printf("%s%n", " * Thin veneer over {@link ApiMessageType}: everything exposed here is spec-derivable and");
+        buffer.printf("%s%n", " * delegates to it, omitting the broker/controller-internal details.");
+        buffer.printf("%s%n", " */");
         buffer.printf("%s%n", "public enum ApiKeys {");
         int numProcessed = 0;
         for (Map.Entry<Short, ApiData> entry : apis.entrySet()) {

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ApiKeysGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ApiKeysGenerator.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Generates the Kroxylicious-owned {@code ApiKeys} enum as a thin veneer over the generated
+ * {@code ApiMessageType}. Everything it exposes is spec-derivable and delegates to
+ * {@code ApiMessageType}; the broker/controller-internal {@code clusterAction} and
+ * {@code forwardable} flags (and members with no proxy consumer, such as the listener
+ * groupings) are intentionally omitted. See issue #4752.
+ */
+public final class ApiKeysGenerator implements TypeClassGenerator {
+
+    // The fixed body emitted after the generated enum constants. Kept as verbatim source lines
+    // (already indented for the class body) so nothing here is spec-derived except the constants.
+    private static final String[] BODY = {
+            "",
+            "    // Versions 0-2 were removed in Apache Kafka 4.0, version 3 is the new baseline. Due to a bug in",
+            "    // librdkafka, version 0 has to be included in the api versions response (see KAFKA-18659).",
+            "    public static final short PRODUCE_API_VERSIONS_RESPONSE_MIN_VERSION = 0;",
+            "",
+            "    /** the permanent and immutable id of an API - this can't change ever */",
+            "    public final short id;",
+            "",
+            "    /** An english description of the api - used for debugging and metric names */",
+            "    public final String name;",
+            "",
+            "    public final ApiMessageType messageType;",
+            "",
+            "    private static final Map<Integer, ApiKeys> ID_TO_TYPE = new HashMap<>();",
+            "",
+            "    static {",
+            "        for (ApiKeys apiKey : values()) {",
+            "            ID_TO_TYPE.put((int) apiKey.id, apiKey);",
+            "        }",
+            "    }",
+            "",
+            "    ApiKeys(ApiMessageType messageType) {",
+            "        this.messageType = messageType;",
+            "        this.id = messageType.apiKey();",
+            "        this.name = messageType.name;",
+            "    }",
+            "",
+            "    public static ApiKeys forId(int id) {",
+            "        ApiKeys apiKey = ID_TO_TYPE.get(id);",
+            "        if (apiKey == null) {",
+            "            throw new IllegalArgumentException(\"Unexpected api key: \" + id);",
+            "        }",
+            "        return apiKey;",
+            "    }",
+            "",
+            "    public static boolean hasId(int id) {",
+            "        return ID_TO_TYPE.containsKey(id);",
+            "    }",
+            "",
+            "    public short latestVersion() {",
+            "        return messageType.highestSupportedVersion(true);",
+            "    }",
+            "",
+            "    public short latestVersion(boolean enableUnstableLastVersion) {",
+            "        return messageType.highestSupportedVersion(enableUnstableLastVersion);",
+            "    }",
+            "",
+            "    public short oldestVersion() {",
+            "        return messageType.lowestSupportedVersion();",
+            "    }",
+            "",
+            "    public List<Short> allVersions() {",
+            "        List<Short> versions = new ArrayList<>(latestVersion() - oldestVersion() + 1);",
+            "        for (short version = oldestVersion(); version <= latestVersion(); version++) {",
+            "            versions.add(version);",
+            "        }",
+            "        return versions;",
+            "    }",
+            "",
+            "    public boolean isVersionSupported(short apiVersion) {",
+            "        return apiVersion >= oldestVersion() && apiVersion <= latestVersion();",
+            "    }",
+            "",
+            "    /**",
+            "     * Returns {@code true} if there is at least one valid version. When {@code false}, the api key",
+            "     * remains assigned to a removed api so it is not accidentally reused for a different api.",
+            "     */",
+            "    public boolean hasValidVersion() {",
+            "        return oldestVersion() <= latestVersion();",
+            "    }",
+            "",
+            "    public short requestHeaderVersion(short apiVersion) {",
+            "        return messageType.requestHeaderVersion(apiVersion);",
+            "    }",
+            "",
+            "    public short responseHeaderVersion(short apiVersion) {",
+            "        return messageType.responseHeaderVersion(apiVersion);",
+            "    }",
+            "}"
+    };
+
+    private final HeaderGenerator headerGenerator;
+    private final CodeBuffer buffer;
+    private final TreeMap<Short, ApiData> apis;
+
+    private static final class ApiData {
+        final short apiKey;
+        MessageSpec requestSpec;
+        MessageSpec responseSpec;
+
+        ApiData(short apiKey) {
+            this.apiKey = apiKey;
+        }
+
+        String name() {
+            if (requestSpec != null) {
+                return MessageGenerator.stripSuffix(requestSpec.name(), MessageGenerator.REQUEST_SUFFIX);
+            }
+            else if (responseSpec != null) {
+                return MessageGenerator.stripSuffix(responseSpec.name(), MessageGenerator.RESPONSE_SUFFIX);
+            }
+            else {
+                throw new RuntimeException("Neither requestSpec nor responseSpec is defined for API key " + apiKey);
+            }
+        }
+
+        String constantName() {
+            return MessageGenerator.toSnakeCase(name()).toUpperCase(Locale.ROOT);
+        }
+    }
+
+    public ApiKeysGenerator(String packageName) {
+        this.headerGenerator = new HeaderGenerator(packageName);
+        this.apis = new TreeMap<>();
+        this.buffer = new CodeBuffer();
+    }
+
+    @Override
+    public String outputName() {
+        return MessageGenerator.API_KEYS_JAVA;
+    }
+
+    @Override
+    public void registerMessageType(MessageSpec spec) {
+        switch (spec.type()) {
+            case REQUEST: {
+                short apiKey = spec.apiKey().orElseThrow();
+                ApiData data = apis.computeIfAbsent(apiKey, ApiData::new);
+                if (data.requestSpec != null) {
+                    throw new RuntimeException("Found more than one request with API key " + apiKey);
+                }
+                data.requestSpec = spec;
+                break;
+            }
+            case RESPONSE: {
+                short apiKey = spec.apiKey().orElseThrow();
+                ApiData data = apis.computeIfAbsent(apiKey, ApiData::new);
+                if (data.responseSpec != null) {
+                    throw new RuntimeException("Found more than one response with API key " + apiKey);
+                }
+                data.responseSpec = spec;
+                break;
+            }
+            default:
+                // do nothing
+                break;
+        }
+    }
+
+    @Override
+    public void generateAndWrite(BufferedWriter writer) throws IOException {
+        generate();
+        write(writer);
+    }
+
+    private void generate() {
+        headerGenerator.addImport("io.kroxylicious.kafka.common.message.ApiMessageType");
+        headerGenerator.addImport("java.util.ArrayList");
+        headerGenerator.addImport("java.util.HashMap");
+        headerGenerator.addImport("java.util.List");
+        headerGenerator.addImport("java.util.Map");
+
+        buffer.printf("%s%n", "public enum ApiKeys {");
+        int numProcessed = 0;
+        for (Map.Entry<Short, ApiData> entry : apis.entrySet()) {
+            numProcessed++;
+            String constant = entry.getValue().constantName();
+            String terminator = (numProcessed == apis.size()) ? ";" : ",";
+            buffer.printf("%s%n", "    " + constant + "(ApiMessageType." + constant + ")" + terminator);
+        }
+        for (String line : BODY) {
+            buffer.printf("%s%n", line);
+        }
+        headerGenerator.generate();
+    }
+
+    private void write(BufferedWriter writer) throws IOException {
+        headerGenerator.buffer().write(writer);
+        buffer.write(writer);
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ApiKeysGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ApiKeysGenerator.java
@@ -46,6 +46,7 @@ public final class ApiKeysGenerator implements TypeClassGenerator {
                 /** An english description of the api - used for debugging and metric names */
                 public final String name;
 
+                /** The generated {@code ApiMessageType} this key delegates to */
                 public final ApiMessageType messageType;
 
                 private static final Map<Integer, ApiKeys> ID_TO_TYPE = new HashMap<>();

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ApiKeysGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ApiKeysGenerator.java
@@ -121,25 +121,9 @@ public final class ApiKeysGenerator implements TypeClassGenerator {
     private final CodeBuffer buffer;
     private final TreeMap<Short, ApiData> apis;
 
-    private static final class ApiData {
-        final short apiKey;
-        MessageSpec requestSpec;
-        MessageSpec responseSpec;
-
+    private static final class ApiData extends ApiSpec {
         ApiData(short apiKey) {
-            this.apiKey = apiKey;
-        }
-
-        String name() {
-            if (requestSpec != null) {
-                return MessageGenerator.stripSuffix(requestSpec.name(), MessageGenerator.REQUEST_SUFFIX);
-            }
-            else if (responseSpec != null) {
-                return MessageGenerator.stripSuffix(responseSpec.name(), MessageGenerator.RESPONSE_SUFFIX);
-            }
-            else {
-                throw new RuntimeException("Neither requestSpec nor responseSpec is defined for API key " + apiKey);
-            }
+            super(apiKey);
         }
 
         String constantName() {

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ApiKeysGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ApiKeysGenerator.java
@@ -32,89 +32,89 @@ import java.util.TreeMap;
  */
 public final class ApiKeysGenerator implements TypeClassGenerator {
 
-    // The fixed body emitted after the generated enum constants. Kept as verbatim source lines
+    // The fixed body emitted after the generated enum constants. Kept as a verbatim source block
     // (already indented for the class body) so nothing here is spec-derived except the constants.
-    private static final String[] BODY = {
-            "",
-            "    // Versions 0-2 were removed in Apache Kafka 4.0, version 3 is the new baseline. Due to a bug in",
-            "    // librdkafka, version 0 has to be included in the api versions response (see KAFKA-18659).",
-            "    public static final short PRODUCE_API_VERSIONS_RESPONSE_MIN_VERSION = 0;",
-            "",
-            "    /** the permanent and immutable id of an API - this can't change ever */",
-            "    public final short id;",
-            "",
-            "    /** An english description of the api - used for debugging and metric names */",
-            "    public final String name;",
-            "",
-            "    public final ApiMessageType messageType;",
-            "",
-            "    private static final Map<Integer, ApiKeys> ID_TO_TYPE = new HashMap<>();",
-            "",
-            "    static {",
-            "        for (ApiKeys apiKey : values()) {",
-            "            ID_TO_TYPE.put((int) apiKey.id, apiKey);",
-            "        }",
-            "    }",
-            "",
-            "    ApiKeys(ApiMessageType messageType) {",
-            "        this.messageType = messageType;",
-            "        this.id = messageType.apiKey();",
-            "        this.name = messageType.name;",
-            "    }",
-            "",
-            "    public static ApiKeys forId(int id) {",
-            "        ApiKeys apiKey = ID_TO_TYPE.get(id);",
-            "        if (apiKey == null) {",
-            "            throw new IllegalArgumentException(\"Unexpected api key: \" + id);",
-            "        }",
-            "        return apiKey;",
-            "    }",
-            "",
-            "    public static boolean hasId(int id) {",
-            "        return ID_TO_TYPE.containsKey(id);",
-            "    }",
-            "",
-            "    public short latestVersion() {",
-            "        return messageType.highestSupportedVersion(true);",
-            "    }",
-            "",
-            "    public short latestVersion(boolean enableUnstableLastVersion) {",
-            "        return messageType.highestSupportedVersion(enableUnstableLastVersion);",
-            "    }",
-            "",
-            "    public short oldestVersion() {",
-            "        return messageType.lowestSupportedVersion();",
-            "    }",
-            "",
-            "    public List<Short> allVersions() {",
-            "        List<Short> versions = new ArrayList<>(latestVersion() - oldestVersion() + 1);",
-            "        for (short version = oldestVersion(); version <= latestVersion(); version++) {",
-            "            versions.add(version);",
-            "        }",
-            "        return versions;",
-            "    }",
-            "",
-            "    public boolean isVersionSupported(short apiVersion) {",
-            "        return apiVersion >= oldestVersion() && apiVersion <= latestVersion();",
-            "    }",
-            "",
-            "    /**",
-            "     * Returns {@code true} if there is at least one valid version. When {@code false}, the api key",
-            "     * remains assigned to a removed api so it is not accidentally reused for a different api.",
-            "     */",
-            "    public boolean hasValidVersion() {",
-            "        return oldestVersion() <= latestVersion();",
-            "    }",
-            "",
-            "    public short requestHeaderVersion(short apiVersion) {",
-            "        return messageType.requestHeaderVersion(apiVersion);",
-            "    }",
-            "",
-            "    public short responseHeaderVersion(short apiVersion) {",
-            "        return messageType.responseHeaderVersion(apiVersion);",
-            "    }",
-            "}"
-    };
+    private static final String[] BODY = """
+
+                // Versions 0-2 were removed in Apache Kafka 4.0, version 3 is the new baseline. Due to a bug in
+                // librdkafka, version 0 has to be included in the api versions response (see KAFKA-18659).
+                public static final short PRODUCE_API_VERSIONS_RESPONSE_MIN_VERSION = 0;
+
+                /** the permanent and immutable id of an API - this can't change ever */
+                public final short id;
+
+                /** An english description of the api - used for debugging and metric names */
+                public final String name;
+
+                public final ApiMessageType messageType;
+
+                private static final Map<Integer, ApiKeys> ID_TO_TYPE = new HashMap<>();
+
+                static {
+                    for (ApiKeys apiKey : values()) {
+                        ID_TO_TYPE.put((int) apiKey.id, apiKey);
+                    }
+                }
+
+                ApiKeys(ApiMessageType messageType) {
+                    this.messageType = messageType;
+                    this.id = messageType.apiKey();
+                    this.name = messageType.name;
+                }
+
+                public static ApiKeys forId(int id) {
+                    ApiKeys apiKey = ID_TO_TYPE.get(id);
+                    if (apiKey == null) {
+                        throw new IllegalArgumentException("Unexpected api key: " + id);
+                    }
+                    return apiKey;
+                }
+
+                public static boolean hasId(int id) {
+                    return ID_TO_TYPE.containsKey(id);
+                }
+
+                public short latestVersion() {
+                    return messageType.highestSupportedVersion(true);
+                }
+
+                public short latestVersion(boolean enableUnstableLastVersion) {
+                    return messageType.highestSupportedVersion(enableUnstableLastVersion);
+                }
+
+                public short oldestVersion() {
+                    return messageType.lowestSupportedVersion();
+                }
+
+                public List<Short> allVersions() {
+                    List<Short> versions = new ArrayList<>(latestVersion() - oldestVersion() + 1);
+                    for (short version = oldestVersion(); version <= latestVersion(); version++) {
+                        versions.add(version);
+                    }
+                    return versions;
+                }
+
+                public boolean isVersionSupported(short apiVersion) {
+                    return apiVersion >= oldestVersion() && apiVersion <= latestVersion();
+                }
+
+                /**
+                 * Returns {@code true} if there is at least one valid version. When {@code false}, the api key
+                 * remains assigned to a removed api so it is not accidentally reused for a different api.
+                 */
+                public boolean hasValidVersion() {
+                    return oldestVersion() <= latestVersion();
+                }
+
+                public short requestHeaderVersion(short apiVersion) {
+                    return messageType.requestHeaderVersion(apiVersion);
+                }
+
+                public short responseHeaderVersion(short apiVersion) {
+                    return messageType.responseHeaderVersion(apiVersion);
+                }
+            }"""
+            .split("\n");
 
     private final HeaderGenerator headerGenerator;
     private final CodeBuffer buffer;

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ApiMessageTypeGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ApiMessageTypeGenerator.java
@@ -36,28 +36,9 @@ public final class ApiMessageTypeGenerator implements TypeClassGenerator {
     private final TreeMap<Short, ApiData> apis;
     private final EnumMap<RequestListenerType, List<ApiData>> apisByListener = new EnumMap<>(RequestListenerType.class);
 
-    private static final class ApiData {
-        short apiKey;
-        MessageSpec requestSpec;
-        MessageSpec responseSpec;
-
+    private static final class ApiData extends ApiSpec {
         ApiData(short apiKey) {
-            this.apiKey = apiKey;
-        }
-
-        String name() {
-            if (requestSpec != null) {
-                return MessageGenerator.stripSuffix(requestSpec.name(),
-                        MessageGenerator.REQUEST_SUFFIX);
-            }
-            else if (responseSpec != null) {
-                return MessageGenerator.stripSuffix(responseSpec.name(),
-                        MessageGenerator.RESPONSE_SUFFIX);
-            }
-            else {
-                throw new RuntimeException("Neither requestSpec nor responseSpec is defined " +
-                        "for API key " + apiKey);
-            }
+            super(apiKey);
         }
 
         String requestSchema() {

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ApiSpec.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/ApiSpec.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.kroxylicious.kafka.message;
+
+/**
+ * The request/response {@link MessageSpec} pair registered against a single API key, shared by
+ * {@link ApiKeysGenerator} and {@link ApiMessageTypeGenerator}.
+ */
+class ApiSpec {
+    final short apiKey;
+    MessageSpec requestSpec;
+    MessageSpec responseSpec;
+
+    ApiSpec(short apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    String name() {
+        if (requestSpec != null) {
+            return MessageGenerator.stripSuffix(requestSpec.name(), MessageGenerator.REQUEST_SUFFIX);
+        }
+        else if (responseSpec != null) {
+            return MessageGenerator.stripSuffix(responseSpec.name(), MessageGenerator.RESPONSE_SUFFIX);
+        }
+        else {
+            throw new RuntimeException("Neither requestSpec nor responseSpec is defined for API key " + apiKey);
+        }
+    }
+}

--- a/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/MessageGenerator.java
+++ b/kroxylicious-kafka-message-generator/src/main/java/io/kroxylicious/kafka/message/MessageGenerator.java
@@ -55,6 +55,8 @@ public final class MessageGenerator {
 
     static final String API_MESSAGE_TYPE_JAVA = "ApiMessageType.java";
 
+    static final String API_KEYS_JAVA = "ApiKeys.java";
+
     static final String API_SCOPE_JAVA = "ApiScope.java";
 
     static final String COORDINATOR_RECORD_TYPE_JAVA = "CoordinatorRecordType.java";
@@ -191,6 +193,9 @@ public final class MessageGenerator {
             switch (type) {
                 case "ApiMessageTypeGenerator":
                     generators.add(new ApiMessageTypeGenerator(packageName));
+                    break;
+                case "ApiKeysGenerator":
+                    generators.add(new ApiKeysGenerator(packageName));
                     break;
                 case "MetadataRecordTypeGenerator":
                     generators.add(new MetadataRecordTypeGenerator(packageName));

--- a/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/ApiKeysGeneratorTest.java
+++ b/kroxylicious-kafka-message-generator/src/test/java/io/kroxylicious/kafka/message/ApiKeysGeneratorTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kroxylicious.kafka.message;
+
+import java.io.BufferedWriter;
+import java.io.StringWriter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ApiKeysGeneratorTest {
+
+    private static final String PACKAGE = "io.kroxylicious.kafka.common.protocol";
+
+    private static MessageSpec requestSpec(int apiKey, String name) throws Exception {
+        return spec(apiKey, "request", name + "Request");
+    }
+
+    private static MessageSpec responseSpec(int apiKey, String name) throws Exception {
+        return spec(apiKey, "response", name + "Response");
+    }
+
+    private static MessageSpec spec(int apiKey, String type, String name) throws Exception {
+        return MessageGenerator.JSON_SERDE.readValue(String.join("\n",
+                "{",
+                "  \"apiKey\": " + apiKey + ",",
+                "  \"type\": \"" + type + "\",",
+                "  \"name\": \"" + name + "\",",
+                "  \"validVersions\": \"none\"",
+                "}"), MessageSpec.class);
+    }
+
+    private static String generate(MessageSpec... specs) throws Exception {
+        var generator = new ApiKeysGenerator(PACKAGE);
+        for (var spec : specs) {
+            generator.registerMessageType(spec);
+        }
+        var writer = new StringWriter();
+        var bufferedWriter = new BufferedWriter(writer);
+        generator.generateAndWrite(bufferedWriter);
+        bufferedWriter.flush();
+        return writer.toString();
+    }
+
+    @Test
+    void outputName() {
+        // Given
+        var generator = new ApiKeysGenerator(PACKAGE);
+
+        // When
+        var outputName = generator.outputName();
+
+        // Then
+        assertEquals("ApiKeys.java", outputName);
+    }
+
+    @Test
+    void generatesEnumConstantVeneeringApiMessageType() throws Exception {
+        // Given
+        var request = requestSpec(0, "FooBar");
+        var response = responseSpec(0, "FooBar");
+
+        // When
+        var generated = generate(request, response);
+
+        // Then
+        assertTrue(generated.contains("package " + PACKAGE + ";"), generated);
+        assertTrue(generated.contains("public enum ApiKeys {"), generated);
+        assertTrue(generated.contains("FOO_BAR(ApiMessageType.FOO_BAR);"), generated);
+    }
+
+    @Test
+    void ordersConstantsByApiKey() throws Exception {
+        // Given
+        var second = requestSpec(1, "Second");
+        var first = requestSpec(0, "First");
+
+        // When
+        var generated = generate(second, first);
+
+        // Then
+        var firstIndex = generated.indexOf("FIRST(ApiMessageType.FIRST),");
+        var secondIndex = generated.indexOf("SECOND(ApiMessageType.SECOND);");
+        assertTrue(firstIndex >= 0, generated);
+        assertTrue(secondIndex > firstIndex, generated);
+    }
+
+    @Test
+    void rejectsDuplicateRequestForSameApiKey() throws Exception {
+        // Given
+        var generator = new ApiKeysGenerator(PACKAGE);
+        generator.registerMessageType(requestSpec(0, "FooBar"));
+        var spec = requestSpec(0, "FooBarAgain");
+
+        // When / Then
+        var exception = assertThrows(RuntimeException.class,
+                () -> generator.registerMessageType(spec));
+        assertTrue(exception.getMessage().contains("more than one request with API key 0"), exception.getMessage());
+    }
+}

--- a/kroxylicious-wire-fidelity-tests/pom.xml
+++ b/kroxylicious-wire-fidelity-tests/pom.xml
@@ -54,6 +54,11 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>

--- a/kroxylicious-wire-fidelity-tests/src/test/java/io/kroxylicious/fidelity/kafka/ApiKeysFidelityTest.java
+++ b/kroxylicious-wire-fidelity-tests/src/test/java/io/kroxylicious/fidelity/kafka/ApiKeysFidelityTest.java
@@ -38,6 +38,17 @@ class ApiKeysFidelityTest {
     }
 
     @Test
+    void sameApiKeyOrder() {
+        // Given
+        var kafkaNames = Arrays.stream(ApiKeys.values()).map(Enum::name).toList();
+        var kroxyliciousNames = Arrays.stream(io.kroxylicious.kafka.common.protocol.ApiKeys.values())
+                .map(Enum::name).toList();
+
+        // When / Then
+        assertThat(kroxyliciousNames).containsExactlyElementsOf(kafkaNames);
+    }
+
+    @Test
     void produceApiVersionsResponseMinVersionMatches() {
         // When / Then
         assertThat(io.kroxylicious.kafka.common.protocol.ApiKeys.PRODUCE_API_VERSIONS_RESPONSE_MIN_VERSION)
@@ -59,6 +70,30 @@ class ApiKeysFidelityTest {
         assertThat(kroxylicious.latestVersion(true)).isEqualTo(kafka.latestVersion(true));
         assertThat(kroxylicious.hasValidVersion()).isEqualTo(kafka.hasValidVersion());
         assertThat(kroxylicious.allVersions()).isEqualTo(kafka.allVersions());
+        assertThat(kroxylicious.messageType.apiKey()).isEqualTo(kroxylicious.id);
+        assertThat(kroxylicious.messageType.name).isEqualTo(kafka.name);
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApiKeys.class)
+    void isVersionSupportedMatchesKafka(ApiKeys kafka) {
+        // Given
+        var kroxylicious = io.kroxylicious.kafka.common.protocol.ApiKeys.valueOf(kafka.name());
+        short belowRange = (short) (kafka.oldestVersion() - 1);
+        short aboveRange = (short) (kafka.latestVersion() + 1);
+
+        // When / Then
+        for (short version : kafka.allVersions()) {
+            assertThat(kroxylicious.isVersionSupported(version))
+                    .as("isVersionSupported(%d) for %s", version, kafka.name())
+                    .isTrue();
+        }
+        assertThat(kroxylicious.isVersionSupported(belowRange))
+                .as("isVersionSupported(%d) for %s", belowRange, kafka.name())
+                .isFalse();
+        assertThat(kroxylicious.isVersionSupported(aboveRange))
+                .as("isVersionSupported(%d) for %s", aboveRange, kafka.name())
+                .isFalse();
     }
 
     @ParameterizedTest

--- a/kroxylicious-wire-fidelity-tests/src/test/java/io/kroxylicious/fidelity/kafka/ApiKeysFidelityTest.java
+++ b/kroxylicious-wire-fidelity-tests/src/test/java/io/kroxylicious/fidelity/kafka/ApiKeysFidelityTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.fidelity.kafka;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Wire-fidelity parity between Apache Kafka's {@link ApiKeys} and the Kroxylicious-owned
+ * {@link io.kroxylicious.kafka.common.protocol.ApiKeys}. The generated enum and the kafka-clients
+ * jar are both pinned to {@code kafka.message-spec.version} (see this module's pom), so there is no
+ * version skew: every api key must agree on id, name, supported version range and per-version
+ * header versions. A divergence here means the proxy would advertise or negotiate a different
+ * protocol surface than a real broker.
+ */
+class ApiKeysFidelityTest {
+
+    @Test
+    void sameApiKeyConstants() {
+        // Given
+        var kafkaNames = Arrays.stream(ApiKeys.values()).map(Enum::name).collect(Collectors.toSet());
+        var kroxyliciousNames = Arrays.stream(io.kroxylicious.kafka.common.protocol.ApiKeys.values())
+                .map(Enum::name).collect(Collectors.toSet());
+
+        // When / Then
+        assertThat(kroxyliciousNames).containsExactlyInAnyOrderElementsOf(kafkaNames);
+    }
+
+    @Test
+    void produceApiVersionsResponseMinVersionMatches() {
+        // When / Then
+        assertThat(io.kroxylicious.kafka.common.protocol.ApiKeys.PRODUCE_API_VERSIONS_RESPONSE_MIN_VERSION)
+                .isEqualTo(ApiKeys.PRODUCE_API_VERSIONS_RESPONSE_MIN_VERSION);
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApiKeys.class)
+    void apiKeyMatchesKafka(ApiKeys kafka) {
+        // Given
+        var kroxylicious = io.kroxylicious.kafka.common.protocol.ApiKeys.valueOf(kafka.name());
+
+        // When / Then
+        assertThat(kroxylicious.id).isEqualTo(kafka.id);
+        assertThat(kroxylicious.name).isEqualTo(kafka.name);
+        assertThat(kroxylicious.oldestVersion()).isEqualTo(kafka.oldestVersion());
+        assertThat(kroxylicious.latestVersion()).isEqualTo(kafka.latestVersion());
+        assertThat(kroxylicious.latestVersion(false)).isEqualTo(kafka.latestVersion(false));
+        assertThat(kroxylicious.latestVersion(true)).isEqualTo(kafka.latestVersion(true));
+        assertThat(kroxylicious.hasValidVersion()).isEqualTo(kafka.hasValidVersion());
+        assertThat(kroxylicious.allVersions()).isEqualTo(kafka.allVersions());
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApiKeys.class)
+    void lookupByIdMatchesKafka(ApiKeys kafka) {
+        // When / Then
+        assertThat(io.kroxylicious.kafka.common.protocol.ApiKeys.hasId(kafka.id)).isTrue();
+        assertThat(io.kroxylicious.kafka.common.protocol.ApiKeys.forId(kafka.id).name()).isEqualTo(kafka.name());
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApiKeys.class)
+    void headerVersionsMatchKafka(ApiKeys kafka) {
+        // Given
+        var kroxylicious = io.kroxylicious.kafka.common.protocol.ApiKeys.valueOf(kafka.name());
+
+        // When / Then
+        for (short version : kafka.allVersions()) {
+            assertThat(kroxylicious.requestHeaderVersion(version))
+                    .as("requestHeaderVersion(%d) for %s", version, kafka.name())
+                    .isEqualTo(kafka.requestHeaderVersion(version));
+            assertThat(kroxylicious.responseHeaderVersion(version))
+                    .as("responseHeaderVersion(%d) for %s", version, kafka.name())
+                    .isEqualTo(kafka.responseHeaderVersion(version));
+        }
+    }
+}

--- a/tools/kafka-vendoring/README.md
+++ b/tools/kafka-vendoring/README.md
@@ -11,10 +11,11 @@
 `io.kroxylicious.kafka.common.*` namespace, so that the API references no
 `org.apache.kafka.*` types. That surface has three parts:
 
-1. **Generated message classes** — the `*Data` / `*DataJsonConverter` classes and
-   `ApiMessageType`, produced on every build by the forked message generator
-   (`kroxylicious-kafka-message-generator`) from the protocol JSON specs. These are
-   **not** committed; they land in `target/generated-sources/kafka-messages`.
+1. **Generated message classes** — the `*Data` / `*DataJsonConverter` classes,
+   `ApiMessageType` and the `ApiKeys` enum (a veneer over `ApiMessageType`), produced on
+   every build by the forked message generator (`kroxylicious-kafka-message-generator`)
+   from the protocol JSON specs. These are **not** committed; they land in
+   `target/generated-sources/kafka-messages`.
 2. **Vendored support classes** — the ~90 non-generated classes the generated code
    needs at runtime (records, compression, protocol readers/writers, a handful of
    utils and errors). These **are** committed, under


### PR DESCRIPTION
### Type of change

Enhancement / new feature

### Description

Introduces a Kroxylicious-owned `ApiKeys` under `io.kroxylicious.kafka.*`, so the public Filter/Route API can eventually stop referencing `org.apache.kafka.*`. **Type only** — no public API / `Router` / metadata signatures are migrated here.

> [!NOTE]
> Scope reduced: the owned `Errors` enum and its exception hierarchy, originally part of this PR, are now handled separately in #4763. This PR is `ApiKeys`-only.

**`ApiKeys` (generated).** A new `ApiKeysGenerator` in `kroxylicious-kafka-message-generator` emits `io.kroxylicious.kafka.common.protocol.ApiKeys` as a thin veneer over the already-generated `ApiMessageType`, wired into `kroxylicious-api`'s build as a second `exec-maven-plugin` execution. It deliberately omits:
- the broker/controller-internal `clusterAction`/`forwardable` flags (not spec-derivable; these flags exist for brokers & controllers, and as a proxy we don't need them), and
- the listener groupings `clientApis()`/`brokerApis()`/`controllerApis()`/`apisForListener()` — not currently needed as public API surface.

**Tests.**
- `ApiKeysGeneratorTest` (`kroxylicious-kafka-message-generator`) exercises the generator in isolation: output name, enum constant emission, api-key ordering, and duplicate-spec rejection.
- `ApiKeysFidelityTest` (`kroxylicious-wire-fidelity-tests`) proves wire parity against Apache Kafka's own `ApiKeys`. Both the generated enum and the `kafka-clients` jar are pinned to `kafka.message-spec.version`, so every api key must agree on id, name, supported version range and per-version request/response header versions — a divergence would mean the proxy advertises a different protocol surface than a real broker.

Verified: `mvn -pl kroxylicious-kafka-message-generator,kroxylicious-wire-fidelity-tests verify` is green and `ApiKeys` generates cleanly under `kroxylicious-api`.

### Additional Context

Part of the #4577 umbrella (design proposal 116). Owned `ApiKeys` unblocks the downstream Filter API migration. Out of scope by design:
- The owned `Errors` enum + exception hierarchy (→ #4763).
- Migrating `RequestFilter`/`ResponseFilter`/`Router`/`filter/metadata` signatures and `KafkaProxyExceptionMapper` (→ #4582/#4583/#4748).
- The broader anti-drift oracle tests (→ separate PR after #4579).

### Checklist

- [x] New tests written (where applicable). — `ApiKeysGeneratorTest` + `ApiKeysFidelityTest` added.
- [x] If making a user-facing change, documentation is provided... — no user-facing change (groundwork only).
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed.
- [x] PR references related GitHub issue(s) so they are closed on merging. — Relates-to #4752.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [x] For user facing changes, add a logchange entry... — N/A (not user-facing).

Relates-to: #4752

🤖 Generated with [Claude Code](https://claude.com/claude-code)