### PR TITLE
build(tests): set default -Xmx5g for failsafe forked JVMs

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-operator/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/pom.xml
@@ -323,6 +323,7 @@
                         <!-- https://junit-pioneer.org/docs/environment-variables/#warnings-for-reflective-access -->
                         --add-opens java.base/java.util=ALL-UNNAMED
                         --add-opens java.base/java.lang=ALL-UNNAMED
+                        -Xmx${it.failsafe.xmx}
                     </argLine>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <maven.compiler.version>3.15.0</maven.compiler.version>
         <maven.failsafe.version>3.5.6</maven.failsafe.version>
         <maven.surefire.version>3.5.6</maven.surefire.version>
+        <it.failsafe.xmx>5g</it.failsafe.xmx>
         <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.release>${java.version}</maven.compiler.release>
@@ -875,6 +876,7 @@
                         </systemPropertyVariables>
                         <argLine>
                             -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+                            -Xmx${it.failsafe.xmx}
                         </argLine>
                         <runOrder>random</runOrder>
                     </configuration>


### PR DESCRIPTION
## Summary
- Investigating #4753, where a batch of integration tests failed with an OOM.
- Failsafe forked JVMs had no `-Xmx` set, so heap defaulted to a fraction of the runner's RAM.
- Adds an `it.failsafe.xmx` property (default `5g`) referenced from both failsafe `argLine` declarations (root pom, and the operator module which overrides `argLine` entirely), so it can be tuned per-build with `-Dit.failsafe.xmx=<value>` without editing the pom.
- Left the CI workflow unchanged for now — the property is configurable, that's enough for this PR.

Relates-to: #4753