### PR TITLE
fix(build): Correct relative paths in modules

### DIFF
--- a/kroxylicious-annotations/pom.xml
+++ b/kroxylicious-annotations/pom.xml
@@ -14,6 +14,7 @@
         <groupId>io.kroxylicious</groupId>
         <artifactId>kroxylicious-parent</artifactId>
         <version>0.24.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>kroxylicious-annotations</artifactId>

--- a/kroxylicious-certificate-test-support/pom.xml
+++ b/kroxylicious-certificate-test-support/pom.xml
@@ -15,6 +15,7 @@
         <groupId>io.kroxylicious</groupId>
         <artifactId>kroxylicious-parent</artifactId>
         <version>0.24.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>kroxylicious-certificate-test-support</artifactId>

--- a/kroxylicious-docs-tests/pom.xml
+++ b/kroxylicious-docs-tests/pom.xml
@@ -16,6 +16,7 @@
         <groupId>io.kroxylicious</groupId>
         <artifactId>kroxylicious-parent</artifactId>
         <version>0.24.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>kroxylicious-docs-tests</artifactId>

--- a/kroxylicious-docs/pom.xml
+++ b/kroxylicious-docs/pom.xml
@@ -15,6 +15,7 @@
         <groupId>io.kroxylicious</groupId>
         <artifactId>kroxylicious-parent</artifactId>
         <version>0.24.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>kroxylicious-docs</artifactId>

--- a/kroxylicious-filters/pom.xml
+++ b/kroxylicious-filters/pom.xml
@@ -13,6 +13,7 @@
         <groupId>io.kroxylicious</groupId>
         <artifactId>kroxylicious-parent</artifactId>
         <version>0.24.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>kroxylicious-filter-parent</artifactId>

--- a/kroxylicious-kafka-message-generator/pom.xml
+++ b/kroxylicious-kafka-message-generator/pom.xml
@@ -14,6 +14,7 @@
         <groupId>io.kroxylicious</groupId>
         <artifactId>kroxylicious-parent</artifactId>
         <version>0.24.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>kroxylicious-kafka-message-generator</artifactId>

--- a/kroxylicious-kafka-message-tools/pom.xml
+++ b/kroxylicious-kafka-message-tools/pom.xml
@@ -14,6 +14,7 @@
         <groupId>io.kroxylicious</groupId>
         <artifactId>kroxylicious-parent</artifactId>
         <version>0.24.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>kroxylicious-kafka-message-tools</artifactId>

--- a/kroxylicious-kms-providers/pom.xml
+++ b/kroxylicious-kms-providers/pom.xml
@@ -14,6 +14,7 @@
         <groupId>io.kroxylicious</groupId>
         <artifactId>kroxylicious-parent</artifactId>
         <version>0.24.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>kroxylicious-kms-providers</artifactId>

--- a/kroxylicious-kms-test-support/pom.xml
+++ b/kroxylicious-kms-test-support/pom.xml
@@ -15,6 +15,7 @@
         <groupId>io.kroxylicious</groupId>
         <artifactId>kroxylicious-parent</artifactId>
         <version>0.24.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>kroxylicious-kms-test-support</artifactId>

--- a/kroxylicious-kms-tls-support/pom.xml
+++ b/kroxylicious-kms-tls-support/pom.xml
@@ -15,6 +15,7 @@
         <groupId>io.kroxylicious</groupId>
         <artifactId>kroxylicious-parent</artifactId>
         <version>0.24.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>kroxylicious-kms-tls-support</artifactId>

--- a/kroxylicious-kubernetes/pom.xml
+++ b/kroxylicious-kubernetes/pom.xml
@@ -13,6 +13,7 @@
         <groupId>io.kroxylicious</groupId>
         <artifactId>kroxylicious-parent</artifactId>
         <version>0.24.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>kroxylicious-kubernetes-parent</artifactId>

--- a/kroxylicious-runtime-plugins/pom.xml
+++ b/kroxylicious-runtime-plugins/pom.xml
@@ -13,6 +13,7 @@
         <groupId>io.kroxylicious</groupId>
         <artifactId>kroxylicious-parent</artifactId>
         <version>0.24.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <!-- Pure aggregator — do not declare this as <parent> in any child module. -->

--- a/kroxylicious-scram-credential-store-providers/pom.xml
+++ b/kroxylicious-scram-credential-store-providers/pom.xml
@@ -14,6 +14,7 @@
         <groupId>io.kroxylicious</groupId>
         <artifactId>kroxylicious-parent</artifactId>
         <version>0.24.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>kroxylicious-scram-credential-store-providers</artifactId>

--- a/kroxylicious-supplementary/pom.xml
+++ b/kroxylicious-supplementary/pom.xml
@@ -13,6 +13,7 @@
         <groupId>io.kroxylicious</groupId>
         <artifactId>kroxylicious-parent</artifactId>
         <version>0.24.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <!-- Pure aggregator — do not declare this as <parent> in any child module. -->

--- a/kroxylicious-systemtests/pom.xml
+++ b/kroxylicious-systemtests/pom.xml
@@ -15,6 +15,7 @@
         <groupId>io.kroxylicious</groupId>
         <artifactId>kroxylicious-parent</artifactId>
         <version>0.24.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>kroxylicious-systemtests</artifactId>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Each parent reference in the the tree should have a relative path. This adds them.

### Additional Context

It seemed to be causing issues in something I was trying to debug.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
