### PR TITLE
fix: stage release failed due to lack of javadoc jar for json module

### DIFF
--- a/kroxylicious-kafka-message-json/pom.xml
+++ b/kroxylicious-kafka-message-json/pom.xml
@@ -155,7 +155,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <excludePackageNames>io.kroxylicious.kafka:io.kroxylicious.kafka.*</excludePackageNames>
+                    <excludePackageNames>io.kroxylicious.kafka.common:io.kroxylicious.kafka.common.*</excludePackageNames>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Staging the release failed due to lack of javadoc jar https://github.com/kroxylicious/kroxylicious/actions/runs/33571482268/job/100066180952

```
Deployment 7ce8d904-f2d8-423b-a4dc-e1e60da4dfe4 failed
pkg:maven/io.kroxylicious/kroxylicious-kafka-message-json@0.24.0:
 - Javadocs must be provided but not found in entries
```

Include the javadoc for the two types created by kroxylicious krpc generator in the javadoc jar

We excluded all javadoc from this module, intending to omit the generated classes with javadoc that doesn't match our linting, but sonatype requires a javadoc jar.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
