### PR TITLE
Update PAT docs

### DIFF
--- a/.github/AUTOMATION_README.md
+++ b/.github/AUTOMATION_README.md
@@ -15,6 +15,13 @@ These tokens must belong to an account, so we use a shared account to hold them.
 is [kroxylicious-robot](https://github.com/kroxylicious-robot) and credentials are shared by some committers, ask in #team-developers
 on slack if you require a new PAT for a GitHub action.
 
+The corresponding secrets in github are:
+
+| Secret                                        | Description                                                                                                                       |
+|-----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `KROXYLICIOUS_CHANGELOG_TOKEN`                | GitHub PAT with write (contents) permission for this repository. Used to commit logchange entry files to Renovate/Dependabot PRs. |
+| `KROXYLICIOUS_RELEASE_TOKEN`                  | GitHub PAT used during the release. See [RELEASING.md](../RELEASING.md) for detail about required permissions                     |
+
 ## Dependabot Integration
 
 We use Dependabot to automatically create Pull Requests (PR) upgrading dependencies. Dependabot is also allowed to merge

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,8 +33,11 @@ Create-or-update the following repository secrets:
 |-----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `KROXYLICIOUS_RELEASE_PRIVATE_KEY`            | Private key, in armor format, of the project admin conducting the release.                                                                            |
 | `KROXYLICIOUS_RELEASE_PRIVATE_KEY_PASSPHRASE` | Passphrase used to protect the private key                                                                                                            |
-| `KROXYLICIOUS_RELEASE_TOKEN`                  | GitHub PAT with write permissions for content, commit status, pull-requests for this repository and the kroxylicious.github.io repository             |
-| `KROXYLICIOUS_CHANGELOG_TOKEN`                | GitHub PAT with write (contents) permission for this repository. Used to commit logchange entry files to Renovate/Dependabot PRs. |
+
+Note that we depend on the following tokens that belong to the `kroxylicious-robot` user, defined at the Organization level (see [AUTOMATION_README.md](.github/AUTOMATION_README.md):
+| Secret                                        | Description                                                                                                                                           |
+|-----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `KROXYLICIOUS_RELEASE_TOKEN`                  | GitHub PAT with write permissions for content, commit status, pull-requests, workflows for this repository and the kroxylicious.github.io repository             |
 
 
 To export your key run something like


### PR DESCRIPTION

### Type of change

- Documentation

### Description

We have a new workflows requirement on the release PAT. Also fixed a couple of problems:
1. changelog token PAT isn't part of releasing
2. updating the release token isn't part of releasing either, it's a distinct thing that doesn't need changing so often
3. nothing said release token should be an org-level secret and it was a bit indirect which account they should live on as the RELEASING.md and AUTOMATION_README.md are split up.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
