### PR TITLE
docs(authentication): make OAuthBearer Validation content optional

### DIFF
--- a/kroxylicious-docs/docs/_assemblies/assembly-built-in-filters.adoc
+++ b/kroxylicious-docs/docs/_assemblies/assembly-built-in-filters.adoc
@@ -36,10 +36,12 @@ For information on using the filter, see the {RecordValidationGuide}.
 The Kroxylicious multi-tenancy filter presents a single Kafka cluster to tenants as if it were multiple clusters.
 For information on using the filter, see the {MultiTenancyGuide}.
 
+ifdef::include-oauth-bearer-validation[]
 == Oauth Bearer Validation filter
 
 The Kroxylicious Oauth Bearer Validation filter enables a validation on the JWT token received from client before forwarding it to cluster.
 For information on using the filter, see the {AuthenticationGuide}.
+endif::include-oauth-bearer-validation[]
 
 == SASL Inspection filter
 

--- a/kroxylicious-docs/docs/_assets/attributes.adoc
+++ b/kroxylicious-docs/docs/_assets/attributes.adoc
@@ -131,6 +131,7 @@
 :include-azure-key-vault-service-config-microsoft-entra-managed-identity: 1
 :include-platform-bare-metal: 1
 :include-platform-kubernetes: 1
+:include-oauth-bearer-validation: 1
 // We're not ready to enable OLM yet
 //:include-olm: 1
 //:OpenShiftOnly: 1

--- a/kroxylicious-docs/docs/_modules/authentication/con-authentication-logging.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/con-authentication-logging.adoc
@@ -133,6 +133,7 @@ The full stack trace is always included.
 
 For detailed authentication flow troubleshooting, enable `DEBUG` logging on `io.kroxylicious.filter.sasl.termination`.
 
+ifdef::include-oauth-bearer-validation[]
 == OAuthBearer Validation filter logs
 
 The `OauthBearerValidation` filter emits log messages at `DEBUG` level for authentication events.
@@ -153,6 +154,7 @@ The full stack trace is always included.
 |An unexpected error occurred during the SASL handshake.
 The full stack trace is always included.
 |===
+endif::include-oauth-bearer-validation[]
 
 == Operational guidance
 
@@ -162,7 +164,9 @@ This is particularly useful when diagnosing authentication failures in environme
 To see full stack traces for authentication failures:
 
 * For the SASL Inspection filter, set the log level for `io.kroxylicious.filter.sasl.inspection` to `DEBUG`.
+ifdef::include-oauth-bearer-validation[]
 * For the OAuthBearer Validation filter, the filter already logs at `DEBUG` level, so set the log level for `io.kroxylicious.filter.oauthbearer` to `DEBUG`.
+endif::include-oauth-bearer-validation[]
 * For runtime authentication announcements, set the log level for `io.kroxylicious.proxy.internal` to `DEBUG`.
 
 For information on configuring log levels, see the monitoring section of the {ProxyGuide}.

--- a/kroxylicious-docs/docs/_modules/authentication/con-choosing-authentication-approach.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/con-choosing-authentication-approach.adoc
@@ -48,11 +48,17 @@ Consider the following:
 
 * The broker still decides whether authentication succeeds.
   An unauthenticated attacker that can reach the proxy still has proxied access to the broker — the proxy forwards their application requests without restriction.
+ifdef::include-oauth-bearer-validation[]
   If your threat model requires that only authenticated clients' requests are forwarded to the broker, consider OAuthBearer Validation, SASL Termination, or mTLS instead.
+endif::include-oauth-bearer-validation[]
+ifndef::include-oauth-bearer-validation[]
+  If your threat model requires that only authenticated clients' requests are forwarded to the broker, consider SASL Termination or mTLS instead.
+endif::include-oauth-bearer-validation[]
 * The proxy observes the SASL exchange and holds the authorization ID in memory.
   For mechanisms that transmit credentials in plain text (such as PLAIN), this means plain-text passwords briefly exist in the proxy's memory.
   The PLAIN mechanism is disabled by default for this reason.
 
+ifdef::include-oauth-bearer-validation[]
 == OAuthBearer Validation
 
 Use OAuthBearer Validation when:
@@ -62,6 +68,7 @@ Use OAuthBearer Validation when:
 * You want to reduce load on the broker from repeated invalid authentication attempts.
 
 This mode requires a reachable JWKS endpoint that provides the public keys used to verify JWT signatures.
+endif::include-oauth-bearer-validation[]
 
 == SASL Termination
 
@@ -97,7 +104,12 @@ mTLS and SASL authentication are not mutually exclusive.
 You can configure both on the same virtual cluster:
 
 * The transport subject builder creates an initial authenticated subject from the TLS client certificate.
+ifdef::include-oauth-bearer-validation[]
 * If SASL Passthrough Inspection or OAuthBearer Validation is also configured, the SASL subject builder replaces the subject after successful SASL authentication.
+endif::include-oauth-bearer-validation[]
+ifndef::include-oauth-bearer-validation[]
+* If SASL Passthrough Inspection is also configured, the SASL subject builder replaces the subject after successful SASL authentication.
+endif::include-oauth-bearer-validation[]
 
 This can be useful when you want transport-level identity as a baseline and application-level identity for fine-grained access control.
 
@@ -123,11 +135,13 @@ This can be useful when you want transport-level identity as a baseline and appl
 |Yes (`SaslInspection` filter)
 |None
 
+ifdef::include-oauth-bearer-validation[]
 |OAuthBearer Validation
 |Yes (from JWT token)
 |Yes (token validation)
 |Yes (`OauthBearerValidation` filter)
 |JWKS endpoint
+endif::include-oauth-bearer-validation[]
 
 |SASL Termination
 |Yes (from SASL exchange)

--- a/kroxylicious-docs/docs/_modules/authentication/con-choosing-sasl-mechanism.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/con-choosing-sasl-mechanism.adoc
@@ -13,7 +13,12 @@
 When configuring SASL authentication, the choice of mechanism affects the security properties, infrastructure requirements, and operational characteristics of your deployment.
 This section compares the PLAIN, SCRAM, and OAUTHBEARER mechanisms across several security and operational dimensions to help you make an informed choice.
 
+ifdef::include-oauth-bearer-validation[]
 The choice of SASL mechanism is independent of the choice of xref:con-choosing-authentication-approach-{context}[authentication approach] (Passthrough, Inspection, Termination, or OAuthBearer Validation).
+endif::include-oauth-bearer-validation[]
+ifndef::include-oauth-bearer-validation[]
+The choice of SASL mechanism is independent of the choice of xref:con-choosing-authentication-approach-{context}[authentication approach] (Passthrough, Inspection, or Termination).
+endif::include-oauth-bearer-validation[]
 However, some authentication approaches constrain the available mechanisms.
 For information about the mechanisms supported by each authentication approach, see xref:con-choosing-authentication-approach-{context}[]
 

--- a/kroxylicious-docs/docs/_modules/authentication/con-configuring-sasl-passthrough.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/con-configuring-sasl-passthrough.adoc
@@ -13,11 +13,21 @@
 SASL Passthrough is the default SASL authentication mode.
 No explicit configuration is required to enable it.
 
+ifdef::include-oauth-bearer-validation[]
 When no SASL-related filter (such as `SaslInspection` or `OauthBearerValidation`) is configured in the filter chain, the proxy forwards all `SaslHandshake` and `SaslAuthenticate` requests from the client to the broker and relays the broker's responses back to the client without inspecting or modifying them.
+endif::include-oauth-bearer-validation[]
+ifndef::include-oauth-bearer-validation[]
+When no SASL-related filter (such as `SaslInspection`) is configured in the filter chain, the proxy forwards all `SaslHandshake` and `SaslAuthenticate` requests from the client to the broker and relays the broker's responses back to the client without inspecting or modifying them.
+endif::include-oauth-bearer-validation[]
 
 If your Kafka clients and brokers are already configured with SASL authentication, the proxy forwards the SASL exchange transparently.
 The client authenticates with the broker exactly as it would without the proxy.
 
 In this mode, the authenticated subject remains anonymous.
 The proxy does not know the client's identity and cannot make per-client decisions or log identity information.
+ifdef::include-oauth-bearer-validation[]
 If you need the proxy to be aware of the client's identity, configure either xref:assembly-configuring-authentication-sasl-inspection-auth-sasl-inspection[SASL Passthrough Inspection] or xref:assembly-configuring-authentication-oauthbearer-auth-oauthbearer[OAuthBearer Validation].
+endif::include-oauth-bearer-validation[]
+ifndef::include-oauth-bearer-validation[]
+If you need the proxy to be aware of the client's identity, configure xref:assembly-configuring-authentication-sasl-inspection-auth-sasl-inspection[SASL Passthrough Inspection].
+endif::include-oauth-bearer-validation[]

--- a/kroxylicious-docs/docs/_modules/authentication/con-sasl-authentication-modes.adoc
+++ b/kroxylicious-docs/docs/_modules/authentication/con-sasl-authentication-modes.adoc
@@ -57,6 +57,7 @@ For the `OAUTHBEARER` mechanism, only JWT tokens that use signatures (JWS) are s
 JWT tokens that use encryption (JWE) are not supported.
 Unsigned JWT tokens are supported but not recommended for production use.
 
+ifdef::include-oauth-bearer-validation[]
 == OAuthBearer Validation
 
 OAuthBearer Validation is a specialized mode in which the proxy validates a client's JWT bearer token _before_ forwarding the SASL exchange to the broker.
@@ -69,6 +70,7 @@ The filter validates tokens against a JSON Web Key Set (JWKS) retrieved from a c
 It supports configurable token validation including expected audience, expected issuer, and custom claim names.
 
 To limit the impact of repeated authentication failures, the filter applies exponential backoff to clients that present invalid tokens.
+endif::include-oauth-bearer-validation[]
 
 == SASL Termination
 

--- a/kroxylicious-docs/docs/authentication-guide/index.adoc
+++ b/kroxylicious-docs/docs/authentication-guide/index.adoc
@@ -58,11 +58,13 @@ ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
 
 // configuring OAuthBearer validation
+ifdef::include-oauth-bearer-validation[]
 ifdef::context[:parent-context: {context}]
 :context: auth-oauthbearer
 include::_assemblies/assembly-configuring-authentication-oauthbearer.adoc[leveloffset=+1]
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
+endif::include-oauth-bearer-validation[]
 
 // configuring the SASL subject builder (applies to both SASL inspection and SASL termination)
 include::_modules/sasl-inspection/con-configuring-sasl-subject-builder.adoc[leveloffset=+1]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Adds an `include-oauth-bearer-validation` conditional-inclusion flag (in `kroxylicious-docs/docs/_assets/attributes.adoc`) so a downstream derivative that omits the `OauthBearerValidation` filter can exclude the corresponding documentation by commenting out a single attribute line. This follows the existing `include-*` convention already used for KMS providers, platforms, and OLM.

The flag is **enabled by default**, so the upstream build is unchanged.

Only references to the **OAuthBearer Validation filter/approach** are gated. **OAUTHBEARER-as-a-SASL-mechanism** content is preserved, because that mechanism is still supported by the `SaslInspection` and `SaslTermination` filters, which remain in a derivative that only drops `OauthBearerValidation`.

Gated content (Client Authentication guide, plus the proxy guide's built-in-filters pointer):
- The `assembly-configuring-authentication-oauthbearer` include
- The `OAuthBearer Validation` sections in `con-sasl-authentication-modes` and `con-choosing-authentication-approach` (and its summary-table row)
- The OAuthBearer Validation filter logs section and troubleshooting bullet
- The `con-configuring-sasl-passthrough` filter mention and cross-reference
- The proxy guide's built-in-filters pointer

Mid-sentence mentions use paired `ifdef`/`ifndef` variants so the prose stays grammatical when the module is dropped.

### Additional Context

Requested to support a downstream derivative version that ships without the OAuthBearer Validation filter and needs to omit its documentation cleanly (no dangling cross-references, which would otherwise fail the docs build since it treats warnings as errors).

### Verification

- **Flag enabled** (default): `kroxylicious-docs` builds clean (no warnings).
- **Flag disabled**: builds clean; generated authentication guide HTML has 0 "OAuthBearer Validation" occurrences, 0 dangling xrefs, and retains OAUTHBEARER-mechanism content.

### Checklist

- [ ] New tests written (where applicable). N/A — documentation-only change.
- [x] If making a user-facing change, documentation is provided.
- [x] Existing unit/integration/system tests passing. (`kroxylicious-docs` renders cleanly; `kroxylicious-docs-tests` requires operator-dist artifacts unrelated to this change.)
- [ ] Any Sonarcloud warnings are addressed. N/A.
- [ ] PR references related GitHub issue(s).
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [ ] For user facing changes, add a logchange entry. N/A — docs build-config change, not a user-facing product change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)