### PR TITLE
fix(runtime): deliver out-of-band responses by recipient, not route (#4808)

### DIFF
--- a/changelog/unreleased/04808-oob-response-by-recipient.yaml
+++ b/changelog/unreleased/04808-oob-response-by-recipient.yaml
@@ -1,0 +1,4 @@
+title: "fix(runtime): deliver a per-route filter's out-of-band response by recipient, so it is not lost when two or more routes issue out-of-band requests on one connection"
+type: fixed
+issues:
+  - 4808

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouteFilterCorrectnessIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouteFilterCorrectnessIT.java
@@ -31,6 +31,7 @@ import io.kroxylicious.it.testplugins.RequestResponseMarkingFilter;
 import io.kroxylicious.it.testplugins.RequestResponseMarkingFilterFactory;
 import io.kroxylicious.it.testplugins.router.ContextCapturingRouterFactory;
 import io.kroxylicious.it.testplugins.router.DynamicProduceRouterFactory;
+import io.kroxylicious.it.testplugins.router.FanOutRouterFactory;
 import io.kroxylicious.it.testplugins.router.PassThroughRouterFactory;
 import io.kroxylicious.proxy.config.ClusterDefinition;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
@@ -221,6 +222,60 @@ class RouteFilterCorrectnessIT {
         }
     }
 
+    // ---------------------------------------------------------------------------
+    // C4: Concurrent out-of-band requests from two routes are each delivered back
+    // ---------------------------------------------------------------------------
+
+    /**
+     * When one client request is fanned to two routes and each route's filter issues an out-of-band
+     * {@code sendRequest()}, both out-of-band responses must be delivered back to the filter that
+     * issued them. All out-of-band requests share one reserved correlation id, so the per-connection
+     * {@code correlationId -> routeName} map collides; before the fix the replies were tagged with
+     * the wrong route and written to the client, and both filters timed out after 20s.
+     */
+    @Test
+    void concurrentOutOfBandRequestsFromTwoRoutesAreEachDelivered() {
+        var markerA = "c4-marker-a";
+        var markerB = "c4-marker-b";
+
+        // Given
+        var markerADef = new NamedFilterDefinitionBuilder(markerA, RequestResponseMarkingFilterFactory.class.getName())
+                .withConfig("keysToMark", Set.of(LIST_TRANSACTIONS),
+                        "direction", Set.of(RequestResponseMarkingFilterFactory.Direction.REQUEST),
+                        "name", markerA,
+                        "forwardingStyle", ForwardingStyle.ASYNCHRONOUS_REQUEST_TO_BROKER)
+                .build();
+        var markerBDef = new NamedFilterDefinitionBuilder(markerB, RequestResponseMarkingFilterFactory.class.getName())
+                .withConfig("keysToMark", Set.of(LIST_TRANSACTIONS),
+                        "direction", Set.of(RequestResponseMarkingFilterFactory.Direction.REQUEST),
+                        "name", markerB,
+                        "forwardingStyle", ForwardingStyle.ASYNCHRONOUS_REQUEST_TO_BROKER)
+                .build();
+
+        try (var tester = KroxyliciousTesters.mockKafkaKroxyliciousTester(
+                mockBootstrap -> fanOutTwoRouteConfig(mockBootstrap, markerADef, markerBDef), ROUTING_ENABLED);
+                var client = tester.simpleTestClient()) {
+
+            ApiVersionsResponseData apiVersions = new ApiVersionsResponseData();
+            apiVersions.apiKeys().add(new ApiVersionsResponseData.ApiVersion()
+                    .setApiKey(FETCH.id).setMaxVersion(FETCH.latestVersion()).setMinVersion(FETCH.oldestVersion()));
+            tester.addMockResponseForApiKey(new ResponsePayload(API_VERSIONS, API_VERSIONS.latestVersion(), apiVersions));
+            tester.addMockResponseForApiKey(new ResponsePayload(LIST_TRANSACTIONS, LIST_TRANSACTIONS.latestVersion(), new ListTransactionsResponseData()));
+            tester.addMockResponseForApiKey(new ResponsePayload(LIST_GROUPS, LIST_GROUPS.latestVersion(), new ListGroupsResponseData()));
+
+            // When
+            var response = client.getSync(new Request(LIST_TRANSACTIONS, LIST_TRANSACTIONS.latestVersion(), "client", new ListTransactionsRequestData()));
+
+            // Then
+            assertThat(response)
+                    .as("client request completes only if both routes' out-of-band responses were delivered")
+                    .isNotNull();
+            assertThat(tester.getRequestsForApiKey(LIST_GROUPS))
+                    .as("both route filters must have issued their out-of-band request on the one connection")
+                    .hasSize(2);
+        }
+    }
+
     /**
      * When a filter on route-a sends an internal request, filters on route-b must not process it.
      * Exposed a bug where {@code RouteFilterHandler} passed all {@code InternalRequestFrame}s
@@ -408,6 +463,27 @@ class RouteFilterCorrectnessIT {
             builder.addToFilterDefinitions(fd);
         }
         return builder;
+    }
+
+    private ConfigurationBuilder fanOutTwoRouteConfig(String bootstrapServers,
+                                                      NamedFilterDefinition routeAFilter,
+                                                      NamedFilterDefinition routeBFilter) {
+        var clusterDef = new ClusterDefinition(CLUSTER_NAME, bootstrapServers, null);
+        var routeA = new RouteDefinition(ROUTE_A, 0, List.of(routeAFilter.name()), new RouteTarget(CLUSTER_NAME, null));
+        var routeB = new RouteDefinition(ROUTE_B, 1, List.of(routeBFilter.name()), new RouteTarget(CLUSTER_NAME, null));
+        var routerDef = new RouterDefinition(ROUTER_NAME, FanOutRouterFactory.class.getName(),
+                new FanOutRouterFactory.Config(List.of(ROUTE_A, ROUTE_B), LIST_TRANSACTIONS.name()), List.of(routeA, routeB));
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, ROUTER_NAME))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder("localhost:9192").build())
+                .build();
+        return baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDef)
+                .addToFilterDefinitions(routeAFilter)
+                .addToFilterDefinitions(routeBFilter)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
     }
 
     private ConfigurationBuilder singleRouteConfig(String bootstrapServers, NamedFilterDefinition filterDef) {

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/FanOutRouterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/FanOutRouterFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.it.testplugins.router;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.router.RouterContext;
+import io.kroxylicious.proxy.router.RouterFactory;
+import io.kroxylicious.proxy.router.RouterFactoryContext;
+import io.kroxylicious.proxy.router.RouterResponse;
+
+/**
+ * A test router that fans a single dynamically-routed API key out to every configured route,
+ * sending the request down each route concurrently, and delivers the first route's response back
+ * to the client. All other API keys are statically routed to the first route.
+ *
+ * <p>Used to exercise the case where two or more routes issue an out-of-band request on the same
+ * client connection at once (see {@code RouteFilterCorrectnessIT}).</p>
+ */
+@Plugin(configType = FanOutRouterFactory.Config.class)
+public class FanOutRouterFactory implements RouterFactory<FanOutRouterFactory.Config, FanOutRouterFactory.Config> {
+
+    /**
+     * Configuration for {@link FanOutRouterFactory}.
+     *
+     * @param routes        the routes to fan the dynamic API key out to, in order; the first route
+     *                      also statically handles every other API key
+     * @param dynamicApiKey name of the {@link ApiKeys} constant that is fanned out
+     */
+    public record Config(List<String> routes, String dynamicApiKey) {}
+
+    @Override
+    public Config initialize(RouterFactoryContext context, Config config) {
+        return config;
+    }
+
+    @Override
+    public Router createRouter(RouterFactoryContext context, Config config) {
+        ApiKeys dynamic = ApiKeys.valueOf(config.dynamicApiKey());
+        String defaultRoute = config.routes().get(0);
+        Map<ApiKeys, String> staticMap = Arrays.stream(ApiKeys.values())
+                .filter(k -> k != dynamic)
+                .collect(Collectors.toUnmodifiableMap(k -> k, k -> defaultRoute));
+        return new Router() {
+            @Override
+            public CompletionStage<RouterResponse> onRequest(ApiKeys apiKey,
+                                                             short apiVersion,
+                                                             RequestHeaderData header,
+                                                             ApiMessage request,
+                                                             RouterContext ctx) {
+                // Send the request down every route first, so all of them are in flight (and any
+                // per-route filter's out-of-band request is issued) before any response is awaited.
+                List<CompletableFuture<ApiMessage>> stages = config.routes().stream()
+                        .map(route -> ctx.sendRequest(ctx.anyNode(route), header, request).toCompletableFuture())
+                        .toList();
+                return CompletableFuture.allOf(stages.toArray(new CompletableFuture[0]))
+                        .thenCompose(ignored -> ctx.respondWith(stages.getFirst().getNow(null)).completed());
+            }
+
+            @Override
+            public Map<ApiKeys, String> staticRoutes() {
+                return staticMap;
+            }
+        };
+    }
+}

--- a/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.router.RouterFactory
+++ b/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.router.RouterFactory
@@ -7,6 +7,7 @@ io.kroxylicious.it.testplugins.router.AlternatingRouterFactory
 io.kroxylicious.it.testplugins.router.ClientIdRouterFactory
 io.kroxylicious.it.testplugins.router.ContextCapturingRouterFactory
 io.kroxylicious.it.testplugins.router.DynamicProduceRouterFactory
+io.kroxylicious.it.testplugins.router.FanOutRouterFactory
 io.kroxylicious.it.testplugins.router.InvocationCountingRouterFactory
 io.kroxylicious.it.testplugins.router.NodeTargetingProduceRouterFactory
 io.kroxylicious.it.testplugins.router.PassThroughRouterFactory

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/RouteFilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/RouteFilterHandler.java
@@ -11,6 +11,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.frame.Frame;
 import io.kroxylicious.proxy.internal.filter.FilterAndInvoker;
 
@@ -24,6 +25,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 class RouteFilterHandler extends FilterHandler {
 
     private final String routeName;
+    private final Filter filter;
 
     RouteFilterHandler(FilterAndInvoker filterAndInvoker,
                        long timeoutMs,
@@ -33,6 +35,7 @@ class RouteFilterHandler extends FilterHandler {
                        String routeName) {
         super(filterAndInvoker, timeoutMs, sniHostname, inboundChannel, clientConnectionStateMachine);
         this.routeName = Objects.requireNonNull(routeName);
+        this.filter = filterAndInvoker.filter();
     }
 
     @Override
@@ -55,7 +58,17 @@ class RouteFilterHandler extends FilterHandler {
     @SuppressWarnings("FutureReturnValueIgnored")
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-        if (matchesRoute(msg)) {
+        // Frames are gated to their route, as before - this is what lets a route's filters observe,
+        // via onResponse, every response (including out-of-band ones) that flows through their route.
+        // The one addition: an out-of-band (internal) response addressed to this handler's own filter
+        // is also delivered even when its route name does not match. All internal responses share the
+        // reserved out-of-band correlation id, so the route name restored on the response path is
+        // unreliable when more than one route has an in-flight OOB request; but such a reply is
+        // self-addressed (its recipient and promise are carried on the frame, matched via the unique
+        // upstream correlation id), so recipient identity is authoritative for delivering it back.
+        boolean deliver = matchesRoute(msg)
+                || (msg instanceof InternalResponseFrame<?> internalResponse && internalResponse.isRecipient(filter));
+        if (deliver) {
             super.write(ctx, msg, promise);
         }
         else {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/RouteFilterHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/RouteFilterHandlerTest.java
@@ -218,16 +218,36 @@ class RouteFilterHandlerTest {
     }
 
     @Test
-    void internalResponseFrameWithNonMatchingRoutePassesThrough() {
+    void internalResponseFrameForRecipientIsCompletedEvenWhenRouteDoesNotMatch() {
         // Given
-        ApiVersionsResponseFilter filter = (apiVersion, header, response, context) -> {
-            throw new AssertionError("Filter should not be invoked for non-matching route");
-        };
+        ApiVersionsResponseFilter filter = (apiVersion, header, response, context) -> context.forwardResponse(header, response);
         buildChannel(filter, ROUTE_A);
         var header = new ResponseHeaderData().setCorrelationId(42);
         var future = new CompletableFuture<>();
         var internalFrame = new InternalResponseFrame<>(
                 filter, ApiKeys.API_VERSIONS.latestVersion(), 42, header, new ApiVersionsResponseData(), future);
+        internalFrame.setRouteName(ROUTE_B);
+
+        // When
+        channel.writeOutbound(internalFrame);
+
+        // Then
+        assertThat(future).isCompleted();
+        assertThat((Object) channel.readOutbound()).isNull();
+    }
+
+    @Test
+    void internalResponseFrameForAnotherFilterOnAnotherRoutePassesThrough() {
+        // Given
+        ApiVersionsResponseFilter filter = (apiVersion, header, response, context) -> {
+            throw new AssertionError("Filter should not process an OOB response addressed to another filter on another route");
+        };
+        buildChannel(filter, ROUTE_A);
+        Filter otherFilter = mock(Filter.class);
+        var header = new ResponseHeaderData().setCorrelationId(42);
+        var future = new CompletableFuture<>();
+        var internalFrame = new InternalResponseFrame<>(
+                otherFilter, ApiKeys.API_VERSIONS.latestVersion(), 42, header, new ApiVersionsResponseData(), future);
         internalFrame.setRouteName(ROUTE_B);
 
         // When


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes #4808.

With dynamic routing, a per-route filter that issues an out-of-band (OOB) request via `FilterContext.sendRequest(...)` never received its response when **two or more routes issued an OOB request on the same client connection**. The broker's response came back correctly but was delivered to the **downstream client** instead of completing the filter's promise, which then timed out after 20s.

**Root cause.** All OOB requests share one correlation id (`CorrelationIdSpace.RESERVED_OUT_OF_BAND_CORRELATION_ID = Integer.MIN_VALUE`), and `RoutingTerminalHandler` keys its per-connection `correlationId -> routeName` map on it. With two concurrent OOB requests the entries collide, so the reply is stamped with the wrong route name. `RouteFilterHandler.write` then gated OOB completion on `matchesRoute(...)`, so the self-addressed reply was passed through every route filter and written to the client; the originating filter's promise never completed.

**Fix.** Keep the existing route gate exactly as-is — this is what lets a route's filters observe, via `onResponse`, every response (including out-of-band ones) that flows through their route — and *additionally* deliver an `InternalResponseFrame` that is addressed to **this** handler's own filter even when its route name doesn't match. Such a reply is self-addressed (its `recipient` filter and promise are carried on the frame, matched via the unique upstream correlation id in `CorrelationManager`), so recipient identity is authoritative for delivering it back regardless of the collided route tag. The change is strictly additive: the only frames it newly delivers are OOB replies that would otherwise have been dropped.

```java
boolean deliver = matchesRoute(msg)
        || (msg instanceof InternalResponseFrame<?> internalResponse && internalResponse.isRecipient(filter));
```

### Additional Context

A single OOB request per connection worked fine; the bug only surfaced with a fan-out (2+ routes) issuing OOB on one connection. The change is confined to `kroxylicious-runtime` internals — no public API or YAML change.

Issue #4808 also notes a complementary hardening (give OOB requests distinct correlation ids from a reserved range so the `correlationId -> routeName` map can't collide, which would additionally re-enable node-id translation for statically-routed OOB). That is intentionally **not** included here — this PR is the minimal, robust delivery fix; the id-range change can follow separately.

### Verification

**Unit tests** — `RouteFilterHandlerTest` covers the three cases at the handler level:
- recipient + matching route → delivered;
- recipient + **non-matching** route → still delivered (the regression);
- non-recipient + matching route → passed through untouched.

**Integration test** — `RouteFilterCorrectnessIT#concurrentOutOfBandRequestsFromTwoRoutesAreEachDelivered` reproduces the bug end-to-end against the mock-Kafka harness: a fan-out router (`FanOutRouterFactory`) sends one client request to two routes, each route's filter issues an OOB `ListGroups` via `sendRequest`, so both OOBs are in flight on one connection. It asserts the client request completes and that both routes' OOB requests reached the broker.

_Without the fix_ (`RouteFilterHandler` reverted to the parent commit) — **fails**:

```
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
concurrentOutOfBandRequestsFromTwoRoutesAreEachDelivered <<< FAILURE!
java.lang.AssertionError:
[both route filters must have issued their out-of-band request on the one connection]
Expected size: 2 but was: 0 in: []
```

_With the fix_ — **passes**:

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.279 s
```

The existing OOB route tests continue to pass, confirming the route-scoped `onResponse` observation of OOB responses is preserved: `NestedRouterOobIT` (3/3) and `StaticRouteOobIT` (2/2).

Also reproduced and fixed end-to-end against a two-cluster SASL credential-swap route (each route's filter performs an OOB SASL handshake/authenticate): before the fix both legs timed out; after the fix a client `listTopics` through the proxy surfaces topics from both clusters.

<!-- @hrishabhg: attach before/after screenshots of the two-route swap demo here -->

### Checklist

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update.
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [x] For user facing changes, add a logchange entry YAML file to `changelog/unreleased/`.
