### PR TITLE
fix(deps): remove duplicate kafka-clients dependencies

### DIFF
--- a/kroxylicious-filters/kroxylicious-multitenant/pom.xml
+++ b/kroxylicious-filters/kroxylicious-multitenant/pom.xml
@@ -31,10 +31,6 @@
             <artifactId>kroxylicious-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-kafka-message-tools</artifactId>
         </dependency>

--- a/kroxylicious-filters/kroxylicious-record-encryption/pom.xml
+++ b/kroxylicious-filters/kroxylicious-record-encryption/pom.xml
@@ -75,10 +75,6 @@
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Ensure a single dependency on kafka-clioents.

### Additional Context

Maven is warning about duplicates and maven 4 will refuse to build with them

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
