### PR TITLE
[DT]  fix loading of images and minikube provision in Record Encryption Quickstart

### DIFF
--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -56,20 +56,10 @@ jobs:
         uses: $/.github/actions/common/cache-maven-packages
       - name: 'Build Kroxylicious Operator/Operand Container Images & Operator Zip'
         run: |
-          # Explicit --projects: docs tests only load the proxy and operator images
-          # into minikube; the admission webhook image is not required here.
+          # Produces target/*.img.tar.gz for the proxy and operator (the admission webhook image
+          # is not needed here). QuickStartDT loads these into the throw-away Minikube profile it
+          # creates per quick start run, so there is no `minikube image load` step in this workflow.
           mvn --batch-mode --activate-profiles dist --also-make --projects :kroxylicious-app,:kroxylicious-operator,:kroxylicious-operator-dist -Dquick package
-      - name: 'Load Kroxylicious Operand Docker Image in Minikube'
-        run: |
-          minikube image load kroxylicious-app/target/kroxylicious-proxy.img.tar.gz
-          minikube image load kroxylicious-kubernetes/kroxylicious-operator/target/kroxylicious-operator.img.tar.gz
-          
-          # https://github.com/kubernetes/minikube/issues/21393 - minikube image load doesn't fail if the load fails.
-          KROXYLICIOUS_PROXY_IMAGE="$(mvn --quiet --projects :kroxylicious-app --activate-profiles dist help:evaluate -Dexpression=io.kroxylicious.proxy.image.name -DforceStdout)"
-          KROXYLICIOUS_OPERATOR_IMAGE="$(mvn --quiet --projects :kroxylicious-operator --activate-profiles dist help:evaluate -Dexpression=io.kroxylicious.operator.image.name -DforceStdout)"
-          KROXYLICIOUS_VERSION="$(mvn --quiet help:evaluate -Dexpression=project.version -DforceStdout)"
-          minikube image ls | grep --fixed-strings ${KROXYLICIOUS_PROXY_IMAGE}
-          minikube image ls | grep --fixed-strings ${KROXYLICIOUS_OPERATOR_IMAGE}
       - name: 'Extract Strimzi version'
         id: strimzi
         run: |

--- a/kroxylicious-docs-tests/src/test/java/io/kroxylicious/doctools/validator/QuickStartDT.java
+++ b/kroxylicious-docs-tests/src/test/java/io/kroxylicious/doctools/validator/QuickStartDT.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
 
 import org.asciidoctor.Attributes;
@@ -57,6 +58,8 @@ class QuickStartDT {
 
     private static List<Arguments> quickStarts() {
         Assertions.assertThat(Utils.OPERATOR_ZIP).exists();
+        Assertions.assertThat(Utils.PROXY_IMAGE_TARBALL).exists();
+        Assertions.assertThat(Utils.OPERATOR_IMAGE_TARBALL).exists();
 
         var attributes = Attributes.builder()
                 .attribute("OperatorAssetZipLink", pathToFileUrl(Utils.OPERATOR_ZIP))
@@ -71,25 +74,57 @@ class QuickStartDT {
     @ParameterizedTest
     @MethodSource("quickStarts")
     void quickStart(List<Block> shellBlocks) {
-        // Given
-        Path shellScript = writeShellScript(shellBlocks);
-
-        // When
-        var actual = executeScript(shellScript);
-
-        // Then
+        // One throw-away Minikube profile per @ParameterizedTest invocation (i.e. per KMS variant),
+        // seeded with the locally built images. The quick start's
+        // `export MINIKUBE_PROFILE=${MINIKUBE_PROFILE:-quickstart-${RANDOM}}` line reuses this value.
+        var profile = "quickstart-" + ThreadLocalRandom.current().nextInt(100_000);
         try {
-            assertThat(actual)
-                    .succeedsWithin(Duration.ofMinutes(10))
-                    .satisfies(er -> assertThat(er.exitValue())
-                            .withFailMessage("Script failed - %s", er)
-                            .isZero());
-        }
-        finally {
-            if (!actual.isDone()) {
-                actual.cancel(true);
+            ShellUtils.exec("minikube", "start", "-p", profile);
+            loadImage(profile, Utils.PROXY_IMAGE_TARBALL, "kroxylicious/proxy");
+            loadImage(profile, Utils.OPERATOR_IMAGE_TARBALL, "kroxylicious/operator");
+
+            // Check 2: the quick start's kubectl commands follow the *active* context, not MINIKUBE_PROFILE.
+            // If it is not our profile, the operator lands in a cluster without the images.
+            boolean contextOk = ShellUtils.execValidate(lines -> lines.anyMatch(l -> l.trim().equals(profile)), lines -> true,
+                    "kubectl", "config", "current-context");
+            if (!contextOk) {
+                throw new AssertionError("active kube-context is not '" + profile + "' before running the quick start (issue #4404)");
+            }
+            LOGGER.atInfo().addKeyValue("profile", profile).log("Quick start: kube-context confirmed, running shell script");
+
+            var actual = executeScript(writeShellScript(shellBlocks), profile);
+            try {
+                assertThat(actual)
+                        .succeedsWithin(Duration.ofMinutes(10))
+                        .satisfies(er -> assertThat(er.exitValue())
+                                .withFailMessage("Script failed - %s", er)
+                                .isZero());
+            }
+            finally {
+                if (!actual.isDone()) {
+                    actual.cancel(true);
+                }
             }
         }
+        finally {
+            try {
+                ShellUtils.exec("minikube", "delete", "-p", profile);
+            }
+            catch (RuntimeException | AssertionError e) {
+                // The quick start's own "minikube delete" cleanup step may already have removed it.
+                LOGGER.atWarn().addKeyValue("profile", profile).setCause(e).log("Minikube profile cleanup failed");
+            }
+        }
+    }
+
+    /**
+     * Loads a container-image tarball into {@code profile}. Delegates to {@code scripts/minikube-image-load.sh},
+     * which fails (unlike a bare {@code minikube image load} — kubernetes/minikube#23471) if the load errored
+     * or if {@code expectedRepo} (e.g. {@code kroxylicious/operator}) is not listed afterwards.
+     */
+    private static void loadImage(String profile, Path tarball, String expectedRepo) {
+        ShellUtils.exec(Utils.SCRIPTS_DIR.resolve("minikube-image-load.sh").toString(), profile, tarball.toString(), expectedRepo);
+        LOGGER.atInfo().addKeyValue("profile", profile).addKeyValue("image", expectedRepo).log("Image loaded into Minikube profile");
     }
 
     private static String pathToFileUrl(Path path) {
@@ -122,9 +157,10 @@ class QuickStartDT {
                 Objects.equals(sn.getAttribute("language", null), "terminal");
     }
 
-    private CompletableFuture<ExecutionResult> executeScript(Path shellScript) {
+    private CompletableFuture<ExecutionResult> executeScript(Path shellScript, String minikubeProfile) {
         return CompletableFuture.supplyAsync(() -> {
             var builder = new ProcessBuilder(shellScript.toAbsolutePath().toString());
+            builder.environment().put("MINIKUBE_PROFILE", minikubeProfile);
 
             try (var stdoutExecutor = Executors.newSingleThreadExecutor();
                     var stderrExecutor = Executors.newSingleThreadExecutor()) {

--- a/kroxylicious-docs-tests/src/test/java/io/kroxylicious/doctools/validator/QuickStartDT.java
+++ b/kroxylicious-docs-tests/src/test/java/io/kroxylicious/doctools/validator/QuickStartDT.java
@@ -123,7 +123,7 @@ class QuickStartDT {
      * or if {@code expectedRepo} (e.g. {@code kroxylicious/operator}) is not listed afterwards.
      */
     private static void loadImage(String profile, Path tarball, String expectedRepo) {
-        ShellUtils.exec(Utils.SCRIPTS_DIR.resolve("minikube-image-load.sh").toString(), profile, tarball.toString(), expectedRepo);
+        ShellUtils.exec(Utils.SCRIPTS_DIR.resolve("minikube-image-load.sh").toString(), "--profile", profile, tarball.toString(), expectedRepo);
         LOGGER.atInfo().addKeyValue("profile", profile).addKeyValue("image", expectedRepo).log("Image loaded into Minikube profile");
     }
 

--- a/kroxylicious-docs-tests/src/test/java/io/kroxylicious/doctools/validator/Utils.java
+++ b/kroxylicious-docs-tests/src/test/java/io/kroxylicious/doctools/validator/Utils.java
@@ -23,10 +23,16 @@ public class Utils {
     static final Predicate<Path> ALL_ASCIIDOC_FILES = f -> f.getFileName().toString().endsWith(".adoc");
     static final Path MODULE_ROOT = Path.of("").toAbsolutePath();
     static final Path DOCS_ROOTDIR = MODULE_ROOT.getParent().resolve("kroxylicious-docs").resolve("docs");
+    static final Path SCRIPTS_DIR = MODULE_ROOT.getParent().resolve("scripts");
 
     // This is Zip artefact containing the Operator. The Maven copy-kroxylicious-operator-zip copies the artefact
     // from the kroxylicious-operator-dist module to this module with a stable name.
     static final Path OPERATOR_ZIP = MODULE_ROOT.resolve("target").resolve("kroxylicious-operator-dist").resolve("kroxylicious-operator.zip");
+
+    // Container-image tarballs produced by `mvn -Pdist package` on the proxy and operator modules.
+    // QuickStartDT loads these into the throw-away Minikube profile it creates for each quick start run
+    static final Path PROXY_IMAGE_TARBALL = MODULE_ROOT.getParent().resolve("kroxylicious-app/target/kroxylicious-proxy.img.tar.gz");
+    static final Path OPERATOR_IMAGE_TARBALL = MODULE_ROOT.getParent().resolve("kroxylicious-kubernetes/kroxylicious-operator/target/kroxylicious-operator.img.tar.gz");
 
     static Stream<Path> asciiDocFilesMatching(final Predicate<Path> pathPredicate) {
 

--- a/kroxylicious-docs/docs/record-encryption-quick-start/index.adoc
+++ b/kroxylicious-docs/docs/record-encryption-quick-start/index.adoc
@@ -64,11 +64,11 @@ You'll need the following software installed:
 == Start Minikube
 
 We'll use a Minikube profile to keep it separate from any other work you are doing in Minikube.
-We use a profile called `quickstart-nnnnn`
+We use a profile called `quickstart-nnnnn` (if you already have `MINIKUBE_PROFILE` set, that profile is used instead).
 
 [source,terminal]
 ----
-$ export MINIKUBE_PROFILE=quickstart-${RANDOM}
+$ export MINIKUBE_PROFILE=${MINIKUBE_PROFILE:-quickstart-${RANDOM}}
 ----
 
 Let's get the Kubernetes Cluster up and running.  Minikube defaults work just fine for this quickstart.

--- a/scripts/minikube-image-load.sh
+++ b/scripts/minikube-image-load.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# Loads a container-image tarball into a Minikube profile and *fails* if it did not actually land.
+#
+# `minikube image load` exits 0 even when the load failed (kubernetes/minikube#23471) - a missing
+# tarball, for example, only prints "The image ... was not found" and still exits 0. So this wrapper:
+#   1. fails up front if the tarball does not exist;
+#   2. after the load, fails unless `minikube image ls` lists <expected-repo> (e.g. kroxylicious/operator).
+#
+# Usage: minikube-image-load.sh <profile> <tarball> <expected-repo>
+
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <profile> <tarball> <expected-repo>" >&2
+  exit 2
+fi
+
+profile=$1
+tarball=$2
+expected_repo=$3
+
+# Check that the tarball exists before attempting to load it
+if [[ ! -f "${tarball}" ]]; then
+  echo "minikube-image-load: tarball does not exist: ${tarball}" >&2
+  exit 1
+fi
+
+# Load the image into the specified Minikube profile
+minikube image load -p "${profile}" "${tarball}"
+
+# Verify that the expected repository is now listed in the profile's images
+if ! minikube image ls -p "${profile}" | grep -qF "${expected_repo}"; then
+  echo "minikube-image-load: ${expected_repo} is not in profile '${profile}' after loading ${tarball} (kubernetes/minikube#23471)" >&2
+  exit 1
+fi
+
+# Print the list of images in the profile that match the expected repository
+minikube image ls -p "${profile}" | grep -F "${expected_repo}"

--- a/scripts/minikube-image-load.sh
+++ b/scripts/minikube-image-load.sh
@@ -12,18 +12,46 @@
 #   1. fails up front if the tarball does not exist;
 #   2. after the load, fails unless `minikube image ls` lists <expected-repo> (e.g. kroxylicious/operator).
 #
-# Usage: minikube-image-load.sh <profile> <tarball> <expected-repo>
+# Usage: minikube-image-load.sh [--profile|-p <profile>] <tarball> <expected-repo>
 
 set -euo pipefail
 
-if [[ $# -ne 3 ]]; then
-  echo "usage: $0 <profile> <tarball> <expected-repo>" >&2
+profile=""
+while getopts "p:-:" opt; do
+  case $opt in
+    p)
+      profile="$OPTARG"
+      ;;
+    -)
+      case "$OPTARG" in
+        profile)
+          profile="${!OPTIND}"
+          OPTIND=$((OPTIND + 1))
+          ;;
+        profile=*)
+          profile="${OPTARG#*=}"
+          ;;
+        *)
+          echo "usage: $0 [--profile|-p <profile>] <tarball> <expected-repo>" >&2
+          exit 2
+          ;;
+      esac
+      ;;
+    *)
+      echo "usage: $0 [--profile|-p <profile>] <tarball> <expected-repo>" >&2
+      exit 2
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 [--profile|-p <profile>] <tarball> <expected-repo>" >&2
   exit 2
 fi
 
-profile=$1
-tarball=$2
-expected_repo=$3
+tarball=$1
+expected_repo=$2
 
 # Check that the tarball exists before attempting to load it
 if [[ ! -f "${tarball}" ]]; then
@@ -31,14 +59,28 @@ if [[ ! -f "${tarball}" ]]; then
   exit 1
 fi
 
-# Load the image into the specified Minikube profile
-minikube image load -p "${profile}" "${tarball}"
+# Load the image into the specified Minikube profile (or current profile if not specified)
+if [[ -n "${profile}" ]]; then
+  minikube image load -p "${profile}" "${tarball}"
+else
+  minikube image load "${tarball}"
+fi
 
 # Verify that the expected repository is now listed in the profile's images
-if ! minikube image ls -p "${profile}" | grep -qF "${expected_repo}"; then
-  echo "minikube-image-load: ${expected_repo} is not in profile '${profile}' after loading ${tarball} (kubernetes/minikube#23471)" >&2
+if [[ -n "${profile}" ]]; then
+  image_list=$(minikube image ls -p "${profile}")
+else
+  image_list=$(minikube image ls)
+fi
+
+if ! grep -qF "${expected_repo}" <<< "${image_list}"; then
+  if [[ -n "${profile}" ]]; then
+    echo "minikube-image-load: ${expected_repo} is not in profile '${profile}' after loading ${tarball} (kubernetes/minikube#23471)" >&2
+  else
+    echo "minikube-image-load: ${expected_repo} is not in current profile after loading ${tarball} (kubernetes/minikube#23471)" >&2
+  fi
   exit 1
 fi
 
 # Print the list of images in the profile that match the expected repository
-minikube image ls -p "${profile}" | grep -F "${expected_repo}"
+grep -F "${expected_repo}" <<< "${image_list}"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes https://github.com/kroxylicious/kroxylicious/issues/4404
The current approach in DT with multiple minikubes did not provide build images in minikube (they did to the different one) test were running on. 

 

### Additional Context (Considered)

implementation in PR: `QuickStartDT` creates a throw-away `quickstart-<random>` Minikube profile per
`@ParameterizedTest` This keeps minimal changes in .doc + keeps intended fix from   https://github.com/kroxylicious/kroxylicious/pull/4390 

alternatives: 
- 1 named minikube created in `documentation-tests.yml` not mentioned in .doc And other variants with different propagation of this value
- shared minikube different namespaces

In alternatives we would lost isolation. There was also option to include changes rather in .doc part but i did not try this one further. 




