### PR TITLE
ci: cache minikube start artifacts to reduce download flakiness

### DIFF
--- a/.github/actions/common/setup-minikube/action.yml
+++ b/.github/actions/common/setup-minikube/action.yml
@@ -26,6 +26,22 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Cache minikube start artifacts
+      # manusa/actions-setup-minikube sets MINIKUBE_HOME to $RUNNER_TEMP, so
+      # `minikube start` caches the kicbase image, the kubernetes preload
+      # tarball, and the k8s component binaries under this path. Restoring it
+      # before the action runs lets `minikube start` skip those downloads.
+      # NOTE: this does NOT cache the minikube CLI binary itself (that download
+      # is unconditional in the action; see #4653).
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      with:
+        path: ${{ runner.temp }}/.minikube/cache
+        # Key off this action's definition so any minikube/kubernetes version
+        # change (incl. Renovate bumps to the lines below) invalidates the
+        # cache automatically - no separate Renovate rule needed, and no risk
+        # of serving stale-version artifacts.
+        key: ${{ runner.os }}-minikube-${{ hashFiles('.github/actions/common/setup-minikube/action.yml') }}
+
     - name: Setup Minikube
       uses: manusa/actions-setup-minikube@b65276017fdec6f1e6498129fb740e34e260dc55
       with:


### PR DESCRIPTION
### Type of change

- Refactoring (CI infrastructure)

### Description

The **Setup Minikube** step intermittently fails while downloading from GitHub (`socket hang up` / `ECONNRESET`, #4653).

With the `docker` driver (used everywhere via the shared composite action), `minikube start` downloads three large artifacts into `$MINIKUBE_HOME/.minikube/cache` — the kicbase image (~520 MiB), the kubernetes preload tarball, and the k8s component binaries. `manusa/actions-setup-minikube` sets `MINIKUBE_HOME` to `$RUNNER_TEMP`, giving a stable path we can cache.

This adds a single `actions/cache` step to the shared `setup-minikube` composite action (before the action runs), so all four callers (`maven`, `integration-tests`, `run-system-tests`, `documentation-tests`) reuse those artifacts across runs — cutting download volume, execution time, and network exposure. The cache key hashes the action definition, so any minikube/kubernetes version bump (including Renovate) invalidates it automatically, with no separate Renovate rule and no risk of serving stale-version artifacts.

This approach was inspired by the `operator-tests-microshift` workflow, which similarly caches the CRC cache (`~/.crc/cache`) with `actions/cache`.

**Scope:** this does **not** cache the minikube **CLI binary** itself — that download is unconditional in the current action and is the exact failure in #4653. The upstream fix for that is [manusa/actions-setup-minikube#155](https://github.com/manusa/actions-setup-minikube/pull/155); once it releases, a follow-up can bump the pinned SHA and add a second cache on `RUNNER_TOOL_CACHE` to close the binary download too. This change is complementary to that.

### Additional Context

Verified on a fork by running the minikube workflows twice:

| | Cold run | Warm run (re-run) |
|---|---|---|
| Cache | miss → saved (732 MiB) | ✅ restored |
| kicbase image | downloaded | ✅ served from cache |
| k8s preload | downloaded | ✅ served from cache |
| minikube CLI binary | downloaded | downloaded (expected, out of scope) |
| Result | ✅ | ✅ |

### Checklist

- [ ] New tests written (where applicable). — N/A, CI config change
- [x] If making a user-facing change, documentation is provided... — N/A, not user-facing
- [x] Existing unit/integration/system tests passing. — verified green on fork
- [x] Any Sonarcloud warnings are addressed... — N/A
- [x] PR references related GitHub issue(s) so they are closed on merging. — Relates-to #4653
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [x] For user facing changes, add a logchange entry... — N/A, CI-only change

Relates-to: #4653

🤖 Generated with [Claude Code](https://claude.com/claude-code)
