### PR TITLE
feat(kafka-message-json): add JSON converters for vendored Kafka message classes

### DIFF
--- a/changelog/unreleased/04778-vendor-json-converters.yaml
+++ b/changelog/unreleased/04778-vendor-json-converters.yaml
@@ -1,0 +1,4 @@
+title: "feat(kafka-message-json): add JSON converters for vendored kafka message classes"
+type: added
+issues:
+  - 4778

--- a/kroxylicious-kafka-message-json/pom.xml
+++ b/kroxylicious-kafka-message-json/pom.xml
@@ -33,6 +33,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -45,7 +50,103 @@
                         <id>unpack-message-specs</id>
                         <phase>generate-sources</phase>
                     </execution>
+                    <!-- Specs for the vendored io.kroxylicious.kafka.common.message.*Data classes are
+                         pinned to kafka.message-spec.version, which can differ from kafka.version (the
+                         Kafka-side converter's spec pin above). Mirrors kroxylicious-api's
+                         unpack-data-class-message-specs so the vendored JsonConverter classes generated
+                         below stay schema-consistent with the vendored *Data classes they convert. -->
+                    <execution>
+                        <id>unpack-data-class-message-specs</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.kafka</groupId>
+                                    <artifactId>kafka-clients</artifactId>
+                                    <version>${kafka.message-spec.version}</version>
+                                    <overWrite>false</overWrite>
+                                    <includes>common/message/**/*.json</includes>
+                                    <outputDirectory>${project.build.directory}/data-class-message-specs
+                                    </outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
                 </executions>
+            </plugin>
+            <!-- Generate io.kroxylicious.kafka.common.message.*DataJsonConverter classes from the
+                 same specs used to generate the vendored *Data classes in kroxylicious-api. The
+                 forked generator is a plugin-scoped dependency so it stays off this module's own
+                 dependency graph. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-vendored-json-converters</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>io.kroxylicious.kafka.message.MessageGenerator</mainClass>
+                            <includePluginDependencies>true</includePluginDependencies>
+                            <arguments>
+                                <argument>-p</argument>
+                                <argument>io.kroxylicious.kafka.common.message</argument>
+                                <argument>-i</argument>
+                                <argument>${project.build.directory}/data-class-message-specs/common/message</argument>
+                                <argument>-o</argument>
+                                <argument>
+                                    ${project.build.directory}/generated-sources/vendored-json-converters/io/kroxylicious/kafka/common/message
+                                </argument>
+                                <argument>-m</argument>
+                                <argument>JsonConverterGenerator</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.kroxylicious</groupId>
+                        <artifactId>kroxylicious-kafka-message-generator</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <!-- This actually shouldn't be needed, as the plug-in itself adds that directory as a source directory;
+                 Unfortunately, Eclipse/M2E doesn't reliably pick it up without this helper plug-in -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/vendored-json-converters</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- The generated vendored io.kroxylicious.kafka.common.message.*DataJsonConverter
+                 classes carry Kafka's own Javadoc, which does not satisfy this project's doclint
+                 gate and is not something we publish API docs for. Mirrors kroxylicious-api's
+                 exclusion of the same package tree. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <excludePackageNames>io.kroxylicious.kafka:io.kroxylicious.kafka.*</excludePackageNames>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>io.kroxylicious</groupId>

--- a/kroxylicious-kafka-message-json/pom.xml
+++ b/kroxylicious-kafka-message-json/pom.xml
@@ -20,9 +20,10 @@
     </parent>
     <artifactId>kroxylicious-kafka-message-json</artifactId>
     <name>Kafka message JSON converter</name>
-    <description>KafkaApiMessageConverter: converts Kafka protocol request/response messages
-        between org.apache.kafka.common.protocol.ApiMessage and their JSON representation,
-        keyed by ApiMessageType.</description>
+    <description>KafkaApiMessageConverter and VendoredKafkaApiMessageConverter: convert Kafka
+        protocol request/response messages between ApiMessage and their JSON representation,
+        keyed by ApiMessageType, for the org.apache.kafka.* and vendored io.kroxylicious.kafka.*
+        message classes respectively.</description>
 
     <dependencies>
         <dependency>
@@ -37,6 +38,21 @@
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-api</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -164,6 +180,29 @@
                             <messageSpecFilter>*{Request,Response}.json</messageSpecFilter>
                             <templateDirectory>${project.basedir}/src/main/templates</templateDirectory>
                             <templateNames>KafkaApiMessageConverter.ftl</templateNames>
+                            <!--suppress MavenModelInspection -->
+                            <outputFilePattern>${templateName}.java</outputFilePattern>
+                            <outputPackage>io.kroxylicious.kafka.message.json</outputPackage>
+                            <outputDirectory>${project.build.directory}/generated-sources/krpc</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <!-- VendoredKafkaApiMessageConverter targets io.kroxylicious.kafka.common.message,
+                         generated from kafka.message-spec.version specs (see
+                         unpack-data-class-message-specs above), which can differ from kafka.version
+                         used by generate-converters above. Kept as its own execution so each template
+                         is generated from the spec set matching the classes it actually targets. -->
+                    <execution>
+                        <id>generate-vendored-converter</id>
+                        <goals>
+                            <goal>generate-multi</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                        <configuration>
+                            <messageSpecDirectory>${project.build.directory}/data-class-message-specs/common/message
+                            </messageSpecDirectory>
+                            <messageSpecFilter>*{Request,Response}.json</messageSpecFilter>
+                            <templateDirectory>${project.basedir}/src/main/templates</templateDirectory>
+                            <templateNames>VendoredKafkaApiMessageConverter.ftl</templateNames>
                             <!--suppress MavenModelInspection -->
                             <outputFilePattern>${templateName}.java</outputFilePattern>
                             <outputPackage>io.kroxylicious.kafka.message.json</outputPackage>

--- a/kroxylicious-kafka-message-json/pom.xml
+++ b/kroxylicious-kafka-message-json/pom.xml
@@ -37,7 +37,6 @@
         <dependency>
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>

--- a/kroxylicious-kafka-message-json/pom.xml
+++ b/kroxylicious-kafka-message-json/pom.xml
@@ -49,11 +49,6 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/kroxylicious-kafka-message-json/src/main/templates/KafkaApiMessageConverter.ftl
+++ b/kroxylicious-kafka-message-json/src/main/templates/KafkaApiMessageConverter.ftl
@@ -27,7 +27,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 /**
  * Provides converters between the JSON representation of Kafka API messages and the
  * corresponding {@link ApiMessage} instances.
+ * @deprecated we will only support conversion of kroxylicious ApiMessages in the future.
+ * Use {@link io.kroxylicious.kafka.message.json.VendoredKafkaApiMessageConverter} instead.
  */
+@Deprecated(forRemoval = true, since = "0.24.0")
 public class KafkaApiMessageConverter {
 
     /**

--- a/kroxylicious-kafka-message-json/src/main/templates/VendoredKafkaApiMessageConverter.ftl
+++ b/kroxylicious-kafka-message-json/src/main/templates/VendoredKafkaApiMessageConverter.ftl
@@ -1,0 +1,98 @@
+<#--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+
+package ${outputPackage};
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+<#list inputSpecs as inputSpec>
+import io.kroxylicious.kafka.common.message.${inputSpec.name}Data;
+import io.kroxylicious.kafka.common.message.${inputSpec.name}DataJsonConverter;
+</#list>
+import io.kroxylicious.kafka.common.message.ApiMessageType;
+import io.kroxylicious.kafka.common.protocol.ApiMessage;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+
+
+/**
+ * Provides converters between the JSON representation of vendored Kafka API messages and the
+ * corresponding {@link ApiMessage} instances.
+ */
+public class VendoredKafkaApiMessageConverter {
+
+    /**
+     * A pair of functions converting between JSON and {@link ApiMessage} at a given API version.
+     *
+     * @param reader function converting a JSON node to an {@link ApiMessage} at the given API version
+     * @param writer function converting an {@link ApiMessage} to a JSON node at the given API version
+     */
+    public record Converter(BiFunction<JsonNode, Short, ApiMessage> reader,
+                            BiFunction<ApiMessage, Short, JsonNode> writer) {
+    }
+
+    private VendoredKafkaApiMessageConverter() {
+    }
+
+    private static final Map<ApiMessageType, Converter> requestConverters;
+    private static final Map<ApiMessageType, Converter> responseConverters;
+
+    static {
+        var reqc = new HashMap<ApiMessageType, Converter>();
+        var resc = new HashMap<ApiMessageType, Converter>();
+
+<#list inputSpecs as inputSpec>
+    <#if inputSpec.type?lower_case == 'request'>
+        reqc.put(ApiMessageType.${inputSpec.kafkaApiKeyEnumName}, new Converter(
+                    ${inputSpec.name}DataJsonConverter::read,
+                (o, ver) -> ${inputSpec.name}DataJsonConverter.write(((${inputSpec.name}Data) o), ver)));
+    </#if>
+    <#if inputSpec.type?lower_case == 'response'>
+        resc.put(ApiMessageType.${inputSpec.kafkaApiKeyEnumName}, new Converter(
+                    ${inputSpec.name}DataJsonConverter::read,
+                (o, ver) -> ${inputSpec.name}DataJsonConverter.write(((${inputSpec.name}Data) o), ver)));
+    </#if>
+</#list>
+        requestConverters = Collections.unmodifiableMap(reqc);
+        responseConverters = Collections.unmodifiableMap(resc);
+    }
+
+    /**
+     * Returns the converter for the request message of the given API message type.
+     *
+     * @param apiMessageType the API message type
+     * @return the request converter
+     * @throws IllegalArgumentException if no request converter is registered for the given type
+     */
+    public static Converter requestConverterFor(ApiMessageType apiMessageType) {
+        var converter = requestConverters.get(apiMessageType);
+        if (converter == null) {
+            throw new IllegalArgumentException("no request converter registered for " + apiMessageType);
+        }
+        return converter;
+    }
+
+    /**
+     * Returns the converter for the response message of the given API message type.
+     *
+     * @param apiMessageType the API message type
+     * @return the response converter
+     * @throws IllegalArgumentException if no response converter is registered for the given type
+     */
+    public static Converter responseConverterFor(ApiMessageType apiMessageType) {
+        var converter = responseConverters.get(apiMessageType);
+        if (converter == null) {
+            throw new IllegalArgumentException("no response converter registered for " + apiMessageType);
+        }
+        return converter;
+    }
+}

--- a/kroxylicious-kafka-message-json/src/test/java/io/kroxylicious/kafka/message/json/VendoredKafkaApiMessageConverterTest.java
+++ b/kroxylicious-kafka-message-json/src/test/java/io/kroxylicious/kafka/message/json/VendoredKafkaApiMessageConverterTest.java
@@ -16,12 +16,15 @@ class VendoredKafkaApiMessageConverterTest {
 
     @Test
     void roundTripsThroughJson() {
+        // Given
         var original = new MetadataRequestData().setAllowAutoTopicCreation(false).setIncludeClusterAuthorizedOperations(true);
         var converter = VendoredKafkaApiMessageConverter.requestConverterFor(ApiMessageType.METADATA);
 
+        // When
         var json = converter.writer().apply(original, (short) 9);
         var roundTripped = converter.reader().apply(json, (short) 9);
 
+        // Then
         assertThat(roundTripped).isEqualTo(original);
     }
 }

--- a/kroxylicious-kafka-message-json/src/test/java/io/kroxylicious/kafka/message/json/VendoredKafkaApiMessageConverterTest.java
+++ b/kroxylicious-kafka-message-json/src/test/java/io/kroxylicious/kafka/message/json/VendoredKafkaApiMessageConverterTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.kafka.message.json;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.kafka.common.message.ApiMessageType;
+import io.kroxylicious.kafka.common.message.MetadataRequestData;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VendoredKafkaApiMessageConverterTest {
+
+    @Test
+    void roundTripsThroughJson() {
+        var original = new MetadataRequestData().setAllowAutoTopicCreation(false).setIncludeClusterAuthorizedOperations(true);
+        var converter = VendoredKafkaApiMessageConverter.requestConverterFor(ApiMessageType.METADATA);
+
+        var json = converter.writer().apply(original, (short) 9);
+        var roundTripped = converter.reader().apply(json, (short) 9);
+
+        assertThat(roundTripped).isEqualTo(original);
+    }
+}

--- a/kroxylicious-wire-fidelity-tests/pom.xml
+++ b/kroxylicious-wire-fidelity-tests/pom.xml
@@ -42,6 +42,16 @@
             <artifactId>kroxylicious-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-kafka-message-json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- Pinned to kafka.message-spec.version rather than the project's managed kafka.version:
              our *Data classes are generated from the IDL specs bundled in this exact kafka-clients
              jar, so fidelity must be proven against that same jar's actual implementations. Mirrors

--- a/kroxylicious-wire-fidelity-tests/src/test/java/io/kroxylicious/fidelity/kafka/JsonConverterFidelityTest.java
+++ b/kroxylicious-wire-fidelity-tests/src/test/java/io/kroxylicious/fidelity/kafka/JsonConverterFidelityTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class JsonConverterFidelityTest {
 
-    private record TypePair(org.apache.kafka.common.message.ApiMessageType kafkaType, io.kroxylicious.kafka.common.message.ApiMessageType vendoredType) {}
+    record TypePair(org.apache.kafka.common.message.ApiMessageType kafkaType, io.kroxylicious.kafka.common.message.ApiMessageType vendoredType) {}
 
     @ParameterizedTest
     @MethodSource("allRequestVersions")

--- a/kroxylicious-wire-fidelity-tests/src/test/java/io/kroxylicious/fidelity/kafka/JsonConverterFidelityTest.java
+++ b/kroxylicious-wire-fidelity-tests/src/test/java/io/kroxylicious/fidelity/kafka/JsonConverterFidelityTest.java
@@ -32,18 +32,26 @@ class JsonConverterFidelityTest {
     @ParameterizedTest
     @MethodSource("allRequestVersions")
     void requestJsonMatchesKafka(TypePair types, short version) {
+        // Given
+
+        // When
         var kafkaJson = KafkaApiMessageConverter.requestConverterFor(types.kafkaType()).writer().apply(types.kafkaType().newRequest(), version);
         var vendoredJson = VendoredKafkaApiMessageConverter.requestConverterFor(types.vendoredType()).writer().apply(types.vendoredType().newRequest(), version);
 
+        // Then
         assertThat(vendoredJson).isEqualTo(kafkaJson);
     }
 
     @ParameterizedTest
     @MethodSource("allResponseVersions")
     void responseJsonMatchesKafka(TypePair types, short version) {
+        // Given
+
+        // When
         var kafkaJson = KafkaApiMessageConverter.responseConverterFor(types.kafkaType()).writer().apply(types.kafkaType().newResponse(), version);
         var vendoredJson = VendoredKafkaApiMessageConverter.responseConverterFor(types.vendoredType()).writer().apply(types.vendoredType().newResponse(), version);
 
+        // Then
         assertThat(vendoredJson).isEqualTo(kafkaJson);
     }
 

--- a/kroxylicious-wire-fidelity-tests/src/test/java/io/kroxylicious/fidelity/kafka/JsonConverterFidelityTest.java
+++ b/kroxylicious-wire-fidelity-tests/src/test/java/io/kroxylicious/fidelity/kafka/JsonConverterFidelityTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.fidelity.kafka;
+
+import java.util.Optional;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.kroxylicious.kafka.message.json.KafkaApiMessageConverter;
+import io.kroxylicious.kafka.message.json.VendoredKafkaApiMessageConverter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Confirms that {@link VendoredKafkaApiMessageConverter} produces the same JSON representation as
+ * {@link KafkaApiMessageConverter} for a default-constructed instance of every message type shared
+ * between {@code org.apache.kafka.common.message.ApiMessageType} and its vendored equivalent, at
+ * every version supported by both.
+ */
+class JsonConverterFidelityTest {
+
+    private record TypePair(org.apache.kafka.common.message.ApiMessageType kafkaType, io.kroxylicious.kafka.common.message.ApiMessageType vendoredType) {}
+
+    @ParameterizedTest
+    @MethodSource("allRequestVersions")
+    void requestJsonMatchesKafka(TypePair types, short version) {
+        var kafkaJson = KafkaApiMessageConverter.requestConverterFor(types.kafkaType()).writer().apply(types.kafkaType().newRequest(), version);
+        var vendoredJson = VendoredKafkaApiMessageConverter.requestConverterFor(types.vendoredType()).writer().apply(types.vendoredType().newRequest(), version);
+
+        assertThat(vendoredJson).isEqualTo(kafkaJson);
+    }
+
+    @ParameterizedTest
+    @MethodSource("allResponseVersions")
+    void responseJsonMatchesKafka(TypePair types, short version) {
+        var kafkaJson = KafkaApiMessageConverter.responseConverterFor(types.kafkaType()).writer().apply(types.kafkaType().newResponse(), version);
+        var vendoredJson = VendoredKafkaApiMessageConverter.responseConverterFor(types.vendoredType()).writer().apply(types.vendoredType().newResponse(), version);
+
+        assertThat(vendoredJson).isEqualTo(kafkaJson);
+    }
+
+    static Stream<Arguments> allRequestVersions() {
+        return sharedApiMessageTypes().flatMap(types -> versionsOf(types).mapToObj(
+                version -> Arguments.argumentSet(types.kafkaType().name() + "Request - v" + version, types, (short) version)));
+    }
+
+    static Stream<Arguments> allResponseVersions() {
+        return sharedApiMessageTypes().flatMap(types -> versionsOf(types).mapToObj(
+                version -> Arguments.argumentSet(types.kafkaType().name() + "Response - v" + version, types, (short) version)));
+    }
+
+    private static IntStream versionsOf(TypePair types) {
+        return IntStream.rangeClosed(types.kafkaType().lowestSupportedVersion(), types.kafkaType().highestSupportedVersion(true));
+    }
+
+    private static Stream<TypePair> sharedApiMessageTypes() {
+        return Stream.of(org.apache.kafka.common.message.ApiMessageType.values())
+                .flatMap(kafkaType -> vendoredEquivalent(kafkaType).map(vendoredType -> new TypePair(kafkaType, vendoredType)).stream());
+    }
+
+    private static Optional<io.kroxylicious.kafka.common.message.ApiMessageType> vendoredEquivalent(org.apache.kafka.common.message.ApiMessageType kafkaType) {
+        try {
+            return Optional.of(io.kroxylicious.kafka.common.message.ApiMessageType.valueOf(kafkaType.name()));
+        }
+        catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+}


### PR DESCRIPTION
## Problem/Gap
kroxylicious-api's vendored io.kroxylicious.kafka.common.message.*Data
classes have no JSON converters, unlike their org.apache.kafka.common.message
equivalents (KafkaApiMessageConverter). This blocks JSON-based tooling and
diagnostics on the vendored types ahead of the filter API migration
(#4581, #4582).

## What changed
kroxylicious-kafka-message-json now also generates JsonConverterGenerator
output for the vendored *Data classes and exposes
VendoredKafkaApiMessageConverter, parallel to the existing
KafkaApiMessageConverter. A parity test confirms JSON output matches the
Kafka-side converter across every shared message type and version.

## API changes
New public class io.kroxylicious.kafka.message.json.VendoredKafkaApiMessageConverter
(plus generated per-message *DataJsonConverter classes) in
kroxylicious-kafka-message-json.

Closes #4778