### PR TITLE
Vendor the Kafka Errors enum

### DIFF
--- a/kroxylicious-api/src/main/java/io/kroxylicious/kafka/common/protocol/Errors.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/kafka/common/protocol/Errors.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kroxylicious.kafka.common.protocol;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class contains all the client-server errors--those errors that must be sent from the server to the client. These
+ * are thus part of the protocol. The names can be changed but the error code cannot.
+ *
+ * Note that client library will convert an unknown error code to the non-retriable UnknownServerException if the client library
+ * version is old and does not recognize the newly-added error code. Therefore when a new server-side error is added,
+ * we may need extra logic to convert the new error code to another existing error code before sending the response back to
+ * the client if the request version suggests that the client may not recognize the new error code.
+ *
+ * Do not add exceptions that occur only on the client or only on the server here.
+ *
+ * @see io.kroxylicious.kafka.common.network.SslTransportLayer
+ */
+public enum Errors {
+    UNKNOWN_SERVER_ERROR(-1, "The server experienced an unexpected error when processing the request."),
+    NONE(0, null),
+    OFFSET_OUT_OF_RANGE(1, "The requested offset is not within the range of offsets maintained by the server."),
+    CORRUPT_MESSAGE(2, "This message has failed its CRC checksum, exceeds the valid size, has a null key for a compacted topic, or is otherwise corrupt."),
+    UNKNOWN_TOPIC_OR_PARTITION(3, "This server does not host this topic-partition."),
+    INVALID_FETCH_SIZE(4, "The requested fetch size is invalid."),
+    LEADER_NOT_AVAILABLE(5, "There is no leader for this topic-partition as we are in the middle of a leadership election."),
+    NOT_LEADER_OR_FOLLOWER(6, "For requests intended only for the leader, this error indicates that the broker is not the current leader. " +
+            "For requests intended for any replica, this error indicates that the broker is not a replica of the topic partition."),
+    REQUEST_TIMED_OUT(7, "The request timed out."),
+    BROKER_NOT_AVAILABLE(8, "The broker is not available."),
+    REPLICA_NOT_AVAILABLE(9, "The replica is not available for the requested topic-partition. Produce/Fetch requests and other requests " +
+            "intended only for the leader or follower return NOT_LEADER_OR_FOLLOWER if the broker is not a replica of the topic-partition."),
+    MESSAGE_TOO_LARGE(10, "The request included a message larger than the max message size the server will accept."),
+    STALE_CONTROLLER_EPOCH(11, "The controller moved to another broker."),
+    OFFSET_METADATA_TOO_LARGE(12, "The metadata field of the offset request was too large."),
+    NETWORK_EXCEPTION(13, "The server disconnected before a response was received."),
+    COORDINATOR_LOAD_IN_PROGRESS(14, "The coordinator is loading and hence can't process requests."),
+    COORDINATOR_NOT_AVAILABLE(15, "The coordinator is not available."),
+    NOT_COORDINATOR(16, "This is not the correct coordinator."),
+    INVALID_TOPIC_EXCEPTION(17, "The request attempted to perform an operation on an invalid topic."),
+    RECORD_LIST_TOO_LARGE(18, "The request included message batch larger than the configured segment size on the server."),
+    NOT_ENOUGH_REPLICAS(19, "Messages are rejected since there are fewer in-sync replicas than required."),
+    NOT_ENOUGH_REPLICAS_AFTER_APPEND(20, "Messages are written to the log, but to fewer in-sync replicas than required."),
+    INVALID_REQUIRED_ACKS(21, "Produce request specified an invalid value for required acks."),
+    ILLEGAL_GENERATION(22, "Specified group generation id is not valid."),
+    INCONSISTENT_GROUP_PROTOCOL(23,
+            "The group member's supported protocols are incompatible with those of existing members " +
+                    "or first group member tried to join with empty protocol type or empty protocol list."),
+    INVALID_GROUP_ID(24, "The group id is invalid."),
+    UNKNOWN_MEMBER_ID(25, "The coordinator is not aware of this member."),
+    INVALID_SESSION_TIMEOUT(26,
+            "The session timeout is not within the range allowed by the broker " +
+                    "(as configured by group.min.session.timeout.ms and group.max.session.timeout.ms)."),
+    REBALANCE_IN_PROGRESS(27, "The group is rebalancing, so a rejoin is needed."),
+    INVALID_COMMIT_OFFSET_SIZE(28, "The committing offset data size is not valid."),
+    TOPIC_AUTHORIZATION_FAILED(29, "Topic authorization failed."),
+    GROUP_AUTHORIZATION_FAILED(30, "Group authorization failed."),
+    CLUSTER_AUTHORIZATION_FAILED(31, "Cluster authorization failed."),
+    INVALID_TIMESTAMP(32, "The timestamp of the message is out of acceptable range."),
+    UNSUPPORTED_SASL_MECHANISM(33, "The broker does not support the requested SASL mechanism."),
+    ILLEGAL_SASL_STATE(34, "Request is not valid given the current SASL state."),
+    UNSUPPORTED_VERSION(35, "The version of API is not supported."),
+    TOPIC_ALREADY_EXISTS(36, "Topic with this name already exists."),
+    INVALID_PARTITIONS(37, "Number of partitions is below 1."),
+    INVALID_REPLICATION_FACTOR(38, "Replication factor is below 1 or larger than the number of available brokers."),
+    INVALID_REPLICA_ASSIGNMENT(39, "Replica assignment is invalid."),
+    INVALID_CONFIG(40, "Configuration is invalid."),
+    NOT_CONTROLLER(41, "This is not the correct controller for this cluster."),
+    INVALID_REQUEST(42, "This most likely occurs because of a request being malformed by the " +
+            "client library or the message was sent to an incompatible broker. See the broker logs " +
+            "for more details."),
+    UNSUPPORTED_FOR_MESSAGE_FORMAT(43, "The message format version on the broker does not support the request."),
+    POLICY_VIOLATION(44, "Request parameters do not satisfy the configured policy."),
+    OUT_OF_ORDER_SEQUENCE_NUMBER(45, "The broker received an out of order sequence number."),
+    DUPLICATE_SEQUENCE_NUMBER(46, "The broker received a duplicate sequence number."),
+    INVALID_PRODUCER_EPOCH(47, "Producer attempted to produce with an old epoch."),
+    INVALID_TXN_STATE(48, "The producer attempted a transactional operation in an invalid state."),
+    INVALID_PRODUCER_ID_MAPPING(49, "The producer attempted to use a producer id which is not currently assigned to " +
+            "its transactional id."),
+    INVALID_TRANSACTION_TIMEOUT(50, "The transaction timeout is larger than the maximum value allowed by " +
+            "the broker (as configured by transaction.max.timeout.ms)."),
+    CONCURRENT_TRANSACTIONS(51, "The producer attempted to update a transaction " +
+            "while another concurrent operation on the same transaction was ongoing."),
+    TRANSACTION_COORDINATOR_FENCED(52, "Indicates that the transaction coordinator sending a WriteTxnMarker " +
+            "is no longer the current coordinator for a given producer."),
+    TRANSACTIONAL_ID_AUTHORIZATION_FAILED(53, "Transactional Id authorization failed."),
+    SECURITY_DISABLED(54, "Security features are disabled."),
+    OPERATION_NOT_ATTEMPTED(55, "The broker did not attempt to execute this operation. This may happen for " +
+            "batched RPCs where some operations in the batch failed, causing the broker to respond without " +
+            "trying the rest."),
+    KAFKA_STORAGE_ERROR(56, "Disk error when trying to access log file on the disk."),
+    LOG_DIR_NOT_FOUND(57, "The user-specified log directory is not found in the broker config."),
+    SASL_AUTHENTICATION_FAILED(58, "SASL Authentication failed."),
+    UNKNOWN_PRODUCER_ID(59, "This exception is raised by the broker if it could not locate the producer metadata " +
+            "associated with the producerId in question. This could happen if, for instance, the producer's records " +
+            "were deleted because their retention time had elapsed. Once the last records of the producerId are " +
+            "removed, the producer's metadata is removed from the broker, and future appends by the producer will " +
+            "return this exception."),
+    REASSIGNMENT_IN_PROGRESS(60, "A partition reassignment is in progress."),
+    DELEGATION_TOKEN_AUTH_DISABLED(61, "Delegation Token feature is not enabled."),
+    DELEGATION_TOKEN_NOT_FOUND(62, "Delegation Token is not found on server."),
+    DELEGATION_TOKEN_OWNER_MISMATCH(63, "Specified Principal is not valid Owner/Renewer."),
+    DELEGATION_TOKEN_REQUEST_NOT_ALLOWED(64, "Delegation Token requests are not allowed on PLAINTEXT/1-way SSL " +
+            "channels and on delegation token authenticated channels."),
+    DELEGATION_TOKEN_AUTHORIZATION_FAILED(65, "Delegation Token authorization failed."),
+    DELEGATION_TOKEN_EXPIRED(66, "Delegation Token is expired."),
+    INVALID_PRINCIPAL_TYPE(67, "Supplied principalType is not supported."),
+    NON_EMPTY_GROUP(68, "The group is not empty."),
+    GROUP_ID_NOT_FOUND(69, "The group id does not exist."),
+    FETCH_SESSION_ID_NOT_FOUND(70, "The fetch session ID was not found."),
+    INVALID_FETCH_SESSION_EPOCH(71, "The fetch session epoch is invalid."),
+    LISTENER_NOT_FOUND(72, "There is no listener on the leader broker that matches the listener on which " +
+            "metadata request was processed."),
+    TOPIC_DELETION_DISABLED(73, "Topic deletion is disabled."),
+    FENCED_LEADER_EPOCH(74, "The leader epoch in the request is older than the epoch on the broker."),
+    UNKNOWN_LEADER_EPOCH(75, "The leader epoch in the request is newer than the epoch on the broker."),
+    UNSUPPORTED_COMPRESSION_TYPE(76, "The requesting client does not support the compression type of given partition."),
+    STALE_BROKER_EPOCH(77, "Broker epoch has changed."),
+    OFFSET_NOT_AVAILABLE(78, "The leader high watermark has not caught up from a recent leader " +
+            "election so the offsets cannot be guaranteed to be monotonically increasing."),
+    MEMBER_ID_REQUIRED(79, "The group member needs to have a valid member id before actually entering a consumer group."),
+    PREFERRED_LEADER_NOT_AVAILABLE(80, "The preferred leader was not available."),
+    GROUP_MAX_SIZE_REACHED(81, "The group has reached its maximum size."),
+    FENCED_INSTANCE_ID(82, "The broker rejected this static consumer since " +
+            "another consumer with the same group.instance.id has registered with a different member.id."),
+    ELIGIBLE_LEADERS_NOT_AVAILABLE(83, "Eligible topic partition leaders are not available."),
+    ELECTION_NOT_NEEDED(84, "Leader election not needed for topic partition."),
+    NO_REASSIGNMENT_IN_PROGRESS(85, "No partition reassignment is in progress."),
+    GROUP_SUBSCRIBED_TO_TOPIC(86, "Deleting offsets of a topic is forbidden while the consumer group is actively subscribed to it."),
+    INVALID_RECORD(87, "This record has failed the validation on broker and hence will be rejected."),
+    UNSTABLE_OFFSET_COMMIT(88, "There are unstable offsets that need to be cleared."),
+    THROTTLING_QUOTA_EXCEEDED(89, "The throttling quota has been exceeded."),
+    PRODUCER_FENCED(90, "There is a newer producer with the same transactionalId " +
+            "which fences the current one."),
+    RESOURCE_NOT_FOUND(91, "A request illegally referred to a resource that does not exist."),
+    DUPLICATE_RESOURCE(92, "A request illegally referred to the same resource twice."),
+    UNACCEPTABLE_CREDENTIAL(93, "Requested credential would not meet criteria for acceptability."),
+    INCONSISTENT_VOTER_SET(94, "Indicates that the either the sender or recipient of a " +
+            "voter-only request is not one of the expected voters."),
+    INVALID_UPDATE_VERSION(95, "The given update version was invalid."),
+    FEATURE_UPDATE_FAILED(96, "Unable to update finalized features due to an unexpected server error."),
+    PRINCIPAL_DESERIALIZATION_FAILURE(97, "Request principal deserialization failed during forwarding. " +
+            "This indicates an internal error on the broker cluster security setup."),
+    SNAPSHOT_NOT_FOUND(98, "Requested snapshot was not found."),
+    POSITION_OUT_OF_RANGE(99, "Requested position is not greater than or equal to zero, and less than the size of the snapshot."),
+    UNKNOWN_TOPIC_ID(100, "This server does not host this topic ID."),
+    DUPLICATE_BROKER_REGISTRATION(101, "This broker ID is already in use."),
+    BROKER_ID_NOT_REGISTERED(102, "The given broker ID was not registered."),
+    INCONSISTENT_TOPIC_ID(103, "The log's topic ID did not match the topic ID in the request."),
+    INCONSISTENT_CLUSTER_ID(104, "The clusterId in the request does not match that found on the server."),
+    TRANSACTIONAL_ID_NOT_FOUND(105, "The transactionalId could not be found."),
+    FETCH_SESSION_TOPIC_ID_ERROR(106, "The fetch session encountered inconsistent topic ID usage."),
+    INELIGIBLE_REPLICA(107, "The new ISR contains at least one ineligible replica."),
+    NEW_LEADER_ELECTED(108, "The AlterPartition request successfully updated the partition state but the leader has changed."),
+    OFFSET_MOVED_TO_TIERED_STORAGE(109, "The requested offset is moved to tiered storage."),
+    FENCED_MEMBER_EPOCH(110, "The member epoch is fenced by the group coordinator. The member must abandon all its partitions and rejoin."),
+    UNRELEASED_INSTANCE_ID(111, "The instance ID is still used by another member in the consumer group. That member must leave first."),
+    UNSUPPORTED_ASSIGNOR(112, "The assignor or its version range is not supported by the consumer group."),
+    STALE_MEMBER_EPOCH(113, "The member epoch is stale. The member must retry after receiving its updated member epoch via the ConsumerGroupHeartbeat API."),
+    MISMATCHED_ENDPOINT_TYPE(114, "The request was sent to an endpoint of the wrong type."),
+    UNSUPPORTED_ENDPOINT_TYPE(115, "This endpoint type is not supported yet."),
+    UNKNOWN_CONTROLLER_ID(116, "This controller ID is not known."),
+    UNKNOWN_SUBSCRIPTION_ID(117, "Client sent a push telemetry request with an invalid or outdated subscription ID."),
+    TELEMETRY_TOO_LARGE(118, "Client sent a push telemetry request larger than the maximum size the broker will accept."),
+    INVALID_REGISTRATION(119, "The controller has considered the broker registration to be invalid."),
+    TRANSACTION_ABORTABLE(120, "The server encountered an error with the transaction. The client can abort the transaction to continue using this transactional ID."),
+    INVALID_RECORD_STATE(121, "The record state is invalid. The acknowledgement of delivery could not be completed."),
+    SHARE_SESSION_NOT_FOUND(122, "The share session was not found."),
+    INVALID_SHARE_SESSION_EPOCH(123, "The share session epoch is invalid."),
+    FENCED_STATE_EPOCH(124, "The share coordinator rejected the request because the share-group state epoch did not match."),
+    INVALID_VOTER_KEY(125, "The voter key doesn't match the receiving replica's key."),
+    DUPLICATE_VOTER(126, "The voter is already part of the set of voters."),
+    VOTER_NOT_FOUND(127, "The voter is not part of the set of voters."),
+    INVALID_REGULAR_EXPRESSION(128, "The regular expression is not valid."),
+    REBOOTSTRAP_REQUIRED(129, "Client metadata is stale. The client should rebootstrap to obtain new metadata."),
+    STREAMS_INVALID_TOPOLOGY(130, "The supplied topology is invalid."),
+    STREAMS_INVALID_TOPOLOGY_EPOCH(131, "The supplied topology epoch is invalid."),
+    STREAMS_TOPOLOGY_FENCED(132, "The supplied topology epoch is outdated."),
+    SHARE_SESSION_LIMIT_REACHED(133, "The limit of share sessions has been reached.");
+
+    private static final Logger log = LoggerFactory.getLogger(Errors.class);
+    private static final Map<Short, Errors> CODE_TO_ERROR = new HashMap<>();
+
+    static {
+        for (Errors error : Errors.values()) {
+            if (CODE_TO_ERROR.put(error.code(), error) != null)
+                throw new ExceptionInInitializerError("Code " + error.code() + " for error " +
+                        error + " has already been used");
+        }
+    }
+
+    private final short code;
+
+    private final String message;
+
+    Errors(int code, String defaultMessage) {
+        this.code = (short) code;
+        this.message = defaultMessage;
+    }
+
+    /**
+     * The error code for the exception
+     */
+    public short code() {
+        return this.code;
+    }
+
+    /**
+     * Get a friendly description of the error (if one is available).
+     * @return the error message
+     */
+    public String message() {
+        return this.message;
+    }
+
+    /**
+     * Throw the exception if there is one
+     */
+    public static Errors forCode(short code) {
+        Errors error = CODE_TO_ERROR.get(code);
+        if (error != null) {
+            return error;
+        }
+        else {
+            log.warn("Unexpected error code: {}.", code);
+            return UNKNOWN_SERVER_ERROR;
+        }
+    }
+
+    /**
+     * Check if a Throwable is a commonly wrapped exception type (e.g. `CompletionException`) and return
+     * the cause if so. This is useful to handle cases where exceptions may be raised from a future or a
+     * completion stage (as might be the case for requests sent to the controller in `ControllerApis`).
+     *
+     * @param t The Throwable to check
+     * @return The throwable itself or its cause if it is an instance of a commonly wrapped exception type
+     */
+    public static Throwable maybeUnwrapException(Throwable t) {
+        if (t instanceof CompletionException || t instanceof ExecutionException) {
+            return t.getCause();
+        }
+        else {
+            return t;
+        }
+    }
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/kafka/common/protocol/Errors.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/kafka/common/protocol/Errors.java
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
  *
  * Do not add exceptions that occur only on the client or only on the server here.
  *
- * @see io.kroxylicious.kafka.common.network.SslTransportLayer
  */
 public enum Errors {
     UNKNOWN_SERVER_ERROR(-1, "The server experienced an unexpected error when processing the request."),

--- a/kroxylicious-api/src/main/java/io/kroxylicious/kafka/common/protocol/Errors.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/kafka/common/protocol/Errors.java
@@ -235,7 +235,10 @@ public enum Errors {
     }
 
     /**
-     * Throw the exception if there is one
+     * Map the code for an Error to its Entry in the enum
+     * @param code the {@code short} to map
+     * @return the Errors enum entry for the code. Returns {@code Errors.UNKNOWN_SERVER_ERROR} for all unmapped codes.
+     *
      */
     public static Errors forCode(short code) {
         Errors error = CODE_TO_ERROR.get(code);

--- a/kroxylicious-api/src/main/java/io/kroxylicious/kafka/common/protocol/Errors.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/kafka/common/protocol/Errors.java
@@ -18,8 +18,6 @@ package io.kroxylicious.kafka.common.protocol;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -213,9 +211,9 @@ public enum Errors {
 
     private final String message;
 
-    Errors(int code, String defaultMessage) {
+    Errors(int code, String message) {
         this.code = (short) code;
-        this.message = defaultMessage;
+        this.message = message;
     }
 
     /**
@@ -230,7 +228,10 @@ public enum Errors {
      * @return the error message
      */
     public String message() {
-        return this.message;
+        if (this.message != null) {
+            return this.message;
+        }
+        return this.toString();
     }
 
     /**
@@ -244,23 +245,6 @@ public enum Errors {
         else {
             log.warn("Unexpected error code: {}.", code);
             return UNKNOWN_SERVER_ERROR;
-        }
-    }
-
-    /**
-     * Check if a Throwable is a commonly wrapped exception type (e.g. `CompletionException`) and return
-     * the cause if so. This is useful to handle cases where exceptions may be raised from a future or a
-     * completion stage (as might be the case for requests sent to the controller in `ControllerApis`).
-     *
-     * @param t The Throwable to check
-     * @return The throwable itself or its cause if it is an instance of a commonly wrapped exception type
-     */
-    public static Throwable maybeUnwrapException(Throwable t) {
-        if (t instanceof CompletionException || t instanceof ExecutionException) {
-            return t.getCause();
-        }
-        else {
-            return t;
         }
     }
 }

--- a/kroxylicious-api/src/test/java/io/kroxylicious/kafka/common/protocol/ErrorsTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/kafka/common/protocol/ErrorsTest.java
@@ -1,9 +1,19 @@
 /*
- * Copyright Kroxylicious Authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.kroxylicious.kafka.common.protocol;
 
 import java.util.HashSet;

--- a/kroxylicious-api/src/test/java/io/kroxylicious/kafka/common/protocol/ErrorsTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/kafka/common/protocol/ErrorsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kafka.common.protocol;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ErrorsTest {
+
+    @Test
+    void shouldHaveUniqueErrorCodes() {
+        Set<Short> codeSet = new HashSet<>();
+        for (Errors error : Errors.values()) {
+            codeSet.add(error.code());
+        }
+        assertThat(codeSet).hasSize(Errors.values().length);
+    }
+
+    @ParameterizedTest
+    @EnumSource(Errors.class)
+    void shouldHaveAMessage(Errors error) {
+        assertThat(error.message()).isNotNull().isNotBlank();
+    }
+
+    @ParameterizedTest
+    @EnumSource(Errors.class)
+    void shouldMapCodeToEnum(Errors error) {
+        assertThat(Errors.forCode(error.code())).isEqualTo(error);
+    }
+}

--- a/kroxylicious-proxy-core/pom.xml
+++ b/kroxylicious-proxy-core/pom.xml
@@ -44,5 +44,6 @@
         <module>../kroxylicious-integration-test-support</module>
         <module>../kroxylicious-runtime</module>
         <module>../kroxylicious-app</module>
+        <module>../tools/kafka-vendoring</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
         <avro.version>1.12.1</avro.version>
         <protobuf-java.version>4.35.1</protobuf-java.version>
         <jose4j.version>0.9.6</jose4j.version>
+        <rewrite-maven-plugin.version>6.46.1</rewrite-maven-plugin.version>
 
         <!-- Test dependencies -->
         <strimzi.version>1.1.0</strimzi.version>  <!-- when bumping strimzi, be sure to comment out the kafka.version override in the systemtest module's pom -->
@@ -643,7 +644,9 @@
          update the relevant intermediate aggregator pom.xml (kroxylicious-proxy-core/,
          kroxylicious-runtime-plugins/, kroxylicious-supplementary/, or kroxylicious-kubernetes/) — not this file.
          Enforced by the module-profile lint check. -->
-    <modules/>
+    <modules>
+        <module>tools/kafka-vendoring</module>
+    </modules>
 
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -644,10 +644,7 @@
          update the relevant intermediate aggregator pom.xml (kroxylicious-proxy-core/,
          kroxylicious-runtime-plugins/, kroxylicious-supplementary/, or kroxylicious-kubernetes/) — not this file.
          Enforced by the module-profile lint check. -->
-    <modules>
-        <module>tools/kafka-vendoring</module>
-    </modules>
-
+    <modules/>
 
     <build>
         <!-- Keep alphabetic order -->

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,6 @@
         <avro.version>1.12.1</avro.version>
         <protobuf-java.version>4.35.1</protobuf-java.version>
         <jose4j.version>0.9.6</jose4j.version>
-        <rewrite-maven-plugin.version>6.46.1</rewrite-maven-plugin.version>
 
         <!-- Test dependencies -->
         <strimzi.version>1.1.0</strimzi.version>  <!-- when bumping strimzi, be sure to comment out the kafka.version override in the systemtest module's pom -->

--- a/pom.xml
+++ b/pom.xml
@@ -736,8 +736,6 @@
                                     <exclude>kroxylicious-api/src/main/java/io/kroxylicious/kafka/**</exclude>
                                     <exclude>kroxylicious-api/src/test/java/io/kroxylicious/kafka/**</exclude>
                                     <exclude>kroxylicious-api/etc/asf-license.txt</exclude>
-                                    <exclude>tools/kafka-vendoring/requirements.txt</exclude>
-
                                 </excludes>
                             </licenseSet>
                         </licenseSets>
@@ -746,6 +744,7 @@
                             <bicep>DOUBLESLASH_STYLE</bicep>
                             <g4>JAVADOC_STYLE</g4>
                             <operator>SCRIPT_STYLE</operator>
+                            <requirements.txt>SCRIPT_STYLE</requirements.txt>
                         </mapping>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -744,6 +744,7 @@
                             <g4>JAVADOC_STYLE</g4>
                             <operator>SCRIPT_STYLE</operator>
                             <requirements.txt>SCRIPT_STYLE</requirements.txt>
+                            <preserve-kroxylicious.txt>SCRIPT_STYLE</preserve-kroxylicious.txt>
                         </mapping>
                     </configuration>
                 </plugin>

--- a/tools/kafka-vendoring/apply-edits.py
+++ b/tools/kafka-vendoring/apply-edits.py
@@ -16,14 +16,6 @@ import sys, re, os
 import yaml
 from pathlib import Path
 
-def strip_imports(text, patterns):
-    out=[]
-    for line in text.splitlines(keepends=True):
-        if any(re.search(p, line) for p in patterns) and line.lstrip().startswith('import'):
-            continue
-        out.append(line)
-    return ''.join(out)
-
 def _matching_brace(text, open_idx):
     depth=0
     i=open_idx
@@ -154,7 +146,6 @@ def apply_edit(root, entry):
 
     try:
         text = path.read_text(encoding='utf-8')
-        text = strip_imports(text, entry.get('stripImports', []))
 
         for qualified_name in entry.get('qualifyNestedImports', []):
             text = qualify_nested_import(text, qualified_name)

--- a/tools/kafka-vendoring/apply-edits.py
+++ b/tools/kafka-vendoring/apply-edits.py
@@ -14,6 +14,7 @@ Usage: apply-edits.py <copy-root> <edits.yaml>
 """
 import sys, re, os
 import yaml
+from pathlib import Path
 
 def strip_imports(text, patterns):
     out=[]
@@ -149,18 +150,27 @@ def qualify_nested_import(text, qualified_name):
     return re.sub(r'(?<!\.)\b%s\b' % re.escape(simple_name), type_path, text)
 
 def apply_edit(root, entry):
-    path=os.path.join(root, entry['file'])
-    text=open(path, encoding='utf-8').read()
-    text=strip_imports(text, entry.get('stripImports', []))
-    for qualified_name in entry.get('qualifyNestedImports', []):
-        text=qualify_nested_import(text, qualified_name)
-    for block in entry.get('removeBlocks', []):
-        for _ in range(block.get('count', 1)):
-            text=remove_block(text, block['signature'], block['label'])
-    if 'preserveBlocks' in entry:
-        text=preserve_blocks(text, entry['preserveBlocks'])
-    open(path, 'w', encoding='utf-8').write(text)
-    print("edited "+entry['file'])
+    path = Path(root) / entry['file']
+
+    try:
+        text = path.read_text(encoding='utf-8')
+        text = strip_imports(text, entry.get('stripImports', []))
+
+        for qualified_name in entry.get('qualifyNestedImports', []):
+            text = qualify_nested_import(text, qualified_name)
+
+        for block in entry.get('removeBlocks', []):
+            for _ in range(block.get('count', 1)):
+                text = remove_block(text, block['signature'], block['label'])
+
+        if 'preserveBlocks' in entry:
+            text = preserve_blocks(text, entry['preserveBlocks'])
+
+        path.write_text(text, encoding='utf-8')
+        print(f"edited {entry['file']}")
+
+    except (UnicodeDecodeError, OSError) as e:
+        print(f"Skipping {entry['file']} due to error: {e}")
 
 def main():
     root, edits_path = sys.argv[1], sys.argv[2]

--- a/tools/kafka-vendoring/apply-edits.py
+++ b/tools/kafka-vendoring/apply-edits.py
@@ -160,6 +160,9 @@ def apply_edit(root, entry):
         path.write_text(text, encoding='utf-8')
         print(f"edited {entry['file']}")
 
+    except FileNotFoundError:
+        print(f"COULD NOT FIND {entry['file']}")
+        exit(1)
     except (UnicodeDecodeError, OSError) as e:
         print(f"Skipping {entry['file']} due to error: {e}")
 

--- a/tools/kafka-vendoring/main/edits.yaml
+++ b/tools/kafka-vendoring/main/edits.yaml
@@ -27,10 +27,6 @@
 #     once its enclosing type ends up in the same package as the importing file (see test/edits.yaml).
 
 - file: org/apache/kafka/common/record/internal/CompressionType.java
-  stripImports:
-    - '\.config\.ConfigDef'
-    - '\.config\.ConfigException'
-    - '\.config\.ConfigDef\.Range\.between'
   removeBlocks:
     - signature: 'public\s+ConfigDef\.Validator\s+levelValidator\s*\(\s*\)'
       label: CompressionType.levelValidator
@@ -40,10 +36,6 @@
   # Only the config-machinery methods pull org.apache.kafka.common.config into the closure. The
   # nio.file methods are pure JDK (kept). tryWriteTo is cut below along with the rest of the
   # zero-copy send machinery it exists to support (see the comment further down this file).
-  stripImports:
-    - '\.config\.ConfigDef'
-    - '\.config\.ConfigException'
-    - 'network\.TransferableChannel'
   removeBlocks:
     - signature: 'public static Map<String, Object> propsToMap\('
       label: Utils.propsToMap
@@ -57,17 +49,11 @@
       label: Utils.tryWriteTo
 
 - file: org/apache/kafka/common/record/internal/DefaultRecordBatch.java
-  stripImports:
-    - 'record\.internal\.FileLogInputStream'
-    - 'record\.internal\.FileRecords'
   removeBlocks:
     - signature: 'static class DefaultFileChannelRecordBatch extends FileLogInputStream'
       label: DefaultRecordBatch.DefaultFileChannelRecordBatch
 
 - file: org/apache/kafka/common/record/internal/AbstractLegacyRecordBatch.java
-  stripImports:
-    - 'record\.internal\.FileLogInputStream'
-    - 'record\.internal\.FileRecords'
   removeBlocks:
     - signature: 'static class LegacyFileChannelRecordBatch extends FileLogInputStream'
       label: AbstractLegacyRecordBatch.LegacyFileChannelRecordBatch
@@ -91,9 +77,6 @@
       label: BaseRecords.toSend
 
 - file: org/apache/kafka/common/record/internal/TransferableRecords.java
-  stripImports:
-    - 'java\.io\.IOException'
-    - 'network\.TransferableChannel'
   removeBlocks:
     - signature: 'int\s+writeTo\s*\(\s*TransferableChannel\s+channel\s*,\s*int\s+position\s*,\s*int\s+length\s*\)'
       label: TransferableRecords.writeTo
@@ -109,17 +92,11 @@
       label: UnalignedRecords.toSend
 
 - file: org/apache/kafka/common/record/internal/MemoryRecords.java
-  stripImports:
-    - 'network\.TransferableChannel'
   removeBlocks:
     - signature: 'public\s+int\s+writeTo\s*\(\s*TransferableChannel\s+channel\s*,\s*int\s+position\s*,\s*int\s+length\s*\)'
       label: MemoryRecords.writeTo
 
 - file: org/apache/kafka/common/record/internal/UnalignedMemoryRecords.java
-  stripImports:
-    - 'java\.io\.IOException'
-    - 'network\.TransferableChannel'
-    - 'utils\.Utils'
   removeBlocks:
     - signature: 'public\s+int\s+writeTo\s*\(\s*TransferableChannel\s+channel\s*,\s*int\s+position\s*,\s*int\s+length\s*\)'
       label: UnalignedMemoryRecords.writeTo

--- a/tools/kafka-vendoring/main/preserve-kroxylicious.txt
+++ b/tools/kafka-vendoring/main/preserve-kroxylicious.txt
@@ -3,4 +3,5 @@
 #
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
+
 # Kroxylicious authored files in the vendored package space from rsync --delete

--- a/tools/kafka-vendoring/main/preserve-kroxylicious.txt
+++ b/tools/kafka-vendoring/main/preserve-kroxylicious.txt
@@ -1,0 +1,6 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Kroxylicious authored files in the vendored package space from rsync --delete

--- a/tools/kafka-vendoring/main/vendored-files.txt
+++ b/tools/kafka-vendoring/main/vendored-files.txt
@@ -22,6 +22,7 @@
 # kind of dead weight from main-code usage alone, but the forked MemoryRecordsTest constructs
 # RecordHeaders directly as a test fixture, so both stay — a reminder that "unreachable from main
 # code" isn't the same question as "unreachable", once main and test share one vendored tree.
+org/apache/kafka/common/protocol/Errors.java
 org/apache/kafka/common/InvalidRecordException.java
 org/apache/kafka/common/KafkaException.java
 org/apache/kafka/common/Uuid.java

--- a/tools/kafka-vendoring/pom.xml
+++ b/tools/kafka-vendoring/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kroxylicious</groupId>
+        <artifactId>kroxylicious-parent</artifactId>
+        <version>0.24.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>kroxylicious-kafka-vendoring</artifactId>
+    <name>Kroxylicious Vendoring</name>
+    <description>Tooling used in support of vendoring Apache Kafka sources into Kroxylicious</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencyManagement>
+        <dependencies>
+            <!-- Manages OpenRewrite test library versions -->
+            <dependency>
+                <groupId>org.openrewrite.recipe</groupId>
+                <artifactId>rewrite-recipe-bom</artifactId>
+                <version>3.37.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java-${java.version}</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <!-- JUnit 5 test framework -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <configuration>
+                            <ignoredUnusedDeclaredDependencies>
+                                org.apache.kafka:kafka-clients,org.openrewrite:rewrite-java-${java.version},org.jspecify:jspecify
+                            </ignoredUnusedDeclaredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/kafka-vendoring/rewrite-pom.xml
+++ b/tools/kafka-vendoring/rewrite-pom.xml
@@ -82,6 +82,11 @@
             <artifactId>snappy-java</artifactId>
             <version>1.1.10.7</version>
         </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-kafka-vendoring</artifactId>
+            <version>0.24.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -90,9 +95,16 @@
                 <groupId>org.openrewrite.maven</groupId>
                 <artifactId>rewrite-maven-plugin</artifactId>
                 <version>6.46.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.kroxylicious</groupId>
+                        <artifactId>kroxylicious-kafka-vendoring</artifactId>
+                        <version>0.24.0-SNAPSHOT</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <activeRecipes>
-                        <recipe>io.kroxylicious.RewriteCopiedKafka</recipe>
+                        <recipe>io.kroxylicious.vendoring.RewriteCopiedKafka</recipe>
                     </activeRecipes>
                 </configuration>
             </plugin>

--- a/tools/kafka-vendoring/rewrite-pom.xml
+++ b/tools/kafka-vendoring/rewrite-pom.xml
@@ -43,6 +43,11 @@
          symbols we're intentionally relocating are left unresolved. -->
     <dependencies>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>4.3.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>5.14.4</version>

--- a/tools/kafka-vendoring/rewrite-pom.xml
+++ b/tools/kafka-vendoring/rewrite-pom.xml
@@ -109,7 +109,7 @@
                 </dependencies>
                 <configuration>
                     <activeRecipes>
-                        <recipe>io.kroxylicious.vendoring.RewriteCopiedKafka</recipe>
+                        <recipe>io.kroxylicious.vendoring.rewrite.VendorKafkaClients</recipe>
                     </activeRecipes>
                 </configuration>
             </plugin>

--- a/tools/kafka-vendoring/rewrite.yml
+++ b/tools/kafka-vendoring/rewrite.yml
@@ -28,6 +28,7 @@ preconditions:
       filePattern: '**/org/apache/kafka/**'
 recipeList:
   - io.kroxylicious.vendoring.rewrite.PruneKafkaErrorsEnumRecipe
+  - org.openrewrite.java.RemoveUnusedImports
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.kafka.common
       newPackageName: io.kroxylicious.kafka.common

--- a/tools/kafka-vendoring/rewrite.yml
+++ b/tools/kafka-vendoring/rewrite.yml
@@ -18,7 +18,7 @@
 # package.
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: io.kroxylicious.RewriteCopiedKafka
+name: io.kroxylicious.vendoring.RewriteCopiedKafka
 displayName: Relocate vendored/forked Kafka classes to io.kroxylicious.kafka
 description: >-
   Rewrites copied org.apache.kafka.* classes into the io.kroxylicious.kafka.* namespace so the
@@ -35,3 +35,4 @@ recipeList:
       oldPackageName: org.apache.kafka.test
       newPackageName: io.kroxylicious.kafka.test
       recursive: true
+  - io.kroxylicious.vendoring.rewrite.PruneKafkaErrorsEnumRecipe

--- a/tools/kafka-vendoring/rewrite.yml
+++ b/tools/kafka-vendoring/rewrite.yml
@@ -27,6 +27,7 @@ preconditions:
   - org.openrewrite.FindSourceFiles:
       filePattern: '**/org/apache/kafka/**'
 recipeList:
+  - io.kroxylicious.vendoring.rewrite.PruneKafkaErrorsEnumRecipe
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.kafka.common
       newPackageName: io.kroxylicious.kafka.common
@@ -35,4 +36,3 @@ recipeList:
       oldPackageName: org.apache.kafka.test
       newPackageName: io.kroxylicious.kafka.test
       recursive: true
-  - io.kroxylicious.vendoring.rewrite.PruneKafkaErrorsEnumRecipe

--- a/tools/kafka-vendoring/rewrite.yml
+++ b/tools/kafka-vendoring/rewrite.yml
@@ -18,7 +18,7 @@
 # package.
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: io.kroxylicious.vendoring.RewriteCopiedKafka
+name: io.kroxylicious.vendoring.rewrite.VendorKafkaClients
 displayName: Relocate vendored/forked Kafka classes to io.kroxylicious.kafka
 description: >-
   Rewrites copied org.apache.kafka.* classes into the io.kroxylicious.kafka.* namespace so the

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.vendoring.rewrite;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.RemoveUnusedImports;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Applies the required edits to Apache Kafka's hand rolled Errors enum to make it part of the Kroxylicious API
+ */
+public class PruneKafkaErrorsEnumRecipe extends Recipe {
+
+    /**
+     * Create an instance of the recipe.
+     */
+    public PruneKafkaErrorsEnumRecipe() {
+        super();
+    }
+
+    @Override
+    @NonNull
+    public String getDisplayName() {
+        return "Prune exception references from vendored Kafka Errors enum";
+    }
+
+    @Override
+    @NonNull
+    public String getDescription() {
+        return "Strips client exception builders, fields, methods, and imports from Kafka Errors enum.";
+    }
+
+    @Override
+    @NonNull
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaVisitor<>() {
+
+            @Nullable
+            @Override
+            public J.EnumValue visitEnumValue(J.EnumValue enumConstant, ExecutionContext ctx) {
+                J.EnumValue ec = (J.EnumValue) super.visitEnumValue(enumConstant, ctx);
+                J.NewClass initializer = ec.getInitializer();
+                if (initializer != null) {
+                    List<Expression> arguments = initializer.getArguments();
+                    if (arguments.size() == 3) {
+                        List<Expression> replacementArgs = new ArrayList<>(arguments);
+                        replacementArgs.remove(2); // Remove 3rd argument (Exception constructor reference)
+                        return ec.withInitializer(initializer.withArguments(replacementArgs));
+                    }
+                }
+                return ec;
+            }
+
+            @Override
+            public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+                J.VariableDeclarations vd = (J.VariableDeclarations) super.visitVariableDeclarations(multiVariable, ctx);
+                if (vd.getVariables().stream().anyMatch(v -> "builder".equals(v.getSimpleName()))) {
+                    return null; // Remove 'builder' field
+                }
+                return vd;
+            }
+
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                J.MethodDeclaration md = (J.MethodDeclaration) super.visitMethodDeclaration(method, ctx);
+                String name = md.getSimpleName();
+
+                // Remove exception factory methods
+                if ("exception".equals(name) || "forException".equals(name)) {
+                    return null;
+                }
+
+                // Update constructor signature and body
+                if (md.isConstructor()) {
+                    List<Statement> newParams = md.getParameters().stream()
+                            .filter(p -> !(p instanceof J.VariableDeclarations vd &&
+                                    vd.getVariables().stream().anyMatch(v -> "builder".equals(v.getSimpleName()))))
+                            .collect(Collectors.toList());
+
+                    J.Block body = md.getBody();
+                    if (body != null) {
+                        List<Statement> newStatements = body.getStatements().stream()
+                                .filter(stmt -> !stmt.printTrimmed(getCursor()).contains("builder"))
+                                .collect(Collectors.toList());
+                        md = md.withBody(body.withStatements(newStatements));
+                    }
+
+                    return md.withParameters(newParams);
+                }
+
+                return md;
+            }
+
+            @Override
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                J.CompilationUnit c = (J.CompilationUnit) super.visitCompilationUnit(cu, ctx);
+                doAfterVisit(new RemoveUnusedImports().getVisitor());
+                return c;
+            }
+        };
+    }
+}

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -61,7 +61,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
             private final JavaTemplate messageMethodBody = JavaTemplate.builder("return this.message;").contextSensitive().build();
 
             private final JavaTemplate constructorTemplate = JavaTemplate.builder(
-                            "Errors(int code, String defaultMessage) {\n" + "    this.code = (short) code;\n" + "    this.message = defaultMessage;\n" + "}").contextSensitive()
+                    "Errors(int code, String defaultMessage) {\n" + "    this.code = (short) code;\n" + "    this.message = defaultMessage;\n" + "}").contextSensitive()
                     .build();
 
             @Override

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -6,17 +6,20 @@
 
 package io.kroxylicious.vendoring.rewrite;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.RemoveUnusedImports;
+import org.openrewrite.java.TypeNameMatcher;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Statement;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -26,6 +29,9 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * Applies the required edits to Apache Kafka's hand rolled Errors enum to make it part of the Kroxylicious API
  */
 public class PruneKafkaErrorsEnumRecipe extends Recipe {
+
+    private static final TypeNameMatcher FUNCTION_TYPE_MATCHER = TypeNameMatcher.fromPattern("java.util.function.Function");
+    private static final TypeNameMatcher KAFKA_EXCEPTION_TYPE_MATCHER = TypeNameMatcher.fromPattern("org.apache.kafka.common.errors.*Exception");
 
     /**
      * Create an instance of the recipe.
@@ -51,7 +57,36 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaVisitor<>() {
 
-            @Nullable
+            private final Set<String> REMOVED_FIELDS = Set.of("builder", "exception", "CLASS_TO_ERROR");
+            private final Set<String> REMOVED_METHODS = Set.of("exception", "forException", "maybeThrow", "exceptionName", "main", "toHtml");
+
+            private final JavaTemplate messageFieldTemplate = JavaTemplate.builder("private final String message;").contextSensitive().build();
+
+            private final JavaTemplate messageMethodBody = JavaTemplate.builder("return this.message;").contextSensitive().build();
+
+            private final JavaTemplate constructorTemplate = JavaTemplate.builder(
+                            "Errors(int code, String defaultMessage) {\n" + "    this.code = (short) code;\n" + "    this.message = defaultMessage;\n" + "}").contextSensitive()
+                    .build();
+
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDeclaration, ExecutionContext ctx) {
+                J.ClassDeclaration cd = classDeclaration;
+                Statement messageField = findFieldByName(classDeclaration, "message");
+                boolean hasMessageField = messageField != null;
+
+                if (!hasMessageField) {
+                    Statement codeField = findFieldByName(cd, "code");
+
+                    if (codeField != null) {
+                        cd = messageFieldTemplate.apply(updateCursor(cd), codeField.getCoordinates().after());
+                    }
+                    else {
+                        cd = messageFieldTemplate.apply(updateCursor(cd), cd.getBody().getCoordinates().firstStatement());
+                    }
+                }
+                return (J.ClassDeclaration) super.visitClassDeclaration(cd, ctx);
+            }
+
             @Override
             public J.EnumValue visitEnumValue(J.EnumValue enumConstant, ExecutionContext ctx) {
                 J.EnumValue ec = (J.EnumValue) super.visitEnumValue(enumConstant, ctx);
@@ -59,9 +94,32 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
                 if (initializer != null) {
                     List<Expression> arguments = initializer.getArguments();
                     if (arguments.size() == 3) {
-                        List<Expression> replacementArgs = new ArrayList<>(arguments);
-                        replacementArgs.remove(2); // Remove 3rd argument (Exception constructor reference)
-                        return ec.withInitializer(initializer.withArguments(replacementArgs));
+                        List<Expression> safeArgs = arguments.stream().filter(expression -> {
+                            JavaType type = expression.getType();
+                            if (expression instanceof J.MemberReference memberReference) {
+                                var method = memberReference.getMethodType();
+                                if (method != null) {
+                                    JavaType.FullyQualified declaringType = method.getDeclaringType();
+                                    if (declaringType.isAssignableFrom(KAFKA_EXCEPTION_TYPE_MATCHER)) {
+                                        maybeRemoveImport(declaringType);
+                                        return false;
+                                    }
+                                }
+                            }
+                            if (type != null && type.isAssignableFrom(FUNCTION_TYPE_MATCHER)) {
+                                var pt = (JavaType.Parameterized) type;
+                                var matching = pt.getTypeParameters().stream().filter(t -> t.isAssignableFrom(KAFKA_EXCEPTION_TYPE_MATCHER)).collect(Collectors.toSet());
+                                matching.forEach(typ -> maybeRemoveImport(typ.toString()));
+                                return matching.isEmpty();
+                            }
+                            else {
+                                return true;
+                            }
+                        }).toList();
+                        maybeRemoveImport("java.util.function.Function");
+                        maybeRemoveImport("org.apache.kafka.common.errors.RetriableException");
+                        maybeRemoveImport("org.apache.kafka.common.errors.ApiException");
+                        return ec.withInitializer(initializer.withArguments(safeArgs));
                     }
                 }
                 return ec;
@@ -69,42 +127,36 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
 
             @Override
             public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
-                J.VariableDeclarations vd = (J.VariableDeclarations) super.visitVariableDeclarations(multiVariable, ctx);
-                if (vd.getVariables().stream().anyMatch(v -> "builder".equals(v.getSimpleName()))) {
+                if (multiVariable.getVariables().stream().anyMatch(v -> REMOVED_FIELDS.contains(v.getSimpleName()))) {
                     return null; // Remove 'builder' field
                 }
-                return vd;
+                findVariableByName("message", multiVariable);
+
+                return (J.VariableDeclarations) super.visitVariableDeclarations(multiVariable, ctx);
+            }
+
+            @NonNull
+            private J.MethodDeclaration visitConstructorDeclaration(J.MethodDeclaration md) {
+                return constructorTemplate.apply(updateCursor(md), md.getCoordinates().replace());
             }
 
             @Override
-            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
-                J.MethodDeclaration md = (J.MethodDeclaration) super.visitMethodDeclaration(method, ctx);
-                String name = md.getSimpleName();
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration md, ExecutionContext ctx) {
+                if (md.isConstructor() && findParameterByName(md, "builder") != null) {
+                    return visitConstructorDeclaration(md);
+                }
 
                 // Remove exception factory methods
-                if ("exception".equals(name) || "forException".equals(name)) {
+                if (REMOVED_METHODS.contains(md.getSimpleName())) {
                     return null;
                 }
 
-                // Update constructor signature and body
-                if (md.isConstructor()) {
-                    List<Statement> newParams = md.getParameters().stream()
-                            .filter(p -> !(p instanceof J.VariableDeclarations vd &&
-                                    vd.getVariables().stream().anyMatch(v -> "builder".equals(v.getSimpleName()))))
-                            .collect(Collectors.toList());
-
-                    J.Block body = md.getBody();
-                    if (body != null) {
-                        List<Statement> newStatements = body.getStatements().stream()
-                                .filter(stmt -> !stmt.printTrimmed(getCursor()).contains("builder"))
-                                .collect(Collectors.toList());
-                        md = md.withBody(body.withStatements(newStatements));
-                    }
-
-                    return md.withParameters(newParams);
+                J.Block body = md.getBody();
+                if ("message".equals(md.getSimpleName()) && body != null && body.getStatements().size() > 1) {
+                    // TODO either need to make this idempotent or find a better test that we have seen it before
+                    return messageMethodBody.apply(updateCursor(md), md.getCoordinates().replaceBody());
                 }
-
-                return md;
+                return (J.MethodDeclaration) super.visitMethodDeclaration(md, ctx);
             }
 
             @Override
@@ -113,6 +165,50 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
                 doAfterVisit(new RemoveUnusedImports().getVisitor());
                 return c;
             }
+
+            @Override
+            @Nullable
+            public J visitIf(J.If ifSeq, ExecutionContext ctx) {
+                J.If i = (J.If) super.visitIf(ifSeq, ctx);
+
+                if (isClassToErrorIf(i)) {
+                    return null; // Deletes the if-statement from the parent block
+                }
+                return i;
+            }
+
+            private boolean isClassToErrorIf(J.If ifStmt) {
+                Statement body = ifStmt.getThenPart();
+                if (body instanceof J.Block block) {
+                    if (block.getStatements().isEmpty()) {
+                        return false;
+                    }
+                    body = block.getStatements().get(0);
+                }
+                if (body instanceof J.MethodInvocation mi) {
+                    Expression selectExpression = mi.getSelect();
+                    return selectExpression != null && selectExpression.toString().endsWith("CLASS_TO_ERROR") && "put".equals(mi.getSimpleName());
+                }
+                return false;
+            }
+
+            @Nullable
+            private static Statement findFieldByName(J.ClassDeclaration cd, String fieldName) {
+                return cd.getBody().getStatements().stream()
+                        .filter(s -> s instanceof J.VariableDeclarations vd && findVariableByName(fieldName, vd) != null).findFirst()
+                        .orElse(null);
+            }
+
+            private static J.VariableDeclarations.NamedVariable findVariableByName(String fieldName, J.VariableDeclarations vd) {
+                return vd.getVariables().stream().filter(v -> fieldName.equals(v.getSimpleName())).findFirst().orElse(null);
+            }
+
+            @Nullable
+            private J.VariableDeclarations.NamedVariable findParameterByName(J.MethodDeclaration md, String parameterName) {
+                return md.getParameters().stream().filter(J.VariableDeclarations.class::isInstance).map(J.VariableDeclarations.class::cast)
+                        .flatMap(vd -> vd.getVariables().stream()).filter(v -> parameterName.equals(v.getSimpleName())).findFirst().orElse(null);
+            }
         };
     }
+
 }

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -63,12 +63,13 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
         private final Set<String> REMOVED_FIELDS = Set.of("builder", "exception", "CLASS_TO_ERROR");
         private final Set<String> REMOVED_METHODS = Set.of("exception", "forException", "maybeThrow", "exceptionName", "main", "toHtml");
 
-        private final JavaTemplate messageFieldTemplate = JavaTemplate.builder("private final String message;").build();
+        private final JavaTemplate messageFieldTemplate = JavaTemplate.builder("private final String message;").contextSensitive().build();
 
-        private final JavaTemplate messageMethodBody = JavaTemplate.builder("return this.message;").build();
+        private final JavaTemplate messageMethodBody = JavaTemplate.builder("return this.message;").contextSensitive().build();
 
         private final JavaTemplate constructorTemplate = JavaTemplate.builder(
                         "Errors(int code, String defaultMessage) {\n" + "    this.code = (short) code;\n" + "    this.message = defaultMessage;\n" + "}")
+                .contextSensitive()
                 .build();
 
         @Override
@@ -86,9 +87,6 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
 
                 if (codeField != null) {
                     cd = messageFieldTemplate.apply(updateCursor(cd), codeField.getCoordinates().after());
-                }
-                else {
-                    cd = messageFieldTemplate.apply(updateCursor(cd), cd.getBody().getCoordinates().firstStatement());
                 }
             }
             return (J.ClassDeclaration) super.visitClassDeclaration(cd, ctx);
@@ -183,8 +181,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
 
         @Nullable
         private static Statement findFieldByName(J.ClassDeclaration cd, String fieldName) {
-            return cd.getBody().getStatements().stream()
-                    .filter(s -> s instanceof J.VariableDeclarations vd && findVariableByName(fieldName, vd) != null).findFirst()
+            return cd.getBody().getStatements().stream().filter(s -> s instanceof J.VariableDeclarations vd && findVariableByName(fieldName, vd) != null).findFirst()
                     .orElse(null);
         }
 
@@ -243,20 +240,34 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
 
             @Override
             public Javadoc visitDocComment(Javadoc.DocComment docComment, ExecutionContext ctx) {
-                Javadoc.DocComment dc = (Javadoc.DocComment) super.visitDocComment(docComment, ctx);
-                List<Javadoc> body = dc.getBody();
-                List<Javadoc> cleanedBody = new ArrayList<>();
+                Javadoc.DocComment originalComment = (Javadoc.DocComment) super.visitDocComment(docComment, ctx);
+                List<Javadoc> body = originalComment.getBody();
+                List<Javadoc> cleanedBody = pruneLineBreaks(body);
 
-                for (int i = 0; i < body.size(); i++) {
-                    Javadoc current = body.get(i);
-                    // Drop duplicate LineBreaks created when a tag between them is deleted
-                    if (current instanceof Javadoc.LineBreak && i + 1 < body.size() && body.get(i + 1) instanceof Javadoc.LineBreak) {
-                        continue;
-                    }
-                    cleanedBody.add(current);
+                if (cleanedBody.size() == body.size()) {
+                    return originalComment;
                 }
-                return dc.withBody(cleanedBody);
+                return originalComment.withBody(cleanedBody);
             }
+
+            @NonNull
+            private static List<Javadoc> pruneLineBreaks(List<Javadoc> body) {
+                List<Javadoc> cleanedBody = new ArrayList<>(body);
+
+                if (cleanedBody.getLast() instanceof Javadoc.Text text && text.getText().trim().isEmpty()) {
+                    cleanedBody.removeLast();
+                }
+                if (cleanedBody.getLast() instanceof Javadoc.LineBreak lastLine) {
+                    String margin = lastLine.getMargin();
+                    if (margin.contains("*")) {
+                        String newMargin = margin.substring(0, margin.indexOf('*'));
+                        cleanedBody.removeLast();
+                        cleanedBody.addLast(lastLine.withMargin(newMargin));
+                    }
+                }
+                return cleanedBody;
+            }
+
         }
     }
 }

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -11,11 +11,13 @@ import java.util.List;
 import java.util.Set;
 
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.RemoveUnusedImports;
+import org.openrewrite.java.search.FindTypes;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -51,168 +53,169 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
     @Override
     @NonNull
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new JavaVisitor<>() {
-
-            private final Set<String> REMOVED_FIELDS = Set.of("builder", "exception", "CLASS_TO_ERROR");
-            private final Set<String> REMOVED_METHODS = Set.of("exception", "forException", "maybeThrow", "exceptionName", "main", "toHtml");
-
-            private final JavaTemplate messageFieldTemplate = JavaTemplate.builder("private final String message;").contextSensitive().build();
-
-            private final JavaTemplate messageMethodBody = JavaTemplate.builder("return this.message;").contextSensitive().build();
-
-            private final JavaTemplate constructorTemplate = JavaTemplate.builder(
-                    "Errors(int code, String defaultMessage) {\n" + "    this.code = (short) code;\n" + "    this.message = defaultMessage;\n" + "}").contextSensitive()
-                    .build();
-
-            @Override
-            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDeclaration, ExecutionContext ctx) {
-                J.ClassDeclaration cd = classDeclaration;
-                Statement messageField = findFieldByName(classDeclaration, "message");
-                boolean hasMessageField = messageField != null;
-
-                if (!hasMessageField) {
-                    Statement codeField = findFieldByName(cd, "code");
-
-                    if (codeField != null) {
-                        cd = messageFieldTemplate.apply(updateCursor(cd), codeField.getCoordinates().after());
-                    }
-                    else {
-                        cd = messageFieldTemplate.apply(updateCursor(cd), cd.getBody().getCoordinates().firstStatement());
-                    }
-                }
-                return (J.ClassDeclaration) super.visitClassDeclaration(cd, ctx);
-            }
-
-            @Override
-            public J.EnumValue visitEnumValue(J.EnumValue enumConstant, ExecutionContext ctx) {
-                J.EnumValue ec = (J.EnumValue) super.visitEnumValue(enumConstant, ctx);
-                J.NewClass initializer = ec.getInitializer();
-                if (initializer == null) {
-                    return ec;
-                }
-
-                JavaType.Method constructorType = initializer.getConstructorType();
-                if (constructorType == null) {
-                    return ec;
-                }
-
-                return removeBuilderArg(constructorType, initializer, ec);
-            }
-
-            @Override
-            public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
-                if (multiVariable.getVariables().stream().anyMatch(v -> REMOVED_FIELDS.contains(v.getSimpleName()))) {
-                    return null; // Remove 'builder' field
-                }
-                findVariableByName("message", multiVariable);
-
-                return (J.VariableDeclarations) super.visitVariableDeclarations(multiVariable, ctx);
-            }
-
-            @NonNull
-            private J.MethodDeclaration visitConstructorDeclaration(J.MethodDeclaration md) {
-                return constructorTemplate.apply(updateCursor(md), md.getCoordinates().replace());
-            }
-
-            @Override
-            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDeclaration, ExecutionContext ctx) {
-                if (methodDeclaration.isConstructor() && findParameterByName(methodDeclaration, "builder") != null) {
-                    return visitConstructorDeclaration(methodDeclaration);
-                }
-
-                // Remove exception factory methods
-                if (REMOVED_METHODS.contains(methodDeclaration.getSimpleName())) {
-                    return null;
-                }
-
-                var md = (J.MethodDeclaration) super.visitMethodDeclaration(methodDeclaration, ctx);
-
-                J.Block body = md.getBody();
-                if ("message".equals(md.getSimpleName()) && body != null && body.getStatements().size() > 1) {
-                    // TODO either need to make this idempotent or find a better test that we have seen it before
-                    return messageMethodBody.apply(updateCursor(md), md.getCoordinates().replaceBody());
-                }
-                return md;
-            }
-
-            @Override
-            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
-                J.CompilationUnit c = (J.CompilationUnit) super.visitCompilationUnit(cu, ctx);
-                doAfterVisit(new RemoveUnusedImports().getVisitor());
-                return c;
-            }
-
-            @Override
-            @Nullable
-            public J visitIf(J.If ifSeq, ExecutionContext ctx) {
-                J.If i = (J.If) super.visitIf(ifSeq, ctx);
-
-                if (isClassToErrorIf(i)) {
-                    return null; // Deletes the if-statement from the parent block
-                }
-                return i;
-            }
-
-            private boolean isClassToErrorIf(J.If ifStmt) {
-                Statement body = ifStmt.getThenPart();
-                if (body instanceof J.Block block) {
-                    if (block.getStatements().isEmpty()) {
-                        return false;
-                    }
-                    body = block.getStatements().get(0);
-                }
-                if (body instanceof J.MethodInvocation mi) {
-                    Expression selectExpression = mi.getSelect();
-                    return selectExpression != null && selectExpression.toString().endsWith("CLASS_TO_ERROR") && "put".equals(mi.getSimpleName());
-                }
-                return false;
-            }
-
-            @Nullable
-            private static Statement findFieldByName(J.ClassDeclaration cd, String fieldName) {
-                return cd.getBody().getStatements().stream()
-                        .filter(s -> s instanceof J.VariableDeclarations vd && findVariableByName(fieldName, vd) != null).findFirst()
-                        .orElse(null);
-            }
-
-            private static J.VariableDeclarations.NamedVariable findVariableByName(String fieldName, J.VariableDeclarations vd) {
-                return vd.getVariables().stream().filter(v -> fieldName.equals(v.getSimpleName())).findFirst().orElse(null);
-            }
-
-            @Nullable
-            private J.VariableDeclarations.NamedVariable findParameterByName(J.MethodDeclaration md, String parameterName) {
-                return md.getParameters().stream().filter(J.VariableDeclarations.class::isInstance).map(J.VariableDeclarations.class::cast)
-                        .flatMap(vd -> vd.getVariables().stream()).filter(v -> parameterName.equals(v.getSimpleName())).findFirst().orElse(null);
-            }
-
-            @NonNull
-            private J.EnumValue removeBuilderArg(JavaType.Method constructorType, J.NewClass initializer, J.EnumValue enumValue) {
-                List<String> paramNames = constructorType.getParameterNames();
-                List<Expression> args = initializer.getArguments();
-                List<Expression> safeArgs = new ArrayList<>();
-
-                for (int i = 0; i < args.size(); i++) {
-                    Expression arg = args.get(i);
-                    String paramName = (i < paramNames.size()) ? paramNames.get(i) : "";
-
-                    if ("builder".equals(paramName)) {
-                        // Prune import for the referenced exception type in UnknownServerException::new
-                        if (arg instanceof J.MemberReference mr && mr.getContaining().getType() instanceof JavaType.FullyQualified fq) {
-                            maybeRemoveImport(fq.getFullyQualifiedName());
-                        }
-                        maybeRemoveImport("java.util.function.Function");
-                    }
-                    else {
-                        safeArgs.add(arg);
-                    }
-                }
-
-                if (safeArgs.size() != args.size()) {
-                    return enumValue.withInitializer(initializer.withArguments(safeArgs));
-                }
-                return enumValue;
-            }
-        };
+        return Preconditions.check(new FindTypes("org.apache.kafka.common.protocol.Errors", true), new ErrorsEnumVisitor());
     }
 
+    private static class ErrorsEnumVisitor extends JavaVisitor<ExecutionContext> {
+
+        private final Set<String> REMOVED_FIELDS = Set.of("builder", "exception", "CLASS_TO_ERROR");
+        private final Set<String> REMOVED_METHODS = Set.of("exception", "forException", "maybeThrow", "exceptionName", "main", "toHtml");
+
+        private final JavaTemplate messageFieldTemplate = JavaTemplate.builder("private final String message;").contextSensitive().build();
+
+        private final JavaTemplate messageMethodBody = JavaTemplate.builder("return this.message;").contextSensitive().build();
+
+        private final JavaTemplate constructorTemplate = JavaTemplate.builder(
+                        "Errors(int code, String defaultMessage) {\n" + "    this.code = (short) code;\n" + "    this.message = defaultMessage;\n" + "}").contextSensitive()
+                .build();
+
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDeclaration, ExecutionContext ctx) {
+            J.ClassDeclaration cd = classDeclaration;
+            Statement messageField = findFieldByName(classDeclaration, "message");
+            boolean hasMessageField = messageField != null;
+
+            if (!hasMessageField) {
+                Statement codeField = findFieldByName(cd, "code");
+
+                if (codeField != null) {
+                    cd = messageFieldTemplate.apply(updateCursor(cd), codeField.getCoordinates().after());
+                }
+                else {
+                    cd = messageFieldTemplate.apply(updateCursor(cd), cd.getBody().getCoordinates().firstStatement());
+                }
+            }
+            return (J.ClassDeclaration) super.visitClassDeclaration(cd, ctx);
+        }
+
+        @Override
+        public J.EnumValue visitEnumValue(J.EnumValue enumConstant, ExecutionContext ctx) {
+            J.EnumValue ec = (J.EnumValue) super.visitEnumValue(enumConstant, ctx);
+            J.NewClass initializer = ec.getInitializer();
+            if (initializer == null) {
+                return ec;
+            }
+
+            JavaType.Method constructorType = initializer.getConstructorType();
+            if (constructorType == null) {
+                return ec;
+            }
+
+            return removeBuilderArg(constructorType, initializer, ec);
+        }
+
+        @Override
+        public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+            if (multiVariable.getVariables().stream().anyMatch(v -> REMOVED_FIELDS.contains(v.getSimpleName()))) {
+                return null; // Remove 'builder' field
+            }
+            findVariableByName("message", multiVariable);
+
+            return (J.VariableDeclarations) super.visitVariableDeclarations(multiVariable, ctx);
+        }
+
+        @NonNull
+        private J.MethodDeclaration visitConstructorDeclaration(J.MethodDeclaration md) {
+            return constructorTemplate.apply(updateCursor(md), md.getCoordinates().replace());
+        }
+
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDeclaration, ExecutionContext ctx) {
+            if (methodDeclaration.isConstructor() && findParameterByName(methodDeclaration, "builder") != null) {
+                return visitConstructorDeclaration(methodDeclaration);
+            }
+
+            // Remove exception factory methods
+            if (REMOVED_METHODS.contains(methodDeclaration.getSimpleName())) {
+                return null;
+            }
+
+            var md = (J.MethodDeclaration) super.visitMethodDeclaration(methodDeclaration, ctx);
+
+            J.Block body = md.getBody();
+            if ("message".equals(md.getSimpleName()) && body != null && body.getStatements().size() > 1) {
+                // TODO either need to make this idempotent or find a better test that we have seen it before
+                return messageMethodBody.apply(updateCursor(md), md.getCoordinates().replaceBody());
+            }
+            return md;
+        }
+
+        @Override
+        public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+            J.CompilationUnit c = (J.CompilationUnit) super.visitCompilationUnit(cu, ctx);
+            doAfterVisit(new RemoveUnusedImports().getVisitor());
+            return c;
+        }
+
+        @Override
+        @Nullable
+        public J visitIf(J.If ifSeq, ExecutionContext ctx) {
+            J.If i = (J.If) super.visitIf(ifSeq, ctx);
+
+            if (isClassToErrorIf(i)) {
+                return null; // Deletes the if-statement from the parent block
+            }
+            return i;
+        }
+
+        private boolean isClassToErrorIf(J.If ifStmt) {
+            Statement body = ifStmt.getThenPart();
+            if (body instanceof J.Block block) {
+                if (block.getStatements().isEmpty()) {
+                    return false;
+                }
+                body = block.getStatements().get(0);
+            }
+            if (body instanceof J.MethodInvocation mi) {
+                Expression selectExpression = mi.getSelect();
+                return selectExpression != null && selectExpression.toString().endsWith("CLASS_TO_ERROR") && "put".equals(mi.getSimpleName());
+            }
+            return false;
+        }
+
+        @Nullable
+        private static Statement findFieldByName(J.ClassDeclaration cd, String fieldName) {
+            return cd.getBody().getStatements().stream()
+                    .filter(s -> s instanceof J.VariableDeclarations vd && findVariableByName(fieldName, vd) != null).findFirst()
+                    .orElse(null);
+        }
+
+        private static J.VariableDeclarations.NamedVariable findVariableByName(String fieldName, J.VariableDeclarations vd) {
+            return vd.getVariables().stream().filter(v -> fieldName.equals(v.getSimpleName())).findFirst().orElse(null);
+        }
+
+        @Nullable
+        private J.VariableDeclarations.NamedVariable findParameterByName(J.MethodDeclaration md, String parameterName) {
+            return md.getParameters().stream().filter(J.VariableDeclarations.class::isInstance).map(J.VariableDeclarations.class::cast)
+                    .flatMap(vd -> vd.getVariables().stream()).filter(v -> parameterName.equals(v.getSimpleName())).findFirst().orElse(null);
+        }
+
+        @NonNull
+        private J.EnumValue removeBuilderArg(JavaType.Method constructorType, J.NewClass initializer, J.EnumValue enumValue) {
+            List<String> paramNames = constructorType.getParameterNames();
+            List<Expression> args = initializer.getArguments();
+            List<Expression> safeArgs = new ArrayList<>();
+
+            for (int i = 0; i < args.size(); i++) {
+                Expression arg = args.get(i);
+                String paramName = (i < paramNames.size()) ? paramNames.get(i) : "";
+
+                if ("builder".equals(paramName)) {
+                    // Prune import for the referenced exception type in UnknownServerException::new
+                    if (arg instanceof J.MemberReference mr && mr.getContaining().getType() instanceof JavaType.FullyQualified fq) {
+                        maybeRemoveImport(fq.getFullyQualifiedName());
+                    }
+                    maybeRemoveImport("java.util.function.Function");
+                }
+                else {
+                    safeArgs.add(arg);
+                }
+            }
+
+            if (safeArgs.size() != args.size()) {
+                return enumValue.withInitializer(initializer.withArguments(safeArgs));
+            }
+            return enumValue;
+        }
+    }
 }

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -68,7 +68,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
         private final JavaTemplate messageMethodBody = JavaTemplate.builder("return this.message;").contextSensitive().build();
 
         private final JavaTemplate constructorTemplate = JavaTemplate.builder(
-                        "Errors(int code, String defaultMessage) {\n" + "    this.code = (short) code;\n" + "    this.message = defaultMessage;\n" + "}")
+                "Errors(int code, String defaultMessage) {\n" + "    this.code = (short) code;\n" + "    this.message = defaultMessage;\n" + "}")
                 .contextSensitive()
                 .build();
 
@@ -137,8 +137,9 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
 
             var md = (J.MethodDeclaration) super.visitMethodDeclaration(methodDeclaration, ctx);
 
-            if ("message".equals(md.getSimpleName()) && md.getBody() != null) {
-                String currentBody = md.getBody().printTrimmed(getCursor());
+            J.Block body = md.getBody();
+            if ("message".equals(md.getSimpleName()) && body != null) {
+                String currentBody = body.printTrimmed(getCursor());
                 if (!currentBody.contains("this.message")) {
                     return messageMethodBody.apply(updateCursor(md), md.getCoordinates().replaceBody());
                 }

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -6,9 +6,9 @@
 
 package io.kroxylicious.vendoring.rewrite;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
@@ -16,7 +16,6 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.RemoveUnusedImports;
-import org.openrewrite.java.TypeNameMatcher;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -29,9 +28,6 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * Applies the required edits to Apache Kafka's hand rolled Errors enum to make it part of the Kroxylicious API
  */
 public class PruneKafkaErrorsEnumRecipe extends Recipe {
-
-    private static final TypeNameMatcher FUNCTION_TYPE_MATCHER = TypeNameMatcher.fromPattern("java.util.function.Function");
-    private static final TypeNameMatcher KAFKA_EXCEPTION_TYPE_MATCHER = TypeNameMatcher.fromPattern("org.apache.kafka.common.errors.*Exception");
 
     /**
      * Create an instance of the recipe.
@@ -91,38 +87,16 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
             public J.EnumValue visitEnumValue(J.EnumValue enumConstant, ExecutionContext ctx) {
                 J.EnumValue ec = (J.EnumValue) super.visitEnumValue(enumConstant, ctx);
                 J.NewClass initializer = ec.getInitializer();
-                if (initializer != null) {
-                    List<Expression> arguments = initializer.getArguments();
-                    if (arguments.size() == 3) {
-                        List<Expression> safeArgs = arguments.stream().filter(expression -> {
-                            JavaType type = expression.getType();
-                            if (expression instanceof J.MemberReference memberReference) {
-                                var method = memberReference.getMethodType();
-                                if (method != null) {
-                                    JavaType.FullyQualified declaringType = method.getDeclaringType();
-                                    if (declaringType.isAssignableFrom(KAFKA_EXCEPTION_TYPE_MATCHER)) {
-                                        maybeRemoveImport(declaringType);
-                                        return false;
-                                    }
-                                }
-                            }
-                            if (type != null && type.isAssignableFrom(FUNCTION_TYPE_MATCHER)) {
-                                var pt = (JavaType.Parameterized) type;
-                                var matching = pt.getTypeParameters().stream().filter(t -> t.isAssignableFrom(KAFKA_EXCEPTION_TYPE_MATCHER)).collect(Collectors.toSet());
-                                matching.forEach(typ -> maybeRemoveImport(typ.toString()));
-                                return matching.isEmpty();
-                            }
-                            else {
-                                return true;
-                            }
-                        }).toList();
-                        maybeRemoveImport("java.util.function.Function");
-                        maybeRemoveImport("org.apache.kafka.common.errors.RetriableException");
-                        maybeRemoveImport("org.apache.kafka.common.errors.ApiException");
-                        return ec.withInitializer(initializer.withArguments(safeArgs));
-                    }
+                if (initializer == null) {
+                    return ec;
                 }
-                return ec;
+
+                JavaType.Method constructorType = initializer.getConstructorType();
+                if (constructorType == null) {
+                    return ec;
+                }
+
+                return removeBuilderArg(constructorType, initializer, ec);
             }
 
             @Override
@@ -141,22 +115,24 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
             }
 
             @Override
-            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration md, ExecutionContext ctx) {
-                if (md.isConstructor() && findParameterByName(md, "builder") != null) {
-                    return visitConstructorDeclaration(md);
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDeclaration, ExecutionContext ctx) {
+                if (methodDeclaration.isConstructor() && findParameterByName(methodDeclaration, "builder") != null) {
+                    return visitConstructorDeclaration(methodDeclaration);
                 }
 
                 // Remove exception factory methods
-                if (REMOVED_METHODS.contains(md.getSimpleName())) {
+                if (REMOVED_METHODS.contains(methodDeclaration.getSimpleName())) {
                     return null;
                 }
+
+                var md = (J.MethodDeclaration) super.visitMethodDeclaration(methodDeclaration, ctx);
 
                 J.Block body = md.getBody();
                 if ("message".equals(md.getSimpleName()) && body != null && body.getStatements().size() > 1) {
                     // TODO either need to make this idempotent or find a better test that we have seen it before
                     return messageMethodBody.apply(updateCursor(md), md.getCoordinates().replaceBody());
                 }
-                return (J.MethodDeclaration) super.visitMethodDeclaration(md, ctx);
+                return md;
             }
 
             @Override
@@ -207,6 +183,34 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
             private J.VariableDeclarations.NamedVariable findParameterByName(J.MethodDeclaration md, String parameterName) {
                 return md.getParameters().stream().filter(J.VariableDeclarations.class::isInstance).map(J.VariableDeclarations.class::cast)
                         .flatMap(vd -> vd.getVariables().stream()).filter(v -> parameterName.equals(v.getSimpleName())).findFirst().orElse(null);
+            }
+
+            @NonNull
+            private J.EnumValue removeBuilderArg(JavaType.Method constructorType, J.NewClass initializer, J.EnumValue enumValue) {
+                List<String> paramNames = constructorType.getParameterNames();
+                List<Expression> args = initializer.getArguments();
+                List<Expression> safeArgs = new ArrayList<>();
+
+                for (int i = 0; i < args.size(); i++) {
+                    Expression arg = args.get(i);
+                    String paramName = (i < paramNames.size()) ? paramNames.get(i) : "";
+
+                    if ("builder".equals(paramName)) {
+                        // Prune import for the referenced exception type in UnknownServerException::new
+                        if (arg instanceof J.MemberReference mr && mr.getContaining().getType() instanceof JavaType.FullyQualified fq) {
+                            maybeRemoveImport(fq.getFullyQualifiedName());
+                        }
+                        maybeRemoveImport("java.util.function.Function");
+                    }
+                    else {
+                        safeArgs.add(arg);
+                    }
+                }
+
+                if (safeArgs.size() != args.size()) {
+                    return enumValue.withInitializer(initializer.withArguments(safeArgs));
+                }
+                return enumValue;
             }
         };
     }

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -11,16 +11,18 @@ import java.util.List;
 import java.util.Set;
 
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.FindSourceFiles;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.JavadocVisitor;
 import org.openrewrite.java.RemoveUnusedImports;
-import org.openrewrite.java.search.FindTypes;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Javadoc;
 import org.openrewrite.java.tree.Statement;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -53,7 +55,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
     @Override
     @NonNull
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new FindTypes("org.apache.kafka.common.protocol.Errors", true), new ErrorsEnumVisitor());
+        return Preconditions.check(new FindSourceFiles("**/Errors.java"), new ErrorsEnumVisitor());
     }
 
     private static class ErrorsEnumVisitor extends JavaVisitor<ExecutionContext> {
@@ -61,19 +63,23 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
         private final Set<String> REMOVED_FIELDS = Set.of("builder", "exception", "CLASS_TO_ERROR");
         private final Set<String> REMOVED_METHODS = Set.of("exception", "forException", "maybeThrow", "exceptionName", "main", "toHtml");
 
-        private final JavaTemplate messageFieldTemplate = JavaTemplate.builder("private final String message;").contextSensitive().build();
+        private final JavaTemplate messageFieldTemplate = JavaTemplate.builder("private final String message;").build();
 
-        private final JavaTemplate messageMethodBody = JavaTemplate.builder("return this.message;").contextSensitive().build();
+        private final JavaTemplate messageMethodBody = JavaTemplate.builder("return this.message;").build();
 
         private final JavaTemplate constructorTemplate = JavaTemplate.builder(
-                        "Errors(int code, String defaultMessage) {\n" + "    this.code = (short) code;\n" + "    this.message = defaultMessage;\n" + "}").contextSensitive()
+                        "Errors(int code, String defaultMessage) {\n" + "    this.code = (short) code;\n" + "    this.message = defaultMessage;\n" + "}")
                 .build();
+
+        @Override
+        protected JavadocVisitor<ExecutionContext> getJavadocVisitor() {
+            return new PruneJavadocVisitor();
+        }
 
         @Override
         public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDeclaration, ExecutionContext ctx) {
             J.ClassDeclaration cd = classDeclaration;
-            Statement messageField = findFieldByName(classDeclaration, "message");
-            boolean hasMessageField = messageField != null;
+            boolean hasMessageField = findFieldByName(classDeclaration, "message") != null;
 
             if (!hasMessageField) {
                 Statement codeField = findFieldByName(cd, "code");
@@ -121,21 +127,23 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
 
         @Override
         public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDeclaration, ExecutionContext ctx) {
-            if (methodDeclaration.isConstructor() && findParameterByName(methodDeclaration, "builder") != null) {
-                return visitConstructorDeclaration(methodDeclaration);
-            }
 
             // Remove exception factory methods
             if (REMOVED_METHODS.contains(methodDeclaration.getSimpleName())) {
                 return null;
             }
 
+            if (methodDeclaration.isConstructor() && findParameterByName(methodDeclaration, "builder") != null) {
+                return visitConstructorDeclaration(methodDeclaration);
+            }
+
             var md = (J.MethodDeclaration) super.visitMethodDeclaration(methodDeclaration, ctx);
 
-            J.Block body = md.getBody();
-            if ("message".equals(md.getSimpleName()) && body != null && body.getStatements().size() > 1) {
-                // TODO either need to make this idempotent or find a better test that we have seen it before
-                return messageMethodBody.apply(updateCursor(md), md.getCoordinates().replaceBody());
+            if ("message".equals(md.getSimpleName()) && md.getBody() != null) {
+                String currentBody = md.getBody().printTrimmed(getCursor());
+                if (!currentBody.contains("this.message")) {
+                    return messageMethodBody.apply(updateCursor(md), md.getCoordinates().replaceBody());
+                }
             }
             return md;
         }
@@ -195,27 +203,60 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
             List<String> paramNames = constructorType.getParameterNames();
             List<Expression> args = initializer.getArguments();
             List<Expression> safeArgs = new ArrayList<>();
+            if (paramNames.contains("builder")) {
+                for (int i = 0; i < args.size(); i++) {
+                    Expression arg = args.get(i);
+                    String paramName = (i < paramNames.size()) ? paramNames.get(i) : "";
 
-            for (int i = 0; i < args.size(); i++) {
-                Expression arg = args.get(i);
-                String paramName = (i < paramNames.size()) ? paramNames.get(i) : "";
-
-                if ("builder".equals(paramName)) {
-                    // Prune import for the referenced exception type in UnknownServerException::new
-                    if (arg instanceof J.MemberReference mr && mr.getContaining().getType() instanceof JavaType.FullyQualified fq) {
-                        maybeRemoveImport(fq.getFullyQualifiedName());
+                    if ("builder".equals(paramName)) {
+                        // Prune import for the referenced exception type in UnknownServerException::new
+                        if (arg instanceof J.MemberReference mr && mr.getContaining().getType() instanceof JavaType.FullyQualified fq) {
+                            maybeRemoveImport(fq.getFullyQualifiedName());
+                        }
+                        maybeRemoveImport("java.util.function.Function");
                     }
-                    maybeRemoveImport("java.util.function.Function");
+                    else {
+                        safeArgs.add(arg);
+                    }
                 }
-                else {
-                    safeArgs.add(arg);
-                }
-            }
 
-            if (safeArgs.size() != args.size()) {
-                return enumValue.withInitializer(initializer.withArguments(safeArgs));
+                if (safeArgs.size() != args.size()) {
+                    return enumValue.withInitializer(initializer.withArguments(safeArgs));
+                }
             }
             return enumValue;
+        }
+
+        private class PruneJavadocVisitor extends JavadocVisitor<ExecutionContext> {
+            PruneJavadocVisitor() {
+                super(ErrorsEnumVisitor.this);
+            }
+
+            @Override
+            public Javadoc visitSee(Javadoc.See see, ExecutionContext ctx) {
+                // Check if the @see reference targets SslTransportLayer
+                if (see.printTrimmed(getCursor()).contains("SslTransportLayer")) {
+                    return null; // Safely deletes the @see tag node from the Javadoc AST
+                }
+                return super.visitSee(see, ctx);
+            }
+
+            @Override
+            public Javadoc visitDocComment(Javadoc.DocComment docComment, ExecutionContext ctx) {
+                Javadoc.DocComment dc = (Javadoc.DocComment) super.visitDocComment(docComment, ctx);
+                List<Javadoc> body = dc.getBody();
+                List<Javadoc> cleanedBody = new ArrayList<>();
+
+                for (int i = 0; i < body.size(); i++) {
+                    Javadoc current = body.get(i);
+                    // Drop duplicate LineBreaks created when a tag between them is deleted
+                    if (current instanceof Javadoc.LineBreak && i + 1 < body.size() && body.get(i + 1) instanceof Javadoc.LineBreak) {
+                        continue;
+                    }
+                    cleanedBody.add(current);
+                }
+                return dc.withBody(cleanedBody);
+            }
         }
     }
 }

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import org.jspecify.annotations.NullMarked;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.FindSourceFiles;
 import org.openrewrite.Preconditions;
@@ -88,6 +89,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
         }
 
         @Override
+        @NullMarked
         public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDeclaration, ExecutionContext ctx) {
             J.ClassDeclaration cd = classDeclaration;
             boolean hasMessageField = findFieldByName(cd, "message") != null;
@@ -104,7 +106,8 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
         }
 
         @Override
-        public J.EnumValue visitEnumValue(J.EnumValue enumConstant, ExecutionContext ctx) {
+        @NonNull
+        public J.EnumValue visitEnumValue(@NonNull J.EnumValue enumConstant, @NonNull ExecutionContext ctx) {
             J.EnumValue ec = (J.EnumValue) super.visitEnumValue(enumConstant, ctx);
             J.NewClass initializer = ec.getInitializer();
             if (initializer == null) {
@@ -120,7 +123,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
         }
 
         @Override
-        public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+        public @Nullable J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, @NonNull ExecutionContext ctx) {
             if (multiVariable.getVariables().stream().anyMatch(v -> REMOVED_FIELDS.contains(v.getSimpleName()))) {
                 return null; // Remove 'builder' field
             }
@@ -133,7 +136,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
         }
 
         @Override
-        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDeclaration, ExecutionContext ctx) {
+        public @Nullable J.MethodDeclaration visitMethodDeclaration(@NonNull J.MethodDeclaration methodDeclaration, @NonNull ExecutionContext ctx) {
 
             // Remove exception factory methods
             if (REMOVED_METHODS.contains(methodDeclaration.getSimpleName())) {
@@ -157,15 +160,15 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
         }
 
         @Override
-        public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+        @NonNull
+        public J.CompilationUnit visitCompilationUnit(@NonNull J.CompilationUnit cu, @NonNull ExecutionContext ctx) {
             J.CompilationUnit c = (J.CompilationUnit) super.visitCompilationUnit(cu, ctx);
             doAfterVisit(new RemoveUnusedImports().getVisitor());
             return c;
         }
 
         @Override
-        @Nullable
-        public J visitIf(J.If ifSeq, ExecutionContext ctx) {
+        public @Nullable J visitIf(@NonNull J.If ifSeq, @NonNull ExecutionContext ctx) {
             J.If i = (J.If) super.visitIf(ifSeq, ctx);
 
             if (isClassToErrorIf(i)) {
@@ -180,7 +183,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
                 if (block.getStatements().isEmpty()) {
                     return false;
                 }
-                body = block.getStatements().get(0);
+                body = block.getStatements().getFirst();
             }
             if (body instanceof J.MethodInvocation mi) {
                 Expression selectExpression = mi.getSelect();
@@ -243,7 +246,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
             }
 
             @Override
-            public Javadoc visitSee(Javadoc.See see, ExecutionContext ctx) {
+            public @Nullable Javadoc visitSee(@NonNull Javadoc.See see, @NonNull ExecutionContext ctx) {
                 // Check if the @see reference targets SslTransportLayer
                 if (see.printTrimmed(getCursor()).contains("SslTransportLayer")) {
                     return null; // Safely deletes the @see tag node from the Javadoc AST
@@ -252,7 +255,8 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
             }
 
             @Override
-            public Javadoc visitDocComment(Javadoc.DocComment docComment, ExecutionContext ctx) {
+            @NonNull
+            public Javadoc visitDocComment(@NonNull Javadoc.DocComment docComment, @NonNull ExecutionContext ctx) {
                 Javadoc.DocComment originalComment = (Javadoc.DocComment) super.visitDocComment(docComment, ctx);
                 List<Javadoc> body = originalComment.getBody();
                 List<Javadoc> cleanedBody = pruneLineBreaks(body);

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -79,11 +79,11 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
                 """).contextSensitive().build();
 
         private final JavaTemplate constructorTemplate = JavaTemplate.builder(
-                """
-                        Errors(int code, String message) {
-                            this.code = (short) code;
-                            this.message = message;
-                        }""")
+                        """
+                                Errors(int code, String message) {
+                                    this.code = (short) code;
+                                    this.message = message;
+                                }""")
                 .contextSensitive()
                 .build();
 
@@ -184,12 +184,6 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
 
         private boolean isClassToErrorIf(J.If ifStmt) {
             Statement body = ifStmt.getThenPart();
-            if (body instanceof J.Block block) {
-                if (block.getStatements().isEmpty()) {
-                    return false;
-                }
-                body = block.getStatements().getFirst();
-            }
             if (body instanceof J.MethodInvocation mi) {
                 Expression selectExpression = mi.getSelect();
                 return selectExpression != null && selectExpression.toString().endsWith("CLASS_TO_ERROR") && "put".equals(mi.getSimpleName());

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -259,15 +259,16 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
                 Javadoc.DocComment originalComment = (Javadoc.DocComment) super.visitDocComment(docComment, ctx);
                 List<Javadoc> body = originalComment.getBody();
                 J host = getCursor().firstEnclosing(J.class);
+                String margin = extractMargin(body);
 
                 if (host instanceof J.MethodDeclaration method && method.getSimpleName().equals("forCode")) {
                     if (docComment.print(getCursor()).contains(EXCEPTION)) {
-                        List<Javadoc> newBody = buildReplacementForCodeComment(docComment, method, body);
+                        List<Javadoc> newBody = buildReplacementForCodeComment(docComment, method, margin);
                         return originalComment.withBody(newBody);
                     }
                 }
                 else if (host instanceof J.ClassDeclaration) {
-                    List<Javadoc> cleanedBody = pruneLineBreaks(body);
+                    List<Javadoc> cleanedBody = trailingLineBreaks(body, margin);
 
                     if (cleanedBody.size() == body.size()) {
                         return originalComment;
@@ -279,8 +280,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
             }
 
             @NonNull
-            private List<Javadoc> buildReplacementForCodeComment(@NonNull Javadoc.DocComment docComment, J.MethodDeclaration method, List<Javadoc> body) {
-                String margin = extractMargin(body);
+            private List<Javadoc> buildReplacementForCodeComment(@NonNull Javadoc.DocComment docComment, J.MethodDeclaration method, String margin) {
                 J.Identifier codeParamName = findParameterNamed(method, "code");
                 Markers markers = existingMarkers(docComment);
                 Javadoc.Text returnText = new Javadoc.Text(Tree.randomId(), Markers.EMPTY,
@@ -294,7 +294,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
                         new Javadoc.LineBreak(Tree.randomId(), margin + " ", Markers.EMPTY),
                         new Javadoc.Return(Tree.randomId(), Markers.EMPTY, List.of(returnText)),
                         new Javadoc.LineBreak(Tree.randomId(), margin, Markers.EMPTY),
-                        new Javadoc.LineBreak(Tree.randomId(), margin.substring(0, margin.lastIndexOf('*')), Markers.EMPTY));
+                        newTerminalLineBreak(margin));
             }
 
             @NonNull
@@ -313,22 +313,32 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
             }
 
             @NonNull
-            private static List<Javadoc> pruneLineBreaks(List<Javadoc> body) {
-                List<Javadoc> cleanedBody = new ArrayList<>(body);
-                if (body.isEmpty()) {
-                    return body;
+            private static List<Javadoc> trailingLineBreaks(List<Javadoc> elements, String margin) {
+                if (elements.isEmpty()) {
+                    return elements;
                 }
-                if (cleanedBody.getLast() instanceof Javadoc.Text text && text.getText().trim().isEmpty()) {
-                    cleanedBody.removeLast();
-                }
-                if (cleanedBody.getLast() instanceof Javadoc.LineBreak lastLine) {
-                    String margin = lastLine.getMargin();
-                    if (margin.endsWith("*")) {
-                        cleanedBody.removeLast();
-                        cleanedBody.addLast(lastLine.withMargin(margin.substring(0, margin.lastIndexOf('*'))));
+
+                int end = elements.size() - 1;
+                while (end >= 0) {
+                    Javadoc item = elements.get(end);
+                    if (item instanceof Javadoc.LineBreak) {
+                        end--;
+                    }
+                    else if (item instanceof Javadoc.Text textItem && textItem.getText().trim().isEmpty()) {
+                        end--;
+                    }
+                    else {
+                        break;
                     }
                 }
-                return cleanedBody;
+                ArrayList<Javadoc> cleaned = new ArrayList<>(elements.subList(0, end + 1));
+                cleaned.addLast(newTerminalLineBreak(margin));
+                return cleaned;
+            }
+
+            @NonNull
+            private static Javadoc.LineBreak newTerminalLineBreak(String margin) {
+                return new Javadoc.LineBreak(Tree.randomId(), margin.substring(0, margin.lastIndexOf('*')), Markers.EMPTY);
             }
 
         }

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -33,7 +33,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
- * Applies the required edits to Apache Kafka's hand rolled Errors enum to make it part of the Kroxylicious API
+ * Strips client exception builders, fields, methods, and imports from Kafka Errors enum.to Apache Kafka's hand rolled Errors enum to make it part of the Kroxylicious API
  */
 public class PruneKafkaErrorsEnumRecipe extends Recipe {
 
@@ -268,7 +268,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
 
                 if (host instanceof J.MethodDeclaration method && method.getSimpleName().equals("forCode")) {
                     if (docComment.print(getCursor()).contains(EXCEPTION)) {
-                        List<Javadoc> newBody = buildReplacmentForCodeComment(docComment, method, body);
+                        List<Javadoc> newBody = buildReplacementForCodeComment(docComment, method, body);
                         return originalComment.withBody(newBody);
                     }
                 }
@@ -285,7 +285,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
             }
 
             @NonNull
-            private List<Javadoc> buildReplacmentForCodeComment(@NonNull Javadoc.DocComment docComment, J.MethodDeclaration method, List<Javadoc> body) {
+            private List<Javadoc> buildReplacementForCodeComment(@NonNull Javadoc.DocComment docComment, J.MethodDeclaration method, List<Javadoc> body) {
                 String margin = extractMargin(body);
                 J.Identifier codeParamName = findParameterNamed(method, "code");
                 Markers markers = existingMarkers(docComment);

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -79,11 +79,11 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
                 """).contextSensitive().build();
 
         private final JavaTemplate constructorTemplate = JavaTemplate.builder(
-                """
-                        Errors(int code, String message) {
-                            this.code = (short) code;
-                            this.message = message;
-                        }""")
+                        """
+                                Errors(int code, String message) {
+                                    this.code = (short) code;
+                                    this.message = message;
+                                }""")
                 .contextSensitive()
                 .build();
 
@@ -321,16 +321,17 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
             @NonNull
             private static List<Javadoc> pruneLineBreaks(List<Javadoc> body) {
                 List<Javadoc> cleanedBody = new ArrayList<>(body);
-
+                if (body.isEmpty()) {
+                    return body;
+                }
                 if (cleanedBody.getLast() instanceof Javadoc.Text text && text.getText().trim().isEmpty()) {
                     cleanedBody.removeLast();
                 }
                 if (cleanedBody.getLast() instanceof Javadoc.LineBreak lastLine) {
                     String margin = lastLine.getMargin();
-                    if (margin.contains("*")) {
-                        String newMargin = margin.substring(0, margin.indexOf('*'));
+                    if (margin.endsWith("*")) {
                         cleanedBody.removeLast();
-                        cleanedBody.addLast(lastLine.withMargin(newMargin));
+                        cleanedBody.addLast(lastLine.withMargin(margin.substring(0, margin.lastIndexOf('*'))));
                     }
                 }
                 return cleanedBody;

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -15,6 +15,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.FindSourceFiles;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
@@ -24,7 +25,9 @@ import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Javadoc;
+import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
+import org.openrewrite.marker.Markers;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -61,8 +64,10 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
 
     private static class ErrorsEnumVisitor extends JavaVisitor<ExecutionContext> {
 
-        private final Set<String> REMOVED_FIELDS = Set.of("builder", "exception", "CLASS_TO_ERROR");
-        private final Set<String> REMOVED_METHODS = Set.of("exception", "forException", "maybeThrow", "exceptionName", "main", "toHtml", "maybeUnwrapException");
+        private static final String BUILDER_METHOD_NAME = "builder";
+        private static final String EXCEPTION = "exception";
+        private static final Set<String> REMOVED_FIELDS = Set.of(BUILDER_METHOD_NAME, EXCEPTION, "CLASS_TO_ERROR");
+        private static final Set<String> REMOVED_METHODS = Set.of(EXCEPTION, "forException", "maybeThrow", "exceptionName", "main", "toHtml", "maybeUnwrapException");
 
         private final JavaTemplate messageFieldTemplate = JavaTemplate.builder("private final String message;").contextSensitive().build();
 
@@ -152,7 +157,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
             J.Block body = md.getBody();
             if ("message".equals(md.getSimpleName()) && body != null) {
                 String currentBody = body.printTrimmed(getCursor());
-                if (currentBody.contains("exception")) {
+                if (currentBody.contains(EXCEPTION)) {
                     return messageMethodBody.apply(updateCursor(md), md.getCoordinates().replaceBody());
                 }
             }
@@ -208,7 +213,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
                     .filter(J.VariableDeclarations.class::isInstance)
                     .map(J.VariableDeclarations.class::cast)
                     .flatMap(vd -> vd.getVariables().stream())
-                    .anyMatch(v -> "builder".equals(v.getSimpleName()));
+                    .anyMatch(v -> BUILDER_METHOD_NAME.equals(v.getSimpleName()));
         }
 
         @NonNull
@@ -216,12 +221,12 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
             List<String> paramNames = constructorType.getParameterNames();
             List<Expression> args = initializer.getArguments();
             List<Expression> safeArgs = new ArrayList<>();
-            if (paramNames.contains("builder")) {
+            if (paramNames.contains(BUILDER_METHOD_NAME)) {
                 for (int i = 0; i < args.size(); i++) {
                     Expression arg = args.get(i);
                     String paramName = (i < paramNames.size()) ? paramNames.get(i) : "";
 
-                    if ("builder".equals(paramName)) {
+                    if (BUILDER_METHOD_NAME.equals(paramName)) {
                         // Prune import for the referenced exception type in UnknownServerException::new
                         if (arg instanceof J.MemberReference mr && mr.getContaining().getType() instanceof JavaType.FullyQualified fq) {
                             maybeRemoveImport(fq.getFullyQualifiedName());
@@ -259,12 +264,59 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
             public Javadoc visitDocComment(@NonNull Javadoc.DocComment docComment, @NonNull ExecutionContext ctx) {
                 Javadoc.DocComment originalComment = (Javadoc.DocComment) super.visitDocComment(docComment, ctx);
                 List<Javadoc> body = originalComment.getBody();
-                List<Javadoc> cleanedBody = pruneLineBreaks(body);
+                J host = getCursor().firstEnclosing(J.class);
 
-                if (cleanedBody.size() == body.size()) {
-                    return originalComment;
+                if (host instanceof J.MethodDeclaration method && method.getSimpleName().equals("forCode")) {
+                    if (docComment.print(getCursor()).contains(EXCEPTION)) {
+                        List<Javadoc> newBody = buildReplacmentForCodeComment(docComment, method, body);
+                        return originalComment.withBody(newBody);
+                    }
                 }
-                return originalComment.withBody(cleanedBody);
+                else if (host instanceof J.ClassDeclaration) {
+                    List<Javadoc> cleanedBody = pruneLineBreaks(body);
+
+                    if (cleanedBody.size() == body.size()) {
+                        return originalComment;
+                    }
+                    return originalComment.withBody(cleanedBody);
+
+                }
+                return docComment;
+            }
+
+            @NonNull
+            private List<Javadoc> buildReplacmentForCodeComment(@NonNull Javadoc.DocComment docComment, J.MethodDeclaration method, List<Javadoc> body) {
+                String margin = extractMargin(body);
+                J.Identifier codeParamName = findParameterNamed(method, "code");
+                Markers markers = existingMarkers(docComment);
+                Javadoc.Text returnText = new Javadoc.Text(Tree.randomId(), Markers.EMPTY,
+                        " the Errors enum entry for the code. Returns {@code Errors.UNKNOWN_SERVER_ERROR} for all unmapped codes.");
+                return List.of(
+                        new Javadoc.LineBreak(Tree.randomId(), margin, markers),
+                        new Javadoc.Text(Tree.randomId(), Markers.EMPTY, " Map the code for an Error to its Entry in the enum"),
+                        new Javadoc.LineBreak(Tree.randomId(), margin + " ", Markers.EMPTY),
+                        new Javadoc.Parameter(Tree.randomId(), Markers.EMPTY, List.of(), codeParamName.withPrefix(Space.format(" ")), null,
+                                List.of(new Javadoc.Text(Tree.randomId(), Markers.EMPTY, " the {@code short} to map"))),
+                        new Javadoc.LineBreak(Tree.randomId(), margin + " ", Markers.EMPTY),
+                        new Javadoc.Return(Tree.randomId(), Markers.EMPTY, List.of(returnText)),
+                        new Javadoc.LineBreak(Tree.randomId(), margin, Markers.EMPTY),
+                        new Javadoc.LineBreak(Tree.randomId(), margin.substring(0, margin.lastIndexOf('*')), Markers.EMPTY)
+                );
+            }
+
+            @NonNull
+            private static Markers existingMarkers(@NonNull Javadoc.DocComment docComment) {
+                return docComment.getBody().isEmpty() ? Markers.EMPTY : docComment.getBody().getFirst().getMarkers();
+            }
+
+            @NonNull
+            private static String extractMargin(List<Javadoc> body) {
+                return body.stream()
+                        .filter(Javadoc.LineBreak.class::isInstance)
+                        .map(Javadoc.LineBreak.class::cast)
+                        .map(Javadoc.LineBreak::getMargin)
+                        .findFirst()
+                        .orElse("\n * ");
             }
 
             @NonNull
@@ -286,5 +338,18 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
             }
 
         }
+
+        @NonNull
+        private static J.Identifier findParameterNamed(J.MethodDeclaration method, String paramName) {
+            return method.getParameters().stream()
+                    .filter(J.VariableDeclarations.class::isInstance)
+                    .map(J.VariableDeclarations.class::cast)
+                    .flatMap(vd -> vd.getVariables().stream())
+                    .filter(v -> paramName.equals(v.getSimpleName()))
+                    .map(J.VariableDeclarations.NamedVariable::getName)
+                    .findFirst()
+                    .orElseThrow();
+        }
     }
+
 }

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -79,11 +79,11 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
                 """).contextSensitive().build();
 
         private final JavaTemplate constructorTemplate = JavaTemplate.builder(
-                        """
-                                Errors(int code, String message) {
-                                    this.code = (short) code;
-                                    this.message = message;
-                                }""")
+                """
+                        Errors(int code, String message) {
+                            this.code = (short) code;
+                            this.message = message;
+                        }""")
                 .contextSensitive()
                 .build();
 

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -79,11 +79,11 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
                 """).contextSensitive().build();
 
         private final JavaTemplate constructorTemplate = JavaTemplate.builder(
-                        """
-                                Errors(int code, String message) {
-                                    this.code = (short) code;
-                                    this.message = message;
-                                }""")
+                """
+                        Errors(int code, String message) {
+                            this.code = (short) code;
+                            this.message = message;
+                        }""")
                 .contextSensitive()
                 .build();
 
@@ -300,8 +300,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
                         new Javadoc.LineBreak(Tree.randomId(), margin + " ", Markers.EMPTY),
                         new Javadoc.Return(Tree.randomId(), Markers.EMPTY, List.of(returnText)),
                         new Javadoc.LineBreak(Tree.randomId(), margin, Markers.EMPTY),
-                        new Javadoc.LineBreak(Tree.randomId(), margin.substring(0, margin.lastIndexOf('*')), Markers.EMPTY)
-                );
+                        new Javadoc.LineBreak(Tree.randomId(), margin.substring(0, margin.lastIndexOf('*')), Markers.EMPTY));
             }
 
             @NonNull

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -73,15 +73,16 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
                 """).contextSensitive().build();
 
         private final JavaTemplate constructorTemplate = JavaTemplate.builder(
-                """
-                        Errors(int code, String message) {
-                            this.code = (short) code;
-                            this.message = message;
-                        }""")
+                        """
+                                Errors(int code, String message) {
+                                    this.code = (short) code;
+                                    this.message = message;
+                                }""")
                 .contextSensitive()
                 .build();
 
         @Override
+        @NonNull
         protected JavadocVisitor<ExecutionContext> getJavadocVisitor() {
             return new PruneJavadocVisitor();
         }
@@ -139,7 +140,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
                 return null;
             }
 
-            if (methodDeclaration.isConstructor() && findParameterByName(methodDeclaration, "builder") != null) {
+            if (methodDeclaration.isConstructor() && hasBuilderParameter(methodDeclaration)) {
                 return visitConstructorDeclaration(methodDeclaration);
             }
 
@@ -199,14 +200,12 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
                     .orElse(null);
         }
 
-        private static J.VariableDeclarations.NamedVariable findVariableByName(String fieldName, J.VariableDeclarations vd) {
-            return vd.getVariables().stream().filter(v -> fieldName.equals(v.getSimpleName())).findFirst().orElse(null);
-        }
-
-        @Nullable
-        private J.VariableDeclarations.NamedVariable findParameterByName(J.MethodDeclaration md, String parameterName) {
-            return md.getParameters().stream().filter(J.VariableDeclarations.class::isInstance).map(J.VariableDeclarations.class::cast)
-                    .flatMap(vd -> vd.getVariables().stream()).filter(v -> parameterName.equals(v.getSimpleName())).findFirst().orElse(null);
+        private boolean hasBuilderParameter(J.MethodDeclaration md) {
+            return md.getParameters().stream()
+                    .filter(J.VariableDeclarations.class::isInstance)
+                    .map(J.VariableDeclarations.class::cast)
+                    .flatMap(vd -> vd.getVariables().stream())
+                    .anyMatch(v -> "builder".equals(v.getSimpleName()));
         }
 
         @NonNull

--- a/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
+++ b/tools/kafka-vendoring/src/main/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipe.java
@@ -61,14 +61,23 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
     private static class ErrorsEnumVisitor extends JavaVisitor<ExecutionContext> {
 
         private final Set<String> REMOVED_FIELDS = Set.of("builder", "exception", "CLASS_TO_ERROR");
-        private final Set<String> REMOVED_METHODS = Set.of("exception", "forException", "maybeThrow", "exceptionName", "main", "toHtml");
+        private final Set<String> REMOVED_METHODS = Set.of("exception", "forException", "maybeThrow", "exceptionName", "main", "toHtml", "maybeUnwrapException");
 
         private final JavaTemplate messageFieldTemplate = JavaTemplate.builder("private final String message;").contextSensitive().build();
 
-        private final JavaTemplate messageMethodBody = JavaTemplate.builder("return this.message;").contextSensitive().build();
+        private final JavaTemplate messageMethodBody = JavaTemplate.builder("""
+                if (this.message != null) {
+                    return this.message;
+                }
+                return this.toString();
+                """).contextSensitive().build();
 
         private final JavaTemplate constructorTemplate = JavaTemplate.builder(
-                "Errors(int code, String defaultMessage) {\n" + "    this.code = (short) code;\n" + "    this.message = defaultMessage;\n" + "}")
+                """
+                        Errors(int code, String message) {
+                            this.code = (short) code;
+                            this.message = message;
+                        }""")
                 .contextSensitive()
                 .build();
 
@@ -80,7 +89,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
         @Override
         public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDeclaration, ExecutionContext ctx) {
             J.ClassDeclaration cd = classDeclaration;
-            boolean hasMessageField = findFieldByName(classDeclaration, "message") != null;
+            boolean hasMessageField = findFieldByName(cd, "message") != null;
 
             if (!hasMessageField) {
                 Statement codeField = findFieldByName(cd, "code");
@@ -89,6 +98,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
                     cd = messageFieldTemplate.apply(updateCursor(cd), codeField.getCoordinates().after());
                 }
             }
+
             return (J.ClassDeclaration) super.visitClassDeclaration(cd, ctx);
         }
 
@@ -113,8 +123,6 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
             if (multiVariable.getVariables().stream().anyMatch(v -> REMOVED_FIELDS.contains(v.getSimpleName()))) {
                 return null; // Remove 'builder' field
             }
-            findVariableByName("message", multiVariable);
-
             return (J.VariableDeclarations) super.visitVariableDeclarations(multiVariable, ctx);
         }
 
@@ -140,7 +148,7 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
             J.Block body = md.getBody();
             if ("message".equals(md.getSimpleName()) && body != null) {
                 String currentBody = body.printTrimmed(getCursor());
-                if (!currentBody.contains("this.message")) {
+                if (currentBody.contains("exception")) {
                     return messageMethodBody.apply(updateCursor(md), md.getCoordinates().replaceBody());
                 }
             }
@@ -182,7 +190,12 @@ public class PruneKafkaErrorsEnumRecipe extends Recipe {
 
         @Nullable
         private static Statement findFieldByName(J.ClassDeclaration cd, String fieldName) {
-            return cd.getBody().getStatements().stream().filter(s -> s instanceof J.VariableDeclarations vd && findVariableByName(fieldName, vd) != null).findFirst()
+            return cd.getBody().getStatements().stream()
+                    .filter(J.VariableDeclarations.class::isInstance)
+                    .map(J.VariableDeclarations.class::cast)
+                    .filter(vd -> vd.getVariables().stream()
+                            .anyMatch(v -> v.getSimpleName().equals(fieldName)))
+                    .findFirst()
                     .orElse(null);
         }
 

--- a/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
+++ b/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.vendoring.rewrite;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new PruneKafkaErrorsEnumRecipe())
+                .parser(JavaParser.fromJavaVersion()
+                        .classpath("kafka-clients"));
+    }
+
+    @SuppressWarnings("java:S2699") // rewriteRun contains assertions
+    @Test
+    void shouldRemoveExceptionsFromErrorsEnum() {
+        rewriteRun(
+                java(
+                        """
+                                package org.apache.kafka.common.protocol;
+
+                                import java.util.function.Function;
+
+                                import org.apache.kafka.common.errors.ApiException;
+                                import org.apache.kafka.common.errors.InvalidRequestException;
+                                import org.apache.kafka.common.errors.UnknownServerException;
+
+                                public enum Errors {
+                                    UNKNOWN_SERVER_ERROR(-1, "Unexpected error", UnknownServerException::new),
+                                    INVALID_REQUEST(42, "Invalid request", InvalidRequestException::new);
+
+                                    private final short code;
+                                    private final String message;
+                                    private final Function<String, ApiException> builder;
+
+                                    Errors(int code, String defaultMessage, Function<String, ApiException> builder) {
+                                        this.code = (short) code;
+                                        this.message = defaultMessage;
+                                        this.builder = builder;
+                                    }
+
+                                    public ApiException exception() {
+                                        return builder.apply(message);
+                                    }
+
+                                    public ApiException exception(String message) {
+                                        return builder.apply(message);
+                                    }
+
+                                    public static Errors forException(Throwable cause) {
+                                        return UNKNOWN_SERVER_ERROR;
+                                    }
+
+                                    public short code() {
+                                        return code;
+                                    }
+
+                                    public String message() {
+                                        return message;
+                                    }
+                                }
+                                """,
+                        """
+                                package org.apache.kafka.common.protocol;
+
+                                public enum Errors {
+                                    UNKNOWN_SERVER_ERROR(-1, "Unexpected error"),
+                                    INVALID_REQUEST(42, "Invalid request");
+
+                                    private final short code;
+                                    private final String message;
+
+                                    Errors(int code, String defaultMessage) {
+                                        this.code = (short) code;
+                                        this.message = defaultMessage;
+                                    }
+
+                                    public short code() {
+                                        return code;
+                                    }
+
+                                    public String message() {
+                                        return message;
+                                    }
+                                }
+                                """));
+    }
+}

--- a/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
+++ b/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
@@ -28,69 +28,72 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
         rewriteRun(
                 java(
                         """
-
+                                
                                   package org.apache.kafka.common.protocol;
-
+                                
                                   import java.util.HashMap;
                                   import java.util.Map;
                                   import java.util.function.Function;
-
+                                
                                   import org.apache.kafka.common.errors.ApiException;
                                   import org.apache.kafka.common.errors.InvalidRequestException;
                                   import org.apache.kafka.common.errors.UnknownServerException;
-
+                                
+                                  /**
+                                  * some javadoc
+                                  */
                                   public enum Errors {
                                       UNKNOWN_SERVER_ERROR(-1, "Unexpected error", UnknownServerException::new),
                                       INVALID_REQUEST(42, "Invalid request", InvalidRequestException::new);
-
+                                
                                       private final short code;
                                       private String message;
-
+                                
                                       private final Function<String, ApiException> builder;
-
+                                
                                       private static final Map<Class<?>, Errors> CLASS_TO_ERROR = new HashMap<>();
                                       private static final Map<Short, Errors> CODE_TO_ERROR = new HashMap<>();
-
+                                
                                       private ApiException exception;
-
+                                
                                       static {
                                           for (Errors error : Errors.values()) {
                                               if (CODE_TO_ERROR.put(error.code(), error) != null)
                                                   throw new ExceptionInInitializerError("Code " + error.code() + " for error " +
                                                           error + " has already been used");
-
+                                
                                               if (error.exception != null)
                                                   CLASS_TO_ERROR.put(error.exception.getClass(), error);
                                           }
                                       }
-
+                                
                                       Errors(int code, String defaultMessage, Function<String, ApiException> builder) {
                                           this.code = (short) code;
                                           this.builder = builder;
                                       }
-
+                                
                                       public ApiException exception() {
                                           return builder.apply(message);
                                       }
-
+                                
                                       public ApiException exception(String message) {
                                           return builder.apply(message);
                                       }
-
+                                
                                       public static Errors forException(Throwable cause) {
                                           return UNKNOWN_SERVER_ERROR;
                                       }
-
+                                
                                       public short code() {
                                           return code;
                                       }
-
+                                
                                       public String message() {
                                           if (exception != null)
                                               return exception.getMessage();
                                           return toString();
                                       }
-
+                                
                                       public static Errors forCode(short code) {
                                           Errors error = CODE_TO_ERROR.get(code);
                                           if (error != null) {
@@ -99,17 +102,17 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                               return UNKNOWN_SERVER_ERROR;
                                           }
                                       }
-
+                                
                                       public void maybeThrow() {
                                           if (exception != null) {
                                               throw this.exception;
                                           }
                                       }
-
+                                
                                       public String exceptionName() {
                                           return exception == null ? null : exception.getClass().getName();
                                       }
-
+                                
                                       private static String toHtml() {
                                           final StringBuilder b = new StringBuilder();
                                           b.append("<table class=\\"data-table\\"><tbody>\\n");
@@ -122,25 +125,25 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                           b.append("</tbody></table>\\n");
                                           return b.toString();
                                       }
-
+                                
                                       public static void main(String[] args) {
                                       }
                                   }
                                 """,
                         """
                                 package org.apache.kafka.common.protocol;
-
+                                
                                 import java.util.HashMap;
                                 import java.util.Map;
-
+                                
                                 public enum Errors {
                                     UNKNOWN_SERVER_ERROR(-1, "Unexpected error"),
                                     INVALID_REQUEST(42, "Invalid request");
-
+                                
                                     private final short code;
                                     private String message;
                                     private static final Map<Short, Errors> CODE_TO_ERROR = new HashMap<>();
-
+                                
                                     static {
                                         for (Errors error : Errors.values()) {
                                             if (CODE_TO_ERROR.put(error.code(), error) != null)
@@ -148,20 +151,20 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                                         error + " has already been used");
                                         }
                                     }
-
+                                
                                     Errors(int code, String defaultMessage) {
                                         this.code = (short) code;
                                         this.message = defaultMessage;
                                     }
-
+                                
                                     public short code() {
                                         return code;
                                     }
-
+                                
                                     public String message() {
                                         return this.message;
                                     }
-
+                                
                                     public static Errors forCode(short code) {
                                         Errors error = CODE_TO_ERROR.get(code);
                                         if (error != null) {
@@ -170,6 +173,36 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                             return UNKNOWN_SERVER_ERROR;
                                         }
                                     }
+                                }
+                                """));
+    }
+
+    @SuppressWarnings("java:S2699") // rewriteRun contains assertions
+    @Test
+    void shouldAtSeeTagFromJavaDoc() {
+        rewriteRun(
+                java(
+                        """
+                                package org.apache.kafka.common.protocol;
+                                
+                                /**
+                                 * javadoc text
+                                 * @see org.apache.kafka.common.network.SslTransportLayer
+                                 */
+                                public enum Errors {
+                                    UNKNOWN_SERVER_ERROR,
+                                    INVALID_REQUEST;
+                                }
+                                """,
+                        """
+                                package org.apache.kafka.common.protocol;
+                                
+                                /**
+                                 * javadoc text
+                                 */
+                                public enum Errors {
+                                    UNKNOWN_SERVER_ERROR,
+                                    INVALID_REQUEST;
                                 }
                                 """));
     }

--- a/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
+++ b/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
@@ -28,13 +28,13 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
         rewriteRun(
                 java(
                         """
-                                
+
                                   package org.apache.kafka.common.protocol;
-                                
+
                                   import java.util.HashMap;
                                   import java.util.Map;
                                   import java.util.function.Function;
-                                
+
                                   import org.apache.kafka.common.errors.ApiException;
                                   import org.apache.kafka.common.errors.InvalidRequestException;
                                   import org.apache.kafka.common.errors.UnknownServerException;
@@ -42,55 +42,55 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                   public enum Errors {
                                       UNKNOWN_SERVER_ERROR(-1, "Unexpected error", UnknownServerException::new),
                                       INVALID_REQUEST(42, "Invalid request", InvalidRequestException::new);
-                                
+
                                       private final short code;
                                       private String message;
-                                
+
                                       private final Function<String, ApiException> builder;
-                                
+
                                       private static final Map<Class<?>, Errors> CLASS_TO_ERROR = new HashMap<>();
                                       private static final Map<Short, Errors> CODE_TO_ERROR = new HashMap<>();
-                                
+
                                       private ApiException exception;
-                                
+
                                       static {
                                           for (Errors error : Errors.values()) {
                                               if (CODE_TO_ERROR.put(error.code(), error) != null)
                                                   throw new ExceptionInInitializerError("Code " + error.code() + " for error " +
                                                           error + " has already been used");
-                                
+
                                               if (error.exception != null)
                                                   CLASS_TO_ERROR.put(error.exception.getClass(), error);
                                           }
                                       }
-                                
+
                                       Errors(int code, String defaultMessage, Function<String, ApiException> builder) {
                                           this.code = (short) code;
                                           this.builder = builder;
                                       }
-                                
+
                                       public ApiException exception() {
                                           return builder.apply(message);
                                       }
-                                
+
                                       public ApiException exception(String message) {
                                           return builder.apply(message);
                                       }
-                                
+
                                       public static Errors forException(Throwable cause) {
                                           return UNKNOWN_SERVER_ERROR;
                                       }
-                                
+
                                       public short code() {
                                           return code;
                                       }
-                                
+
                                       public String message() {
                                           if (exception != null)
                                               return exception.getMessage();
                                           return toString();
                                       }
-                                
+
                                       public static Errors forCode(short code) {
                                           Errors error = CODE_TO_ERROR.get(code);
                                           if (error != null) {
@@ -99,17 +99,17 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                               return UNKNOWN_SERVER_ERROR;
                                           }
                                       }
-                                
+
                                       public void maybeThrow() {
                                           if (exception != null) {
                                               throw this.exception;
                                           }
                                       }
-                                
+
                                       public String exceptionName() {
                                           return exception == null ? null : exception.getClass().getName();
                                       }
-                                
+
                                       private static String toHtml() {
                                           final StringBuilder b = new StringBuilder();
                                           b.append("<table class=\\"data-table\\"><tbody>\\n");
@@ -122,25 +122,25 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                           b.append("</tbody></table>\\n");
                                           return b.toString();
                                       }
-                                
+
                                       public static void main(String[] args) {
                                       }
                                   }
                                 """,
                         """
                                 package org.apache.kafka.common.protocol;
-                                
+
                                 import java.util.HashMap;
                                 import java.util.Map;
-                                
+
                                 public enum Errors {
                                     UNKNOWN_SERVER_ERROR(-1, "Unexpected error"),
                                     INVALID_REQUEST(42, "Invalid request");
-                                
+
                                     private final short code;
                                     private String message;
                                     private static final Map<Short, Errors> CODE_TO_ERROR = new HashMap<>();
-                                
+
                                     static {
                                         for (Errors error : Errors.values()) {
                                             if (CODE_TO_ERROR.put(error.code(), error) != null)
@@ -148,20 +148,20 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                                         error + " has already been used");
                                         }
                                     }
-                                
+
                                     Errors(int code, String defaultMessage) {
                                         this.code = (short) code;
                                         this.message = defaultMessage;
                                     }
-                                
+
                                     public short code() {
                                         return code;
                                     }
-                                
+
                                     public String message() {
                                         return this.message;
                                     }
-                                
+
                                     public static Errors forCode(short code) {
                                         Errors error = CODE_TO_ERROR.get(code);
                                         if (error != null) {
@@ -181,7 +181,7 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                 java(
                         """
                                 package org.apache.kafka.common.protocol;
-                                
+
                                 /**
                                  * javadoc text
                                  * @see org.apache.kafka.common.network.SslTransportLayer
@@ -193,7 +193,7 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                 """,
                         """
                                 package org.apache.kafka.common.protocol;
-                                
+
                                 /**
                                  * javadoc text
                                  */

--- a/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
+++ b/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
@@ -28,58 +28,126 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
         rewriteRun(
                 java(
                         """
-                                package org.apache.kafka.common.protocol;
 
-                                import java.util.function.Function;
+                                  package org.apache.kafka.common.protocol;
 
-                                import org.apache.kafka.common.errors.ApiException;
-                                import org.apache.kafka.common.errors.InvalidRequestException;
-                                import org.apache.kafka.common.errors.UnknownServerException;
+                                  import java.util.HashMap;
+                                  import java.util.Map;
+                                  import java.util.function.Function;
 
-                                public enum Errors {
-                                    UNKNOWN_SERVER_ERROR(-1, "Unexpected error", UnknownServerException::new),
-                                    INVALID_REQUEST(42, "Invalid request", InvalidRequestException::new);
+                                  import org.apache.kafka.common.errors.ApiException;
+                                  import org.apache.kafka.common.errors.InvalidRequestException;
+                                  import org.apache.kafka.common.errors.UnknownServerException;
 
-                                    private final short code;
-                                    private final String message;
-                                    private final Function<String, ApiException> builder;
+                                  public enum Errors {
+                                      UNKNOWN_SERVER_ERROR(-1, "Unexpected error", UnknownServerException::new),
+                                      INVALID_REQUEST(42, "Invalid request", InvalidRequestException::new);
 
-                                    Errors(int code, String defaultMessage, Function<String, ApiException> builder) {
-                                        this.code = (short) code;
-                                        this.message = defaultMessage;
-                                        this.builder = builder;
-                                    }
+                                      private final short code;
+                                      private String message;
 
-                                    public ApiException exception() {
-                                        return builder.apply(message);
-                                    }
+                                      private final Function<String, ApiException> builder;
 
-                                    public ApiException exception(String message) {
-                                        return builder.apply(message);
-                                    }
+                                      private static final Map<Class<?>, Errors> CLASS_TO_ERROR = new HashMap<>();
+                                      private static final Map<Short, Errors> CODE_TO_ERROR = new HashMap<>();
 
-                                    public static Errors forException(Throwable cause) {
-                                        return UNKNOWN_SERVER_ERROR;
-                                    }
+                                      private ApiException exception;
 
-                                    public short code() {
-                                        return code;
-                                    }
+                                      static {
+                                          for (Errors error : Errors.values()) {
+                                              if (CODE_TO_ERROR.put(error.code(), error) != null)
+                                                  throw new ExceptionInInitializerError("Code " + error.code() + " for error " +
+                                                          error + " has already been used");
 
-                                    public String message() {
-                                        return message;
-                                    }
-                                }
+                                              if (error.exception != null)
+                                                  CLASS_TO_ERROR.put(error.exception.getClass(), error);
+                                          }
+                                      }
+
+                                      Errors(int code, String defaultMessage, Function<String, ApiException> builder) {
+                                          this.code = (short) code;
+                                          this.builder = builder;
+                                      }
+
+                                      public ApiException exception() {
+                                          return builder.apply(message);
+                                      }
+
+                                      public ApiException exception(String message) {
+                                          return builder.apply(message);
+                                      }
+
+                                      public static Errors forException(Throwable cause) {
+                                          return UNKNOWN_SERVER_ERROR;
+                                      }
+
+                                      public short code() {
+                                          return code;
+                                      }
+
+                                      public String message() {
+                                          if (exception != null)
+                                              return exception.getMessage();
+                                          return toString();
+                                      }
+
+                                      public static Errors forCode(short code) {
+                                          Errors error = CODE_TO_ERROR.get(code);
+                                          if (error != null) {
+                                              return error;
+                                          } else {
+                                              return UNKNOWN_SERVER_ERROR;
+                                          }
+                                      }
+
+                                      public void maybeThrow() {
+                                          if (exception != null) {
+                                              throw this.exception;
+                                          }
+                                      }
+
+                                      public String exceptionName() {
+                                          return exception == null ? null : exception.getClass().getName();
+                                      }
+
+                                      private static String toHtml() {
+                                          final StringBuilder b = new StringBuilder();
+                                          b.append("<table class=\\"data-table\\"><tbody>\\n");
+                                          b.append("<tr>");
+                                          b.append("<th>Error</th>\\n");
+                                          b.append("<th>Code</th>\\n");
+                                          b.append("<th>Retriable</th>\\n");
+                                          b.append("<th>Description</th>\\n");
+                                          b.append("</tr>\\n");
+                                          b.append("</tbody></table>\\n");
+                                          return b.toString();
+                                      }
+
+                                      public static void main(String[] args) {
+                                      }
+                                  }
                                 """,
                         """
                                 package org.apache.kafka.common.protocol;
+
+                                import java.util.HashMap;
+                                import java.util.Map;
 
                                 public enum Errors {
                                     UNKNOWN_SERVER_ERROR(-1, "Unexpected error"),
                                     INVALID_REQUEST(42, "Invalid request");
 
                                     private final short code;
-                                    private final String message;
+                                    private String message;
+                                    private static final Map<Short, Errors> CODE_TO_ERROR = new HashMap<>();
+
+                                    static {
+                                        for (Errors error : Errors.values()) {
+                                            if (CODE_TO_ERROR.put(error.code(), error) != null)
+                                                throw new ExceptionInInitializerError("Code " + error.code() + " for error " +
+                                                        error + " has already been used");
+                                        }
+                                    }
 
                                     Errors(int code, String defaultMessage) {
                                         this.code = (short) code;
@@ -91,7 +159,16 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                     }
 
                                     public String message() {
-                                        return message;
+                                        return this.message;
+                                    }
+
+                                    public static Errors forCode(short code) {
+                                        Errors error = CODE_TO_ERROR.get(code);
+                                        if (error != null) {
+                                            return error;
+                                        } else {
+                                            return UNKNOWN_SERVER_ERROR;
+                                        }
                                     }
                                 }
                                 """));

--- a/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
+++ b/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
@@ -38,10 +38,7 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                   import org.apache.kafka.common.errors.ApiException;
                                   import org.apache.kafka.common.errors.InvalidRequestException;
                                   import org.apache.kafka.common.errors.UnknownServerException;
-                                
-                                  /**
-                                  * some javadoc
-                                  */
+
                                   public enum Errors {
                                       UNKNOWN_SERVER_ERROR(-1, "Unexpected error", UnknownServerException::new),
                                       INVALID_REQUEST(42, "Invalid request", InvalidRequestException::new);

--- a/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
+++ b/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
@@ -44,7 +44,6 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                       INVALID_REQUEST(42, "Invalid request", InvalidRequestException::new);
 
                                       private final short code;
-                                      private String message;
 
                                       private final Function<String, ApiException> builder;
 
@@ -70,7 +69,7 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                       }
 
                                       public ApiException exception() {
-                                          return builder.apply(message);
+                                          return builder.apply(message());
                                       }
 
                                       public ApiException exception(String message) {
@@ -138,7 +137,8 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                     INVALID_REQUEST(42, "Invalid request");
 
                                     private final short code;
-                                    private String message;
+
+                                    private final String message;
                                     private static final Map<Short, Errors> CODE_TO_ERROR = new HashMap<>();
 
                                     static {
@@ -149,9 +149,9 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                         }
                                     }
 
-                                    Errors(int code, String defaultMessage) {
+                                    Errors(int code, String message) {
                                         this.code = (short) code;
-                                        this.message = defaultMessage;
+                                        this.message = message;
                                     }
 
                                     public short code() {
@@ -159,7 +159,10 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                     }
 
                                     public String message() {
-                                        return this.message;
+                                        if (this.message != null) {
+                                            return this.message;
+                                        }
+                                        return this.toString();
                                     }
 
                                     public static Errors forCode(short code) {
@@ -200,6 +203,49 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                 public enum Errors {
                                     UNKNOWN_SERVER_ERROR,
                                     INVALID_REQUEST;
+                                }
+                                """));
+    }
+
+    @SuppressWarnings("java:S2699") // rewriteRun contains assertions
+    @Test
+    void shouldReplaceMessageGetterBody() {
+        rewriteRun(
+                java(
+                        """
+                                package org.apache.kafka.common.protocol;
+
+                                public enum Errors {
+                                    UNKNOWN_SERVER_ERROR(-1, "Unexpected error"),
+                                    INVALID_REQUEST(42, "Invalid request");
+
+                                    private final short code;
+                                    private RuntimeException exception = new RuntimeException("boom");
+
+                                    public String message() {
+                                      if (exception != null)
+                                          return exception.getMessage();
+                                      return toString();
+                                      }
+                                }
+                                """,
+                        """
+                                package org.apache.kafka.common.protocol;
+
+                                public enum Errors {
+                                    UNKNOWN_SERVER_ERROR(-1, "Unexpected error"),
+                                    INVALID_REQUEST(42, "Invalid request");
+
+                                    private final short code;
+
+                                    private final String message;
+
+                                    public String message() {
+                                        if (this.message != null) {
+                                            return this.message;
+                                        }
+                                        return this.toString();
+                                    }
                                 }
                                 """));
     }

--- a/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
+++ b/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
@@ -286,4 +286,39 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                 }
                                 """));
     }
+
+    @Test
+    void shouldRemoveTrailingLineBreaksFromJavadoc() {
+        rewriteRun(
+                java(
+                        """
+                                package org.apache.kafka.common.protocol;
+
+                                /**
+                                 * javadoc text line 1
+                                 *
+                                 * line 2
+                                 *
+                                 * @see org.apache.kafka.common.network.SslTransportLayer
+                                 *
+                                 */
+                                public enum Errors {
+                                    UNKNOWN_SERVER_ERROR(-1, "Unexpected error"),
+                                    INVALID_REQUEST(42, "Invalid request");
+                                }
+                                """,
+                        """
+                                package org.apache.kafka.common.protocol;
+
+                                /**
+                                 * javadoc text line 1
+                                 *
+                                 * line 2
+                                 */
+                                public enum Errors {
+                                    UNKNOWN_SERVER_ERROR(-1, "Unexpected error"),
+                                    INVALID_REQUEST(42, "Invalid request");
+                                }
+                                """));
+    }
 }

--- a/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
+++ b/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
@@ -208,19 +208,58 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
     }
 
     @Test
+    void shouldReplaceJavaDocOnForCode() {
+        rewriteRun(
+                java(
+                        """
+                                package org.apache.kafka.common.protocol;
+                                
+                                public enum Errors {
+                                    UNKNOWN_SERVER_ERROR,
+                                    INVALID_REQUEST;
+                                
+                                    /**
+                                     * Throw the exception if there is one
+                                     */
+                                    public static Errors forCode(short code) {
+                                        return Errors.UNKNOWN_SERVER_ERROR;
+                                    }
+                                }
+                                """,
+                        """
+                                package org.apache.kafka.common.protocol;
+                                
+                                public enum Errors {
+                                    UNKNOWN_SERVER_ERROR,
+                                    INVALID_REQUEST;
+                                
+                                    /**
+                                     * Map the code for an Error to its Entry in the enum
+                                     * @param code the {@code short} to map
+                                     * @return the Errors enum entry for the code. Returns {@code Errors.UNKNOWN_SERVER_ERROR} for all unmapped codes.
+                                     *
+                                     */
+                                    public static Errors forCode(short code) {
+                                        return Errors.UNKNOWN_SERVER_ERROR;
+                                    }
+                                }
+                                """));
+    }
+
+    @Test
     void shouldReplaceMessageGetterBody() {
         rewriteRun(
                 java(
                         """
                                 package org.apache.kafka.common.protocol;
-
+                                
                                 public enum Errors {
                                     UNKNOWN_SERVER_ERROR(-1, "Unexpected error"),
                                     INVALID_REQUEST(42, "Invalid request");
-
+                                
                                     private final short code;
                                     private RuntimeException exception = new RuntimeException("boom");
-
+                                
                                     public String message() {
                                       if (exception != null)
                                           return exception.getMessage();

--- a/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
+++ b/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
@@ -177,7 +177,6 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                 """));
     }
 
-
     @Test
     void shouldRemoveSslTransportLayerFromJavaDoc() {
         rewriteRun(
@@ -213,11 +212,11 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                 java(
                         """
                                 package org.apache.kafka.common.protocol;
-                                
+
                                 public enum Errors {
                                     UNKNOWN_SERVER_ERROR,
                                     INVALID_REQUEST;
-                                
+
                                     /**
                                      * Throw the exception if there is one
                                      */
@@ -228,11 +227,11 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                 """,
                         """
                                 package org.apache.kafka.common.protocol;
-                                
+
                                 public enum Errors {
                                     UNKNOWN_SERVER_ERROR,
                                     INVALID_REQUEST;
-                                
+
                                     /**
                                      * Map the code for an Error to its Entry in the enum
                                      * @param code the {@code short} to map
@@ -252,14 +251,14 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                 java(
                         """
                                 package org.apache.kafka.common.protocol;
-                                
+
                                 public enum Errors {
                                     UNKNOWN_SERVER_ERROR(-1, "Unexpected error"),
                                     INVALID_REQUEST(42, "Invalid request");
-                                
+
                                     private final short code;
                                     private RuntimeException exception = new RuntimeException("boom");
-                                
+
                                     public String message() {
                                       if (exception != null)
                                           return exception.getMessage();

--- a/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
+++ b/tools/kafka-vendoring/src/test/java/io/kroxylicious/vendoring/rewrite/PruneKafkaErrorsEnumRecipeTest.java
@@ -13,6 +13,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
+@SuppressWarnings("java:S2699") // rewriteRun contains assertions
 class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
 
     @Override
@@ -22,7 +23,6 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                         .classpath("kafka-clients"));
     }
 
-    @SuppressWarnings("java:S2699") // rewriteRun contains assertions
     @Test
     void shouldRemoveExceptionsFromErrorsEnum() {
         rewriteRun(
@@ -177,9 +177,9 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                 """));
     }
 
-    @SuppressWarnings("java:S2699") // rewriteRun contains assertions
+
     @Test
-    void shouldAtSeeTagFromJavaDoc() {
+    void shouldRemoveSslTransportLayerFromJavaDoc() {
         rewriteRun(
                 java(
                         """
@@ -207,7 +207,6 @@ class PruneKafkaErrorsEnumRecipeTest implements RewriteTest {
                                 """));
     }
 
-    @SuppressWarnings("java:S2699") // rewriteRun contains assertions
     @Test
     void shouldReplaceMessageGetterBody() {
         rewriteRun(

--- a/tools/kafka-vendoring/test/edits.yaml
+++ b/tools/kafka-vendoring/test/edits.yaml
@@ -28,9 +28,6 @@
 # so nothing depends on what OpenRewrite decides to do with the import.
 
 - file: org/apache/kafka/common/compress/GzipCompressionTest.java
-  stripImports:
-    - '\.config\.ConfigDef'
-    - '\.config\.ConfigException'
   removeBlocks:
     - signature: 'public\s+void\s+testLevelValidator\s*\(\s*\)'
       label: GzipCompressionTest.testLevelValidator
@@ -38,8 +35,6 @@
 - file: org/apache/kafka/common/utils/UtilsTest.java
   # These ten methods test the four Utils methods (propsToMap, castToStringObjectMap,
   # ensureConcreteSubclass, mergeConfigs) that main/edits.yaml already strips from Utils.java.
-  stripImports:
-    - '\.config\.ConfigException'
   removeBlocks:
     - signature: 'public\s+void\s+testPropsToMap\s*\(\s*\)'
       label: UtilsTest.testPropsToMap

--- a/tools/kafka-vendoring/test/preserve-kroxylicious.txt
+++ b/tools/kafka-vendoring/test/preserve-kroxylicious.txt
@@ -1,0 +1,9 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# Kroxylicious authored files in the vendored package space from rsync --delete
+common/protocol/
+common/protocol/ErrorsTest.java

--- a/tools/kafka-vendoring/vendor.sh
+++ b/tools/kafka-vendoring/vendor.sh
@@ -81,12 +81,18 @@ for root in main test; do
   [ -d "$REWRITTEN" ] || { echo "ERROR: OpenRewrite did not produce $REWRITTEN" >&2; exit 1; }
 
   DEST="$API_SRC/$root/java/io/kroxylicious/kafka"
+  PRESERVE_FILE="$HERE/$root/preserve-kroxylicious.txt"
+
   echo "==> [$root] syncing into $DEST"
   mkdir -p "$DEST"
-  # Wipe only the vendored/forked (non-message) tree; the generated message.* package is never
-  # committed here.
-  find "$DEST" -mindepth 1 -type d -name message -prune -o -type f -name '*.java' -print | xargs -r rm -f
-  rsync -a --exclude='message/' "$REWRITTEN/" "$DEST/"
+
+  RSYNC_ARGS=(-a --delete --exclude='message/')
+  if [ -f "$PRESERVE_FILE" ]; then
+    RSYNC_ARGS+=(--exclude-from="$PRESERVE_FILE")
+  fi
+  set -x
+  rsync "${RSYNC_ARGS[@]}" "$REWRITTEN/" "$DEST/"
+  set +x
 done
 
 echo "==> formatting (mvn -pl kroxylicious-api -am process-test-sources)"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Copies the Errors enum into the Kroxylicious source tree while removing the ApiException class hierarchy.

### Additional Context

Is the version of errors required to support https://github.com/kroxylicious/design/pull/131

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
