### PR TITLE
Remove kafka Request usage from test

### DIFF
--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/EagerMetadataLearnerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/EagerMetadataLearnerTest.java
@@ -20,12 +20,6 @@ import org.apache.kafka.common.message.SaslAuthenticateRequestData;
 import org.apache.kafka.common.message.SaslHandshakeRequestData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
-import org.apache.kafka.common.requests.AbstractRequest;
-import org.apache.kafka.common.requests.ApiVersionsRequest;
-import org.apache.kafka.common.requests.MetadataRequest;
-import org.apache.kafka.common.requests.ProduceRequest;
-import org.apache.kafka.common.requests.SaslAuthenticateRequest;
-import org.apache.kafka.common.requests.SaslHandshakeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -55,11 +49,18 @@ class EagerMetadataLearnerTest {
         learner = new EagerMetadataLearner();
     }
 
+    record Request(ApiMessage data, short version) {
+
+        public ApiKeys apiKey() {
+            return ApiKeys.forId(data.apiKey());
+        }
+    }
+
     public static Stream<Arguments> preludeRequests() {
         return Stream.of(
-                toArgs("ApiVersionsRequest", new ApiVersionsRequest(new ApiVersionsRequestData(), ApiVersionsRequestData.HIGHEST_SUPPORTED_VERSION)),
-                toArgs("SaslHandshakeRequest", new SaslHandshakeRequest(new SaslHandshakeRequestData(), SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION)),
-                toArgs("SaslAuthenticateRequest", new SaslAuthenticateRequest(new SaslAuthenticateRequestData(), SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION)));
+                toArgs("ApiVersionsRequest", new Request(new ApiVersionsRequestData(), ApiVersionsRequestData.HIGHEST_SUPPORTED_VERSION)),
+                toArgs("SaslHandshakeRequest", new Request(new SaslHandshakeRequestData(), SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION)),
+                toArgs("SaslAuthenticateRequest", new Request(new SaslAuthenticateRequestData(), SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION)));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -72,10 +73,10 @@ class EagerMetadataLearnerTest {
 
     public static Stream<Arguments> postPreludeRequests() {
         return Stream.of(
-                toArgs("ProduceRequest replaced by MetadataRequest", new ProduceRequest(new ProduceRequestData(), ProduceRequestData.HIGHEST_SUPPORTED_VERSION)),
-                toArgs("MetadataRequest (highest supported)", new MetadataRequest(new MetadataRequestData(), MetadataRequestData.HIGHEST_SUPPORTED_VERSION)),
-                toArgs("MetadataRequest (lowest supported)", new MetadataRequest(new MetadataRequestData(), MetadataRequestData.LOWEST_SUPPORTED_VERSION)),
-                toArgs("MetadataRequest (payload fidelity)", new MetadataRequest(new MetadataRequestData().setTopics(List.of(new MetadataRequestTopic().setName("foo"))),
+                toArgs("ProduceRequest replaced by MetadataRequest", new Request(new ProduceRequestData(), ProduceRequestData.HIGHEST_SUPPORTED_VERSION)),
+                toArgs("MetadataRequest (highest supported)", new Request(new MetadataRequestData(), MetadataRequestData.HIGHEST_SUPPORTED_VERSION)),
+                toArgs("MetadataRequest (lowest supported)", new Request(new MetadataRequestData(), MetadataRequestData.LOWEST_SUPPORTED_VERSION)),
+                toArgs("MetadataRequest (payload fidelity)", new Request(new MetadataRequestData().setTopics(List.of(new MetadataRequestTopic().setName("foo"))),
                         MetadataRequestData.LOWEST_SUPPORTED_VERSION)));
     }
 
@@ -103,7 +104,7 @@ class EagerMetadataLearnerTest {
         assertThat(result.closeConnection()).isTrue();
     }
 
-    private static Arguments toArgs(String name, AbstractRequest request) {
+    private static Arguments toArgs(String name, Request request) {
         var header = new RequestHeaderData().setRequestApiKey(request.apiKey().id).setRequestApiVersion(request.version());
         var apiKey = request.apiKey();
         var request1 = request.data();


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Remove usage of Request wrapper classes from kroxylicious-runtime test

As part of #4581 we will be overhauling kroxylicious-runtime to depend on kroxylicious-api that does not offer Request/Response wrapper classes. This test is just using *Request classes as a way of bundling data + version.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
