### PR TITLE
fix(deployment): add pending phase timeout for pod readiness checks

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
@@ -61,6 +61,7 @@ public class DeploymentUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(DeploymentUtils.class);
     private static final Duration READINESS_TIMEOUT = Duration.ofMinutes(6);
     private static final Duration DELETION_TIMEOUT = Duration.ofMinutes(5);
+    private static final Duration PENDING_PHASE_TIMEOUT = Duration.ofMinutes(5);
     private static final String TEST_LOAD_BALANCER_NAME = "test-load-balancer";
 
     private DeploymentUtils() {
@@ -190,7 +191,7 @@ public class DeploymentUtils {
      */
     public static void waitForLeavingPendingPhase(String namespaceName, String podName) {
         await().alias("await pod to leave pending phase")
-                .atMost(Duration.ofMinutes(1))
+                .atMost(PENDING_PHASE_TIMEOUT)
                 .pollInterval(Duration.ofMillis(200))
                 .until(() -> Optional.ofNullable(kubeClient().getPod(namespaceName, podName)).map(Pod::getStatus).map(PodStatus::getPhase),
                         s -> s.filter(Predicate.not(DeploymentUtils::isPendingPhase)).isPresent());


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Refactoring
### Description

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [X] PR references related GitHub issue(s) so they are closed on merging. Fixes: #4754 
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
