### PR TITLE
fix(api)!: stop deriving TopicNameMappingException cause from Errors.exception()

### DIFF
--- a/changelog/unreleased/04768-topic-name-mapping-exception-drop-cause.yaml
+++ b/changelog/unreleased/04768-topic-name-mapping-exception-drop-cause.yaml
@@ -1,0 +1,15 @@
+title: "fix(api)!: stop deriving TopicNameMappingException cause from Errors.exception()"
+type: fixed
+merge_requests:
+  - 4768
+issues:
+  - 4748
+important_notes:
+  - |
+    Small breaking change for filter authors: the `TopicNameMappingException(Errors)` and
+    `TopicNameMappingException(Errors, String)` constructors no longer set the exception cause
+    to `Errors.exception()`. Filters that relied on `TopicNameMappingException.getCause()`
+    returning the corresponding kafka-clients `ApiException` will now see a `null` cause. This
+    removes a dependency on the kafka-clients `Errors.exception()` wrapper API ahead of the move
+    to the vendored `Errors` enum. Use the `TopicNameMappingException(Errors, String, Throwable)`
+    constructor if you need to supply a cause, or `getError()` to obtain the underlying `Errors`.

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopicNameMappingException.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopicNameMappingException.java
@@ -24,16 +24,17 @@ public class TopicNameMappingException extends RuntimeException {
      * @param error the kafka error underlying this exception
      */
     public TopicNameMappingException(Errors error) {
-        this(error, error.message(), error.exception());
+        this(error, error.message());
     }
 
     /**
-     * Creates a new exception for the given error with a custom message.
+     * Creates a new exception for the given error with a custom message and cause.
      * @param error the kafka error underlying this exception
      * @param message the detail message
      */
     public TopicNameMappingException(Errors error, String message) {
-        this(error, message, error.exception());
+        super(message);
+        this.error = Objects.requireNonNull(error);
     }
 
     /**

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/filter/metadata/TopicNameMappingExceptionTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/filter/metadata/TopicNameMappingExceptionTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.metadata;
+
+import org.apache.kafka.common.protocol.Errors;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TopicNameMappingExceptionTest {
+
+    @Test
+    void errorConstructorUsesDefaultMessageAndNoCause() {
+        // Given
+        var error = Errors.UNKNOWN_TOPIC_OR_PARTITION;
+
+        // When
+        var exception = new TopicNameMappingException(error);
+
+        // Then
+        assertThat(exception.getError()).isEqualTo(error);
+        assertThat(exception.getMessage()).isEqualTo(error.message());
+        assertThat(exception.getCause()).isNull();
+    }
+
+    @Test
+    void errorAndMessageConstructorUsesCustomMessageAndNoCause() {
+        // Given
+        var error = Errors.UNKNOWN_TOPIC_OR_PARTITION;
+
+        // When
+        var exception = new TopicNameMappingException(error, "custom message");
+
+        // Then
+        assertThat(exception.getError()).isEqualTo(error);
+        assertThat(exception.getMessage()).isEqualTo("custom message");
+        assertThat(exception.getCause()).isNull();
+    }
+
+    @Test
+    void errorMessageAndCauseConstructorRetainsCause() {
+        // Given
+        var error = Errors.UNKNOWN_TOPIC_OR_PARTITION;
+        var cause = new RuntimeException("boom");
+
+        // When
+        var exception = new TopicNameMappingException(error, "custom message", cause);
+
+        // Then
+        assertThat(exception.getError()).isEqualTo(error);
+        assertThat(exception.getMessage()).isEqualTo("custom message");
+        assertThat(exception.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void rejectsNullError() {
+        // When / Then
+        assertThatThrownBy(() -> new TopicNameMappingException(null, "custom message"))
+                .isInstanceOf(NullPointerException.class);
+    }
+}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `TopicNameMappingException(Errors)` and `TopicNameMappingException(Errors, String)` constructors derived their cause from `error.exception()`, which returns a kafka-clients `ApiException`. This drops that behaviour so the two constructors build the exception from the error and message alone.

A unit test covering all three constructors (and null-error rejection) is added, giving the class new-code coverage.

### Additional Context

`Errors.exception()` is part of the kafka-clients wrapper API that is **not** carried over into the vendored `Errors` enum introduced in #4763. Removing this dependency prepares the ground for switching the project to the vendored `Errors` class. See #4748 for the wider migration context.

> [!WARNING]
> **Small breaking change for filter authors.** Any filter that relied on `TopicNameMappingException.getCause()` returning the matching `ApiException` will now see a `null` cause. Callers that need a cause can use the three-argument `TopicNameMappingException(Errors, String, Throwable)` constructor, and `getError()` still exposes the underlying `Errors`.

### Checklist

- [x] New tests written (where applicable).
- [x] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update.
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [x] For user facing changes, add a logchange entry YAML file to `changelog/unreleased/`.

Relates-to: #4748

🤖 Generated with [Claude Code](https://claude.com/claude-code)
