### PR TITLE
fix(tests): tests running out of heap

### DIFF
--- a/kroxylicious-filters/kroxylicious-authorization/pom.xml
+++ b/kroxylicious-filters/kroxylicious-authorization/pom.xml
@@ -107,6 +107,11 @@
             <artifactId>logsquelcher</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/log4j2-test.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/log4j2-test.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+Configuration:
+  status: WARN
+  name: Tests
+  Appenders:
+    Console:
+        name: Console
+        type: Console
+        target: SYSTEM_OUT
+        PatternLayout:
+            pattern: '%d{yyyy-MM-dd HH:mm:ss} %-5p <%t> %c{1.} - %m%replace{ %K{ctx}}{'' $''}{}%n'
+  Loggers:
+    Root:
+      additivity: false
+      level: OFF
+      AppenderRef:
+        - ref: Console
+    Logger:
+      - name: io.kroxylicious.filter.authorization.AuthorizationFilter
+        additivity: false
+        level: DEBUG
+        AppenderRef:
+          - ref: Console
+

--- a/kroxylicious-filters/kroxylicious-protocol-logger/pom.xml
+++ b/kroxylicious-filters/kroxylicious-protocol-logger/pom.xml
@@ -91,6 +91,11 @@
             <artifactId>logsquelcher</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/kroxylicious-filters/kroxylicious-protocol-logger/pom.xml
+++ b/kroxylicious-filters/kroxylicious-protocol-logger/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j2-impl</artifactId>
-            <scope>runtime</scope>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/kroxylicious-filters/kroxylicious-protocol-logger/src/test/resources/log4j2-test.yaml
+++ b/kroxylicious-filters/kroxylicious-protocol-logger/src/test/resources/log4j2-test.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+Configuration:
+  status: WARN
+  name: Tests
+  Appenders:
+    Console:
+        name: Console
+        type: Console
+        target: SYSTEM_OUT
+        PatternLayout:
+            pattern: '%d{yyyy-MM-dd HH:mm:ss} %-5p <%t> %c{1.} - %m%replace{ %K{ctx}}{'' $''}{}%n'
+  Loggers:
+    Root:
+      additivity: false
+      level: OFF
+      AppenderRef:
+        - ref: Console
+    Logger:
+      - name: io.kroxylicious.filter.protocollogger
+        additivity: false
+        level: DEBUG
+        AppenderRef:
+          - ref: Console
+      - name: test.custom.logger
+        additivity: false
+        level: DEBUG
+        AppenderRef:
+          - ref: Console
+

--- a/kroxylicious-integration-tests/src/test/resources/log4j2-test.yaml
+++ b/kroxylicious-integration-tests/src/test/resources/log4j2-test.yaml
@@ -62,3 +62,9 @@ Configuration:
          AppenderRef:
            - ref: Console
 
+      -  name: io.kroxylicious.filter.protocollogger.ProtocolLoggerFilter
+         additivity: false
+         level: DEBUG
+         AppenderRef:
+           - ref: Console
+

--- a/kroxylicious-runtime/src/test/resources/log4j2-test.yaml
+++ b/kroxylicious-runtime/src/test/resources/log4j2-test.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+Configuration:
+  status: WARN
+  name: Tests
+  Appenders:
+    Console:
+        name: Console
+        type: Console
+        target: SYSTEM_OUT
+        PatternLayout:
+            pattern: '%d{yyyy-MM-dd HH:mm:ss} %-5p <%t> %c{1.} - %m%replace{ %K{ctx}}{'' $''}{}%n'
+  Loggers:
+    Root:
+      additivity: false
+      level: WARN
+      AppenderRef:
+        - ref: Console
+          level: WARN
+

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <azure.core.version>1.58.1</azure.core.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
         <apache.httpcore.version>4.4.16</apache.httpcore.version>
-        <logsquelcher.version>0.2.1</logsquelcher.version>
+        <logsquelcher.version>0.2.2</logsquelcher.version>
         <async-profiler.version>4.5</async-profiler.version>
         <json-unit-assertj.version>6.0.1</json-unit-assertj.version>
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

on debugging I found that large amounts of heap were going into the logsquelcher buffer during test TransactionalIdTracingIT and likely the culprit causing later tests to OOM

The new version of logsquelcher uses the delegate logger to control whether it recieves events so that we only buffer events the delegate wants to log. So we will stop buffering the heavy Kafka TRACE logs.

This affects existing tests because until now logsquelcher has captured logs of all levels so they are available for assertion. So we add a log4j logging configuration to kroxylicious-runtime so that we opt to buffer WARN logs. It's a bit brittle having the tests tied to log4j config, but this is being improved in logsquelcher 0.3.x by letting tests control the levels at runtime.

Closes #4753

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
