### PR TITLE
fix: release artefact signatures not produced

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,6 @@
         <central.publishing.skip>false</central.publishing.skip>
         <maven.javadoc.skip>${central.publishing.skip}</maven.javadoc.skip>
         <maven.source.skip>${central.publishing.skip}</maven.source.skip>
-        <gpg.skip>${central.publishing.skip}</gpg.skip>
         <rewrite-maven-plugin.version>6.46.1</rewrite-maven-plugin.version>
     </properties>
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We have some artefacts that we do not deploy to sonatype central to reduce the size of our deployment. So we switched off gpg signing for those modules to save time. However, our stage release automation expects the release tarballs to have a companion `.asc` signature file that it can eventually deliver to the github release artefacts ([see failure](https://github.com/kroxylicious/kroxylicious/actions/runs/33585999741)).

This change means that all artefacts will be signed by the gpg plugin regardless of whether they are destined for sonatype central, figure it's simpler to always have them on hand even if it costs a little signing time.

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
