### PR TITLE
refactor(filter-test-support): remove ApiException from MockFilterContext

### DIFF
--- a/changelog/unreleased/04769-mock-filter-context-errors.yaml
+++ b/changelog/unreleased/04769-mock-filter-context-errors.yaml
@@ -1,0 +1,11 @@
+title: "changed(filter-test-support): MockFilterContextAssert.errorResponse asserts on Errors codes"
+type: changed
+issues:
+  - 4769
+important_notes:
+  - |
+    `MockFilterContextAssert.errorResponse()` no longer returns a `ThrowableAssert<ApiException>`.
+    It now returns a `MockErrorResponseAssert` exposing `hasError(Errors)` and `hasMessage(String)`,
+    so the kafka-clients exception hierarchy no longer leaks into the test-support API. Migrate
+    assertions such as `.errorResponse().isInstanceOf(InvalidRecordException.class).hasMessage(msg)`
+    to `.errorResponse().hasError(Errors.INVALID_RECORD).hasMessage(msg)`.

--- a/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/testing/filter/assertj/MockFilterContextAssert.java
+++ b/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/testing/filter/assertj/MockFilterContextAssert.java
@@ -8,13 +8,12 @@ package io.kroxylicious.testing.filter.assertj;
 
 import java.util.function.Consumer;
 
-import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.BooleanAssert;
 import org.assertj.core.api.ObjectAssert;
-import org.assertj.core.api.ThrowableAssert;
 
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
@@ -372,14 +371,14 @@ public class MockFilterContextAssert {
         }
 
         /**
-         * Verifies that the result is an error response and creates an assertion for its exception.
+         * Verifies that the result is an error response and creates an assertion for its error code and message.
          *
-         * @return the exception assertion
+         * @return the error response assertion
          */
-        public ThrowableAssert<ApiException> errorResponse() {
+        public MockErrorResponseAssert errorResponse() {
             isNotNull();
             Assertions.assertThat(actual).isInstanceOf(MockErrorRequestFilterResult.class);
-            return new ThrowableAssert<>(((MockErrorRequestFilterResult) actual).apiException());
+            return new MockErrorResponseAssert((MockErrorRequestFilterResult) actual);
         }
 
         /**
@@ -429,6 +428,42 @@ public class MockFilterContextAssert {
         @NonNull
         private BooleanAssert forwardRequest() {
             return new BooleanAssert(!actual.shortCircuitResponse() && !actual.drop());
+        }
+    }
+
+    /**
+     * Assertions for the error code and message captured by a short-circuit error response.
+     */
+    public static class MockErrorResponseAssert {
+
+        private final MockErrorRequestFilterResult actual;
+
+        private MockErrorResponseAssert(MockErrorRequestFilterResult actual) {
+            this.actual = actual;
+        }
+
+        /**
+         * Verifies that the error response was created with the given error code.
+         *
+         * @param expected the expected error code
+         * @return this assertion
+         */
+        public MockErrorResponseAssert hasError(Errors expected) {
+            Assertions.assertThat(actual.error()).isEqualTo(expected);
+            return this;
+        }
+
+        /**
+         * Verifies that the error response has the given message, resolving to the error's default message
+         * when no explicit message was supplied.
+         *
+         * @param expected the expected message
+         * @return this assertion
+         */
+        public MockErrorResponseAssert hasMessage(String expected) {
+            String effectiveMessage = actual.errorMessage() != null ? actual.errorMessage() : actual.error().message();
+            Assertions.assertThat(effectiveMessage).isEqualTo(expected);
+            return this;
         }
     }
 }

--- a/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/testing/filter/context/MockFilterContext.java
+++ b/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/testing/filter/context/MockFilterContext.java
@@ -19,7 +19,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
@@ -542,8 +541,7 @@ public class MockFilterContext implements FilterContext {
             if (error == Errors.NONE) {
                 throw new IllegalArgumentException("error must denote an actual error, but was Errors.NONE");
             }
-            // Errors.exception(String) returns the default-message exception when message is null.
-            return new MockErrorCloseOrTerminalRequestStage(header, requestMessage, error.exception(message));
+            return new MockErrorCloseOrTerminalRequestStage(header, requestMessage, error, message);
         }
 
         @Override
@@ -574,12 +572,14 @@ public class MockFilterContext implements FilterContext {
      *
      * @param header the request header passed to errorResponse
      * @param message the request message passed to errorResponse
-     * @param apiException the exception passed to errorResponse
+     * @param error the error code passed to errorResponse
+     * @param errorMessage the error message passed to errorResponse, or {@code null} to use the error's default message
      * @param closeConnection whether the connection should be closed
      */
     public record MockErrorRequestFilterResult(ApiMessage header,
                                                ApiMessage message,
-                                               ApiException apiException,
+                                               Errors error,
+                                               @Nullable String errorMessage,
                                                boolean closeConnection)
             implements RequestFilterResult {
         @Override
@@ -638,13 +638,14 @@ public class MockFilterContext implements FilterContext {
 
     private record MockErrorTerminalRequestStage(RequestHeaderData header,
                                                  ApiMessage requestMessage,
-                                                 ApiException apiException,
+                                                 Errors error,
+                                                 @Nullable String errorMessage,
                                                  boolean closeConnection)
             implements TerminalStage<RequestFilterResult> {
 
         @Override
         public RequestFilterResult build() {
-            return new MockErrorRequestFilterResult(header, requestMessage, apiException, closeConnection);
+            return new MockErrorRequestFilterResult(header, requestMessage, error, errorMessage, closeConnection);
         }
 
         @Override
@@ -655,12 +656,13 @@ public class MockFilterContext implements FilterContext {
 
     private record MockErrorCloseOrTerminalRequestStage(RequestHeaderData header,
                                                         ApiMessage requestMessage,
-                                                        ApiException apiException)
+                                                        Errors error,
+                                                        @Nullable String errorMessage)
             implements CloseOrTerminalStage<RequestFilterResult> {
 
         @Override
         public RequestFilterResult build() {
-            return new MockErrorRequestFilterResult(header, requestMessage, apiException, false);
+            return new MockErrorRequestFilterResult(header, requestMessage, error, errorMessage, false);
         }
 
         @Override
@@ -670,7 +672,7 @@ public class MockFilterContext implements FilterContext {
 
         @Override
         public TerminalStage<RequestFilterResult> withCloseConnection() {
-            return new MockErrorTerminalRequestStage(header, requestMessage, apiException, true);
+            return new MockErrorTerminalRequestStage(header, requestMessage, error, errorMessage, true);
         }
     }
 

--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/testing/filter/context/MockFilterContextTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/testing/filter/context/MockFilterContextTest.java
@@ -452,7 +452,7 @@ class MockFilterContextTest {
                 .isErrorResponse()
                 .isNotDropRequest()
                 .errorResponse()
-                .isInstanceOf(Errors.UNKNOWN_SERVER_ERROR.exception().getClass())
+                .hasError(Errors.UNKNOWN_SERVER_ERROR)
                 .hasMessage(Errors.UNKNOWN_SERVER_ERROR.message());
     }
 
@@ -473,7 +473,7 @@ class MockFilterContextTest {
                 .isErrorResponse()
                 .isNotDropRequest()
                 .errorResponse()
-                .isInstanceOf(Errors.UNKNOWN_SERVER_ERROR.exception().getClass())
+                .hasError(Errors.UNKNOWN_SERVER_ERROR)
                 .hasMessage(Errors.UNKNOWN_SERVER_ERROR.message()));
     }
 
@@ -495,7 +495,7 @@ class MockFilterContextTest {
                 .isErrorResponse()
                 .isNotDropRequest()
                 .errorResponse()
-                .isInstanceOf(Errors.UNKNOWN_SERVER_ERROR.exception().getClass())
+                .hasError(Errors.UNKNOWN_SERVER_ERROR)
                 .hasMessage(Errors.UNKNOWN_SERVER_ERROR.message());
     }
 
@@ -518,7 +518,7 @@ class MockFilterContextTest {
                 .isErrorResponse()
                 .isNotDropRequest()
                 .errorResponse()
-                .isInstanceOf(Errors.UNKNOWN_SERVER_ERROR.exception().getClass())
+                .hasError(Errors.UNKNOWN_SERVER_ERROR)
                 .hasMessage(Errors.UNKNOWN_SERVER_ERROR.message()));
     }
 
@@ -539,7 +539,7 @@ class MockFilterContextTest {
                 .isErrorResponse()
                 .isNotDropRequest()
                 .errorResponse()
-                .isInstanceOf(Errors.INVALID_REQUEST.exception().getClass())
+                .hasError(Errors.INVALID_REQUEST)
                 .hasMessage(Errors.INVALID_REQUEST.message());
     }
 
@@ -561,7 +561,7 @@ class MockFilterContextTest {
                 .isErrorResponse()
                 .isNotDropRequest()
                 .errorResponse()
-                .isInstanceOf(Errors.INVALID_REQUEST.exception().getClass())
+                .hasError(Errors.INVALID_REQUEST)
                 .hasMessage(message);
     }
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionFilterTest.java
@@ -22,11 +22,9 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.LongStream;
 
-import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.errors.NetworkException;
-import org.apache.kafka.common.errors.UnknownTopicIdException;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.FetchResponseData.FetchableTopicResponse;
@@ -301,7 +299,7 @@ class RecordEncryptionFilterTest {
         assertThat(stage).succeedsWithin(0, TimeUnit.SECONDS).satisfies(requestFilterResult -> {
             MockFilterContextAssert.assertThat(requestFilterResult).isShortCircuitResponse()
                     .isErrorResponse().errorResponse()
-                    .isInstanceOf(UnknownTopicIdException.class);
+                    .hasError(Errors.UNKNOWN_TOPIC_ID);
         });
 
     }
@@ -354,7 +352,7 @@ class RecordEncryptionFilterTest {
         assertThat(stage).succeedsWithin(0, TimeUnit.SECONDS).satisfies(requestFilterResult -> {
             MockFilterContextAssert.assertThat(requestFilterResult).isShortCircuitResponse()
                     .isErrorResponse().errorResponse()
-                    .isInstanceOf(InvalidRecordException.class)
+                    .hasError(Errors.INVALID_RECORD)
                     .hasMessage("failed to resolve key for: [" + UNRESOLVED_TOPIC + "]");
         });
 
@@ -463,7 +461,7 @@ class RecordEncryptionFilterTest {
                             .isErrorResponse()
                             .isShortCircuitResponse()
                             .errorResponse()
-                            .isInstanceOf(NetworkException.class)
+                            .hasError(Errors.NETWORK_EXCEPTION)
                             .hasMessage("could not acquire a DEK");
                 });
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/RecordValidationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/RecordValidationFilterTest.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.errors.UnknownTopicIdException;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
@@ -136,7 +135,7 @@ class RecordValidationFilterTest {
                 .satisfies(rfr -> {
                     MockFilterContextAssert.assertThat(rfr)
                             .isErrorResponse()
-                            .errorResponse().isInstanceOf(UnknownTopicIdException.class);
+                            .errorResponse().hasError(Errors.UNKNOWN_TOPIC_ID);
                 });
     }
 

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/test/java/io/kroxylicious/filter/simpletransform/ProduceRequestTransformationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/test/java/io/kroxylicious/filter/simpletransform/ProduceRequestTransformationFilterTest.java
@@ -16,11 +16,11 @@ import java.util.stream.StreamSupport;
 
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
-import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.ProduceRequestData.PartitionProduceData;
 import org.apache.kafka.common.message.ProduceRequestData.TopicProduceData;
 import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.Record;
@@ -205,7 +205,7 @@ class ProduceRequestTransformationFilterTest {
         var stage = filter.onProduceRequest(produceRequest.apiKey(), header, produceRequest, mockFilterContext);
         assertThat(stage).succeedsWithin(Duration.ZERO).satisfies(requestFilterResult -> {
             MockFilterContextAssert.assertThat(requestFilterResult).isShortCircuitResponse().isErrorResponse()
-                    .errorResponse().isInstanceOf(UnknownServerException.class);
+                    .errorResponse().hasError(Errors.UNKNOWN_SERVER_ERROR);
         });
     }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Removes `org.apache.kafka.common.errors.ApiException` from `io.kroxylicious.testing.filter.context.MockFilterContext` and its AssertJ helper, storing and asserting on `org.apache.kafka.common.protocol.Errors` codes (plus an optional message) instead.

- `MockErrorRequestFilterResult` (and the intermediate builder stages) now carry `Errors error` + `@Nullable String errorMessage` rather than a pre-built `ApiException`; `errorResponse(...)` no longer calls `Errors.exception(message)`.
- `MockFilterContextAssert.errorResponse()` now returns a new fluent `MockErrorResponseAssert` exposing `hasError(Errors)` and `hasMessage(String)` (the message resolving to the error's default when none was supplied), replacing the old `ThrowableAssert<ApiException>`.
- Consumer tests migrated from exception-type assertions to `hasError(Errors.…)`.

### Additional Context

Follow-on to #4756 / #4763. The vendored `io.kroxylicious.kafka.common.protocol.Errors` enum deliberately omits the exception-mapping methods (`exception()`, `forException(...)`), so the `ApiException` coupling in this mock blocks its adoption. This change removes that coupling and unblocks swapping the upstream `Errors` enum for the vendored copy in the mock.

### Checklist

- [x] New tests written (where applicable).
- [x] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update.
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [x] For user facing changes, add a logchange entry YAML file to `changelog/unreleased/` (includes test-artefact API changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)