### PR TITLE
feat(record-validation): remove redundant wireFormatVersion config

### DIFF
--- a/changelog/unreleased/04744-remove-wireformatversion-config.yaml
+++ b/changelog/unreleased/04744-remove-wireformatversion-config.yaml
@@ -1,0 +1,10 @@
+title: "feat(record-validation): remove redundant `wireFormatVersion` configuration option."
+type: removed
+issues:
+  - 4744
+important_notes:
+  - |
+    The `wireFormatVersion` option of the record validation filter's `schemaValidationConfig` is removed.
+    The filter supports only the Apicurio Registry v3 wire format, which uses Confluent-compatible 4-byte content IDs,
+    so the option had a single legal value (`V3`) and was no longer read.
+    Any configuration that still sets `wireFormatVersion` must delete the line, otherwise the configuration will fail to load.

--- a/kroxylicious-docs/docs/_modules/record-validation/proc-configuring-record-validation-filter.adoc
+++ b/kroxylicious-docs/docs/_modules/record-validation/proc-configuring-record-validation-filter.adoc
@@ -67,7 +67,6 @@ schemaValidationConfig:
       storePassword:
         passwordFile: /opt/proxy/trust/store.password
       storeType: PKCS12
-  wireFormatVersion: V3
 allowNulls: true
 allowEmpty: true
 ----
@@ -84,8 +83,6 @@ allowEmpty: true
 ** `storeFile` path to the truststore file that contains the trust anchors used to validate the server connection.
 ** `storePassword` (Optional) password used to protect the truststore.
 ** `storeType` truststore type. Supported values include `PKCS12`, `JKS`, and `PEM`.
-* `wireFormatVersion` specifies the Apicurio wire format version. `V3` is the default and only supported value.
-   The `apicurioId` property identifies schema by content ID, and the filter expects the Kafka producer to use content IDs to identify schema.
 * `allowNulls` specifies whether the validator allows record keys or values to be `null`. The default is `false`.
 * `allowEmpty` specifies whether the validator allows record keys or values to be empty. The default is `false`.
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/config/SchemaValidationConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/config/SchemaValidationConfig.java
@@ -19,13 +19,11 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * Configuration for validating a component ByteBuffer of a {@link io.kroxylicious.kafka.common.record.internal.Record} is valid using the schema in Apicurio Registry.
  * @param apicurioRegistryUrl apicurio registry url
  * @param apicurioId schema identifier - interpreted as contentId
- * @param wireFormatVersion wire format version (defaults to V3 if null)
  * @param tls optional TLS configuration for connecting to a schema registry protected by TLS
  * @param schemaType the type of schema to validate against (defaults to JSON_SCHEMA if null)
  */
 public record SchemaValidationConfig(URL apicurioRegistryUrl,
                                      long apicurioId,
-                                     WireFormatVersion wireFormatVersion,
                                      @Nullable Tls tls,
                                      @Nullable SchemaType schemaType) {
 
@@ -50,36 +48,19 @@ public record SchemaValidationConfig(URL apicurioRegistryUrl,
     }
 
     /**
-     * Wire format versions for Apicurio Registry schema identifiers.
-     * <p>
-     * V3 uses 4-byte content IDs (Confluent-compatible format) and is the default and only supported format.
-     * </p>
-     */
-    public enum WireFormatVersion {
-        /**
-         * Apicurio Registry v3 wire format using 4-byte content IDs (Confluent-compatible).
-         * This is the recommended and default format.
-         */
-        V3
-    }
-
-    /**
-     * Construct SchemaValidationConfig with explicit wire format version, TLS configuration, and schema type
+     * Construct SchemaValidationConfig with explicit TLS configuration and schema type
      * @param apicurioRegistryUrl Apicurio Registry instance url
      * @param apicurioId schema identifier - interpreted as contentId
-     * @param wireFormatVersion wire format version (defaults to V3 if null)
      * @param tls optional TLS configuration for connecting to a schema registry protected by TLS with a custom trust store
      * @param schemaType the type of schema to validate against (defaults to JSON_SCHEMA if null)
      */
     @JsonCreator
     public SchemaValidationConfig(@JsonProperty(value = "apicurioRegistryUrl", required = true) URL apicurioRegistryUrl,
                                   @JsonProperty(value = "apicurioId", required = true) long apicurioId,
-                                  @Nullable @JsonProperty(value = "wireFormatVersion") WireFormatVersion wireFormatVersion,
                                   @JsonProperty(value = "tls") @Nullable Tls tls,
                                   @Nullable @JsonProperty(value = "schemaType") SchemaType schemaType) {
         this.apicurioId = apicurioId;
         this.apicurioRegistryUrl = apicurioRegistryUrl;
-        this.wireFormatVersion = wireFormatVersion != null ? wireFormatVersion : WireFormatVersion.V3;
         this.tls = tls;
         this.schemaType = schemaType != null ? schemaType : SchemaType.JSON_SCHEMA;
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/ProduceRequestValidatorBuilderTlsTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/ProduceRequestValidatorBuilderTlsTest.java
@@ -191,7 +191,7 @@ class ProduceRequestValidatorBuilderTlsTest {
     }
 
     private SchemaValidationConfig schemaConfig(@Nullable Tls tls) {
-        return new SchemaValidationConfig(registryUrl, 1L, null, tls, null);
+        return new SchemaValidationConfig(registryUrl, 1L, tls, null);
     }
 
     private Object buildValidatorConfig(SchemaValidationConfig schemaConfig) {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/config/ValidationConfigTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/config/ValidationConfigTest.java
@@ -37,7 +37,7 @@ class ValidationConfigTest {
     private static ValidationConfig expectedApicurioTlsTrustStoreConfig() throws MalformedURLException {
         var tls = new Tls(null, new TrustStore("/path/to/truststore.jks", new InlinePassword("changeit"), "JKS"), null, null);
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
-                new BytebufValidation(null, new SchemaValidationConfig(URI.create("http://localhost:8080").toURL(), 1L, null, tls, null),
+                new BytebufValidation(null, new SchemaValidationConfig(URI.create("http://localhost:8080").toURL(), 1L, tls, null),
                         null, false, true));
         return new ValidationConfig(List.of(ruleOne), null);
     }
@@ -45,7 +45,7 @@ class ValidationConfigTest {
     private static ValidationConfig expectedApicurioTlsInsecureConfig() throws MalformedURLException {
         var tls = new Tls(null, new InsecureTls(true), null, null);
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
-                new BytebufValidation(null, new SchemaValidationConfig(URI.create("http://localhost:8080").toURL(), 1L, null, tls, null),
+                new BytebufValidation(null, new SchemaValidationConfig(URI.create("http://localhost:8080").toURL(), 1L, tls, null),
                         null, false, true));
         return new ValidationConfig(List.of(ruleOne), null);
     }
@@ -53,7 +53,7 @@ class ValidationConfigTest {
     private static ValidationConfig expectedApicurioConfig() throws MalformedURLException {
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
                 new BytebufValidation(new SyntacticallyCorrectJsonConfig(true),
-                        new SchemaValidationConfig(URI.create("http://localhost:8080").toURL(), 1L, null, null, null),
+                        new SchemaValidationConfig(URI.create("http://localhost:8080").toURL(), 1L, null, null),
                         new JwsSignatureValidationConfig(ECDSA_VERIFY_JWKS, null, null, null), false,
                         true));
         TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, null, false, true), null);

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/JsonSchemaRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/JsonSchemaRecordValidationIT.java
@@ -320,31 +320,8 @@ class JsonSchemaRecordValidationIT extends RecordSchemaValidationBaseIT {
     }
 
     @Test
-    void v3WireFormatValidationWorks(KafkaCluster cluster, Topic topic) {
-        // Explicitly configure V3 wire format (4-byte content IDs, Confluent-compatible)
-        var config = createContentIdRecordValidationConfigWithWireFormat(cluster, topic, "valueRule", firstContentId, "V3");
-
-        var keySerde = new Serdes.StringSerde();
-        var producerValueSerde = createJsonSchemaProducerSerde(false, false);
-        var consumerValueSerde = createJsonSchemaConsumerSerde(false, false);
-
-        try (var tester = kroxyliciousTester(config);
-                var producer = tester.producer(keySerde, producerValueSerde, Map.of());
-                var consumer = consumeFromEarliestOffsets(tester, keySerde, consumerValueSerde)) {
-            // Should accept valid data with V3 wire format
-            assertThat(producer.send(new ProducerRecord<>(topic.name(), "my-key", PERSON_BEAN)))
-                    .succeedsWithin(Duration.ofSeconds(10));
-            consumer.subscribe(Set.of(topic.name()));
-
-            var records = consumer.poll(Duration.ofSeconds(10));
-            assertSingleRecordInTopicHasProperty(records, topic, ConsumerRecord::value, OBJECT_MAPPER.valueToTree(PERSON_BEAN));
-        }
-    }
-
-    @Test
-    void v3ValidatorRejectsV2WireFormatData(KafkaCluster cluster, Topic topic) {
-        // Configure V3 wire format validator
-        var config = createContentIdRecordValidationConfigWithWireFormat(cluster, topic, "valueRule", firstContentId, "V3");
+    void shouldRejectRecordUsingUnsupportedLegacy8ByteId(KafkaCluster cluster, Topic topic) {
+        var config = createContentIdRecordValidationConfig(cluster, topic, "valueRule", firstContentId);
 
         var keySerde = new Serdes.StringSerde();
         // Produce data with V2 wire format (8-byte IDs)
@@ -359,46 +336,11 @@ class JsonSchemaRecordValidationIT extends RecordSchemaValidationBaseIT {
         }
     }
 
-    @Test
-    void defaultWireFormatIsV3(KafkaCluster cluster, Topic topic) {
-        // When wireFormatVersion is not specified, it should default to V3
-        var config = createContentIdRecordValidationConfig(cluster, topic, "valueRule", firstContentId);
-
-        var keySerde = new Serdes.StringSerde();
-        var producerValueSerde = createJsonSchemaProducerSerde(false, false);
-        var consumerValueSerde = createJsonSchemaConsumerSerde(false, false);
-
-        try (var tester = kroxyliciousTester(config);
-                var producer = tester.producer(keySerde, producerValueSerde, Map.of());
-                var consumer = consumeFromEarliestOffsets(tester, keySerde, consumerValueSerde)) {
-            // Should accept V3 format by default
-            assertThat(producer.send(new ProducerRecord<>(topic.name(), "my-key", PERSON_BEAN)))
-                    .succeedsWithin(Duration.ofSeconds(10));
-            consumer.subscribe(Set.of(topic.name()));
-
-            var records = consumer.poll(Duration.ofSeconds(10));
-            assertSingleRecordInTopicHasProperty(records, topic, ConsumerRecord::value, OBJECT_MAPPER.valueToTree(PERSON_BEAN));
-        }
-    }
-
     private static ConfigurationBuilder createContentIdRecordValidationConfig(KafkaCluster cluster, Topic topic, String ruleType, int contentId) {
         String className = RecordValidation.class.getName();
         NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(className, className).withConfig("rules",
                 List.of(Map.of("topicNames", List.of(topic.name()), ruleType,
                         Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", apicurioRegistryUrl, "apicurioId", contentId)))))
-                .build();
-        return proxy(cluster)
-                .addToFilterDefinitions(namedFilterDefinition)
-                .addToDefaultFilters(namedFilterDefinition.name());
-    }
-
-    private static ConfigurationBuilder createContentIdRecordValidationConfigWithWireFormat(KafkaCluster cluster, Topic topic, String ruleType, int contentId,
-                                                                                            String wireFormatVersion) {
-        String className = RecordValidation.class.getName();
-        NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(className, className).withConfig("rules",
-                List.of(Map.of("topicNames", List.of(topic.name()), ruleType,
-                        Map.of("schemaValidationConfig",
-                                Map.of("apicurioRegistryUrl", apicurioRegistryUrl, "apicurioId", contentId, "wireFormatVersion", wireFormatVersion)))))
                 .build();
         return proxy(cluster)
                 .addToFilterDefinitions(namedFilterDefinition)


### PR DESCRIPTION
### Type of change

- Enhancement / new feature (config cleanup / removal)

### Description

Removes the record validation filter's redundant `wireFormatVersion` configuration option and the `WireFormatVersion` enum from `SchemaValidationConfig`.

The option's only legal value was `V3` (the `V2` value was removed in a prior change), and the value is no longer read anywhere — the validator hardcodes the Apicurio v3 4-byte content-ID handler (`Default4ByteIdHandler`). Retaining a single-valued, unread option only confuses users.

Changes:
- Remove the `wireFormatVersion` record component and the `WireFormatVersion` enum from `SchemaValidationConfig`.
- Update the record-validation filter docs (example YAML + option description).
- Update unit tests that constructed `SchemaValidationConfig` with the removed argument.
- In `JsonSchemaRecordValidationIT`, remove the now-redundant `defaultWireFormatIsV3` and `v3WireFormatValidationWorks` tests (V3-accept behaviour is already covered by `clientSideUsesValueSchemasToo`/`clientSideUsesKeySchemasToo`) and the `...WithWireFormat` helper; keep the V2-rejection test, renamed to `shouldRejectRecordUsingLegacy8ByteId`.
- Add a `changelog/unreleased` entry documenting the removal.

**Breaking change:** the config mapper enables `FAIL_ON_UNKNOWN_PROPERTIES`, so any configuration still setting `wireFormatVersion` will now fail to load. This is intentional (matching the earlier V2 removal) and documented in the changelog `important_notes`.

### Additional Context

Issue #4744 and the community call (27/08/2026) agreed the option should be removed rather than kept "just in case". Any future need to differentiate wire formats (new Apicurio version, other schema registries) will start from a clean design.

### Checklist

- [x] New tests written (where applicable). _(N/A — removal; existing coverage retained.)_
- [x] If making a user-facing change, documentation is provided.
- [x] Existing unit/integration/system tests passing. _(Filter unit tests pass; ITs compile — container-based ITs not run in this environment.)_
- [x] Any Sonarcloud warnings are addressed.
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [x] For user facing changes, add a logchange entry YAML file to `changelog/unreleased/`.

Fixes: #4744

🤖 Generated with [Claude Code](https://claude.com/claude-code)