### PR TITLE
fix(vault-kms): resolveAlias returns versioned WrappingKey for HashiCorp Vault KMS to improve key rotation cache invalidation

### DIFF
--- a/changelog/unreleased/04150-vault-resolveAlias-versioned-wrapping-key.yaml
+++ b/changelog/unreleased/04150-vault-resolveAlias-versioned-wrapping-key.yaml
@@ -1,0 +1,4 @@
+title: "fix(kms): HashiCorp Vault resolveAlias now returns a versioned key reference so KEK rotations are picked up within the alias cache refresh period"
+type: fixed
+issues:
+  - 4150

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/AbstractVaultTestKmsFacade.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/AbstractVaultTestKmsFacade.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kroxylicious.kms.provider.hashicorp.vault.VaultEdek;
 import io.kroxylicious.kms.provider.hashicorp.vault.VaultKmsService;
 import io.kroxylicious.kms.provider.hashicorp.vault.VaultResponse;
+import io.kroxylicious.kms.provider.hashicorp.vault.WrappingKey;
 import io.kroxylicious.kms.provider.hashicorp.vault.config.Config;
 import io.kroxylicious.kms.service.KmsException;
 import io.kroxylicious.kms.service.UnknownAliasException;
@@ -50,7 +51,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Transit engine REST API, leaving subclasses responsible for the lifecycle of, and connection
  * details for, the underlying Vault instance.
  */
-public abstract class AbstractVaultTestKmsFacade implements TestKmsFacade<Config, String, VaultEdek> {
+public abstract class AbstractVaultTestKmsFacade implements TestKmsFacade<Config, WrappingKey, VaultEdek> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractVaultTestKmsFacade.class);
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/AbstractVaultTestKmsFacadeFactory.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/AbstractVaultTestKmsFacadeFactory.java
@@ -7,13 +7,14 @@
 package io.kroxylicious.testing.kms.vault;
 
 import io.kroxylicious.kms.provider.hashicorp.vault.VaultEdek;
+import io.kroxylicious.kms.provider.hashicorp.vault.WrappingKey;
 import io.kroxylicious.kms.provider.hashicorp.vault.config.Config;
 import io.kroxylicious.testing.kms.TestKmsFacadeFactory;
 
 /**
  * Abstract factory for {@link AbstractVaultTestKmsFacade}s.
  */
-public abstract class AbstractVaultTestKmsFacadeFactory implements TestKmsFacadeFactory<Config, String, VaultEdek> {
+public abstract class AbstractVaultTestKmsFacadeFactory implements TestKmsFacadeFactory<Config, WrappingKey, VaultEdek> {
     /**
      * Creates the factory.
      */

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/VaultTestKmsFacadeFactory.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/testing/kms/vault/VaultTestKmsFacadeFactory.java
@@ -7,13 +7,14 @@
 package io.kroxylicious.testing.kms.vault;
 
 import io.kroxylicious.kms.provider.hashicorp.vault.VaultEdek;
+import io.kroxylicious.kms.provider.hashicorp.vault.WrappingKey;
 import io.kroxylicious.kms.provider.hashicorp.vault.config.Config;
 import io.kroxylicious.testing.kms.TestKmsFacadeFactory;
 
 /**
  * Factory for {@link VaultTestKmsFacade}s.
  */
-public class VaultTestKmsFacadeFactory extends AbstractVaultTestKmsFacadeFactory implements TestKmsFacadeFactory<Config, String, VaultEdek> {
+public class VaultTestKmsFacadeFactory extends AbstractVaultTestKmsFacadeFactory implements TestKmsFacadeFactory<Config, WrappingKey, VaultEdek> {
     /**
      * Creates the factory.
      */

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/test/java/io/kroxylicious/testing/kms/vault/VaultTestKmsFacadeTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault-test-support/src/test/java/io/kroxylicious/testing/kms/vault/VaultTestKmsFacadeTest.java
@@ -12,13 +12,14 @@ import org.testcontainers.DockerClientFactory;
 
 import io.kroxylicious.kms.provider.hashicorp.vault.VaultEdek;
 import io.kroxylicious.kms.provider.hashicorp.vault.VaultKmsService;
+import io.kroxylicious.kms.provider.hashicorp.vault.WrappingKey;
 import io.kroxylicious.kms.provider.hashicorp.vault.config.Config;
 import io.kroxylicious.testing.kms.AbstractTestKmsFacadeTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-class VaultTestKmsFacadeTest extends AbstractTestKmsFacadeTest<Config, String, VaultEdek> {
+class VaultTestKmsFacadeTest extends AbstractTestKmsFacadeTest<Config, WrappingKey, VaultEdek> {
 
     VaultTestKmsFacadeTest() {
         super(new VaultTestKmsFacadeFactory());

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKms.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKms.java
@@ -49,8 +49,25 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * An implementation of the KMS interface backed by a remote instance of HashiCorp Vault (v1).
+ *
+ * <p>HashiCorp Vault Transit uses a <em>key ring</em> model: rotating a key appends a new version
+ * to the ring but keeps the name unchanged. This class is therefore typed as
+ * {@code Kms<WrappingKey, VaultEdek>} rather than {@code Kms<String, VaultEdek>}. The
+ * {@link WrappingKey} pairs the stable name with the {@code latest_version} returned by the
+ * read-key API, so that a rotation produces a value that is no longer {@code equals()} to the
+ * previously resolved one. Downstream caches (e.g. {@code EncryptionDekCache}) key on the full
+ * {@code WrappingKey}; a changed version causes a cache miss and a fresh DEK is generated under
+ * the new key version within the alias cache refresh period, rather than waiting for the longer
+ * DEK expiry.
+ *
+ * <p>The version is <em>not</em> forwarded to Vault on the encrypt path.
+ * {@link #generateDekPair(WrappingKey)} posts to {@code transit/datakey/plaintext/{name}} without a
+ * {@code key_version} field, so Vault always uses the latest version. There is a benign race: if a
+ * rotation lands between {@code resolveAlias} and {@code generateDekPair}, Vault may encrypt with a
+ * version newer than the one in the {@code WrappingKey}. The EDEK is self-describing and decryption
+ * always succeeds regardless.
  */
-public class VaultKms implements Kms<String, VaultEdek> {
+public class VaultKms implements Kms<WrappingKey, VaultEdek> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(VaultKms.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -117,17 +134,17 @@ public class VaultKms implements Kms<String, VaultEdek> {
      * @see <a href="https://developer.hashicorp.com/vault/api-docs/secret/transit#generate-data-key">https://developer.hashicorp.com/vault/api-docs/secret/transit#generate-data-key</a>
      */
     @Override
-    public CompletionStage<DekPair<VaultEdek>> generateDekPair(String kekRef) {
+    public CompletionStage<DekPair<VaultEdek>> generateDekPair(WrappingKey kekRef) {
 
         var request = createVaultRequest()
-                .uri(vaultTransitEngineUrl.resolve("datakey/plaintext/%s".formatted(encode(kekRef, UTF_8))))
+                .uri(vaultTransitEngineUrl.resolve("datakey/plaintext/%s".formatted(encode(kekRef.name(), UTF_8))))
                 .POST(HttpRequest.BodyPublishers.noBody())
                 .build();
 
-        return sendAsync(kekRef, request, DATA_KEY_DATA_TYPE_REF, UnknownKeyException::new)
+        return sendAsync(kekRef.name(), request, DATA_KEY_DATA_TYPE_REF, UnknownKeyException::new)
                 .thenApply(data -> {
                     var secretKey = DestroyableRawSecretKey.takeOwnershipOf(data.plaintext(), AES_KEY_ALGO);
-                    return new DekPair<>(new VaultEdek(kekRef, data.ciphertext().getBytes(UTF_8)), secretKey);
+                    return new DekPair<>(new VaultEdek(kekRef.name(), data.ciphertext().getBytes(UTF_8)), secretKey);
                 });
 
     }
@@ -175,13 +192,13 @@ public class VaultKms implements Kms<String, VaultEdek> {
      * @see <a href="https://developer.hashicorp.com/vault/api-docs/secret/transit#read-key">https://developer.hashicorp.com/vault/api-docs/secret/transit#read-key</a>
      */
     @Override
-    public CompletableFuture<String> resolveAlias(String alias) {
+    public CompletionStage<WrappingKey> resolveAlias(String alias) {
 
         var request = createVaultRequest()
                 .uri(vaultTransitEngineUrl.resolve("keys/%s".formatted(encode(alias, UTF_8))))
                 .build();
         return sendAsync(alias, request, READ_KEY_DATA_TYPE_REF, UnknownAliasException::new)
-                .thenApply(ReadKeyData::name);
+                .thenApply(d -> new WrappingKey(d.name(), d.latestVersion()));
     }
 
     private <T> CompletableFuture<T> sendAsync(String key,

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
@@ -20,7 +20,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * An implementation of the {@link KmsService} interface backed by a remote instance of HashiCorp Vault.
  */
 @Plugin(configType = Config.class)
-public class VaultKmsService implements KmsService<Config, String, VaultEdek> {
+public class VaultKmsService implements KmsService<Config, WrappingKey, VaultEdek> {
 
     @SuppressWarnings("java:S3077") // KMS services are thread safe. As Config is immutable, volatile is sufficient to ensure its safe publication between threads.
     private volatile @Nullable Config config;

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultResponse.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultResponse.java
@@ -41,6 +41,9 @@ public record VaultResponse<D>(D data) {
          */
         public ReadKeyData {
             Objects.requireNonNull(name);
+            if (latestVersion < 1) {
+                throw new IllegalArgumentException("latest_version must be >= 1, got " + latestVersion);
+            }
         }
     }
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultResponse.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultResponse.java
@@ -32,18 +32,20 @@ public record VaultResponse<D>(D data) {
      * <a href="https://developer.hashicorp.com/vault/api-docs/secret/transit#read-key">read key</a> API.
      *
      * @param name the name of the key.
-     * @param latestVersion the latest version of the key.
+     * @param latestVersion the latest (current) version of the key. Not currently listed on
+     *                      HashiCorp's read-key API documentation, but observed present and
+     *                      incrementing on rotation in every Vault release line from 1.2 through
+     *                      2.0, and on every key type creatable on CE — including hmac, where the
+     *                      {@code keys} map is absent but this field is not.
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public record ReadKeyData(String name, @JsonProperty("latest_version") int latestVersion) {
+    public record ReadKeyData(String name,
+                              @JsonProperty(value = "latest_version", required = true) int latestVersion) {
         /**
          * Validates the record components.
          */
         public ReadKeyData {
             Objects.requireNonNull(name);
-            if (latestVersion < 1) {
-                throw new IllegalArgumentException("latest_version must be >= 1, got " + latestVersion);
-            }
         }
     }
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/WrappingKey.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/WrappingKey.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.hashicorp.vault;
+
+import java.util.Objects;
+
+/**
+ * A reference to a HashiCorp Vault Transit wrapping key (KEK), combining the stable key name
+ * with the version number from the most recent {@code resolveAlias} call.
+ *
+ * <p>In Vault Transit, rotating a key appends a new version to the same named key ring — the name
+ * never changes. {@code WrappingKey} captures both pieces of information so that the resolved value
+ * can serve as a cache-invalidation token: when a rotation bumps {@code version}, the resolved value
+ * is no longer {@code equals()} to the previously cached one. Downstream caches (e.g.
+ * {@code EncryptionDekCache}) key on the full {@code WrappingKey}, so a changed version causes a
+ * cache miss and forces a fresh DEK to be generated under the new key version.
+ *
+ * <p>The version is <em>not</em> sent to Vault on the encrypt path. {@code generateDekPair} posts to
+ * {@code transit/datakey/plaintext/{name}} without a {@code key_version} field, which causes Vault to
+ * use the latest version automatically. There is therefore a benign race: if a rotation lands between
+ * {@code resolveAlias} and {@code generateDekPair}, Vault may encrypt with a version newer than the one
+ * recorded here. This is acceptable — the EDEK is self-describing and decryption always succeeds.
+ *
+ * @param name    the stable name of the key ring in Vault Transit (unchanged across rotations)
+ * @param version the latest key version as returned by the Vault read-key API ({@code latest_version});
+ *                changes on each rotation and is used only for cache invalidation
+ */
+public record WrappingKey(String name, int version) {
+
+    /**
+     * Creates a wrapping key reference.
+     */
+    public WrappingKey {
+        Objects.requireNonNull(name, "name must not be null");
+    }
+}

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/TestVault.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/TestVault.java
@@ -122,4 +122,9 @@ public class TestVault implements Closeable {
         }, "vault", "write", "-f", "transit/keys/%s".formatted(keyId));
     }
 
+    VaultResponse.ReadKeyData rotateKek(String keyId) {
+        return runVaultCommand(new TypeReference<>() {
+        }, "vault", "write", "-f", "transit/keys/%s/rotate".formatted(keyId));
+    }
+
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsRotationIT.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsRotationIT.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.hashicorp.vault;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+
+import io.kroxylicious.kms.provider.hashicorp.vault.config.Config;
+import io.kroxylicious.proxy.config.secret.InlinePassword;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+/**
+ * Integration tests verifying that a real HashiCorp Vault instance returns {@code latest_version}
+ * and that rotating a key causes {@link VaultKms#resolveAlias} to return a different
+ * {@link WrappingKey} with a higher version number.
+ */
+class VaultKmsRotationIT {
+
+    private static final String VAULT_TOKEN = "token";
+    private TestVault vault;
+    private VaultKms kms;
+
+    @BeforeEach
+    void beforeEach() {
+        assumeThat(DockerClientFactory.instance().isDockerAvailable()).withFailMessage("docker unavailable").isTrue();
+        vault = TestVault.start();
+        var config = new Config(vault.getEndpoint(), new InlinePassword(VAULT_TOKEN), null);
+        var service = new VaultKmsService();
+        service.initialize(config);
+        kms = service.buildKms();
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (vault != null) {
+            vault.close();
+        }
+    }
+
+    @Test
+    void resolveAliasReturnsLatestVersionFromRealVault() {
+        // Given
+        var keyName = "rotation-test-key";
+        vault.createKek(keyName);
+
+        // When
+        var wrappingKey = kms.resolveAlias(keyName).toCompletableFuture().join();
+
+        // Then - real Vault must populate latest_version (proves the field is available)
+        assertThat(wrappingKey.name()).isEqualTo(keyName);
+        assertThat(wrappingKey.version()).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void rotationIncreasesVersionAndChangesWrappingKeyIdentity() {
+        // Given
+        var keyName = "rotation-identity-key";
+        vault.createKek(keyName);
+
+        // When
+        var before = kms.resolveAlias(keyName).toCompletableFuture().join();
+        vault.rotateKek(keyName);
+        var after = kms.resolveAlias(keyName).toCompletableFuture().join();
+
+        // Then
+        assertThat(before.name()).isEqualTo(after.name());
+        assertThat(after.version()).isGreaterThan(before.version());
+        assertThat(before)
+                .as("WrappingKey identity must differ after rotation so EncryptionDekCache sees a cache miss")
+                .isNotEqualTo(after);
+    }
+
+}

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsRotationIT.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsRotationIT.java
@@ -6,31 +6,31 @@
 
 package io.kroxylicious.kms.provider.hashicorp.vault;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.testcontainers.DockerClientFactory;
 
 import io.kroxylicious.kms.provider.hashicorp.vault.config.Config;
 import io.kroxylicious.proxy.config.secret.InlinePassword;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * Integration tests verifying that a real HashiCorp Vault instance returns {@code latest_version}
  * and that rotating a key causes {@link VaultKms#resolveAlias} to return a different
  * {@link WrappingKey} with a higher version number.
  */
+@EnabledIf(value = "isDockerAvailable", disabledReason = "docker unavailable")
 class VaultKmsRotationIT {
 
     private static final String VAULT_TOKEN = "token";
-    private TestVault vault;
-    private VaultKms kms;
+    private static TestVault vault;
+    private static VaultKms kms;
 
-    @BeforeEach
-    void beforeEach() {
-        assumeThat(DockerClientFactory.instance().isDockerAvailable()).withFailMessage("docker unavailable").isTrue();
+    @BeforeAll
+    static void beforeAll() {
         vault = TestVault.start();
         var config = new Config(vault.getEndpoint(), new InlinePassword(VAULT_TOKEN), null);
         var service = new VaultKmsService();
@@ -38,8 +38,8 @@ class VaultKmsRotationIT {
         kms = service.buildKms();
     }
 
-    @AfterEach
-    void afterEach() {
+    @AfterAll
+    static void afterAll() {
         if (vault != null) {
             vault.close();
         }
@@ -48,7 +48,7 @@ class VaultKmsRotationIT {
     @Test
     void resolveAliasReturnsLatestVersionFromRealVault() {
         // Given
-        var keyName = "rotation-test-key";
+        var keyName = "latest-version-key";
         vault.createKek(keyName);
 
         // When
@@ -78,4 +78,7 @@ class VaultKmsRotationIT {
                 .isNotEqualTo(after);
     }
 
+    static boolean isDockerAvailable() {
+        return DockerClientFactory.instance().isDockerAvailable();
+    }
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsTest.java
@@ -79,6 +79,7 @@ class VaultKmsTest {
 
     @Test
     void resolveAlias() {
+        // Given
         String response = """
                 {
                   "data": {
@@ -88,11 +89,14 @@ class VaultKmsTest {
                     "exportable": false,
                     "allow_plaintext_backup": false,
                     "keys": {
-                      "1": 1442851412
+                      "1": 1442851412,
+                      "2": 1442851413,
+                      "3": 1442851414
                     },
                     "min_decryption_version": 1,
                     "min_encryption_version": 0,
                     "name": "resolved",
+                    "latest_version": 3,
                     "supports_encryption": true,
                     "supports_decryption": true,
                     "supports_derivation": true,
@@ -105,17 +109,63 @@ class VaultKmsTest {
         server.stubFor(get(urlEqualTo("/v1/transit/keys/alias"))
                 .willReturn(aResponse().withBody(response)));
 
+        // When / Then
         assertThat(kms.resolveAlias("alias"))
                 .succeedsWithin(Duration.ofSeconds(5))
-                .isEqualTo("resolved");
+                .extracting(WrappingKey::name, WrappingKey::version)
+                .containsExactly("resolved", 3);
+    }
+
+    @Test
+    void resolveAliasChangesIdentityAfterRotation() {
+        // Given - version 1
+        String responseV1 = """
+                {
+                  "data": {
+                    "keys": { "1": 1442851412 },
+                    "name": "mykey",
+                    "latest_version": 1
+                  }
+                }
+                """;
+        server.stubFor(get(urlEqualTo("/v1/transit/keys/mykey"))
+                .willReturn(aResponse().withBody(responseV1)));
+
+        // When
+        var first = kms.resolveAlias("mykey").toCompletableFuture().join();
+
+        // Given - version 2 after rotation
+        server.resetAll();
+        String responseV2 = """
+                {
+                  "data": {
+                    "keys": { "1": 1442851412, "2": 1442851500 },
+                    "name": "mykey",
+                    "latest_version": 2
+                  }
+                }
+                """;
+        server.stubFor(get(urlEqualTo("/v1/transit/keys/mykey"))
+                .willReturn(aResponse().withBody(responseV2)));
+
+        // When
+        var second = kms.resolveAlias("mykey").toCompletableFuture().join();
+
+        // Then
+        assertThat(first.name()).isEqualTo(second.name());
+        assertThat(first).isNotEqualTo(second);
+        assertThat(first.version()).isEqualTo(1);
+        assertThat(second.version()).isEqualTo(2);
     }
 
     @Test
     void resolveAliasNotFound() {
+        // Given
         server.stubFor(
                 get(urlEqualTo("/v1/transit/keys/alias"))
                         .willReturn(aResponse().withStatus(404)));
 
+        // When / Then
         var aliasStage = kms.resolveAlias("alias");
         assertThat(aliasStage)
                 .failsWithin(Duration.ofSeconds(5))
@@ -126,10 +176,12 @@ class VaultKmsTest {
 
     @Test
     void resolveAliasInternalServerError() {
+        // Given
         server.stubFor(
                 get(urlEqualTo("/v1/transit/keys/alias"))
                         .willReturn(aResponse().withStatus(500)));
 
+        // When / Then
         var aliasStage = kms.resolveAlias("alias");
         assertThat(aliasStage)
                 .failsWithin(Duration.ofSeconds(5))
@@ -140,6 +192,7 @@ class VaultKmsTest {
 
     @Test
     void generateDekPair() {
+        // Given
         String plaintext = "dGhlIHF1aWNrIGJyb3duIGZveAo=";
         String ciphertext = "vault:v1:abcdefgh";
         byte[] decoded = Base64.getDecoder().decode(plaintext);
@@ -157,7 +210,8 @@ class VaultKmsTest {
         server.stubFor(post(urlEqualTo("/v1/transit/datakey/plaintext/kekref"))
                 .willReturn(aResponse().withBody(response)));
 
-        assertThat(kms.generateDekPair("kekref"))
+        // When / Then
+        assertThat(kms.generateDekPair(new WrappingKey("kekref", 1)))
                 .succeedsWithin(Duration.ofSeconds(5))
                 .satisfies(dekPair -> {
                     assertThat(dekPair)
@@ -168,11 +222,62 @@ class VaultKmsTest {
                             .asInstanceOf(InstanceOfAssertFactories.type(DestroyableRawSecretKey.class))
                             .matches(key -> SecretKeyUtils.same(key, expectedKey));
                 });
+    }
 
+    @Test
+    void generateDekPairUsesKeyNameNotVersion() {
+        // Given - the datakey URL must contain the plain name, not the version
+        String plaintext = "dGhlIHF1aWNrIGJyb3duIGZveAo=";
+        String ciphertext = "vault:v2:abcdefgh";
+
+        var response = """
+                {
+                  "data": {
+                    "plaintext": "%s",
+                    "ciphertext": "%s"
+                  }
+                }
+                """.formatted(plaintext, ciphertext);
+
+        server.stubFor(post(urlEqualTo("/v1/transit/datakey/plaintext/kekref"))
+                .willReturn(aResponse().withBody(response)));
+
+        // When / Then - WrappingKey with version 2, but URL path uses the name only
+        assertThat(kms.generateDekPair(new WrappingKey("kekref", 2)))
+                .succeedsWithin(Duration.ofSeconds(5))
+                .satisfies(dekPair -> {
+                    // EDEK still keyed on plain name, not version — wire format unchanged
+                    assertThat(dekPair.edek().kekRef()).isEqualTo("kekref");
+                });
+    }
+
+    @Test
+    void generateDekPairWithUriEncodedKeyName() {
+        // Given - key name containing a space (requires URI encoding in path)
+        String plaintext = "dGhlIHF1aWNrIGJyb3duIGZveAo=";
+        String ciphertext = "vault:v1:abcdefgh";
+
+        var response = """
+                {
+                  "data": {
+                    "plaintext": "%s",
+                    "ciphertext": "%s"
+                  }
+                }
+                """.formatted(plaintext, ciphertext);
+
+        server.stubFor(post(urlEqualTo("/v1/transit/datakey/plaintext/my+key"))
+                .willReturn(aResponse().withBody(response)));
+
+        // When / Then
+        assertThat(kms.generateDekPair(new WrappingKey("my key", 1)))
+                .succeedsWithin(Duration.ofSeconds(5))
+                .satisfies(dekPair -> assertThat(dekPair.edek().kekRef()).isEqualTo("my key"));
     }
 
     @Test
     void decryptEdek() {
+        // Given
         String edek = "dGhlIHF1aWNrIGJyb3duIGZveAo=";
         byte[] edekBytes = Base64.getDecoder().decode(edek);
         String plaintext = "qWruWwlmc7USk6uP41LZBs+gLVfkFWChb+jKivcWK0c=";
@@ -190,6 +295,7 @@ class VaultKmsTest {
         server.stubFor(post(urlEqualTo("/v1/transit/decrypt/kekref"))
                 .willReturn(aResponse().withBody(response)));
 
+        // When / Then
         assertThat(kms.decryptEdek(new VaultEdek("kekref", edekBytes)))
                 .succeedsWithin(Duration.ofSeconds(5))
                 .isInstanceOf(DestroyableRawSecretKey.class)

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsTlsIT.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsTlsIT.java
@@ -122,6 +122,7 @@ class VaultKmsTlsIT {
         var resolved = service.resolveAlias(keyName);
         assertThat(resolved)
                 .succeedsWithin(Duration.ofSeconds(5))
+                .extracting(WrappingKey::name)
                 .isEqualTo(keyName);
         testVault.close();
     }
@@ -135,6 +136,7 @@ class VaultKmsTlsIT {
         var resolved = vaultKms.resolveAlias(keyName);
         assertThat(resolved)
                 .succeedsWithin(Duration.ofSeconds(5))
+                .extracting(WrappingKey::name)
                 .isEqualTo(keyName);
 
     }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultResponseTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultResponseTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.hashicorp.vault;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.kroxylicious.kms.provider.hashicorp.vault.VaultResponse.ReadKeyData;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class VaultResponseTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final TypeReference<VaultResponse<ReadKeyData>> READ_KEY_TYPE = new TypeReference<>() {
+    };
+
+    @Test
+    void readKeyDataDeserialisesLatestVersion() throws Exception {
+        // Given
+        String json = """
+                {
+                  "data": {
+                    "name": "mykey",
+                    "latest_version": 3
+                  }
+                }
+                """;
+
+        // When
+        var result = MAPPER.readValue(json, READ_KEY_TYPE).data();
+
+        // Then
+        assertThat(result.name()).isEqualTo("mykey");
+        assertThat(result.latestVersion()).isEqualTo(3);
+    }
+
+    @Test
+    void readKeyDataRejectsMissingLatestVersion() {
+        // Given - body with no latest_version field; Jackson defaults primitive int to 0
+        String json = """
+                {
+                  "data": {
+                    "name": "mykey"
+                  }
+                }
+                """;
+
+        // When / Then
+        assertThatThrownBy(() -> MAPPER.readValue(json, READ_KEY_TYPE))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("latest_version must be >= 1, got 0");
+    }
+
+    @Test
+    void readKeyDataRejectsZeroLatestVersion() {
+        // Given
+        String json = """
+                {
+                  "data": {
+                    "name": "mykey",
+                    "latest_version": 0
+                  }
+                }
+                """;
+
+        // When / Then
+        assertThatThrownBy(() -> MAPPER.readValue(json, READ_KEY_TYPE))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("latest_version must be >= 1, got 0");
+    }
+}

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultResponseTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultResponseTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.kroxylicious.kms.provider.hashicorp.vault.VaultResponse.ReadKeyData;
 
@@ -44,7 +45,7 @@ class VaultResponseTest {
 
     @Test
     void readKeyDataRejectsMissingLatestVersion() {
-        // Given - body with no latest_version field; Jackson defaults primitive int to 0
+        // Given
         String json = """
                 {
                   "data": {
@@ -55,25 +56,6 @@ class VaultResponseTest {
 
         // When / Then
         assertThatThrownBy(() -> MAPPER.readValue(json, READ_KEY_TYPE))
-                .hasRootCauseInstanceOf(IllegalArgumentException.class)
-                .hasRootCauseMessage("latest_version must be >= 1, got 0");
-    }
-
-    @Test
-    void readKeyDataRejectsZeroLatestVersion() {
-        // Given
-        String json = """
-                {
-                  "data": {
-                    "name": "mykey",
-                    "latest_version": 0
-                  }
-                }
-                """;
-
-        // When / Then
-        assertThatThrownBy(() -> MAPPER.readValue(json, READ_KEY_TYPE))
-                .hasRootCauseInstanceOf(IllegalArgumentException.class)
-                .hasRootCauseMessage("latest_version must be >= 1, got 0");
+                .isInstanceOf(MismatchedInputException.class);
     }
 }

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/WrappingKeyTest.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/WrappingKeyTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.hashicorp.vault;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class WrappingKeyTest {
+
+    @Test
+    void equalWhenNameAndVersionMatch() {
+        assertThat(new WrappingKey("key", 1)).isEqualTo(new WrappingKey("key", 1));
+    }
+
+    @Test
+    void hashCodeConsistentWithEquals() {
+        var a = new WrappingKey("key", 1);
+        var b = new WrappingKey("key", 1);
+        assertThat(a).hasSameHashCodeAs(b);
+    }
+
+    @Test
+    void differentVersionsMeansNotEqual() {
+        // EncryptionDekCache.CacheKey wraps WrappingKey; two keys with the same name but
+        // different versions must be unequal so a rotation causes a cache miss.
+        var beforeRotation = new WrappingKey("mykey", 1);
+        var afterRotation = new WrappingKey("mykey", 2);
+        assertThat(beforeRotation).isNotEqualTo(afterRotation);
+    }
+
+    @Test
+    void differentNamesMeansNotEqual() {
+        assertThat(new WrappingKey("key-a", 1)).isNotEqualTo(new WrappingKey("key-b", 1));
+    }
+
+    @Test
+    void nullNameIsRejected() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> new WrappingKey(null, 1))
+                .withMessageContaining("name must not be null");
+    }
+
+    @Test
+    void nameAndVersionAccessors() {
+        var key = new WrappingKey("mykey", 3);
+        assertThat(key.name()).isEqualTo("mykey");
+        assertThat(key.version()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
Fixes #4150
 
Makes `VaultKms.resolveAlias` return a versioned key reference, so a KEK rotation invalidates the cached DEK instead of being masked by it.
 
## Why the name alone isn't enough
 
Rotating a Vault Transit key appends a version to the existing named key ring — `KEK_orders` stays `KEK_orders`, gaining version 2 alongside version 1. The name is deliberately stable across rotations, and that stability is what defeats the cache.
 
Two caches sit in the encrypt path:
 
| Cache | Keyed on | `refreshAfterWrite` | `expireAfterWrite` |
|---|---|---|---|
| `CachingKms` (resolved alias) | alias `String` | 8 min | 10 min |
| `EncryptionDekCache` | `record CacheKey<K>(K kek, CipherSpec)` | 1 h | 2 h |
 
The alias cache does refresh every 8 minutes and does re-query Vault. It just gets back a `String` identical to the one it had, so `CacheKey.equals()` still matches and `EncryptionDekCache` keeps serving a DEK wrapped under the old version — for up to two hours after the operator rotated.
 
Carrying the version means the refreshed value is no longer `equals()` to the cached one, subsequent lookups land on a different `CacheKey`, and a fresh DEK is minted under the new version. Worst-case rotation pickup drops from the DEK expiry (~2 h) to the alias refresh (~8 min).
 
The mechanism is worth stating precisely, because it's easy to misread as an invalidation. The two caches never communicate; nothing is evicted. Changing the resolved value simply causes later lookups to miss on a *new* key, and the stale entry is orphaned and ages out on its own. It rests entirely on `equals`/`hashCode` of `K`, which is why a record is the right shape and why the caches themselves needed no change.
 
## Where the version comes from
 
`VaultResponse.ReadKeyData` already bound `latest_version` — `resolveAlias` fetched it and then discarded it via `.thenApply(ReadKeyData::name)`. This change stops discarding it.
 
The issue suggested deriving the version from the `keys` map instead. That turns out to be the less reliable of the two. `keys` maps *version number → creation epoch-seconds*, so the version is the map key rather than the value, and the map is absent altogether for some key types — see the evidence section below. Verified against a live Vault v2.0.4:
 
    // before rotate
    { "name": "foo", "latest_version": 1, "keys": { "1": 1787846981 }, ... }
 
    // after POST /v1/transit/keys/foo/rotate
    { "name": "foo", "latest_version": 2, "keys": { "1": 1787846981, "2": 1787846983 }, ... }
 
Because the field is now load-bearing, it is bound with `@JsonProperty(value = "latest_version", required = true)`. `latestVersion` is a primitive `int`, so an absent field would otherwise deserialise to `0` silently, making every `WrappingKey` compare equal and reintroducing the exact bug this fixes — which is what the stale WireMock fixtures were hiding. Jackson enforces `required` for creator-bound properties, so a missing field now fails loudly at deserialisation.
 
An earlier revision also rejected `latestVersion < 1`. That has been removed: nothing documents a lower bound, and `min_encryption_version` uses `0` as a sentinel in the same response, so `0` cannot be assumed impossible. The trade was also wrong — a legitimate `0` without the guard means a stable `WrappingKey` and a silent loss of prompt rotation pickup, whereas with the guard `resolveAlias` throws and the proxy stops encrypting. Absence is the real risk, and `required = true` targets it precisely without asserting anything undocumented.
 
## Evidence that `latest_version` can be relied on
 
The field is returned by every Vault tested, but is not currently listed on the [Read Key](https://developer.hashicorp.com/vault/api-docs/secret/transit#read-key) API documentation. Raised upstream as [hashicorp/vault#32102](https://github.com/hashicorp/vault/issues/32102).
 
**Across Vault versions.** Present and incrementing on rotation (`create=1 → rotate=2`) in every release line from 1.2.6 (2019) through 2.0.0, testing the oldest available patch of each minor: 1.2.6, 1.3.7, 1.4.3, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0, 1.10.0, 1.11.0, 1.12.0, 1.13.0, 1.14.0, 1.15.0, 1.16.0, 1.17.0, 1.18.0, 1.19.0, 1.20.0, 1.21.0, 2.0.0. So this is not a recently added field, and upgrading Kroxylicious should not break users on older self-managed Vault.
 
**Across key types**, on 2.0.4 CE:
 
    aes128-gcm96        latest_version=1   keys=yes
    aes256-gcm96        latest_version=1   keys=yes
    chacha20-poly1305   latest_version=1   keys=yes
    ed25519             latest_version=1   keys=yes
    ecdsa-p256/384/521  latest_version=1   keys=yes
    rsa-2048/3072/4096  latest_version=1   keys=yes
    hmac                latest_version=1   keys=NO
    aes128/256-cmac     enterprise only, not testable on CE
    managed_key         enterprise only, not testable on CE
 
The `hmac` row is the notable one: `keys` is absent, because Vault never exposes the raw HMAC secret, but `latest_version` is still present. Deriving the version from the `keys` map would have returned nothing for that type. The three enterprise-only types are untested but moot here — we only resolve aliases for keys subsequently passed to `datakey/plaintext`, which requires an encryption-capable key, and hmac and CMAC keys cannot serve as KEKs.
 
**Checked with HashiCorp.** Raised this with HashiCorp's Vault SMEs internally. Their response, summarised:
 
- HCP Vault's transit API is the same as self-managed Vault's, with the caveat to line up Vault versions in case a later release changes the API. So HCP needs no separate handling — it is only a question of which Vault version a cluster runs, which the version matrix above covers.
- They expected `latest_version` to be present for all key types, since it is a function of the transit engine rather than the algorithm, and suggested confirming locally — which the key-type table above does.
- Versions start at 1 and increment on rotation, and earlier key material is retained so a payload encrypted under version 1 still decrypts when the key is on version 3.
That last point is also why the EDEK format needs no change.
 
## What doesn't change
 
`VaultEdek` stays `(String kekRef, byte[] edek)`, keyed by name. No serde change, no wire-format change, no migration — `git diff -- '*VaultEdek*'` is empty.
 
Decryption is unaffected for the same reason it was never broken: Vault ciphertext is self-describing (`vault:v1:`, `vault:v2:`), and `decryptEdek` posts it to `transit/decrypt/{name}`, so Vault selects the right version. Records encrypted before a rotation keep decrypting afterwards.
 
## The version is not a pinning instruction
 
`generateDekPair` uses `kekRef.name()` for the URL and the EDEK, and deliberately sends no `key_version` — unset means Vault uses the latest at call time.
 
So there is a benign race: if a rotation lands between alias resolution and the datakey call, Vault may use a version newer than the one in the `WrappingKey`. That's harmless and intentional, because the version exists to make the cache key change rather than to select a key. `CipherTrustKms` documents the same behaviour; the Javadoc here says so explicitly, so nobody later "fixes" it by pinning the version.
 
## Changes
 
**New — `WrappingKey`**
`record WrappingKey(String name, int version)` in the vault package, with a null-name guard. `int` matches `ReadKeyData.latestVersion` and avoids a cast. Per-provider rather than shared, consistent with the existing CipherTrust and Azure records, which have differently-shaped versions (`long` and `String` respectively). Javadoc covers the cache-invalidation rationale and the race above.
 
**`VaultKms`**
Now `Kms<WrappingKey, VaultEdek>`. `resolveAlias` ends `.thenApply(d -> new WrappingKey(d.name(), d.latestVersion()))`. `generateDekPair(WrappingKey)` uses `kekRef.name()` in three places: the `datakey/plaintext/%s` URL, the `sendAsync` key argument (error messages only), and the `VaultEdek` construction. URI encoding of path components was already present and is unchanged.
 
**`VaultResponse.ReadKeyData`**
`latest_version` bound with `required = true`. Javadoc records that the field is not currently listed in HashiCorp's API documentation, and what was observed across versions and key types.
 
**`VaultKmsService`**
Now `KmsService<Config, WrappingKey, VaultEdek>`.
 
**Test-support module**
Generic parameter widened in `AbstractVaultTestKmsFacade`, `AbstractVaultTestKmsFacadeFactory` and `VaultTestKmsFacadeFactory`. `KubeVaultTestKmsFacade` in `kroxylicious-systemtests` needed no change — it extends the abstract class without re-declaring type parameters and inherits the new type.
 
**`TestVault`**
Adds `rotateKek`, following the existing `createKek`/`runVaultCommand` pattern. Needed because `kroxylicious-kms-provider-hashicorp-vault-test-support` depends on the vault module, so `VaultKmsTestKekManager.rotateKek` is unreachable from an IT living in the vault module.
 
**Changelog**
`changelog/unreleased/04150-vault-resolveAlias-versioned-wrapping-key.yaml`.
 
## Testing
 
All tests passing across the two vault modules. New coverage:
 
- `resolveAlias` returns the expected name and version
- re-stubbing with an incremented `latest_version` produces a `WrappingKey` that is `isNotEqualTo` the previous one, with an equal `name()` — asserted on the objects rather than the version field, since object inequality is what `EncryptionDekCache.CacheKey` actually depends on
- `generateDekPair` still produces a `VaultEdek` keyed by the plain name, proving the EDEK format is unchanged
- a key name requiring URI encoding still resolves
- `WrappingKeyTest` — equality, `hashCode`, null rejection, and explicitly that same-name/different-version instances are unequal
- `VaultResponseTest` — `latest_version` deserialises, and a body omitting it is rejected with Jackson's `MismatchedInputException`
- existing `UnknownAliasException` / `KmsException` paths unregressed
`VaultKmsRotationIT` adds two tests against a live Vault container rather than WireMock: that a real Vault populates `latest_version`, and that rotation increments it and changes `WrappingKey` identity. A mock can only show the code handles the field when a stub supplies it, so the IT is what establishes the field is genuinely there. It uses a class-level `@EnabledIf` and a `@BeforeAll`/`@AfterAll` shared container, following the pattern in `KeyVaultClientIT`; each test uses its own key name so they remain order-independent.
 
All read-key WireMock fixtures were updated to include `latest_version`. They previously omitted it, so `latestVersion` had been deserialising to `0` in every test.
 
## Not covered
 
The end-to-end path through `EncryptionDekCache` isn't exercised by an integration test — the KMS is verified in isolation. The cache-miss behaviour follows from `WrappingKey` inequality plus `CacheKey<K>` delegating to it, which is unit-tested and true by inspection, but not measured end to end. Same position as #4043; happy to add coverage if wanted.
 
🤖 Assisted by Claude Opus