### PR TITLE
build(migrations): silence surefire classpath conflict warnings

### DIFF
--- a/kroxylicious-proxy-core/kroxylicious-migrations/pom.xml
+++ b/kroxylicious-proxy-core/kroxylicious-migrations/pom.xml
@@ -92,6 +92,55 @@
 
     <build>
         <plugins>
+            <!--
+              Override the additionalClasspathDependencies inherited from the parent POM to silence
+              surefire's "Potential classpath conflict" warnings, which are specific to this module.
+              This module's OpenRewrite dependencies pull in byte-buddy 1.18.3 (via assertj-core) and
+              objenesis 3.6, which clash with the byte-buddy 1.17.7 / objenesis 3.3 that mockito-core
+              brings transitively. surefire resolves additionalClasspathDependencies independently of
+              <dependencyManagement>, so the versions must be reconciled here via exclusions.
+              mockito-core is not actually used by this module's tests (it is inherited globally),
+              so dropping its transitive byte-buddy/objenesis in favour of the versions already on
+              the project test classpath is safe:
+                - drop assertj-core (and its byte-buddy) from logsquelcher: only the SLF4J provider is
+                  needed, and the project test classpath already provides assertj/byte-buddy 1.18.3;
+                - drop byte-buddy and objenesis from mockito-core: the project test classpath already
+                  provides byte-buddy 1.18.3 and objenesis 3.6.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <additionalClasspathDependencies combine.self="override">
+                        <dependency>
+                            <groupId>io.github.sambarker</groupId>
+                            <artifactId>logsquelcher</artifactId>
+                            <version>${logsquelcher.version}</version>
+                            <exclusions>
+                                <exclusion>
+                                    <groupId>org.assertj</groupId>
+                                    <artifactId>assertj-core</artifactId>
+                                </exclusion>
+                            </exclusions>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.mockito</groupId>
+                            <artifactId>mockito-core</artifactId>
+                            <version>${mockito.version}</version>
+                            <exclusions>
+                                <exclusion>
+                                    <groupId>net.bytebuddy</groupId>
+                                    <artifactId>byte-buddy</artifactId>
+                                </exclusion>
+                                <exclusion>
+                                    <groupId>org.objenesis</groupId>
+                                    <artifactId>objenesis</artifactId>
+                                </exclusion>
+                            </exclusions>
+                        </dependency>
+                    </additionalClasspathDependencies>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>


### PR DESCRIPTION
### Type of change

- Bugfix (build hygiene)

### Description

The `kroxylicious-migrations` module build emits two surefire "Potential classpath conflict" warnings:

```
[WARNING] Potential classpath conflict among resolved additionalClasspathDependencies:
  Found multiple versions of net.bytebuddy:byte-buddy:jar: 1.17.7 and 1.18.3
[WARNING] Potential classpath conflict between project dependency and resolved
  additionalClasspathDependency: Found multiple versions of org.objenesis:objenesis:jar: 3.3 and 3.6
```

The module's OpenRewrite dependencies pull in byte-buddy 1.18.3 (via assertj-core) and objenesis 3.6, which diverge from the byte-buddy 1.17.7 / objenesis 3.3 that `mockito-core` brings transitively. Both `mockito-core` and `logsquelcher` are injected globally as surefire `additionalClasspathDependencies` in the parent POM, so the conflict only surfaces in this module.

surefire resolves `additionalClasspathDependencies` independently of `<dependencyManagement>` (verified empirically — DM pins have no effect, and omitting the `<version>` fails outright). It does, however, honour `<exclusions>`. The fix therefore overrides the inherited list in this module (`combine.self="override"`) and excludes the diverging transitives, deferring to the versions already on the module's test classpath:

- exclude `assertj-core` from `logsquelcher` (only its SLF4J provider is needed)
- exclude `byte-buddy` and `objenesis` from `mockito-core` (which this module's tests don't use)

The change is scoped to the migrations module so the rationale stays discoverable next to where the conflict actually arises, rather than being managed globally.

### Additional Context

Keeps the build output clean. The warnings were benign (surefire picks one version), but they add noise and can mask genuine conflicts.

Only `maven-surefire-plugin` is overridden, not failsafe: this module has no integration tests, so failsafe never triggers the warning (confirmed via `mvn verify`).

### Checklist

- [ ] New tests written (where applicable). — N/A, build-only change; existing tests unchanged.
- [x] If making a user-facing change, documentation is provided... — N/A, not user-facing.
- [x] Existing unit/integration/system tests passing. — `mvn verify -pl :kroxylicious-migrations` passes (10 tests), warnings gone.
- [x] Any Sonarcloud warnings are addressed.
- [ ] PR references related GitHub issue(s). — No tracking issue.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [x] For user facing changes, add a logchange entry. — N/A, build-only change, not user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)