### PR TITLE
feat(api): express short-circuit error response APIs in terms of Errors codes (rather than ApiException)

### DIFF
--- a/changelog/unreleased/04756-error-response-errors-codes.yaml
+++ b/changelog/unreleased/04756-error-response-errors-codes.yaml
@@ -1,16 +1,14 @@
 title: "feat(api): express short-circuit error responses in terms of Errors codes"
-type: added
+type: changed
 issues:
   - 4756
 important_notes:
   - |
-    `RequestFilterResultBuilder.errorResponse` and `RouterContext.respondWithError` now offer
-    overloads that take an `org.apache.kafka.common.protocol.Errors` code (with an optional message)
-    instead of a client exception. Prefer these over constructing an `ApiException`.
+    `RequestFilterResultBuilder.errorResponse` and `RouterContext.respondWithError` now take an
+    `org.apache.kafka.common.protocol.Errors` code (with an optional message) instead of a client
+    exception, so the kafka-clients exception hierarchy no longer leaks into the API.
   - |
     The exception-based overloads (`errorResponse(RequestHeaderData, ApiMessage, ApiException)` and
-    `respondWithError(RequestHeaderData, ApiMessage, ApiException)`) are deprecated for removal. Their
-    parameter has been widened from `org.apache.kafka.common.errors.ApiException` to
-    `java.lang.Throwable`; existing callers keep compiling (every `ApiException` is a `Throwable`), but
-    the deprecated overloads now throw `IllegalArgumentException` at runtime if the throwable is not an
-    `ApiException`. Migrate to the `Errors`-based overloads.
+    `respondWithError(RequestHeaderData, ApiMessage, ApiException)`) have been removed. Migrate to the
+    `Errors`-based overloads, e.g. replace `errorResponse(header, request, new InvalidRequestException(msg))`
+    with `errorResponse(header, request, Errors.INVALID_REQUEST, msg)`.

--- a/changelog/unreleased/04756-error-response-errors-codes.yaml
+++ b/changelog/unreleased/04756-error-response-errors-codes.yaml
@@ -1,0 +1,16 @@
+title: "feat(api): express short-circuit error responses in terms of Errors codes"
+type: added
+issues:
+  - 4756
+important_notes:
+  - |
+    `RequestFilterResultBuilder.errorResponse` and `RouterContext.respondWithError` now offer
+    overloads that take an `org.apache.kafka.common.protocol.Errors` code (with an optional message)
+    instead of a client exception. Prefer these over constructing an `ApiException`.
+  - |
+    The exception-based overloads (`errorResponse(RequestHeaderData, ApiMessage, ApiException)` and
+    `respondWithError(RequestHeaderData, ApiMessage, ApiException)`) are deprecated for removal. Their
+    parameter has been widened from `org.apache.kafka.common.errors.ApiException` to
+    `java.lang.Throwable`; existing callers keep compiling (every `ApiException` is a `Throwable`), but
+    the deprecated overloads now throw `IllegalArgumentException` at runtime if the throwable is not an
+    `ApiException`. Migrate to the `Errors`-based overloads.

--- a/kroxylicious-api/pom.xml
+++ b/kroxylicious-api/pom.xml
@@ -384,6 +384,20 @@
                                         io.kroxylicious.proxy.filter.FilterContext#clientSaslAuthenticationSuccess(java.lang.String,
                                         java.lang.String)
                                     </exclude>
+                                    <!-- The error-response entry points were widened from org.apache.kafka.common.errors.ApiException to
+                                         java.lang.Throwable (and re-expressed in terms of Errors codes) at 0.24.0. Every ApiException is a
+                                         Throwable, so existing callers keep compiling; the ApiException-typed overload is deprecated for removal.
+                                         See https://github.com/kroxylicious/kroxylicious/issues/4756 -->
+                                    <exclude>
+                                        io.kroxylicious.proxy.filter.RequestFilterResultBuilder#errorResponse(org.apache.kafka.common.message.RequestHeaderData,
+                                        org.apache.kafka.common.protocol.ApiMessage,
+                                        org.apache.kafka.common.errors.ApiException)
+                                    </exclude>
+                                    <exclude>
+                                        io.kroxylicious.proxy.router.RouterContext#respondWithError(org.apache.kafka.common.message.RequestHeaderData,
+                                        org.apache.kafka.common.protocol.ApiMessage,
+                                        org.apache.kafka.common.errors.ApiException)
+                                    </exclude>
                                 </excludes>
                                 <!-- see documentation -->
                             </parameter>

--- a/kroxylicious-api/pom.xml
+++ b/kroxylicious-api/pom.xml
@@ -384,9 +384,9 @@
                                         io.kroxylicious.proxy.filter.FilterContext#clientSaslAuthenticationSuccess(java.lang.String,
                                         java.lang.String)
                                     </exclude>
-                                    <!-- The error-response entry points were widened from org.apache.kafka.common.errors.ApiException to
-                                         java.lang.Throwable (and re-expressed in terms of Errors codes) at 0.24.0. Every ApiException is a
-                                         Throwable, so existing callers keep compiling; the ApiException-typed overload is deprecated for removal.
+                                    <!-- The ApiException-typed error-response entry points were removed at 0.24.0 and replaced by overloads
+                                         taking an org.apache.kafka.common.protocol.Errors code (with an optional message), so the kafka-clients
+                                         exception hierarchy no longer leaks into the API. Removing the released overloads is binary-incompatible.
                                          See https://github.com/kroxylicious/kroxylicious/issues/4756 -->
                                     <exclude>
                                         io.kroxylicious.proxy.filter.RequestFilterResultBuilder#errorResponse(org.apache.kafka.common.message.RequestHeaderData,

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterResultBuilder.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterResultBuilder.java
@@ -82,23 +82,4 @@ public interface RequestFilterResultBuilder extends FilterResultBuilder<RequestH
                                                             @Nullable String message)
             throws IllegalArgumentException;
 
-    /**
-     * Generate a short-circuit error response towards the client.
-     * The generated error response is API-specific, and adds an error code (corresponding to the throwable), and possibly error message (from the message of the throwable), either at the top level of the response (if the API for the response has a global error code), or for all entities given in the request (if the API for the response has only-per entity error codes).
-     * @param header the headers from the request
-     * @param requestMessage the API request message to generate an error in response too.
-     * @param apiException the throwable that triggered the error response. Must be an
-     *                  {@code org.apache.kafka.common.errors.ApiException}. Note Kafka will map the throwable to an {@link org.apache.kafka.common.requests.ApiError} using {@link org.apache.kafka.common.protocol.Errors#forException(java.lang.Throwable)} so callers may wish to choose their throwable to trigger the appropriate error code
-     * @return next stage in the fluent builder API
-     * @throws IllegalArgumentException header or message do not meet criteria described above, or {@code apiException} is not an {@code org.apache.kafka.common.errors.ApiException}.
-     * @deprecated use {@link #errorResponse(RequestHeaderData, ApiMessage, Errors)} or
-     *             {@link #errorResponse(RequestHeaderData, ApiMessage, Errors, String)} instead,
-     *             which express the error as a code rather than requiring a client exception.
-     */
-    @Deprecated(since = "0.24.0", forRemoval = true)
-    CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header,
-                                                            ApiMessage requestMessage,
-                                                            Throwable apiException)
-            throws IllegalArgumentException;
-
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterResultBuilder.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterResultBuilder.java
@@ -53,8 +53,10 @@ public interface RequestFilterResultBuilder extends FilterResultBuilder<RequestH
      * @param requestMessage the API request message to generate an error in response too.
      * @param error the error to convey to the client; its {@link Errors#code() code} is set on the
      *              generated response and its {@link Errors#message() default message} is used.
+     *              Must denote an actual error; {@link Errors#NONE} is not permitted.
      * @return next stage in the fluent builder API
-     * @throws IllegalArgumentException header or message do not meet criteria described above.
+     * @throws IllegalArgumentException header or message do not meet criteria described above, or
+     *         {@code error} is {@link Errors#NONE}.
      */
     CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header,
                                                             ApiMessage requestMessage,
@@ -70,11 +72,12 @@ public interface RequestFilterResultBuilder extends FilterResultBuilder<RequestH
      * @param header the headers from the request
      * @param requestMessage the API request message to generate an error in response too.
      * @param error the error to convey to the client; its {@link Errors#code() code} is set on the
-     *              generated response.
+     *              generated response. Must denote an actual error; {@link Errors#NONE} is not permitted.
      * @param message the error message to convey to the client, or {@code null} to use the error's
      *                default message.
      * @return next stage in the fluent builder API
-     * @throws IllegalArgumentException header or message do not meet criteria described above.
+     * @throws IllegalArgumentException header or message do not meet criteria described above, or
+     *         {@code error} is {@link Errors#NONE}.
      */
     CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header,
                                                             ApiMessage requestMessage,

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterResultBuilder.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterResultBuilder.java
@@ -6,10 +6,10 @@
 
 package io.kroxylicious.proxy.filter;
 
-import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
 
 import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
 
@@ -45,16 +45,60 @@ public interface RequestFilterResultBuilder extends FilterResultBuilder<RequestH
 
     /**
      * Generate a short-circuit error response towards the client.
-     * The generated error response is API-specific, and add an error code (corresponding to the ApiException), and possibly error message (from the message of the ApiException), either at the top level of the response (if the API for the response has a global error code), or for all entities given in the request (if the API for the response has only-per entity error codes).
+     * The generated error response is API-specific: it carries the given {@code error}'s code, and
+     * the error's default message, either at the top level of the response (if the API for the
+     * response has a global error code), or for all entities given in the request (if the API for
+     * the response has only per-entity error codes).
      * @param header the headers from the request
      * @param requestMessage the API request message to generate an error in response too.
-     * @param apiException the exception that triggered the error response. Note Kafka will map the exception to an {@link org.apache.kafka.common.requests.ApiError} using {@link org.apache.kafka.common.protocol.Errors#forException(java.lang.Throwable)} so callers may wish to supply choose their exception to trigger the appropriate error code
+     * @param error the error to convey to the client; its {@link Errors#code() code} is set on the
+     *              generated response and its {@link Errors#message() default message} is used.
      * @return next stage in the fluent builder API
      * @throws IllegalArgumentException header or message do not meet criteria described above.
      */
     CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header,
                                                             ApiMessage requestMessage,
-                                                            ApiException apiException)
+                                                            Errors error)
+            throws IllegalArgumentException;
+
+    /**
+     * Generate a short-circuit error response towards the client.
+     * The generated error response is API-specific: it carries the given {@code error}'s code, and
+     * the given message, either at the top level of the response (if the API for the response has a
+     * global error code), or for all entities given in the request (if the API for the response has
+     * only per-entity error codes).
+     * @param header the headers from the request
+     * @param requestMessage the API request message to generate an error in response too.
+     * @param error the error to convey to the client; its {@link Errors#code() code} is set on the
+     *              generated response.
+     * @param message the error message to convey to the client, or {@code null} to use the error's
+     *                default message.
+     * @return next stage in the fluent builder API
+     * @throws IllegalArgumentException header or message do not meet criteria described above.
+     */
+    CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header,
+                                                            ApiMessage requestMessage,
+                                                            Errors error,
+                                                            @Nullable String message)
+            throws IllegalArgumentException;
+
+    /**
+     * Generate a short-circuit error response towards the client.
+     * The generated error response is API-specific, and adds an error code (corresponding to the throwable), and possibly error message (from the message of the throwable), either at the top level of the response (if the API for the response has a global error code), or for all entities given in the request (if the API for the response has only-per entity error codes).
+     * @param header the headers from the request
+     * @param requestMessage the API request message to generate an error in response too.
+     * @param apiException the throwable that triggered the error response. Must be an
+     *                  {@code org.apache.kafka.common.errors.ApiException}. Note Kafka will map the throwable to an {@link org.apache.kafka.common.requests.ApiError} using {@link org.apache.kafka.common.protocol.Errors#forException(java.lang.Throwable)} so callers may wish to choose their throwable to trigger the appropriate error code
+     * @return next stage in the fluent builder API
+     * @throws IllegalArgumentException header or message do not meet criteria described above, or {@code apiException} is not an {@code org.apache.kafka.common.errors.ApiException}.
+     * @deprecated use {@link #errorResponse(RequestHeaderData, ApiMessage, Errors)} or
+     *             {@link #errorResponse(RequestHeaderData, ApiMessage, Errors, String)} instead,
+     *             which express the error as a code rather than requiring a client exception.
+     */
+    @Deprecated(since = "0.24.0", forRemoval = true)
+    CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header,
+                                                            ApiMessage requestMessage,
+                                                            Throwable apiException)
             throws IllegalArgumentException;
 
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterContext.java
@@ -211,8 +211,10 @@ public interface RouterContext {
      * @param request the request body
      * @param error the error to convey to the client; its {@link Errors#code() code}
      *              is set on the generated response and its {@link Errors#message()
-     *              default message} is used.
+     *              default message} is used. Must denote an actual error;
+     *              {@link Errors#NONE} is not permitted.
      * @return a stage that can optionally close the connection
+     * @throws IllegalArgumentException if {@code error} is {@link Errors#NONE}.
      */
     CloseOrTerminalStage respondWithError(
                                           RequestHeaderData header,
@@ -227,10 +229,12 @@ public interface RouterContext {
      * @param header the request header
      * @param request the request body
      * @param error the error to convey to the client; its {@link Errors#code() code}
-     *              is set on the generated response.
+     *              is set on the generated response. Must denote an actual error;
+     *              {@link Errors#NONE} is not permitted.
      * @param message the error message to convey to the client, or {@code null} to
      *                use the error's default message.
      * @return a stage that can optionally close the connection
+     * @throws IllegalArgumentException if {@code error} is {@link Errors#NONE}.
      */
     CloseOrTerminalStage respondWithError(
                                           RequestHeaderData header,

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterContext.java
@@ -9,13 +9,15 @@ package io.kroxylicious.proxy.router;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
-import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
 
 import io.kroxylicious.proxy.authentication.Subject;
 import io.kroxylicious.proxy.topology.VirtualNode;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Context passed to {@link Router#onRequest} for issuing requests
@@ -202,17 +204,61 @@ public interface RouterContext {
 
     /**
      * Begins building a router result that generates an error response
-     * for the client. The generated error response is API-specific.
+     * for the client. The generated error response is API-specific and
+     * carries the given {@code error}'s code and its default message.
      *
      * @param header the request header
      * @param request the request body
-     * @param exception the exception that triggered the error
+     * @param error the error to convey to the client; its {@link Errors#code() code}
+     *              is set on the generated response and its {@link Errors#message()
+     *              default message} is used.
      * @return a stage that can optionally close the connection
      */
     CloseOrTerminalStage respondWithError(
                                           RequestHeaderData header,
                                           ApiMessage request,
-                                          ApiException exception);
+                                          Errors error);
+
+    /**
+     * Begins building a router result that generates an error response
+     * for the client. The generated error response is API-specific and
+     * carries the given {@code error}'s code and the given message.
+     *
+     * @param header the request header
+     * @param request the request body
+     * @param error the error to convey to the client; its {@link Errors#code() code}
+     *              is set on the generated response.
+     * @param message the error message to convey to the client, or {@code null} to
+     *                use the error's default message.
+     * @return a stage that can optionally close the connection
+     */
+    CloseOrTerminalStage respondWithError(
+                                          RequestHeaderData header,
+                                          ApiMessage request,
+                                          Errors error,
+                                          @Nullable String message);
+
+    /**
+     * Begins building a router result that generates an error response
+     * for the client. The generated error response is API-specific.
+     *
+     * @param header the request header
+     * @param request the request body
+     * @param apiException the throwable that triggered the error. Must be an
+     *                  {@code org.apache.kafka.common.errors.ApiException}.
+     * @return a stage that can optionally close the connection
+     * @throws IllegalArgumentException if {@code apiException} is not an
+     *         {@code org.apache.kafka.common.errors.ApiException}.
+     * @deprecated use {@link #respondWithError(RequestHeaderData, ApiMessage, Errors)}
+     *             or {@link #respondWithError(RequestHeaderData, ApiMessage, Errors, String)}
+     *             instead, which express the error as a code rather than requiring a
+     *             client exception.
+     */
+    @Deprecated(since = "0.24.0", forRemoval = true)
+    CloseOrTerminalStage respondWithError(
+                                          RequestHeaderData header,
+                                          ApiMessage request,
+                                          Throwable apiException);
 
     /**
      * Begins building a router result for a fire-and-forget request

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/router/RouterContext.java
@@ -239,28 +239,6 @@ public interface RouterContext {
                                           @Nullable String message);
 
     /**
-     * Begins building a router result that generates an error response
-     * for the client. The generated error response is API-specific.
-     *
-     * @param header the request header
-     * @param request the request body
-     * @param apiException the throwable that triggered the error. Must be an
-     *                  {@code org.apache.kafka.common.errors.ApiException}.
-     * @return a stage that can optionally close the connection
-     * @throws IllegalArgumentException if {@code apiException} is not an
-     *         {@code org.apache.kafka.common.errors.ApiException}.
-     * @deprecated use {@link #respondWithError(RequestHeaderData, ApiMessage, Errors)}
-     *             or {@link #respondWithError(RequestHeaderData, ApiMessage, Errors, String)}
-     *             instead, which express the error as a code rather than requiring a
-     *             client exception.
-     */
-    @Deprecated(since = "0.24.0", forRemoval = true)
-    CloseOrTerminalStage respondWithError(
-                                          RequestHeaderData header,
-                                          ApiMessage request,
-                                          Throwable apiException);
-
-    /**
      * Begins building a router result for a fire-and-forget request
      * where no response is delivered to the client (e.g. acks=0
      * {@code PRODUCE}).

--- a/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/testing/filter/context/MockFilterContext.java
+++ b/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/testing/filter/context/MockFilterContext.java
@@ -542,16 +542,6 @@ public class MockFilterContext implements FilterContext {
             return new MockErrorCloseOrTerminalRequestStage(header, requestMessage, error.exception(message));
         }
 
-        @SuppressWarnings("removal")
-        @Override
-        public CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header, ApiMessage requestMessage, Throwable apiException)
-                throws IllegalArgumentException {
-            if (!(apiException instanceof ApiException asApiException)) {
-                throw new IllegalArgumentException("apiException must be an " + ApiException.class.getName() + " but was " + apiException.getClass().getName());
-            }
-            return new MockErrorCloseOrTerminalRequestStage(header, requestMessage, asApiException);
-        }
-
         @Override
         public CloseOrTerminalStage<RequestFilterResult> forward(RequestHeaderData header, ApiMessage message) throws IllegalArgumentException {
             return new MockCloseOrTerminalRequestStage(false, header, message, false, false);

--- a/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/testing/filter/context/MockFilterContext.java
+++ b/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/testing/filter/context/MockFilterContext.java
@@ -538,6 +538,10 @@ public class MockFilterContext implements FilterContext {
         @Override
         public CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header, ApiMessage requestMessage, Errors error, @Nullable String message)
                 throws IllegalArgumentException {
+            Objects.requireNonNull(error, "error must not be null");
+            if (error == Errors.NONE) {
+                throw new IllegalArgumentException("error must denote an actual error, but was Errors.NONE");
+            }
             // Errors.exception(String) returns the default-message exception when message is null.
             return new MockErrorCloseOrTerminalRequestStage(header, requestMessage, error.exception(message));
         }

--- a/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/testing/filter/context/MockFilterContext.java
+++ b/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/testing/filter/context/MockFilterContext.java
@@ -530,10 +530,26 @@ public class MockFilterContext implements FilterContext {
         }
 
         @Override
-        public CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header, ApiMessage requestMessage,
-                                                                       ApiException apiException)
+        public CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header, ApiMessage requestMessage, Errors error)
                 throws IllegalArgumentException {
-            return new MockErrorCloseOrTerminalRequestStage(header, requestMessage, apiException);
+            return errorResponse(header, requestMessage, error, null);
+        }
+
+        @Override
+        public CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header, ApiMessage requestMessage, Errors error, @Nullable String message)
+                throws IllegalArgumentException {
+            // Errors.exception(String) returns the default-message exception when message is null.
+            return new MockErrorCloseOrTerminalRequestStage(header, requestMessage, error.exception(message));
+        }
+
+        @SuppressWarnings("removal")
+        @Override
+        public CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header, ApiMessage requestMessage, Throwable apiException)
+                throws IllegalArgumentException {
+            if (!(apiException instanceof ApiException asApiException)) {
+                throw new IllegalArgumentException("apiException must be an " + ApiException.class.getName() + " but was " + apiException.getClass().getName());
+            }
+            return new MockErrorCloseOrTerminalRequestStage(header, requestMessage, asApiException);
         }
 
         @Override

--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/testing/filter/context/MockFilterContextTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/testing/filter/context/MockFilterContextTest.java
@@ -12,8 +12,6 @@ import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.errors.ApiException;
-import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
@@ -441,11 +439,10 @@ class MockFilterContextTest {
     void shouldBuildErrorRequestFilterResult() {
         // given
         MockFilterContext context = MockFilterContext.builder(HEADER, MESSAGE).build();
-        ApiException exception = new UnknownServerException("Test Error");
 
         // when
         RequestFilterResult result = context.requestFilterResultBuilder()
-                .errorResponse(HEADER, MESSAGE, exception)
+                .errorResponse(HEADER, MESSAGE, Errors.UNKNOWN_SERVER_ERROR)
                 .build();
 
         // then
@@ -454,18 +451,19 @@ class MockFilterContextTest {
                 .isShortCircuitResponse()
                 .isErrorResponse()
                 .isNotDropRequest()
-                .errorResponse().isEqualTo(exception);
+                .errorResponse()
+                .isInstanceOf(Errors.UNKNOWN_SERVER_ERROR.exception().getClass())
+                .hasMessage(Errors.UNKNOWN_SERVER_ERROR.message());
     }
 
     @Test
     void shouldBuildErrorRequestFilterResultCompleted() {
         // given
         MockFilterContext context = MockFilterContext.builder(HEADER, MESSAGE).build();
-        ApiException exception = new UnknownServerException("Test Error");
 
         // when
         CompletionStage<RequestFilterResult> result = context.requestFilterResultBuilder()
-                .errorResponse(HEADER, MESSAGE, exception)
+                .errorResponse(HEADER, MESSAGE, Errors.UNKNOWN_SERVER_ERROR)
                 .completed();
 
         // then
@@ -474,18 +472,19 @@ class MockFilterContextTest {
                 .isShortCircuitResponse()
                 .isErrorResponse()
                 .isNotDropRequest()
-                .errorResponse().isEqualTo(exception));
+                .errorResponse()
+                .isInstanceOf(Errors.UNKNOWN_SERVER_ERROR.exception().getClass())
+                .hasMessage(Errors.UNKNOWN_SERVER_ERROR.message()));
     }
 
     @Test
     void shouldBuildErrorWithCloseConnectionRequestFilterResult() {
         // given
         MockFilterContext context = MockFilterContext.builder(HEADER, MESSAGE).build();
-        ApiException exception = new UnknownServerException("Test Error");
 
         // when
         RequestFilterResult result = context.requestFilterResultBuilder()
-                .errorResponse(HEADER, MESSAGE, exception)
+                .errorResponse(HEADER, MESSAGE, Errors.UNKNOWN_SERVER_ERROR)
                 .withCloseConnection()
                 .build();
 
@@ -495,18 +494,19 @@ class MockFilterContextTest {
                 .isShortCircuitResponse()
                 .isErrorResponse()
                 .isNotDropRequest()
-                .errorResponse().isEqualTo(exception);
+                .errorResponse()
+                .isInstanceOf(Errors.UNKNOWN_SERVER_ERROR.exception().getClass())
+                .hasMessage(Errors.UNKNOWN_SERVER_ERROR.message());
     }
 
     @Test
     void shouldBuildErrorWithCloseConnectionRequestFilterResultCompleted() {
         // given
         MockFilterContext context = MockFilterContext.builder(HEADER, MESSAGE).build();
-        ApiException exception = new UnknownServerException("Test Error");
 
         // when
         CompletionStage<RequestFilterResult> result = context.requestFilterResultBuilder()
-                .errorResponse(HEADER, MESSAGE, exception)
+                .errorResponse(HEADER, MESSAGE, Errors.UNKNOWN_SERVER_ERROR)
                 .withCloseConnection()
                 .completed();
 
@@ -517,7 +517,9 @@ class MockFilterContextTest {
                 .isShortCircuitResponse()
                 .isErrorResponse()
                 .isNotDropRequest()
-                .errorResponse().isEqualTo(exception));
+                .errorResponse()
+                .isInstanceOf(Errors.UNKNOWN_SERVER_ERROR.exception().getClass())
+                .hasMessage(Errors.UNKNOWN_SERVER_ERROR.message()));
     }
 
     @Test
@@ -561,17 +563,6 @@ class MockFilterContextTest {
                 .errorResponse()
                 .isInstanceOf(Errors.INVALID_REQUEST.exception().getClass())
                 .hasMessage(message);
-    }
-
-    @Test
-    void shouldRejectNonApiExceptionThrowable() {
-        // given
-        MockFilterContext context = MockFilterContext.builder(HEADER, MESSAGE).build();
-        Throwable notAnApiException = new IllegalStateException("not an ApiException");
-
-        // when / then
-        assertThatThrownBy(() -> context.requestFilterResultBuilder().errorResponse(HEADER, MESSAGE, notAnApiException))
-                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/testing/filter/context/MockFilterContextTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/testing/filter/context/MockFilterContextTest.java
@@ -521,6 +521,60 @@ class MockFilterContextTest {
     }
 
     @Test
+    void shouldBuildErrorRequestFilterResultFromErrors() {
+        // given
+        MockFilterContext context = MockFilterContext.builder(HEADER, MESSAGE).build();
+
+        // when
+        RequestFilterResult result = context.requestFilterResultBuilder()
+                .errorResponse(HEADER, MESSAGE, Errors.INVALID_REQUEST)
+                .build();
+
+        // then
+        MockFilterContextAssert.assertThat(result)
+                .isNotCloseConnection()
+                .isShortCircuitResponse()
+                .isErrorResponse()
+                .isNotDropRequest()
+                .errorResponse()
+                .isInstanceOf(Errors.INVALID_REQUEST.exception().getClass())
+                .hasMessage(Errors.INVALID_REQUEST.message());
+    }
+
+    @Test
+    void shouldBuildErrorRequestFilterResultFromErrorsWithMessage() {
+        // given
+        MockFilterContext context = MockFilterContext.builder(HEADER, MESSAGE).build();
+        String message = "custom explanation";
+
+        // when
+        RequestFilterResult result = context.requestFilterResultBuilder()
+                .errorResponse(HEADER, MESSAGE, Errors.INVALID_REQUEST, message)
+                .build();
+
+        // then
+        MockFilterContextAssert.assertThat(result)
+                .isNotCloseConnection()
+                .isShortCircuitResponse()
+                .isErrorResponse()
+                .isNotDropRequest()
+                .errorResponse()
+                .isInstanceOf(Errors.INVALID_REQUEST.exception().getClass())
+                .hasMessage(message);
+    }
+
+    @Test
+    void shouldRejectNonApiExceptionThrowable() {
+        // given
+        MockFilterContext context = MockFilterContext.builder(HEADER, MESSAGE).build();
+        Throwable notAnApiException = new IllegalStateException("not an ApiException");
+
+        // when / then
+        assertThatThrownBy(() -> context.requestFilterResultBuilder().errorResponse(HEADER, MESSAGE, notAnApiException))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     void shouldBuildDropRequestFilterResult() {
         // given
         MockFilterContext context = MockFilterContext.builder(HEADER, MESSAGE).build();

--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/testing/filter/context/MockFilterContextTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/testing/filter/context/MockFilterContextTest.java
@@ -566,6 +566,32 @@ class MockFilterContextTest {
     }
 
     @Test
+    void shouldRejectErrorsNone() {
+        // given
+        MockFilterContext context = MockFilterContext.builder(HEADER, MESSAGE).build();
+        var builder = context.requestFilterResultBuilder();
+
+        // when / then
+        assertThatThrownBy(() -> builder.errorResponse(HEADER, MESSAGE, Errors.NONE))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.errorResponse(HEADER, MESSAGE, Errors.NONE, "some message"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldRejectNullError() {
+        // given
+        MockFilterContext context = MockFilterContext.builder(HEADER, MESSAGE).build();
+        var builder = context.requestFilterResultBuilder();
+
+        // when / then
+        assertThatThrownBy(() -> builder.errorResponse(HEADER, MESSAGE, null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> builder.errorResponse(HEADER, MESSAGE, null, "some message"))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
     void shouldBuildDropRequestFilterResult() {
         // given
         MockFilterContext context = MockFilterContext.builder(HEADER, MESSAGE).build();

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/AuthorizationFilter.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/AuthorizationFilter.java
@@ -295,7 +295,7 @@ public class AuthorizationFilter implements RequestFilter, ResponseFilter {
         else {
             logUnsupportedVersion(apiKey, header);
             return context.requestFilterResultBuilder()
-                    .errorResponse(header, request, Errors.UNSUPPORTED_VERSION.exception())
+                    .errorResponse(header, request, Errors.UNSUPPORTED_VERSION)
                     .completed();
         }
     }

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/ConsumerGroupDescribeEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/ConsumerGroupDescribeEnforcement.java
@@ -67,7 +67,7 @@ class ConsumerGroupDescribeEnforcement extends ApiEnforcement<ConsumerGroupDescr
         List<Action> describeGroupActions = getActions(request, includeAuthorizedOperations);
         return authorizationFilter.authorization(context, describeGroupActions).thenCompose(authorizeResult -> {
             if (authorizeResult.allowed(GroupResource.DESCRIBE).isEmpty()) {
-                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED.exception()).completed();
+                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED).completed();
             }
             else if (!authorizeResult.denied().isEmpty()) {
                 Map<Decision, List<String>> groupsByDecision = authorizeResult.partition(request.groupIds(), GroupResource.DESCRIBE, Function.identity());

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/ConsumerGroupHeartbeatEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/ConsumerGroupHeartbeatEnforcement.java
@@ -52,7 +52,7 @@ class ConsumerGroupHeartbeatEnforcement extends ApiEnforcement<ConsumerGroupHear
         List<Action> actions = Stream.concat(Stream.of(groupReadAction), topicDescribeActions(request)).toList();
         return authorizationFilter.authorization(context, actions).thenCompose(result -> {
             if (result.denied().contains(groupReadAction)) {
-                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED.exception()).completed();
+                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED).completed();
             }
             else if (request.subscribedTopicNames() == null || request.subscribedTopicNames().isEmpty()) {
                 return context.forwardRequest(header, request);

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/DeleteGroupsEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/DeleteGroupsEnforcement.java
@@ -54,7 +54,7 @@ public class DeleteGroupsEnforcement extends ApiEnforcement<DeleteGroupsRequestD
                 return context.forwardRequest(header, request);
             }
             else if (authorizeResult.allowed().isEmpty()) {
-                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED.exception()).completed();
+                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED).completed();
             }
             else {
                 Map<Decision, List<String>> partitioned = authorizeResult.partition(request.groupsNames(), GroupResource.DELETE, s -> s);

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/DescribeGroupsEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/DescribeGroupsEnforcement.java
@@ -55,7 +55,7 @@ public class DescribeGroupsEnforcement extends ApiEnforcement<DescribeGroupsRequ
         List<Action> actions = actionsToAuthorize(request, isIncludeAuthorizedOps);
         return authorizationFilter.authorization(context, actions).thenCompose(authorizeResult -> {
             if (authorizeResult.allowed().isEmpty()) {
-                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED.exception()).completed();
+                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED).completed();
             }
             // we can only short-circuit if we are not including the proxy authorized operations
             else if (authorizeResult.denied().isEmpty() && !isIncludeAuthorizedOps) {

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/HeartbeatEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/HeartbeatEnforcement.java
@@ -49,7 +49,7 @@ public class HeartbeatEnforcement extends ApiEnforcement<HeartbeatRequestData, H
         Action readGroup = new Action(GroupResource.READ, request.groupId());
         return authorizationFilter.authorization(context, List.of(readGroup)).thenCompose(authorizeResult -> {
             if (authorizeResult.denied().contains(readGroup)) {
-                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED.exception()).completed();
+                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED).completed();
             }
             else {
                 return context.forwardRequest(header, request);

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/JoinGroupEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/JoinGroupEnforcement.java
@@ -49,7 +49,7 @@ public class JoinGroupEnforcement extends ApiEnforcement<JoinGroupRequestData, J
         Action readGroup = new Action(GroupResource.READ, request.groupId());
         return authorizationFilter.authorization(context, List.of(readGroup)).thenCompose(authorizeResult -> {
             if (authorizeResult.denied().contains(readGroup)) {
-                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED.exception()).completed();
+                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED).completed();
             }
             else {
                 return context.forwardRequest(header, request);

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/LeaveGroupEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/LeaveGroupEnforcement.java
@@ -49,7 +49,7 @@ public class LeaveGroupEnforcement extends ApiEnforcement<LeaveGroupRequestData,
         Action readGroup = new Action(GroupResource.READ, request.groupId());
         return authorizationFilter.authorization(context, List.of(readGroup)).thenCompose(authorizeResult -> {
             if (authorizeResult.denied().contains(readGroup)) {
-                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED.exception()).completed();
+                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED).completed();
             }
             else {
                 return context.forwardRequest(header, request);

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/OffsetCommitEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/OffsetCommitEnforcement.java
@@ -52,7 +52,7 @@ class OffsetCommitEnforcement extends ApiEnforcement<OffsetCommitRequestData, Of
                                                            AuthorizationFilter authorizationFilter,
                                                            TopicNameMapping topicNameMapping) {
         if (topicNameMapping.anyFailures()) {
-            return context.requestFilterResultBuilder().errorResponse(header, request, Errors.UNKNOWN_TOPIC_ID.exception()).completed();
+            return context.requestFilterResultBuilder().errorResponse(header, request, Errors.UNKNOWN_TOPIC_ID).completed();
         }
 
         Action readGroup = new Action(GroupResource.READ, request.groupId());
@@ -60,7 +60,7 @@ class OffsetCommitEnforcement extends ApiEnforcement<OffsetCommitRequestData, Of
         return authorizationFilter.authorization(context, actions)
                 .thenCompose(authorization -> {
                     if (authorization.denied().contains(readGroup)) {
-                        return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED.exception()).completed();
+                        return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED).completed();
                     }
                     var decisions = authorization.partition(request.topics(),
                             TopicResource.READ,

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/OffsetDeleteEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/OffsetDeleteEnforcement.java
@@ -42,7 +42,7 @@ class OffsetDeleteEnforcement extends ApiEnforcement<OffsetDeleteRequestData, Of
         return authorizationFilter.authorization(context, actions)
                 .thenCompose(authorization -> {
                     if (authorization.denied().contains(groupDeleteAction)) {
-                        return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED.exception()).completed();
+                        return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED).completed();
                     }
                     var decisions = authorization.partition(request.topics(),
                             TopicResource.READ,

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/ProduceEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/ProduceEnforcement.java
@@ -90,7 +90,7 @@ class ProduceEnforcement extends ApiEnforcement<ProduceRequestData, ProduceRespo
                                                                                boolean requiresResponse,
                                                                                TopicNameMapping topicNameMapping) {
         if (requiresResponse) {
-            return context.requestFilterResultBuilder().errorResponse(header, request, UNKNOWN_TOPIC_ID.exception()).completed();
+            return context.requestFilterResultBuilder().errorResponse(header, request, UNKNOWN_TOPIC_ID).completed();
         }
         else {
             LOGGER.atWarn()
@@ -113,7 +113,7 @@ class ProduceEnforcement extends ApiEnforcement<ProduceRequestData, ProduceRespo
         if (allowedTopicWrites.isEmpty()) {
             if (requiresResponse) {
                 return context.requestFilterResultBuilder()
-                        .errorResponse(header, request, Errors.TOPIC_AUTHORIZATION_FAILED.exception())
+                        .errorResponse(header, request, Errors.TOPIC_AUTHORIZATION_FAILED)
                         .completed();
             }
             else {
@@ -155,7 +155,7 @@ class ProduceEnforcement extends ApiEnforcement<ProduceRequestData, ProduceRespo
     private static CompletionStage<RequestFilterResult> transactionalIdErrorResponse(FilterContext context, RequestHeaderData header, ProduceRequestData produceRequest,
                                                                                      boolean requiresResponse) {
         if (requiresResponse) {
-            return context.requestFilterResultBuilder().errorResponse(header, produceRequest, TRANSACTIONAL_ID_AUTHORIZATION_FAILED.exception()).completed();
+            return context.requestFilterResultBuilder().errorResponse(header, produceRequest, TRANSACTIONAL_ID_AUTHORIZATION_FAILED).completed();
         }
         else {
             return context.requestFilterResultBuilder().drop().completed();

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/SyncGroupEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/SyncGroupEnforcement.java
@@ -49,7 +49,7 @@ public class SyncGroupEnforcement extends ApiEnforcement<SyncGroupRequestData, S
         Action readGroup = new Action(GroupResource.READ, request.groupId());
         return authorizationFilter.authorization(context, List.of(readGroup)).thenCompose(authorizeResult -> {
             if (authorizeResult.denied().contains(readGroup)) {
-                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED.exception()).completed();
+                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED).completed();
             }
             else {
                 return context.forwardRequest(header, request);

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/TxnOffsetCommitEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/TxnOffsetCommitEnforcement.java
@@ -44,11 +44,11 @@ class TxnOffsetCommitEnforcement extends ApiEnforcement<TxnOffsetCommitRequestDa
         return authorization.thenCompose(result -> {
             Decision transactionalResult = result.decision(TransactionalIdResource.WRITE, request.transactionalId());
             if (transactionalResult == Decision.DENY) {
-                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED.exception()).completed();
+                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED).completed();
             }
             Decision groupResult = result.decision(GroupResource.READ, request.groupId());
             if (groupResult == Decision.DENY) {
-                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED.exception()).completed();
+                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED).completed();
             }
             Map<Decision, List<TxnOffsetCommitRequestTopic>> partitioned = result.partition(request.topics(), TopicResource.READ,
                     TxnOffsetCommitRequestTopic::name);

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/MockFilterContext.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/MockFilterContext.java
@@ -238,6 +238,10 @@ public record MockFilterContext(ApiMessage header, ApiMessage message, Subject s
         public CloseOrTerminalStage<RequestFilterResult> errorResponse(@NonNull RequestHeaderData header, @NonNull ApiMessage requestMessage, @NonNull Errors error,
                                                                        @Nullable String message)
                 throws IllegalArgumentException {
+            Objects.requireNonNull(error, "error must not be null");
+            if (error == Errors.NONE) {
+                throw new IllegalArgumentException("error must denote an actual error, but was Errors.NONE");
+            }
             // Errors.exception(String) returns the default-message exception when message is null.
             return new ErrorCloseOrTerminalStage(header, requestMessage, error.exception(message), false);
         }

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/MockFilterContext.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/MockFilterContext.java
@@ -242,18 +242,6 @@ public record MockFilterContext(ApiMessage header, ApiMessage message, Subject s
             return new ErrorCloseOrTerminalStage(header, requestMessage, error.exception(message), false);
         }
 
-        @SuppressWarnings("removal")
-        @NonNull
-        @Override
-        public CloseOrTerminalStage<RequestFilterResult> errorResponse(@NonNull RequestHeaderData header, @NonNull ApiMessage requestMessage,
-                                                                       @NonNull Throwable apiException)
-                throws IllegalArgumentException {
-            if (!(apiException instanceof ApiException asApiException)) {
-                throw new IllegalArgumentException("apiException must be an " + ApiException.class.getName() + " but was " + apiException.getClass().getName());
-            }
-            return new ErrorCloseOrTerminalStage(header, requestMessage, asApiException, false);
-        }
-
         @NonNull
         @Override
         public CloseOrTerminalStage<RequestFilterResult> forward(@NonNull RequestHeaderData header, @NonNull ApiMessage message) throws IllegalArgumentException {

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/MockFilterContext.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/MockFilterContext.java
@@ -228,10 +228,30 @@ public record MockFilterContext(ApiMessage header, ApiMessage message, Subject s
 
         @NonNull
         @Override
-        public CloseOrTerminalStage<RequestFilterResult> errorResponse(@NonNull RequestHeaderData header, @NonNull ApiMessage requestMessage,
-                                                                       @NonNull ApiException apiException)
+        public CloseOrTerminalStage<RequestFilterResult> errorResponse(@NonNull RequestHeaderData header, @NonNull ApiMessage requestMessage, @NonNull Errors error)
                 throws IllegalArgumentException {
-            return new ErrorCloseOrTerminalStage(header, requestMessage, apiException, false);
+            return errorResponse(header, requestMessage, error, null);
+        }
+
+        @NonNull
+        @Override
+        public CloseOrTerminalStage<RequestFilterResult> errorResponse(@NonNull RequestHeaderData header, @NonNull ApiMessage requestMessage, @NonNull Errors error,
+                                                                       @Nullable String message)
+                throws IllegalArgumentException {
+            // Errors.exception(String) returns the default-message exception when message is null.
+            return new ErrorCloseOrTerminalStage(header, requestMessage, error.exception(message), false);
+        }
+
+        @SuppressWarnings("removal")
+        @NonNull
+        @Override
+        public CloseOrTerminalStage<RequestFilterResult> errorResponse(@NonNull RequestHeaderData header, @NonNull ApiMessage requestMessage,
+                                                                       @NonNull Throwable apiException)
+                throws IllegalArgumentException {
+            if (!(apiException instanceof ApiException asApiException)) {
+                throw new IllegalArgumentException("apiException must be an " + ApiException.class.getName() + " but was " + apiException.getClass().getName());
+            }
+            return new ErrorCloseOrTerminalStage(header, requestMessage, asApiException, false);
         }
 
         @NonNull

--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/EntityIsolationFilter.java
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/EntityIsolationFilter.java
@@ -96,7 +96,7 @@ class EntityIsolationFilter implements RequestFilter, ResponseFilter {
                         if (eip.versionIsOutOfRange(apiVersion)) {
                             logUnexpectedApiVersion(filterContext, apiKey, apiVersion, eip.minSupportedVersion(), eip.maxSupportedVersion());
                             return filterContext.requestFilterResultBuilder()
-                                    .errorResponse(header, request, Errors.UNSUPPORTED_VERSION.exception())
+                                    .errorResponse(header, request, Errors.UNSUPPORTED_VERSION)
                                     .withCloseConnection()
                                     .completed();
                         }
@@ -117,7 +117,7 @@ class EntityIsolationFilter implements RequestFilter, ResponseFilter {
         catch (EntityMapperException e) {
             logMappingException(filterContext, apiKey, apiVersion, e);
             return filterContext.requestFilterResultBuilder()
-                    .errorResponse(header, request, Errors.UNKNOWN_SERVER_ERROR.exception())
+                    .errorResponse(header, request, Errors.UNKNOWN_SERVER_ERROR)
                     .withCloseConnection()
                     .completed();
         }

--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/ListTransactionsEntityIsolationProcessor.java
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/ListTransactionsEntityIsolationProcessor.java
@@ -83,7 +83,7 @@ class ListTransactionsEntityIsolationProcessor
                     Pattern.compile(transactionalIdPattern);
                 }
                 catch (PatternSyntaxException pse) {
-                    return filterContext.requestFilterResultBuilder().errorResponse(header, request, Errors.INVALID_REGULAR_EXPRESSION.exception()).completed();
+                    return filterContext.requestFilterResultBuilder().errorResponse(header, request, Errors.INVALID_REGULAR_EXPRESSION).completed();
                 }
                 // Idea: n.b. there's a half-way house where we pass the isolation prefix as
                 // our own RE (based on the entity prefix) and apply the user's at the response stage.

--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/test/java/io/kroxylicious/filter/entityisolation/MockFilterContext.java
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/test/java/io/kroxylicious/filter/entityisolation/MockFilterContext.java
@@ -238,6 +238,10 @@ record MockFilterContext(ApiMessage header, ApiMessage message, Subject subject,
         public CloseOrTerminalStage<RequestFilterResult> errorResponse(@NonNull RequestHeaderData header, @NonNull ApiMessage requestMessage, @NonNull Errors error,
                                                                        @Nullable String message)
                 throws IllegalArgumentException {
+            Objects.requireNonNull(error, "error must not be null");
+            if (error == Errors.NONE) {
+                throw new IllegalArgumentException("error must denote an actual error, but was Errors.NONE");
+            }
             // Errors.exception(String) returns the default-message exception when message is null.
             return new ErrorCloseOrTerminalStage(header, requestMessage, error.exception(message), false);
         }

--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/test/java/io/kroxylicious/filter/entityisolation/MockFilterContext.java
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/test/java/io/kroxylicious/filter/entityisolation/MockFilterContext.java
@@ -242,18 +242,6 @@ record MockFilterContext(ApiMessage header, ApiMessage message, Subject subject,
             return new ErrorCloseOrTerminalStage(header, requestMessage, error.exception(message), false);
         }
 
-        @SuppressWarnings("removal")
-        @NonNull
-        @Override
-        public CloseOrTerminalStage<RequestFilterResult> errorResponse(@NonNull RequestHeaderData header, @NonNull ApiMessage requestMessage,
-                                                                       @NonNull Throwable apiException)
-                throws IllegalArgumentException {
-            if (!(apiException instanceof ApiException asApiException)) {
-                throw new IllegalArgumentException("apiException must be an " + ApiException.class.getName() + " but was " + apiException.getClass().getName());
-            }
-            return new ErrorCloseOrTerminalStage(header, requestMessage, asApiException, false);
-        }
-
         @NonNull
         @Override
         public CloseOrTerminalStage<RequestFilterResult> forward(@NonNull RequestHeaderData header, @NonNull ApiMessage message) throws IllegalArgumentException {

--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/test/java/io/kroxylicious/filter/entityisolation/MockFilterContext.java
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/test/java/io/kroxylicious/filter/entityisolation/MockFilterContext.java
@@ -228,10 +228,30 @@ record MockFilterContext(ApiMessage header, ApiMessage message, Subject subject,
 
         @NonNull
         @Override
-        public CloseOrTerminalStage<RequestFilterResult> errorResponse(@NonNull RequestHeaderData header, @NonNull ApiMessage requestMessage,
-                                                                       @NonNull ApiException apiException)
+        public CloseOrTerminalStage<RequestFilterResult> errorResponse(@NonNull RequestHeaderData header, @NonNull ApiMessage requestMessage, @NonNull Errors error)
                 throws IllegalArgumentException {
-            return new ErrorCloseOrTerminalStage(header, requestMessage, apiException, false);
+            return errorResponse(header, requestMessage, error, null);
+        }
+
+        @NonNull
+        @Override
+        public CloseOrTerminalStage<RequestFilterResult> errorResponse(@NonNull RequestHeaderData header, @NonNull ApiMessage requestMessage, @NonNull Errors error,
+                                                                       @Nullable String message)
+                throws IllegalArgumentException {
+            // Errors.exception(String) returns the default-message exception when message is null.
+            return new ErrorCloseOrTerminalStage(header, requestMessage, error.exception(message), false);
+        }
+
+        @SuppressWarnings("removal")
+        @NonNull
+        @Override
+        public CloseOrTerminalStage<RequestFilterResult> errorResponse(@NonNull RequestHeaderData header, @NonNull ApiMessage requestMessage,
+                                                                       @NonNull Throwable apiException)
+                throws IllegalArgumentException {
+            if (!(apiException instanceof ApiException asApiException)) {
+                throw new IllegalArgumentException("apiException must be an " + ApiException.class.getName() + " but was " + apiException.getClass().getName());
+            }
+            return new ErrorCloseOrTerminalStage(header, requestMessage, asApiException, false);
         }
 
         @NonNull

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryptionFilter.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryptionFilter.java
@@ -102,7 +102,9 @@ class RecordEncryptionFilter<K> implements ProduceRequestFilter, FetchResponseFi
             return maybeEncodeProduce(request, context, topicNameMapping).thenCompose(yy -> context.forwardRequest(header, request)).exceptionallyCompose(throwable -> {
                 final ApiException clientFacingException = getClientFacingException(throwable);
                 if (clientFacingException != null) {
-                    return context.requestFilterResultBuilder().errorResponse(header, request, clientFacingException).completed();
+                    return context.requestFilterResultBuilder()
+                            .errorResponse(header, request, Errors.forException(clientFacingException), clientFacingException.getMessage())
+                            .completed();
                 }
                 else {
                     // returning a failed stage is effectively asking the runtime to kill the connection.
@@ -122,7 +124,7 @@ class RecordEncryptionFilter<K> implements ProduceRequestFilter, FetchResponseFi
             return context.requestFilterResultBuilder().drop().completed();
         }
         else {
-            return context.requestFilterResultBuilder().errorResponse(header, request, Errors.UNKNOWN_TOPIC_ID.exception()).completed();
+            return context.requestFilterResultBuilder().errorResponse(header, request, Errors.UNKNOWN_TOPIC_ID).completed();
         }
     }
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/RecordValidationFilter.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/RecordValidationFilter.java
@@ -76,7 +76,7 @@ class RecordValidationFilter implements ProduceRequestFilter, ProduceResponseFil
         List<Uuid> uuids = extractTopicIds(request);
         return context.topicNames(uuids).thenCompose(topicNameMapping -> {
             if (topicNameMapping.anyFailures()) {
-                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.UNKNOWN_TOPIC_ID.exception()).completed();
+                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.UNKNOWN_TOPIC_ID).completed();
             }
             List<NamedTopicProduceData> namedTopicProduceData = request.topicData().stream()
                     .map(data -> namedData(topicNameMapping, data)).toList();

--- a/kroxylicious-filters/kroxylicious-sasl-inspection/src/main/java/io/kroxylicious/filter/sasl/inspection/SaslInspectionFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-inspection/src/main/java/io/kroxylicious/filter/sasl/inspection/SaslInspectionFilter.java
@@ -99,7 +99,7 @@ class SaslInspectionFilter
                 }
                 else {
                     yield context.requestFilterResultBuilder()
-                            .errorResponse(header, request, Errors.SASL_AUTHENTICATION_FAILED.exception())
+                            .errorResponse(header, request, Errors.SASL_AUTHENTICATION_FAILED)
                             .withCloseConnection()
                             .completed();
                 }

--- a/kroxylicious-filters/kroxylicious-sasl-inspection/src/test/java/io/kroxylicious/filter/sasl/inspection/SaslInspectionFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-inspection/src/test/java/io/kroxylicious/filter/sasl/inspection/SaslInspectionFilterTest.java
@@ -130,7 +130,7 @@ class SaslInspectionFilterTest {
                 return requestCloseOrTerminalStage;
             });
 
-            lenient().when(requestBuilder.errorResponse(any(), any(), any())).thenReturn(requestCloseOrTerminalStage);
+            lenient().when(requestBuilder.errorResponse(any(), any(), any(Errors.class))).thenReturn(requestCloseOrTerminalStage);
             return requestBuilder;
         });
 

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/main/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilter.java
@@ -578,7 +578,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
         }
 
         return filterContext.requestFilterResultBuilder()
-                .errorResponse(header, request, Errors.SASL_AUTHENTICATION_FAILED.exception())
+                .errorResponse(header, request, Errors.SASL_AUTHENTICATION_FAILED)
                 .withCloseConnection()
                 .completed();
     }
@@ -596,7 +596,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                 .addKeyValue(LOG_KEY_REASON, reason)
                 .log("Rejecting unsupported API request");
         return filterContext.requestFilterResultBuilder()
-                .errorResponse(header, request, Errors.UNSUPPORTED_VERSION.exception(reason))
+                .errorResponse(header, request, Errors.UNSUPPORTED_VERSION, reason)
                 .completed();
     }
 
@@ -663,7 +663,7 @@ class SaslTerminationFilter implements RequestFilter, ApiVersionsResponseFilter 
                 .addKeyValue("apiVersion", apiVersion)
                 .log("Rejecting SASL request with unsupported API version");
         return filterContext.requestFilterResultBuilder()
-                .errorResponse(header, request, Errors.UNSUPPORTED_VERSION.exception())
+                .errorResponse(header, request, Errors.UNSUPPORTED_VERSION)
                 .withCloseConnection()
                 .completed();
     }

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationFilterTest.java
@@ -19,8 +19,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.security.sasl.SaslException;
 
-import org.apache.kafka.common.errors.ApiException;
-import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.MetadataRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
@@ -591,8 +589,8 @@ class SaslTerminationFilterTest {
     void shouldRejectUnauthenticatedDefaultRequest() throws Exception {
         // Given
         var filter = createFilter();
-        var exceptionCaptor = ArgumentCaptor.forClass(ApiException.class);
-        var filterContext = mockErrorFilterContextWithClose(exceptionCaptor);
+        var errorsCaptor = ArgumentCaptor.forClass(Errors.class);
+        var filterContext = mockErrorFilterContextWithClose(errorsCaptor);
 
         // When
         filter.onRequest(ApiKeys.METADATA, ApiKeys.METADATA.latestVersion(),
@@ -601,7 +599,7 @@ class SaslTerminationFilterTest {
                 filterContext).toCompletableFuture().get();
 
         // Then
-        assertThat(exceptionCaptor.getValue()).isInstanceOf(SaslAuthenticationException.class);
+        assertThat(errorsCaptor.getValue()).isEqualTo(Errors.SASL_AUTHENTICATION_FAILED);
     }
 
     @Test
@@ -654,8 +652,8 @@ class SaslTerminationFilterTest {
         Instant pastExpiry = FIXED_INSTANT.minusSeconds(60);
         setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", pastExpiry));
 
-        var exceptionCaptor = ArgumentCaptor.forClass(ApiException.class);
-        var filterContext = mockErrorFilterContextWithClose(exceptionCaptor);
+        var errorsCaptor = ArgumentCaptor.forClass(Errors.class);
+        var filterContext = mockErrorFilterContextWithClose(errorsCaptor);
 
         // When
         filter.onRequest(ApiKeys.METADATA, ApiKeys.METADATA.latestVersion(),
@@ -664,7 +662,7 @@ class SaslTerminationFilterTest {
                 filterContext).toCompletableFuture().get();
 
         // Then
-        assertThat(exceptionCaptor.getValue()).isInstanceOf(SaslAuthenticationException.class);
+        assertThat(errorsCaptor.getValue()).isEqualTo(Errors.SASL_AUTHENTICATION_FAILED);
         assertThat(meterRegistry.find(SaslTerminationFilter.SESSION_EXPIRED_METRIC)
                 .tags(List.of(Tag.of("mechanism", "OAUTHBEARER"), Tag.of(SaslTerminationFilter.VIRTUAL_CLUSTER_TAG, TEST_VIRTUAL_CLUSTER)))
                 .counter()).isNotNull()
@@ -684,8 +682,9 @@ class SaslTerminationFilterTest {
         var handler = mock(MechanismStateMachine.class);
         var authenticating = State.start().nextState(handler);
         setFilterState(filter, authenticating.nextStateSuccess("alice", "OAUTHBEARER", null));
-        var exceptionCaptor = ArgumentCaptor.forClass(ApiException.class);
-        var filterContext = mockErrorFilterContextWithoutClose(exceptionCaptor);
+        var errorsCaptor = ArgumentCaptor.forClass(Errors.class);
+        var messageCaptor = ArgumentCaptor.forClass(String.class);
+        var filterContext = mockErrorFilterContextWithoutClose(errorsCaptor, messageCaptor);
 
         // When
         filter.onRequest(apiKey, apiKey.latestVersion(),
@@ -694,7 +693,7 @@ class SaslTerminationFilterTest {
                 filterContext).toCompletableFuture().get();
 
         // Then
-        assertThat(exceptionCaptor.getValue().getMessage())
+        assertThat(messageCaptor.getValue())
                 .isEqualTo(apiKey + " is not supported when SASL is terminated at the proxy");
     }
 
@@ -723,8 +722,9 @@ class SaslTerminationFilterTest {
         var handler = mock(MechanismStateMachine.class);
         var authenticating = State.start().nextState(handler);
         setFilterState(filter, authenticating.nextStateSuccess("alice", "SCRAM-SHA-256", null));
-        var exceptionCaptor = ArgumentCaptor.forClass(ApiException.class);
-        var filterContext = mockErrorFilterContextWithoutClose(exceptionCaptor);
+        var errorsCaptor = ArgumentCaptor.forClass(Errors.class);
+        var messageCaptor = ArgumentCaptor.forClass(String.class);
+        var filterContext = mockErrorFilterContextWithoutClose(errorsCaptor, messageCaptor);
 
         // When
         filter.onRequest(ApiKeys.ALTER_USER_SCRAM_CREDENTIALS, ApiKeys.ALTER_USER_SCRAM_CREDENTIALS.latestVersion(),
@@ -733,7 +733,7 @@ class SaslTerminationFilterTest {
                 filterContext).toCompletableFuture().get();
 
         // Then
-        assertThat(exceptionCaptor.getValue().getMessage())
+        assertThat(messageCaptor.getValue())
                 .isEqualTo(ApiKeys.ALTER_USER_SCRAM_CREDENTIALS + " is not supported when SASL is terminated at the proxy");
     }
 
@@ -944,7 +944,7 @@ class SaslTerminationFilterTest {
     }
 
     @SuppressWarnings("unchecked")
-    private static FilterContext mockErrorFilterContextWithClose(ArgumentCaptor<ApiException> exceptionCaptor) {
+    private static FilterContext mockErrorFilterContextWithClose(ArgumentCaptor<Errors> errorsCaptor) {
         var filterContext = mock(FilterContext.class);
         var builder = mock(RequestFilterResultBuilder.class);
         var closeOrTerminal = mock(CloseOrTerminalStage.class);
@@ -954,7 +954,7 @@ class SaslTerminationFilterTest {
         when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
         when(filterContext.sessionId()).thenReturn("test-session");
         when(filterContext.getVirtualClusterName()).thenReturn(TEST_VIRTUAL_CLUSTER);
-        when(builder.errorResponse(any(), any(), exceptionCaptor.capture())).thenReturn(closeOrTerminal);
+        when(builder.errorResponse(any(), any(), errorsCaptor.capture())).thenReturn(closeOrTerminal);
         when(closeOrTerminal.withCloseConnection()).thenReturn(terminal);
         when(terminal.completed()).thenReturn(CompletableFuture.completedFuture(result));
 
@@ -962,7 +962,7 @@ class SaslTerminationFilterTest {
     }
 
     @SuppressWarnings("unchecked")
-    private static FilterContext mockErrorFilterContextWithoutClose(ArgumentCaptor<ApiException> exceptionCaptor) {
+    private static FilterContext mockErrorFilterContextWithoutClose(ArgumentCaptor<Errors> errorsCaptor, ArgumentCaptor<String> messageCaptor) {
         var filterContext = mock(FilterContext.class);
         var builder = mock(RequestFilterResultBuilder.class);
         var closeOrTerminal = mock(CloseOrTerminalStage.class);
@@ -970,7 +970,7 @@ class SaslTerminationFilterTest {
 
         when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
         when(filterContext.sessionId()).thenReturn("test-session");
-        when(builder.errorResponse(any(), any(), exceptionCaptor.capture())).thenReturn(closeOrTerminal);
+        when(builder.errorResponse(any(), any(), errorsCaptor.capture(), messageCaptor.capture())).thenReturn(closeOrTerminal);
         when(closeOrTerminal.completed()).thenReturn(CompletableFuture.completedFuture(result));
 
         return filterContext;

--- a/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
+++ b/kroxylicious-filters/kroxylicious-sasl-termination/src/test/java/io/kroxylicious/filter/sasl/termination/SaslTerminationTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.message.SaslAuthenticateRequestData;
 import org.apache.kafka.common.message.SaslHandshakeRequestData;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.security.scram.internals.ScramMechanism;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -871,7 +872,7 @@ class SaslTerminationTest {
         var result = mock(RequestFilterResult.class);
 
         when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
-        when(builder.errorResponse(any(), any(), any())).thenReturn(closeOrTerminal);
+        when(builder.errorResponse(any(), any(), any(Errors.class))).thenReturn(closeOrTerminal);
         when(closeOrTerminal.withCloseConnection()).thenReturn(terminal);
         when(terminal.completed()).thenReturn(CompletableFuture.completedFuture(result));
 
@@ -886,7 +887,7 @@ class SaslTerminationTest {
         var result = mock(RequestFilterResult.class);
 
         when(filterContext.requestFilterResultBuilder()).thenReturn(builder);
-        when(builder.errorResponse(any(), any(), any())).thenReturn(closeOrTerminal);
+        when(builder.errorResponse(any(), any(), any(Errors.class), any())).thenReturn(closeOrTerminal);
         when(closeOrTerminal.completed()).thenReturn(CompletableFuture.completedFuture(result));
 
         return filterContext;

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/ProduceRequestTransformationFilter.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/filter/simpletransform/ProduceRequestTransformationFilter.java
@@ -101,7 +101,7 @@ class ProduceRequestTransformationFilter implements ProduceRequestFilter {
         }
         else {
             logTopicLookupFailure(topicNameMapping, "responding with UNKNOWN_SERVER_ERROR");
-            return ctx.requestFilterResultBuilder().errorResponse(header, req, Errors.UNKNOWN_SERVER_ERROR.exception()).completed();
+            return ctx.requestFilterResultBuilder().errorResponse(header, req, Errors.UNKNOWN_SERVER_ERROR).completed();
         }
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingContextContractIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RoutingContextContractIT.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.ListGroupsRequestData;
@@ -368,7 +367,7 @@ class RoutingContextContractIT {
     void respondWithErrorDeliversApiSpecificErrorResponseToClient(KafkaCluster cluster) {
         // Given: router returns an error for every API_VERSIONS request
         ContextCapturingRouterFactory.currentAction
-                .set((apiKey, apiVersion, header, request, ctx) -> ctx.respondWithError(header, request, new UnknownServerException("routing failed")).completed());
+                .set((apiKey, apiVersion, header, request, ctx) -> ctx.respondWithError(header, request, Errors.UNKNOWN_SERVER_ERROR, "routing failed").completed());
 
         try (var tester = KroxyliciousTesters.newBuilder(config(cluster))
                 .setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/SaslPlainInitiationFilter.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/SaslPlainInitiationFilter.java
@@ -181,7 +181,7 @@ public class SaslPlainInitiationFilter implements RequestFilter, ApiVersionsResp
         if (!bufferedRequests.isEmpty()) {
             BufferedRequest bufferedRequest = bufferedRequests.get(0);
             bufferedRequest.fut().complete(context.requestFilterResultBuilder()
-                    .errorResponse(bufferedRequest.header(), bufferedRequest.request(), Errors.UNKNOWN_SERVER_ERROR.exception())
+                    .errorResponse(bufferedRequest.header(), bufferedRequest.request(), Errors.UNKNOWN_SERVER_ERROR)
                     .build());
         }
         return context.responseFilterResultBuilder().withCloseConnection().completed();

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/SaslPlainTerminationFilter.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/SaslPlainTerminationFilter.java
@@ -167,7 +167,7 @@ public class SaslPlainTerminationFilter
                 }
                 else {
                     yield context.requestFilterResultBuilder()
-                            .errorResponse(header, request, Errors.SASL_AUTHENTICATION_FAILED.exception())
+                            .errorResponse(header, request, Errors.SASL_AUTHENTICATION_FAILED)
                             .withCloseConnection()
                             .completed();
                 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/ShortCircuitErrorResponse.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/ShortCircuitErrorResponse.java
@@ -13,6 +13,7 @@ import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractResponse;
 
 import io.kroxylicious.proxy.filter.Filter;
@@ -31,8 +32,10 @@ import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 @Plugin(configType = ShortCircuitErrorResponse.Config.class)
 public class ShortCircuitErrorResponse implements FilterFactory<ShortCircuitErrorResponse.Config, ShortCircuitErrorResponse.ResponseMechanism> {
 
+    private static final String ERROR_MESSAGE = ShortCircuitErrorResponse.class.getName() + ": responding error to all requests";
+
     private static UnknownServerException exception() {
-        return new UnknownServerException(ShortCircuitErrorResponse.class.getName() + ": responding error to all requests");
+        return new UnknownServerException(ERROR_MESSAGE);
     }
 
     public enum ResponseMechanism implements RequestFilter {
@@ -40,7 +43,7 @@ public class ShortCircuitErrorResponse implements FilterFactory<ShortCircuitErro
             @Override
             public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, short apiVersion, RequestHeaderData header, ApiMessage request, FilterContext context) {
                 return context.requestFilterResultBuilder()
-                        .errorResponse(header, request, exception())
+                        .errorResponse(header, request, Errors.UNKNOWN_SERVER_ERROR, ERROR_MESSAGE)
                         .completed();
             }
         },

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/TopicIdToNameResponseStamper.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/TopicIdToNameResponseStamper.java
@@ -18,11 +18,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.RawTaggedField;
 
 import io.kroxylicious.it.UnknownTaggedFields;
@@ -78,7 +78,7 @@ public class TopicIdToNameResponseStamper implements FilterFactory<TopicIdToName
         public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, short apiVersion, RequestHeaderData header, ApiMessage request, FilterContext context) {
             List<String> list = UnknownTaggedFields.unknownTaggedFieldsToStrings(request, TOPIC_ID_TAG).toList();
             if (list.isEmpty()) {
-                return context.requestFilterResultBuilder().errorResponse(header, request, new InvalidRequestException("no topic id tag")).withCloseConnection()
+                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.INVALID_REQUEST, "no topic id tag").withCloseConnection()
                         .completed();
             }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderImpl.java
@@ -10,6 +10,7 @@ import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractResponse;
 
 import io.kroxylicious.proxy.filter.RequestFilterResult;
@@ -63,8 +64,29 @@ public class RequestFilterResultBuilderImpl extends FilterResultBuilderImpl<Requ
     }
 
     @Override
-    public CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header, ApiMessage requestMessage, ApiException apiException)
+    public CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header, ApiMessage requestMessage, Errors error)
             throws IllegalArgumentException {
+        return errorResponse(header, requestMessage, error, null);
+    }
+
+    @Override
+    public CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header, ApiMessage requestMessage, Errors error, @Nullable String message)
+            throws IllegalArgumentException {
+        // Errors.exception(String) returns the default-message exception when message is null.
+        return errorResponseForException(header, requestMessage, error.exception(message));
+    }
+
+    @SuppressWarnings("removal")
+    @Override
+    public CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header, ApiMessage requestMessage, Throwable apiException)
+            throws IllegalArgumentException {
+        if (!(apiException instanceof ApiException asApiException)) {
+            throw new IllegalArgumentException("apiException must be an " + ApiException.class.getName() + " but was " + apiException.getClass().getName());
+        }
+        return errorResponseForException(header, requestMessage, asApiException);
+    }
+
+    private CloseOrTerminalStage<RequestFilterResult> errorResponseForException(RequestHeaderData header, ApiMessage requestMessage, ApiException apiException) {
         final AbstractResponse errorResponseMessage = KafkaProxyExceptionMapper.errorResponseForMessage(header, requestMessage, apiException);
         validateShortCircuitResponse(errorResponseMessage.data());
         final ResponseHeaderData responseHeaders = new ResponseHeaderData();

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderImpl.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy.internal.filter;
 
+import java.util.Objects;
+
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
@@ -72,6 +74,10 @@ public class RequestFilterResultBuilderImpl extends FilterResultBuilderImpl<Requ
     @Override
     public CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header, ApiMessage requestMessage, Errors error, @Nullable String message)
             throws IllegalArgumentException {
+        Objects.requireNonNull(error, "error must not be null");
+        if (error == Errors.NONE) {
+            throw new IllegalArgumentException("error must denote an actual error, but was Errors.NONE");
+        }
         // Errors.exception(String) returns the default-message exception when message is null.
         return errorResponseForException(header, requestMessage, error.exception(message));
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderImpl.java
@@ -76,16 +76,6 @@ public class RequestFilterResultBuilderImpl extends FilterResultBuilderImpl<Requ
         return errorResponseForException(header, requestMessage, error.exception(message));
     }
 
-    @SuppressWarnings("removal")
-    @Override
-    public CloseOrTerminalStage<RequestFilterResult> errorResponse(RequestHeaderData header, ApiMessage requestMessage, Throwable apiException)
-            throws IllegalArgumentException {
-        if (!(apiException instanceof ApiException asApiException)) {
-            throw new IllegalArgumentException("apiException must be an " + ApiException.class.getName() + " but was " + apiException.getClass().getName());
-        }
-        return errorResponseForException(header, requestMessage, asApiException);
-    }
-
     private CloseOrTerminalStage<RequestFilterResult> errorResponseForException(RequestHeaderData header, ApiMessage requestMessage, ApiException apiException) {
         final AbstractResponse errorResponseMessage = KafkaProxyExceptionMapper.errorResponseForMessage(header, requestMessage, apiException);
         validateShortCircuitResponse(errorResponseMessage.data());

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/impl/TopicNameCacheFilter.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/impl/TopicNameCacheFilter.java
@@ -14,13 +14,13 @@ import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.message.MetadataRequestData;
 import org.apache.kafka.common.message.MetadataRequestData.MetadataRequestTopic;
 import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.Errors;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -122,8 +122,9 @@ public class TopicNameCacheFilter implements MetadataRequestFilter, MetadataResp
                 }
             }
             else {
-                UnknownServerException exception = new UnknownServerException("received an internal topic name request with no topics");
-                return context.requestFilterResultBuilder().errorResponse(header, request, exception).completed();
+                return context.requestFilterResultBuilder()
+                        .errorResponse(header, request, Errors.UNKNOWN_SERVER_ERROR, "received an internal topic name request with no topics")
+                        .completed();
             }
         }
         return context.forwardRequest(header, request);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterContextImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterContextImpl.java
@@ -124,6 +124,10 @@ class RouterContextImpl implements RouterContext {
                                                  ApiMessage request,
                                                  Errors error,
                                                  @Nullable String message) {
+        Objects.requireNonNull(error, "error must not be null");
+        if (error == Errors.NONE) {
+            throw new IllegalArgumentException("error must denote an actual error, but was Errors.NONE");
+        }
         // Errors.exception(String) returns the default-message exception when message is null.
         return RouterResponseImpl.builder(new RouterResponseImpl.RespondWithError(header, request, error.exception(message), false));
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterContextImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterContextImpl.java
@@ -9,7 +9,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
-import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
@@ -127,17 +126,6 @@ class RouterContextImpl implements RouterContext {
                                                  @Nullable String message) {
         // Errors.exception(String) returns the default-message exception when message is null.
         return RouterResponseImpl.builder(new RouterResponseImpl.RespondWithError(header, request, error.exception(message), false));
-    }
-
-    @SuppressWarnings("removal")
-    @Override
-    public CloseOrTerminalStage respondWithError(RequestHeaderData header,
-                                                 ApiMessage request,
-                                                 Throwable apiException) {
-        if (!(apiException instanceof ApiException asApiException)) {
-            throw new IllegalArgumentException("apiException must be an " + ApiException.class.getName() + " but was " + apiException.getClass().getName());
-        }
-        return RouterResponseImpl.builder(new RouterResponseImpl.RespondWithError(header, request, asApiException, false));
     }
 
     @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterContextImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterContextImpl.java
@@ -13,6 +13,7 @@ import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
 
 import io.kroxylicious.proxy.authentication.Subject;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
@@ -115,8 +116,28 @@ class RouterContextImpl implements RouterContext {
     @Override
     public CloseOrTerminalStage respondWithError(RequestHeaderData header,
                                                  ApiMessage request,
-                                                 ApiException exception) {
-        return RouterResponseImpl.builder(new RouterResponseImpl.RespondWithError(header, request, exception, false));
+                                                 Errors error) {
+        return respondWithError(header, request, error, null);
+    }
+
+    @Override
+    public CloseOrTerminalStage respondWithError(RequestHeaderData header,
+                                                 ApiMessage request,
+                                                 Errors error,
+                                                 @Nullable String message) {
+        // Errors.exception(String) returns the default-message exception when message is null.
+        return RouterResponseImpl.builder(new RouterResponseImpl.RespondWithError(header, request, error.exception(message), false));
+    }
+
+    @SuppressWarnings("removal")
+    @Override
+    public CloseOrTerminalStage respondWithError(RequestHeaderData header,
+                                                 ApiMessage request,
+                                                 Throwable apiException) {
+        if (!(apiException instanceof ApiException asApiException)) {
+            throw new IllegalArgumentException("apiException must be an " + ApiException.class.getName() + " but was " + apiException.getClass().getName());
+        }
+        return RouterResponseImpl.builder(new RouterResponseImpl.RespondWithError(header, request, asApiException, false));
     }
 
     @Override

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderTest.java
@@ -9,7 +9,6 @@ package io.kroxylicious.proxy.internal.filter;
 import java.time.Duration;
 import java.util.stream.Stream;
 
-import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.FetchRequestData;
@@ -35,7 +34,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RequestFilterResultBuilderTest {
 
-    private final UnknownServerException filterRuntimeException = new UnknownServerException("Filter says yeah, nah!");
     private final RequestFilterResultBuilder builder = new RequestFilterResultBuilderImpl();
 
     @Test
@@ -155,7 +153,7 @@ class RequestFilterResultBuilderTest {
         header.setCorrelationId(23456);
 
         // When
-        var future = builder.errorResponse(header, versionedMessage.apiMessage(), filterRuntimeException).completed();
+        var future = builder.errorResponse(header, versionedMessage.apiMessage(), Errors.UNKNOWN_SERVER_ERROR).completed();
 
         // Then
         assertThat(future)
@@ -179,7 +177,7 @@ class RequestFilterResultBuilderTest {
         header.setCorrelationId(23456);
 
         // When
-        var future = builder.errorResponse(header, new LeaveGroupRequestData(), filterRuntimeException).completed();
+        var future = builder.errorResponse(header, new LeaveGroupRequestData(), Errors.UNKNOWN_SERVER_ERROR).completed();
 
         // Then
         assertThat(future)
@@ -202,7 +200,7 @@ class RequestFilterResultBuilderTest {
         header.setCorrelationId(23456);
 
         // When
-        var future = builder.errorResponse(header, request.apiMessage(), filterRuntimeException).completed();
+        var future = builder.errorResponse(header, request.apiMessage(), Errors.UNKNOWN_SERVER_ERROR).completed();
 
         // Then
         assertThat(future)
@@ -223,7 +221,7 @@ class RequestFilterResultBuilderTest {
         header.setCorrelationId(23456);
 
         // When
-        var future = builder.errorResponse(header, request.apiMessage(), filterRuntimeException).completed();
+        var future = builder.errorResponse(header, request.apiMessage(), Errors.UNKNOWN_SERVER_ERROR).completed();
 
         // Then
         assertThat(future)
@@ -248,32 +246,18 @@ class RequestFilterResultBuilderTest {
     }
 
     @Test
-    void errorResponseFromErrorsMatchesEquivalentException() {
-        // Given
-        var header = apiVersionsHeader();
-
-        // When
-        var fromErrors = builder.errorResponse(header, new ApiVersionsRequestData(), Errors.INVALID_REQUEST).build();
-        var fromException = new RequestFilterResultBuilderImpl()
-                .errorResponse(header, new ApiVersionsRequestData(), Errors.INVALID_REQUEST.exception()).build();
-
-        // Then
-        assertThat(fromErrors.message()).isEqualTo(fromException.message());
-    }
-
-    @Test
-    void errorResponseFromErrorsWithMessageMatchesEquivalentException() {
+    void errorResponseFromErrorsWithMessageSetsErrorCode() {
         // Given
         var header = apiVersionsHeader();
         var message = "custom explanation";
 
         // When
-        var fromErrors = builder.errorResponse(header, new ApiVersionsRequestData(), Errors.INVALID_REQUEST, message).build();
-        var fromException = new RequestFilterResultBuilderImpl()
-                .errorResponse(header, new ApiVersionsRequestData(), Errors.INVALID_REQUEST.exception(message)).build();
+        var result = builder.errorResponse(header, new ApiVersionsRequestData(), Errors.INVALID_REQUEST, message).build();
 
         // Then
-        assertThat(fromErrors.message()).isEqualTo(fromException.message());
+        assertThat(result.message())
+                .asInstanceOf(InstanceOfAssertFactories.type(ApiVersionsResponseData.class))
+                .satisfies(response -> assertThat(response.errorCode()).isEqualTo(Errors.INVALID_REQUEST.code()));
     }
 
     @Test
@@ -288,17 +272,6 @@ class RequestFilterResultBuilderTest {
 
         // Then
         assertThat(fromNullMessage.message()).isEqualTo(fromNoMessage.message());
-    }
-
-    @Test
-    void deprecatedErrorResponseRejectsNonApiException() {
-        // Given
-        var header = apiVersionsHeader();
-        var notAnApiException = new IllegalStateException("not an ApiException");
-
-        // When / Then
-        assertThatThrownBy(() -> builder.errorResponse(header, new ApiVersionsRequestData(), notAnApiException))
-                .isInstanceOf(IllegalArgumentException.class);
     }
 
     private static RequestHeaderData apiVersionsHeader() {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderTest.java
@@ -274,6 +274,46 @@ class RequestFilterResultBuilderTest {
         assertThat(fromNullMessage.message()).isEqualTo(fromNoMessage.message());
     }
 
+    @Test
+    void errorResponseFromErrorsRejectsNone() {
+        // Given
+        var header = apiVersionsHeader();
+
+        // When / Then
+        assertThatThrownBy(() -> builder.errorResponse(header, new ApiVersionsRequestData(), Errors.NONE))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void errorResponseFromErrorsWithMessageRejectsNone() {
+        // Given
+        var header = apiVersionsHeader();
+
+        // When / Then
+        assertThatThrownBy(() -> builder.errorResponse(header, new ApiVersionsRequestData(), Errors.NONE, "some message"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void errorResponseFromErrorsRejectsNullError() {
+        // Given
+        var header = apiVersionsHeader();
+
+        // When / Then
+        assertThatThrownBy(() -> builder.errorResponse(header, new ApiVersionsRequestData(), null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void errorResponseFromErrorsWithMessageRejectsNullError() {
+        // Given
+        var header = apiVersionsHeader();
+
+        // When / Then
+        assertThatThrownBy(() -> builder.errorResponse(header, new ApiVersionsRequestData(), null, "some message"))
+                .isInstanceOf(NullPointerException.class);
+    }
+
     private static RequestHeaderData apiVersionsHeader() {
         var header = new RequestHeaderData();
         header.setRequestApiKey(ApiKeys.API_VERSIONS.id);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderTest.java
@@ -278,9 +278,10 @@ class RequestFilterResultBuilderTest {
     void errorResponseFromErrorsRejectsNone() {
         // Given
         var header = apiVersionsHeader();
+        var requestMessage = new ApiVersionsRequestData();
 
         // When / Then
-        assertThatThrownBy(() -> builder.errorResponse(header, new ApiVersionsRequestData(), Errors.NONE))
+        assertThatThrownBy(() -> builder.errorResponse(header, requestMessage, Errors.NONE))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -288,9 +289,10 @@ class RequestFilterResultBuilderTest {
     void errorResponseFromErrorsWithMessageRejectsNone() {
         // Given
         var header = apiVersionsHeader();
+        var requestMessage = new ApiVersionsRequestData();
 
         // When / Then
-        assertThatThrownBy(() -> builder.errorResponse(header, new ApiVersionsRequestData(), Errors.NONE, "some message"))
+        assertThatThrownBy(() -> builder.errorResponse(header, requestMessage, Errors.NONE, "some message"))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -298,9 +300,10 @@ class RequestFilterResultBuilderTest {
     void errorResponseFromErrorsRejectsNullError() {
         // Given
         var header = apiVersionsHeader();
+        var requestMessage = new ApiVersionsRequestData();
 
         // When / Then
-        assertThatThrownBy(() -> builder.errorResponse(header, new ApiVersionsRequestData(), null))
+        assertThatThrownBy(() -> builder.errorResponse(header, requestMessage, null))
                 .isInstanceOf(NullPointerException.class);
     }
 
@@ -308,9 +311,10 @@ class RequestFilterResultBuilderTest {
     void errorResponseFromErrorsWithMessageRejectsNullError() {
         // Given
         var header = apiVersionsHeader();
+        var requestMessage = new ApiVersionsRequestData();
 
         // When / Then
-        assertThatThrownBy(() -> builder.errorResponse(header, new ApiVersionsRequestData(), null, "some message"))
+        assertThatThrownBy(() -> builder.errorResponse(header, requestMessage, null, "some message"))
                 .isInstanceOf(NullPointerException.class);
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderTest.java
@@ -10,6 +10,8 @@ import java.time.Duration;
 import java.util.stream.Stream;
 
 import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.FetchRequestData;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.LeaveGroupRequestData;
@@ -17,6 +19,7 @@ import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
@@ -228,6 +231,82 @@ class RequestFilterResultBuilderTest {
                 .satisfies(result -> {
                     assertThat(result.closeConnection()).describedAs("connection closed").isFalse();
                 });
+    }
+
+    @Test
+    void errorResponseFromErrorsSetsErrorCode() {
+        // Given
+        var header = apiVersionsHeader();
+
+        // When
+        var result = builder.errorResponse(header, new ApiVersionsRequestData(), Errors.INVALID_REQUEST).build();
+
+        // Then
+        assertThat(result.message())
+                .asInstanceOf(InstanceOfAssertFactories.type(ApiVersionsResponseData.class))
+                .satisfies(response -> assertThat(response.errorCode()).isEqualTo(Errors.INVALID_REQUEST.code()));
+    }
+
+    @Test
+    void errorResponseFromErrorsMatchesEquivalentException() {
+        // Given
+        var header = apiVersionsHeader();
+
+        // When
+        var fromErrors = builder.errorResponse(header, new ApiVersionsRequestData(), Errors.INVALID_REQUEST).build();
+        var fromException = new RequestFilterResultBuilderImpl()
+                .errorResponse(header, new ApiVersionsRequestData(), Errors.INVALID_REQUEST.exception()).build();
+
+        // Then
+        assertThat(fromErrors.message()).isEqualTo(fromException.message());
+    }
+
+    @Test
+    void errorResponseFromErrorsWithMessageMatchesEquivalentException() {
+        // Given
+        var header = apiVersionsHeader();
+        var message = "custom explanation";
+
+        // When
+        var fromErrors = builder.errorResponse(header, new ApiVersionsRequestData(), Errors.INVALID_REQUEST, message).build();
+        var fromException = new RequestFilterResultBuilderImpl()
+                .errorResponse(header, new ApiVersionsRequestData(), Errors.INVALID_REQUEST.exception(message)).build();
+
+        // Then
+        assertThat(fromErrors.message()).isEqualTo(fromException.message());
+    }
+
+    @Test
+    void errorResponseFromErrorsWithNullMessageUsesDefaultMessage() {
+        // Given
+        var header = apiVersionsHeader();
+
+        // When
+        var fromNullMessage = builder.errorResponse(header, new ApiVersionsRequestData(), Errors.INVALID_REQUEST, null).build();
+        var fromNoMessage = new RequestFilterResultBuilderImpl()
+                .errorResponse(header, new ApiVersionsRequestData(), Errors.INVALID_REQUEST).build();
+
+        // Then
+        assertThat(fromNullMessage.message()).isEqualTo(fromNoMessage.message());
+    }
+
+    @Test
+    void deprecatedErrorResponseRejectsNonApiException() {
+        // Given
+        var header = apiVersionsHeader();
+        var notAnApiException = new IllegalStateException("not an ApiException");
+
+        // When / Then
+        assertThatThrownBy(() -> builder.errorResponse(header, new ApiVersionsRequestData(), notAnApiException))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static RequestHeaderData apiVersionsHeader() {
+        var header = new RequestHeaderData();
+        header.setRequestApiKey(ApiKeys.API_VERSIONS.id);
+        header.setRequestApiVersion(ApiKeys.API_VERSIONS.latestVersion());
+        header.setCorrelationId(23456);
+        return header;
     }
 
     public static Stream<Arguments> latestVersions() {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/impl/TopicNameCacheFilterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/impl/TopicNameCacheFilterTest.java
@@ -14,8 +14,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.errors.ApiException;
-import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.message.MetadataRequestData;
 import org.apache.kafka.common.message.MetadataRequestData.MetadataRequestTopic;
 import org.apache.kafka.common.message.MetadataResponseData;
@@ -23,6 +21,7 @@ import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -91,7 +90,7 @@ class TopicNameCacheFilterTest {
         MetadataRequestData request = new MetadataRequestData();
         CompletableFuture<RequestFilterResult> result = CompletableFuture.completedFuture(null);
         when(filterContext.requestFilterResultBuilder()).thenReturn(requestFilterResultBuilder);
-        when(requestFilterResultBuilder.errorResponse(eq(header), eq(request), any())).thenReturn(closeOrTerminalStage);
+        when(requestFilterResultBuilder.errorResponse(eq(header), eq(request), any(Errors.class), any(String.class))).thenReturn(closeOrTerminalStage);
         when(closeOrTerminalStage.completed()).thenReturn(result);
         // when
         CompletionStage<RequestFilterResult> resultStage = topicNameCacheFilter.onMetadataRequest(ApiKeys.METADATA.latestVersion(), header,
@@ -99,9 +98,11 @@ class TopicNameCacheFilterTest {
         // then
         // we respond with an error as it's an illegal state for an internal topic name retrieval request to have an empty topics list
         assertThat(resultStage).isSameAs(result);
-        ArgumentCaptor<ApiException> captor = ArgumentCaptor.forClass(ApiException.class);
-        verify(requestFilterResultBuilder).errorResponse(eq(header), eq(request), captor.capture());
-        assertThat(captor.getValue()).isInstanceOf(UnknownServerException.class).hasMessage("received an internal topic name request with no topics");
+        ArgumentCaptor<Errors> errorsCaptor = ArgumentCaptor.forClass(Errors.class);
+        ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(requestFilterResultBuilder).errorResponse(eq(header), eq(request), errorsCaptor.capture(), messageCaptor.capture());
+        assertThat(errorsCaptor.getValue()).isEqualTo(Errors.UNKNOWN_SERVER_ERROR);
+        assertThat(messageCaptor.getValue()).isEqualTo("received an internal topic name request with no topics");
     }
 
     @Test
@@ -114,7 +115,7 @@ class TopicNameCacheFilterTest {
         request.setTopics(null);
         CompletableFuture<RequestFilterResult> result = CompletableFuture.completedFuture(null);
         when(filterContext.requestFilterResultBuilder()).thenReturn(requestFilterResultBuilder);
-        when(requestFilterResultBuilder.errorResponse(eq(header), eq(request), any())).thenReturn(closeOrTerminalStage);
+        when(requestFilterResultBuilder.errorResponse(eq(header), eq(request), any(Errors.class), any(String.class))).thenReturn(closeOrTerminalStage);
         when(closeOrTerminalStage.completed()).thenReturn(result);
         // when
         CompletionStage<RequestFilterResult> resultStage = topicNameCacheFilter.onMetadataRequest(ApiKeys.METADATA.latestVersion(), header,
@@ -122,9 +123,11 @@ class TopicNameCacheFilterTest {
         // then
         // we respond with an error as it's an illegal state for an internal topic name retrieval request to have an empty topics list
         assertThat(resultStage).isSameAs(result);
-        ArgumentCaptor<ApiException> captor = ArgumentCaptor.forClass(ApiException.class);
-        verify(requestFilterResultBuilder).errorResponse(eq(header), eq(request), captor.capture());
-        assertThat(captor.getValue()).isInstanceOf(UnknownServerException.class).hasMessage("received an internal topic name request with no topics");
+        ArgumentCaptor<Errors> errorsCaptor = ArgumentCaptor.forClass(Errors.class);
+        ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(requestFilterResultBuilder).errorResponse(eq(header), eq(request), errorsCaptor.capture(), messageCaptor.capture());
+        assertThat(errorsCaptor.getValue()).isEqualTo(Errors.UNKNOWN_SERVER_ERROR);
+        assertThat(messageCaptor.getValue()).isEqualTo("received an internal topic name request with no topics");
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterContextImplTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterContextImplTest.java
@@ -15,6 +15,7 @@ import org.apache.kafka.common.message.FetchRequestData;
 import org.apache.kafka.common.message.MetadataRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.Errors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -214,6 +215,57 @@ class RouterContextImplTest {
         var rwe = (RouterResponseImpl.RespondWithError) response;
         assertThat(rwe.exception()).isSameAs(exception);
         assertThat(rwe.closeConnection()).isFalse();
+    }
+
+    @Test
+    void respondWithErrorFromErrorsShouldBuildErrorResult() {
+        // Given
+        var ctx = createContext();
+        var header = new RequestHeaderData();
+        var request = new MetadataRequestData();
+
+        // When
+        RouterResponse response = ctx.respondWithError(header, request, Errors.INVALID_REQUEST).build();
+
+        // Then
+        assertThat(response).isInstanceOf(RouterResponseImpl.RespondWithError.class);
+        var rwe = (RouterResponseImpl.RespondWithError) response;
+        assertThat(rwe.exception())
+                .isInstanceOf(Errors.INVALID_REQUEST.exception().getClass())
+                .hasMessage(Errors.INVALID_REQUEST.message());
+        assertThat(rwe.closeConnection()).isFalse();
+    }
+
+    @Test
+    void respondWithErrorFromErrorsWithMessageShouldSetMessage() {
+        // Given
+        var ctx = createContext();
+        var header = new RequestHeaderData();
+        var request = new MetadataRequestData();
+        var message = "custom explanation";
+
+        // When
+        RouterResponse response = ctx.respondWithError(header, request, Errors.INVALID_REQUEST, message).build();
+
+        // Then
+        assertThat(response).isInstanceOf(RouterResponseImpl.RespondWithError.class);
+        var rwe = (RouterResponseImpl.RespondWithError) response;
+        assertThat(rwe.exception())
+                .isInstanceOf(Errors.INVALID_REQUEST.exception().getClass())
+                .hasMessage(message);
+    }
+
+    @Test
+    void respondWithErrorShouldRejectNonApiExceptionThrowable() {
+        // Given
+        var ctx = createContext();
+        var header = new RequestHeaderData();
+        var request = new MetadataRequestData();
+        Throwable notAnApiException = new IllegalStateException("not an ApiException");
+
+        // When / Then
+        assertThatThrownBy(() -> ctx.respondWithError(header, request, notAnApiException))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterContextImplTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterContextImplTest.java
@@ -9,8 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.kafka.common.errors.ApiException;
-import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.message.FetchRequestData;
 import org.apache.kafka.common.message.MetadataRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
@@ -200,24 +198,6 @@ class RouterContextImplTest {
     }
 
     @Test
-    void respondWithErrorShouldBuildErrorResult() {
-        // Given
-        var ctx = createContext();
-        var header = new RequestHeaderData();
-        var request = new MetadataRequestData();
-        ApiException exception = new UnknownServerException("test error");
-
-        // When
-        RouterResponse response = ctx.respondWithError(header, request, exception).build();
-
-        // Then
-        assertThat(response).isInstanceOf(RouterResponseImpl.RespondWithError.class);
-        var rwe = (RouterResponseImpl.RespondWithError) response;
-        assertThat(rwe.exception()).isSameAs(exception);
-        assertThat(rwe.closeConnection()).isFalse();
-    }
-
-    @Test
     void respondWithErrorFromErrorsShouldBuildErrorResult() {
         // Given
         var ctx = createContext();
@@ -253,19 +233,6 @@ class RouterContextImplTest {
         assertThat(rwe.exception())
                 .isInstanceOf(Errors.INVALID_REQUEST.exception().getClass())
                 .hasMessage(message);
-    }
-
-    @Test
-    void respondWithErrorShouldRejectNonApiExceptionThrowable() {
-        // Given
-        var ctx = createContext();
-        var header = new RequestHeaderData();
-        var request = new MetadataRequestData();
-        Throwable notAnApiException = new IllegalStateException("not an ApiException");
-
-        // When / Then
-        assertThatThrownBy(() -> ctx.respondWithError(header, request, notAnApiException))
-                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -327,10 +294,9 @@ class RouterContextImplTest {
     void respondWithErrorWithCloseConnectionShouldSetFlag() {
         // Given
         var ctx = createContext();
-        ApiException exception = new UnknownServerException("test error");
 
         // When
-        RouterResponse response = ctx.respondWithError(new RequestHeaderData(), new MetadataRequestData(), exception)
+        RouterResponse response = ctx.respondWithError(new RequestHeaderData(), new MetadataRequestData(), Errors.UNKNOWN_SERVER_ERROR)
                 .withCloseConnection().build();
 
         // Then

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterContextImplTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterContextImplTest.java
@@ -305,6 +305,54 @@ class RouterContextImplTest {
     }
 
     @Test
+    void respondWithErrorFromErrorsRejectsNone() {
+        // Given
+        var ctx = createContext();
+        var header = new RequestHeaderData();
+        var request = new MetadataRequestData();
+
+        // When / Then
+        assertThatThrownBy(() -> ctx.respondWithError(header, request, Errors.NONE))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void respondWithErrorFromErrorsWithMessageRejectsNone() {
+        // Given
+        var ctx = createContext();
+        var header = new RequestHeaderData();
+        var request = new MetadataRequestData();
+
+        // When / Then
+        assertThatThrownBy(() -> ctx.respondWithError(header, request, Errors.NONE, "some message"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void respondWithErrorFromErrorsRejectsNullError() {
+        // Given
+        var ctx = createContext();
+        var header = new RequestHeaderData();
+        var request = new MetadataRequestData();
+
+        // When / Then
+        assertThatThrownBy(() -> ctx.respondWithError(header, request, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void respondWithErrorFromErrorsWithMessageRejectsNullError() {
+        // Given
+        var ctx = createContext();
+        var header = new RequestHeaderData();
+        var request = new MetadataRequestData();
+
+        // When / Then
+        assertThatThrownBy(() -> ctx.respondWithError(header, request, null, "some message"))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
     void respondWithoutReplyWithCloseConnectionShouldSetFlag() {
         // Given
         var ctx = createContext();


### PR DESCRIPTION
### Type of change

Enhancement / new feature (public API)

### Description

The short-circuit error-response entry points on the public Filter/Router API took a Kafka client exception (`org.apache.kafka.common.errors.ApiException`):

- `RequestFilterResultBuilder.errorResponse(RequestHeaderData, ApiMessage, ApiException)`
- `RouterContext.respondWithError(RequestHeaderData, ApiMessage, ApiException)`

This kept `ApiException` and its ~150 subclasses on the public API surface, even though the thing a caller actually wants to express is an error **code** plus an optional **message**. This PR re-expresses those entry points in those terms so the kafka-clients exception hierarchy no longer leaks into the API.

Following the design proposal ([kroxylicious/design#131](https://github.com/kroxylicious/design/pull/131)), this is a **clean break** — the exception-based overloads are removed outright, with no deprecation window and no transitional `Throwable` signature:

- Adds overloads taking `(Errors)` and `(Errors, @Nullable String message)` to both `RequestFilterResultBuilder.errorResponse` and `RouterContext.respondWithError`.
- **Removes** the existing `ApiException`-based overloads entirely. The `org.apache.kafka.common.errors.ApiException` reference leaves the public API in one step — no deprecated overload, no `Throwable` widening, no runtime type-check to maintain.
- The `error` argument must denote an actual error: `Errors.NONE` is rejected at call time with `IllegalArgumentException` (asking for an error response that carries no error is a programming error), and `null` is rejected (`Objects.requireNonNull`). The removed exception overloads had no equivalent input (there is no `ApiException` for `NONE`), so no existing caller is affected; the check fails fast rather than letting a filter emit a response that claims success on an error path.
- That the proxy still constructs an `ApiException` internally to shape the response is an implementation detail; `KafkaProxyExceptionMapper` and the routing engine are unchanged.
- Behavioural parity: for equivalent input the new `Errors` overload produces the identical response (same error code, same message) the exception overload produced before; unit tests assert this.
- Internal filters, the runtime, and the mock `FilterContext` test doubles are migrated to the `Errors` overloads.
- `japicmp` excludes accept the binary-incompatible removal of the `ApiException`-typed overloads (a pre-compiled plugin linked against the old signature would fail at link time with `NoSuchMethodError` until recompiled — accepted).

### Additional Context

Implements the design in [kroxylicious/design#131](https://github.com/kroxylicious/design/pull/131) ("express error-response API in terms of error codes", #4756).

The clean break is chosen deliberately: 0.24.0 already forces filter authors to make source changes for [proposal 116](https://github.com/kroxylicious/design/blob/main/proposals/116-kafka-api-migration.md) (moving off Kafka's `*Data` classes), so this edit rides along with a migration they are already performing and costs no *additional* migration event. Migration is mechanical, e.g. `errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED.exception())` becomes `errorResponse(header, request, Errors.GROUP_AUTHORIZATION_FAILED)`.

The new overloads use the kafka-clients `org.apache.kafka.common.protocol.Errors` on `main`. When the owned `Errors` enum (#4752/#4755) lands, the `Errors` type in these signatures is swapped for the owned one — that swap, and the resulting removal of the vendored exception classes, is where #4756's payoff is realised (out of scope here).

As a public `kroxylicious-api` change this needs a design proposal (`design-proposal-needed` on #4756) before merge.

### Checklist

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update.
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [x] For user facing changes, add a logchange entry YAML file to `changelog/unreleased/`.

Relates-to: #4756
