### PR TITLE
refactor(kroxylicious-migrations) Use method matchers instead of manually matching method invocations.

### DIFF
--- a/kroxylicious-proxy-core/kroxylicious-migrations/src/main/java/io/kroxylicious/migrations/rewrite/v0_24/UseErrorsInsteadOfExceptions.java
+++ b/kroxylicious-proxy-core/kroxylicious-migrations/src/main/java/io/kroxylicious/migrations/rewrite/v0_24/UseErrorsInsteadOfExceptions.java
@@ -14,6 +14,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 
@@ -21,6 +22,10 @@ import org.openrewrite.java.tree.J;
  * Removes calls to `exception()` from Apaches Error enum. That is it transforms {@code Errors.GROUP_AUTHORIZATION_FAILED.exception()} into {@code Errors.GROUP_AUTHORIZATION_FAILED}
  */
 public class UseErrorsInsteadOfExceptions extends Recipe {
+
+    private static final MethodMatcher requestErrorResponseMatcher = new MethodMatcher(
+            "io.kroxylicious.proxy.filter.RequestFilterResultBuilder errorResponse(org.apache.kafka.common.message.RequestHeaderData, org.apache.kafka.common.protocol.ApiMessage, org.apache.kafka.common.errors.ApiException)");
+    private static final MethodMatcher errorExceptionMatcher = new MethodMatcher("org.apache.kafka.common.protocol.Errors exception()");
 
     /**
      * Instantiates an instance
@@ -52,9 +57,9 @@ public class UseErrorsInsteadOfExceptions extends Recipe {
 
             // Target errorResponse invocations with 3 arguments
             List<Expression> arguments = mi.getArguments();
-            if ("errorResponse".equals(mi.getSimpleName()) && arguments.size() == 3) {
+            if (requestErrorResponseMatcher.matches(mi)) {
                 Expression thirdArg = arguments.get(2);
-                if (thirdArg instanceof J.MethodInvocation invocation && "exception".equals(invocation.getSimpleName()) && invocation.getSelect() != null) {
+                if (errorExceptionMatcher.matches(thirdArg) && thirdArg instanceof J.MethodInvocation invocation && invocation.getSelect() != null) {
                     Expression innerExpression = invocation.getSelect();
                     List<Expression> newArgs = new ArrayList<>(arguments);
                     newArgs.set(2, Objects.requireNonNull(innerExpression).withPrefix(thirdArg.getPrefix()));

--- a/kroxylicious-proxy-core/kroxylicious-migrations/src/test/java/io/kroxylicious/migrations/rewrite/v0_24/UseErrorsInsteadOfExceptionsTest.java
+++ b/kroxylicious-proxy-core/kroxylicious-migrations/src/test/java/io/kroxylicious/migrations/rewrite/v0_24/UseErrorsInsteadOfExceptionsTest.java
@@ -32,14 +32,15 @@ class UseErrorsInsteadOfExceptionsTest implements RewriteTest {
                                         import org.apache.kafka.common.errors.ApiException;
                                         import org.apache.kafka.common.message.ProduceRequestData;
                                         import org.apache.kafka.common.message.RequestHeaderData;
+                                        import org.apache.kafka.common.protocol.ApiMessage;
                                         import org.apache.kafka.common.protocol.Errors;
 
                                         public interface RequestFilterResultBuilder {
                                             // Old overload used in "Before" code
-                                            RequestFilterResultBuilder errorResponse(RequestHeaderData header, ProduceRequestData request, ApiException exception);
+                                            RequestFilterResultBuilder errorResponse(RequestHeaderData header, ApiMessage request, ApiException exception);
 
                                             // New overload used in "After" code
-                                            RequestFilterResultBuilder errorResponse(RequestHeaderData header, ProduceRequestData request, Errors error);
+                                            RequestFilterResultBuilder errorResponse(RequestHeaderData header, ApiMessage request, Errors error);
 
                                             RequestFilterResult completed();
                                         }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Switch to using method matchers instead of manually unpicking the calls.

### Additional Context

[The open rewrite docs](https://docs.openrewrite.org/reference/type-attribution#checking-method-signatures) say this is the recommended pattern for matching method invocations.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
