### PR TITLE
feat(fidelity-harness): add populated-instance fidelity coverage

### DIFF
--- a/kroxylicious-fidelity-harness/pom.xml
+++ b/kroxylicious-fidelity-harness/pom.xml
@@ -50,5 +50,9 @@
             <artifactId>assertj-core</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/FieldPath.java
+++ b/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/FieldPath.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.fidelity;
+
+/**
+ * Identifies a single schema field by name.
+ * <p>
+ * A bare name, not a path: it can't distinguish two same-named fields at different nesting depths (e.g.
+ * two different structs each with their own {@code name} field). Wrapped in its own type now (rather than
+ * a plain {@code String}) so that {@link LeafValueSource}, already public API, can grow this into a real
+ * multi-segment path later without a breaking signature change.
+ *
+ * @param name the schema field's camelCase name
+ */
+public record FieldPath(String name) {
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/InRangeLeafValueSource.java
+++ b/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/InRangeLeafValueSource.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.fidelity;
+
+import java.lang.reflect.Constructor;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.random.RandomGenerator;
+
+/**
+ * Produces deterministic, well-formed, in-bounds values - the default {@link LeafValueSource}, used
+ * whenever a fidelity test just needs realistic, non-default field values rather than deliberately
+ * malformed ones.
+ */
+public final class InRangeLeafValueSource implements LeafValueSource {
+
+    private static final String UUID_RELATIVE_NAME = "common.Uuid";
+    private static final String BASE_RECORDS_RELATIVE_NAME = "common.record.internal.BaseRecords";
+
+    @Override
+    public Optional<Object> valueFor(Class<?> javaType, FieldPath fieldPath, String schemaTypeName, RandomGenerator random) {
+        return scalarValueFor(javaType, schemaTypeName, random)
+                .or(() -> uuidValueFor(javaType, random))
+                .or(() -> baseRecordsValueFor(javaType));
+    }
+
+    /**
+     * Flat, non-recursive leaf values: primitives, their boxed equivalents, and the handful of built-in
+     * reference types ({@code String}, {@code byte[]}, {@code ByteBuffer}) treated as opaque blobs rather
+     * than structures to recurse into. Returns {@link Optional#empty()} for any other type.
+     */
+    private Optional<Object> scalarValueFor(Class<?> type, String schemaTypeName, RandomGenerator random) {
+        // A UINT16 field is wire-typed as an unsigned short but represented as a Java int (a signed short
+        // can't hold the full 0..65535 range); the generated setter rejects anything outside that range,
+        // unlike a genuine INT32 field, so it needs its own bounded value ahead of the plain int check.
+        if ("UINT16".equals(schemaTypeName)) {
+            return Optional.of(1 + random.nextInt(0xFFFF));
+        }
+        if (type == short.class || type == Short.class) {
+            return Optional.of((short) (1 + random.nextInt(Short.MAX_VALUE)));
+        }
+        if (type == int.class || type == Integer.class) {
+            return Optional.of(1 + random.nextInt(Integer.MAX_VALUE - 1));
+        }
+        if (type == long.class || type == Long.class) {
+            return Optional.of(1L + random.nextInt(Integer.MAX_VALUE - 1));
+        }
+        if (type == byte.class || type == Byte.class) {
+            return Optional.of((byte) (1 + random.nextInt(Byte.MAX_VALUE)));
+        }
+        if (type == boolean.class || type == Boolean.class) {
+            return Optional.of(true);
+        }
+        if (type == double.class || type == Double.class) {
+            return Optional.of(1.0 + random.nextInt(1_000_000));
+        }
+        if (type == String.class) {
+            return Optional.of("value-" + random.nextInt(1_000_000));
+        }
+        if (type == byte[].class) {
+            return Optional.of(randomBytes(random));
+        }
+        if (type == ByteBuffer.class) {
+            return Optional.of(ByteBuffer.wrap(randomBytes(random)));
+        }
+        return Optional.empty();
+    }
+
+    private byte[] randomBytes(RandomGenerator random) {
+        byte[] bytes = new byte[4 + random.nextInt(8)];
+        random.nextBytes(bytes);
+        return bytes;
+    }
+
+    private Optional<Object> uuidValueFor(Class<?> type, RandomGenerator random) {
+        if (!isUuid(type)) {
+            return Optional.empty();
+        }
+        try {
+            Constructor<?> constructor = type.getDeclaredConstructor(long.class, long.class);
+            return Optional.of(constructor.newInstance(random.nextLong(), random.nextLong()));
+        }
+        catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to construct " + type + " via its (long, long) constructor", e);
+        }
+    }
+
+    private static boolean isUuid(Class<?> type) {
+        return KroxyliciousSerdes.isApiType(type, UUID_RELATIVE_NAME) || KafkaSerdes.isApiType(type, UUID_RELATIVE_NAME);
+    }
+
+    /**
+     * {@code BaseRecords} is an interface with no general-purpose implementation to populate reflectively;
+     * the canonical empty records value is a leaf-value substitution, the same kind of move as using
+     * {@code Uuid.ZERO_UUID}-shaped construction or an empty {@code ByteBuffer} - not an attempt to
+     * fabricate a real record batch. Doesn't consume {@code random} at all, same as the {@code boolean}
+     * branch above always returning {@code true}.
+     */
+    private Optional<Object> baseRecordsValueFor(Class<?> type) {
+        if (!isBaseRecords(type)) {
+            return Optional.empty();
+        }
+        try {
+            Class<?> memoryRecordsClass = Class.forName(type.getPackageName() + ".MemoryRecords");
+            return Optional.of(memoryRecordsClass.getField("EMPTY").get(null));
+        }
+        catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to look up MemoryRecords.EMPTY alongside " + type, e);
+        }
+    }
+
+    private static boolean isBaseRecords(Class<?> type) {
+        return KroxyliciousSerdes.isApiType(type, BASE_RECORDS_RELATIVE_NAME) || KafkaSerdes.isApiType(type, BASE_RECORDS_RELATIVE_NAME);
+    }
+}

--- a/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/InRangeLeafValueSource.java
+++ b/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/InRangeLeafValueSource.java
@@ -20,6 +20,13 @@ public final class InRangeLeafValueSource implements LeafValueSource {
     private static final String UUID_RELATIVE_NAME = "common.Uuid";
     private static final String BASE_RECORDS_RELATIVE_NAME = "common.record.internal.BaseRecords";
 
+    /**
+     * Construct an instance to provide values which are within bounds for each Kafka Schema type.
+     */
+    public InRangeLeafValueSource() {
+        super();
+    }
+
     @Override
     public Optional<Object> valueFor(Class<?> javaType, FieldPath fieldPath, String schemaTypeName, RandomGenerator random) {
         return scalarValueFor(javaType, schemaTypeName, random)

--- a/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/KafkaSerdes.java
+++ b/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/KafkaSerdes.java
@@ -13,10 +13,15 @@ import org.apache.kafka.common.protocol.MessageSizeAccumulator;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
 
 /**
- * Serializes and deserializes {@code org.apache.kafka.common.protocol.Message} instances to and
- * from raw bytes, using the standard two-pass size-then-write protocol.
+ * Everything scoped to Kafka's generated protocol classes ({@code org.apache.kafka.*}) - the counterpart
+ * to {@link KroxyliciousSerdes}: serializing/deserializing {@code Message} instances to and from raw bytes
+ * (the standard two-pass size-then-write protocol), and recognising a specific type under this namespace
+ * by name, since Kroxylicious's and Kafka's generated classes are structurally identical but otherwise
+ * unrelated, with no common supertype to {@code instanceof} against.
  */
 public final class KafkaSerdes {
+
+    private static final String ROOT = "org.apache.kafka.";
 
     private KafkaSerdes() {
     }
@@ -55,5 +60,29 @@ public final class KafkaSerdes {
         catch (RuntimeException e) {
             return new ReadResult<>(message, accessor.remaining(), e);
         }
+    }
+
+    /**
+     * Builds the fully-qualified class name under this namespace for a name relative to it.
+     *
+     * @param relativeName the name relative to {@code org.apache.kafka}, e.g. {@code "common.Uuid"}
+     * @return the fully-qualified class name under this namespace
+     */
+    public static String apiType(String relativeName) {
+        return ROOT + relativeName;
+    }
+
+    /**
+     * Tests whether a class is exactly the type named by a name relative to this namespace.
+     *
+     * @param clazz the class to test
+     * @param relativeName the name relative to {@code org.apache.kafka}, e.g. {@code "common.Uuid"}
+     * @return true if {@code clazz} is exactly the type named by {@code relativeName} under this namespace
+     */
+    @SuppressWarnings("java:S1872") // No common supertype exists to instanceof against: Kroxylicious's and
+    // Kafka's generated protocol classes are structurally identical but unrelated types, matched here by
+    // fully-qualified name on purpose.
+    public static boolean isApiType(Class<?> clazz, String relativeName) {
+        return clazz.getName().equals(apiType(relativeName));
     }
 }

--- a/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/KroxyliciousSerdes.java
+++ b/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/KroxyliciousSerdes.java
@@ -13,10 +13,16 @@ import io.kroxylicious.kafka.common.protocol.MessageSizeAccumulator;
 import io.kroxylicious.kafka.common.protocol.ObjectSerializationCache;
 
 /**
- * Serializes and deserializes {@code io.kroxylicious.kafka.common.protocol.Message} instances to and
- * from raw bytes, using the standard two-pass size-then-write protocol.
+ * Everything scoped to Kroxylicious's mirror of Kafka's generated protocol classes
+ * ({@code io.kroxylicious.kafka.*}) - the counterpart to {@link KafkaSerdes}: serializing/deserializing
+ * {@code Message} instances to and from raw bytes (the standard two-pass size-then-write protocol), and
+ * recognising a specific type under this namespace by name, since Kroxylicious's and Kafka's generated
+ * classes are structurally identical but otherwise unrelated, with no common supertype to
+ * {@code instanceof} against.
  */
 public final class KroxyliciousSerdes {
+
+    private static final String ROOT = "io.kroxylicious.kafka.";
 
     private KroxyliciousSerdes() {
     }
@@ -55,5 +61,29 @@ public final class KroxyliciousSerdes {
         catch (RuntimeException e) {
             return new ReadResult<>(message, accessor.remaining(), e);
         }
+    }
+
+    /**
+     * Builds the fully-qualified class name under this namespace for a name relative to it.
+     *
+     * @param relativeName the name relative to {@code io.kroxylicious.kafka}, e.g. {@code "common.Uuid"}
+     * @return the fully-qualified class name under this namespace
+     */
+    public static String apiType(String relativeName) {
+        return ROOT + relativeName;
+    }
+
+    /**
+     * Tests whether a class is exactly the type named by a name relative to this namespace.
+     *
+     * @param clazz the class to test
+     * @param relativeName the name relative to {@code io.kroxylicious.kafka}, e.g. {@code "common.Uuid"}
+     * @return true if {@code clazz} is exactly the type named by {@code relativeName} under this namespace
+     */
+    @SuppressWarnings("java:S1872") // No common supertype exists to instanceof against: Kroxylicious's and
+    // Kafka's generated protocol classes are structurally identical but unrelated types, matched here by
+    // fully-qualified name on purpose.
+    public static boolean isApiType(Class<?> clazz, String relativeName) {
+        return clazz.getName().equals(apiType(relativeName));
     }
 }

--- a/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/LeafValueSource.java
+++ b/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/LeafValueSource.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.fidelity;
+
+import java.util.Optional;
+import java.util.random.RandomGenerator;
+
+/**
+ * Supplies a value for a single leaf field of a generated {@code *Data}/nested-struct instance - a
+ * primitive, a boxed primitive, {@code String}, {@code byte[]}, {@code ByteBuffer}, {@code Uuid}, or
+ * {@code BaseRecords}. Leaf fields are opaque and non-recursive: unlike a nested struct, a {@code List},
+ * or a collection, nothing about their contents is walked further by {@link ReflectiveMessagePopulator}.
+ * <p>
+ * {@code javaType} is always a plain {@link Class}, never a {@link java.lang.reflect.ParameterizedType} -
+ * only {@code List<T>}/struct/collection fields are parameterized, and those never reach this interface.
+ *
+ * @see InRangeLeafValueSource the default implementation, producing well-formed, in-bounds values
+ */
+public interface LeafValueSource {
+
+    /**
+     * Supplies a value for one leaf field.
+     *
+     * @param javaType the field's Java type
+     * @param fieldPath identifies the field being populated; {@code null} when generating a {@code List}/
+     *            collection element, where there's no single field the value individually belongs to
+     * @param schemaTypeName the schema's wire type name (e.g. {@code "UINT16"}, {@code "INT32"},
+     *            {@code "STRING"}); {@code null} under the same circumstances as {@code fieldPath}
+     * @param random the shared randomness source for the whole object graph being populated
+     * @return the value to set, or {@link Optional#empty()} if this source doesn't handle {@code javaType}
+     */
+    Optional<Object> valueFor(Class<?> javaType, FieldPath fieldPath, String schemaTypeName, RandomGenerator random);
+}

--- a/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/ReflectiveMessagePopulator.java
+++ b/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/ReflectiveMessagePopulator.java
@@ -5,13 +5,18 @@
  */
 package io.kroxylicious.fidelity;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -24,33 +29,75 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * default (package) access, and use {@code private} exclusively for the generator's own bookkeeping
  * (the unknown-tagged-fields list) - so that visibility split is a reliable signal of "real payload
  * field" versus "generator internals", without depending on field naming.
+ * <p>
+ * Each call gets its own instance: {@link #populate} recurses into nested structs, lists and
+ * collections, and every level of that recursion needs the same {@link Random} and target
+ * {@code version} - carrying them as instance state avoids threading both through every private method.
  */
 public final class ReflectiveMessagePopulator {
 
-    private ReflectiveMessagePopulator() {
+    private final Random random;
+    private final Short version;
+
+    private ReflectiveMessagePopulator(Random random, Short version) {
+        this.random = random;
+        this.version = version;
     }
 
     /**
      * Populates {@code message}'s fields with deterministic non-default values derived from {@code seed}.
+     * No schema/version information is used, so a primitive field left at a constructor-assigned
+     * non-zero default (a schema-declared default value) is not overwritten, on the assumption that such
+     * a value is exactly the one the field must hold below the version it was introduced in.
      *
      * @param message the instance to populate
      * @param seed the seed controlling the generated values
      */
     @SuppressFBWarnings("PREDICTABLE_RANDOM") // Deterministic pseudorandomness is the point: reproducible test fixtures, not security relevant
     public static void populate(Object message, long seed) {
-        populate(message, new Random(seed));
+        new ReflectiveMessagePopulator(new Random(seed), null).populate(message);
     }
 
-    private static void populate(Object message, Random random) {
+    /**
+     * Populates {@code message}'s fields with deterministic non-default values, restricted to the
+     * fields actually present in {@code message}'s schema at {@code version} - so the result never
+     * trips the generated {@code write()}'s own version guards for fields introduced later, or
+     * excluded again earlier, than {@code version}.
+     *
+     * @param message the instance to populate
+     * @param version the wire version {@code message} will be serialised at
+     * @param seed the seed controlling the generated values
+     */
+    @SuppressFBWarnings("PREDICTABLE_RANDOM") // Deterministic pseudorandomness is the point: reproducible test fixtures, not security relevant
+    public static void populate(Object message, short version, long seed) {
+        new ReflectiveMessagePopulator(new Random(seed), version).populate(message);
+    }
+
+    private void populate(Object message) {
+        Set<String> schemaFieldNames = version == null ? null : schemaFieldNamesAt(message.getClass(), version);
         for (Field field : message.getClass().getDeclaredFields()) {
             int modifiers = field.getModifiers();
-            if (Modifier.isStatic(modifiers) || Modifier.isPrivate(modifiers)) {
+            boolean generatorInternal = Modifier.isStatic(modifiers) || Modifier.isPrivate(modifiers);
+            boolean outsideSchema = schemaFieldNames != null && !schemaFieldNames.contains(field.getName());
+            // Fields outside the target version's schema (not yet introduced, or dropped again before
+            // this version - specs aren't purely additive) must keep their constructor default: it's the
+            // only value the generated write() accepts for them at this version.
+            if (generatorInternal || outsideSchema) {
                 continue;
             }
             field.setAccessible(true);
-            Object value = valueFor(field.getGenericType(), random);
+            Class<?> type = field.getType();
             try {
-                field.set(message, value);
+                // Without schema information we can't tell whether a primitive's constructor-assigned
+                // non-zero value (e.g. an enum-like byte defaulting to 1) is a schema-declared default
+                // that write() requires below its introduction version, so it's left alone in that case.
+                // Once schemaFieldNames has already restricted us to fields the target version's schema
+                // actually declares, no such guard is needed - the field is safe to overwrite outright.
+                boolean unknownSchemaPrimitiveDefault = schemaFieldNames == null && type.isPrimitive() && !isDefaultPrimitiveValue(type, field.get(message));
+                if (unknownSchemaPrimitiveDefault) {
+                    continue;
+                }
+                field.set(message, valueFor(field.getGenericType()));
             }
             catch (IllegalAccessException e) {
                 throw new IllegalStateException("Failed to populate field " + field, e);
@@ -58,38 +105,194 @@ public final class ReflectiveMessagePopulator {
         }
     }
 
-    private static Object valueFor(Type type, Random random) {
+    /**
+     * Reads the {@code SCHEMAS} array every generated message/struct class declares and returns the
+     * camelCase names of the fields present in the schema at {@code version} - the same set write()
+     * consults internally, so filtering against it keeps populate() from ever setting a field write()
+     * would then refuse to serialise at that version.
+     */
+    private static Set<String> schemaFieldNamesAt(Class<?> clazz, short version) {
+        try {
+            Object[] schemas = (Object[]) clazz.getField("SCHEMAS").get(null);
+            if (version < 0 || version >= schemas.length || schemas[version] == null) {
+                return Set.of();
+            }
+            Object schema = schemas[version];
+            Object[] boundFields = (Object[]) schema.getClass().getMethod("fields").invoke(schema);
+            Set<String> names = new HashSet<>();
+            for (Object boundField : boundFields) {
+                Object fieldDef = boundField.getClass().getField("def").get(boundField);
+                String snakeCaseName = (String) fieldDef.getClass().getField("name").get(fieldDef);
+                names.add(toCamelCase(snakeCaseName));
+            }
+            return names;
+        }
+        catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to read schema fields for " + clazz + " at version " + version, e);
+        }
+    }
+
+    private static String toCamelCase(String snakeCaseName) {
+        String[] words = snakeCaseName.split("_");
+        StringBuilder camelCase = new StringBuilder(words[0]);
+        for (int i = 1; i < words.length; i++) {
+            String word = words[i];
+            camelCase.append(Character.toUpperCase(word.charAt(0))).append(word.substring(1));
+        }
+        return camelCase.toString();
+    }
+
+    private static boolean isDefaultPrimitiveValue(Class<?> type, Object currentValue) {
+        if (type == short.class) {
+            return ((Short) currentValue) == 0;
+        }
+        if (type == int.class) {
+            return ((Integer) currentValue) == 0;
+        }
+        if (type == long.class) {
+            return ((Long) currentValue) == 0L;
+        }
+        if (type == byte.class) {
+            return ((Byte) currentValue) == 0;
+        }
+        if (type == boolean.class) {
+            return !((Boolean) currentValue);
+        }
+        if (type == double.class) {
+            return ((Double) currentValue) == 0.0;
+        }
+        throw new IllegalStateException("Unhandled primitive type " + type);
+    }
+
+    private Object valueFor(Type type) {
         if (type == short.class || type == Short.class) {
             return (short) (1 + random.nextInt(Short.MAX_VALUE));
         }
         if (type == int.class || type == Integer.class) {
             return 1 + random.nextInt(Integer.MAX_VALUE - 1);
         }
+        if (type == long.class || type == Long.class) {
+            return 1L + random.nextInt(Integer.MAX_VALUE - 1);
+        }
+        if (type == byte.class || type == Byte.class) {
+            return (byte) (1 + random.nextInt(Byte.MAX_VALUE));
+        }
+        if (type == boolean.class || type == Boolean.class) {
+            return true;
+        }
+        if (type == double.class || type == Double.class) {
+            return 1.0 + random.nextInt(1_000_000);
+        }
         if (type == String.class) {
             return "value-" + random.nextInt(1_000_000);
         }
+        if (type == byte[].class) {
+            byte[] bytes = new byte[4 + random.nextInt(8)];
+            random.nextBytes(bytes);
+            return bytes;
+        }
+        if (type == ByteBuffer.class) {
+            return ByteBuffer.wrap((byte[]) valueFor(byte[].class));
+        }
         if (type instanceof ParameterizedType parameterizedType && parameterizedType.getRawType() == List.class) {
-            return listValueFor(parameterizedType.getActualTypeArguments()[0], random);
+            return listValueFor(parameterizedType.getActualTypeArguments()[0]);
+        }
+        if (type instanceof Class<?> clazz && isUuidType(clazz)) {
+            return newUuid(clazz);
+        }
+        if (type instanceof Class<?> clazz && isMultiCollectionType(clazz)) {
+            return collectionValueFor(clazz);
+        }
+        if (type instanceof Class<?> clazz && isBaseRecordsType(clazz)) {
+            return emptyRecords(clazz);
+        }
+        if (type instanceof Class<?> structClass) {
+            return newStruct(structClass);
         }
         throw new UnsupportedOperationException("Don't know how to populate a field of type " + type);
     }
 
-    private static List<Object> listValueFor(Type elementType, Random random) {
+    private List<Object> listValueFor(Type elementType) {
         List<Object> elements = new ArrayList<>();
         int size = 1 + random.nextInt(2);
         for (int i = 0; i < size; i++) {
-            elements.add(structValueFor(elementType, random));
+            elements.add(valueFor(elementType));
         }
         return elements;
     }
 
-    private static Object structValueFor(Type elementType, Random random) {
-        if (!(elementType instanceof Class<?> structClass)) {
-            throw new UnsupportedOperationException("Don't know how to populate a list element of type " + elementType);
+    private static boolean isUuidType(Class<?> clazz) {
+        return clazz.getSimpleName().equals("Uuid");
+    }
+
+    private Object newUuid(Class<?> uuidClass) {
+        try {
+            Constructor<?> constructor = uuidClass.getDeclaredConstructor(long.class, long.class);
+            return constructor.newInstance(random.nextLong(), random.nextLong());
         }
+        catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to construct " + uuidClass + " via its (long, long) constructor", e);
+        }
+    }
+
+    private static boolean isMultiCollectionType(Class<?> clazz) {
+        for (Class<?> ancestor = clazz.getSuperclass(); ancestor != null; ancestor = ancestor.getSuperclass()) {
+            if (ancestor.getSimpleName().equals("ImplicitLinkedHashMultiCollection")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Object collectionValueFor(Class<?> collectionClass) {
+        Type elementType = ((ParameterizedType) collectionClass.getGenericSuperclass()).getActualTypeArguments()[0];
+        try {
+            Object collection = collectionClass.getDeclaredConstructor().newInstance();
+            Method add = findSingleArgAddMethod(collectionClass);
+            int size = 1 + random.nextInt(2);
+            for (int i = 0; i < size; i++) {
+                add.invoke(collection, valueFor(elementType));
+            }
+            return collection;
+        }
+        catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to populate collection " + collectionClass, e);
+        }
+    }
+
+    private static Method findSingleArgAddMethod(Class<?> collectionClass) {
+        for (Method method : collectionClass.getMethods()) {
+            if (method.getName().equals("add") && method.getParameterCount() == 1) {
+                return method;
+            }
+        }
+        throw new IllegalStateException("No single-argument add(...) method found on " + collectionClass);
+    }
+
+    private static boolean isBaseRecordsType(Class<?> clazz) {
+        return clazz.isInterface() && clazz.getSimpleName().equals("BaseRecords");
+    }
+
+    /**
+     * {@code BaseRecords} is an interface with no general-purpose implementation to populate
+     * reflectively; the canonical empty records value is a leaf-value substitution, the same kind of
+     * move as using {@code Uuid.ZERO_UUID}-shaped construction or an empty {@code ByteBuffer} - not an
+     * attempt to fabricate a real record batch.
+     */
+    private static Object emptyRecords(Class<?> baseRecordsClass) {
+        try {
+            Class<?> memoryRecordsClass = Class.forName(baseRecordsClass.getPackageName() + ".MemoryRecords");
+            return memoryRecordsClass.getField("EMPTY").get(null);
+        }
+        catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to look up MemoryRecords.EMPTY alongside " + baseRecordsClass, e);
+        }
+    }
+
+    private Object newStruct(Class<?> structClass) {
         try {
             Object instance = structClass.getDeclaredConstructor().newInstance();
-            populate(instance, random);
+            populate(instance);
             return instance;
         }
         catch (ReflectiveOperationException e) {

--- a/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/ReflectiveMessagePopulator.java
+++ b/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/ReflectiveMessagePopulator.java
@@ -36,6 +36,20 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 public final class ReflectiveMessagePopulator {
 
+    // Kroxylicious and Kafka each declare their own copy of these types under the same relative path,
+    // one package per namespace - matched by fully-qualified name rather than an import of either
+    // concrete class, so this harness stays symmetric between the two namespaces it's proving fidelity
+    // between.
+    private static final Set<String> UUID_CLASS_NAMES = Set.of(
+            "io.kroxylicious.kafka.common.Uuid",
+            "org.apache.kafka.common.Uuid");
+    private static final Set<String> MULTI_COLLECTION_CLASS_NAMES = Set.of(
+            "io.kroxylicious.kafka.common.utils.ImplicitLinkedHashMultiCollection",
+            "org.apache.kafka.common.utils.ImplicitLinkedHashMultiCollection");
+    private static final Set<String> BASE_RECORDS_CLASS_NAMES = Set.of(
+            "io.kroxylicious.kafka.common.record.internal.BaseRecords",
+            "org.apache.kafka.common.record.internal.BaseRecords");
+
     private final Random random;
     private final Short messageVersion;
 
@@ -221,8 +235,10 @@ public final class ReflectiveMessagePopulator {
         return elements;
     }
 
+    @SuppressWarnings("java:S1872") // No common supertype exists to instanceof against: Kroxylicious's and
+    // Kafka's Uuid are unrelated classes in unrelated packages, matched here by name on purpose.
     private static boolean isUuidType(Class<?> clazz) {
-        return clazz.getSimpleName().equals("Uuid");
+        return UUID_CLASS_NAMES.contains(clazz.getName());
     }
 
     private Object newUuid(Class<?> uuidClass) {
@@ -235,9 +251,12 @@ public final class ReflectiveMessagePopulator {
         }
     }
 
+    @SuppressWarnings("java:S1872") // No common supertype exists to instanceof against: Kroxylicious's and
+    // Kafka's ImplicitLinkedHashMultiCollection are unrelated classes in unrelated packages, matched here
+    // by name on purpose.
     private static boolean isMultiCollectionType(Class<?> clazz) {
         for (Class<?> ancestor = clazz.getSuperclass(); ancestor != null; ancestor = ancestor.getSuperclass()) {
-            if (ancestor.getSimpleName().equals("ImplicitLinkedHashMultiCollection")) {
+            if (MULTI_COLLECTION_CLASS_NAMES.contains(ancestor.getName())) {
                 return true;
             }
         }
@@ -269,8 +288,10 @@ public final class ReflectiveMessagePopulator {
         throw new IllegalStateException("No single-argument add(...) method found on " + collectionClass);
     }
 
+    @SuppressWarnings("java:S1872") // No common supertype exists to instanceof against: Kroxylicious's and
+    // Kafka's BaseRecords are unrelated interfaces in unrelated packages, matched here by name on purpose.
     private static boolean isBaseRecordsType(Class<?> clazz) {
-        return clazz.isInterface() && clazz.getSimpleName().equals("BaseRecords");
+        return BASE_RECORDS_CLASS_NAMES.contains(clazz.getName());
     }
 
     /**

--- a/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/ReflectiveMessagePopulator.java
+++ b/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/ReflectiveMessagePopulator.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.fidelity;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Reflectively populates a generated {@code *Data}/nested-struct instance's own fields with
+ * deterministic, non-default values, so fidelity tests can exercise more than default-constructed
+ * (all-zero) instances without hand-authoring a fixture per spec.
+ * <p>
+ * Only package-private fields are populated: the generated classes declare every real schema field with
+ * default (package) access, and use {@code private} exclusively for the generator's own bookkeeping
+ * (the unknown-tagged-fields list) - so that visibility split is a reliable signal of "real payload
+ * field" versus "generator internals", without depending on field naming.
+ */
+public final class ReflectiveMessagePopulator {
+
+    private ReflectiveMessagePopulator() {
+    }
+
+    /**
+     * Populates {@code message}'s fields with deterministic non-default values derived from {@code seed}.
+     *
+     * @param message the instance to populate
+     * @param seed the seed controlling the generated values
+     */
+    @SuppressFBWarnings("PREDICTABLE_RANDOM") // Deterministic pseudorandomness is the point: reproducible test fixtures, not security relevant
+    public static void populate(Object message, long seed) {
+        populate(message, new Random(seed));
+    }
+
+    private static void populate(Object message, Random random) {
+        for (Field field : message.getClass().getDeclaredFields()) {
+            int modifiers = field.getModifiers();
+            if (Modifier.isStatic(modifiers) || Modifier.isPrivate(modifiers)) {
+                continue;
+            }
+            field.setAccessible(true);
+            Object value = valueFor(field.getGenericType(), random);
+            try {
+                field.set(message, value);
+            }
+            catch (IllegalAccessException e) {
+                throw new IllegalStateException("Failed to populate field " + field, e);
+            }
+        }
+    }
+
+    private static Object valueFor(Type type, Random random) {
+        if (type == short.class || type == Short.class) {
+            return (short) (1 + random.nextInt(Short.MAX_VALUE));
+        }
+        if (type == int.class || type == Integer.class) {
+            return 1 + random.nextInt(Integer.MAX_VALUE - 1);
+        }
+        if (type == String.class) {
+            return "value-" + random.nextInt(1_000_000);
+        }
+        if (type instanceof ParameterizedType parameterizedType && parameterizedType.getRawType() == List.class) {
+            return listValueFor(parameterizedType.getActualTypeArguments()[0], random);
+        }
+        throw new UnsupportedOperationException("Don't know how to populate a field of type " + type);
+    }
+
+    private static List<Object> listValueFor(Type elementType, Random random) {
+        List<Object> elements = new ArrayList<>();
+        int size = 1 + random.nextInt(2);
+        for (int i = 0; i < size; i++) {
+            elements.add(structValueFor(elementType, random));
+        }
+        return elements;
+    }
+
+    private static Object structValueFor(Type elementType, Random random) {
+        if (!(elementType instanceof Class<?> structClass)) {
+            throw new UnsupportedOperationException("Don't know how to populate a list element of type " + elementType);
+        }
+        try {
+            Object instance = structClass.getDeclaredConstructor().newInstance();
+            populate(instance, random);
+            return instance;
+        }
+        catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to instantiate nested struct " + structClass, e);
+        }
+    }
+}

--- a/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/ReflectiveMessagePopulator.java
+++ b/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/ReflectiveMessagePopulator.java
@@ -37,11 +37,11 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public final class ReflectiveMessagePopulator {
 
     private final Random random;
-    private final Short version;
+    private final Short messageVersion;
 
-    private ReflectiveMessagePopulator(Random random, Short version) {
+    private ReflectiveMessagePopulator(Random random, Short messageVersion) {
         this.random = random;
-        this.version = version;
+        this.messageVersion = messageVersion;
     }
 
     /**
@@ -74,7 +74,7 @@ public final class ReflectiveMessagePopulator {
     }
 
     private void populate(Object message) {
-        Set<String> schemaFieldNames = version == null ? null : schemaFieldNamesAt(message.getClass(), version);
+        Set<String> schemaFieldNames = messageVersion == null ? null : schemaFieldNamesAt(message.getClass(), messageVersion);
         for (Field field : message.getClass().getDeclaredFields()) {
             int modifiers = field.getModifiers();
             boolean generatorInternal = Modifier.isStatic(modifiers) || Modifier.isPrivate(modifiers);

--- a/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/ReflectiveMessagePopulator.java
+++ b/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/ReflectiveMessagePopulator.java
@@ -15,6 +15,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 
@@ -179,51 +180,95 @@ public final class ReflectiveMessagePopulator {
     }
 
     private Object valueFor(Type type) {
+        return scalarValueFor(type)
+                .or(() -> containerValueFor(type))
+                .or(() -> uuidValueFor(type))
+                .or(() -> baseRecordsValueFor(type))
+                .or(() -> structValueFor(type))
+                .orElseThrow(() -> new UnsupportedOperationException("Don't know how to populate a field of type " + type));
+    }
+
+    /**
+     * Flat, non-recursive leaf values: primitives, their boxed equivalents, and the handful of built-in
+     * reference types ({@code String}, {@code byte[]}, {@code ByteBuffer}) treated as opaque blobs rather
+     * than structures to recurse into. Returns {@link Optional#empty()} for any other type, deferring to
+     * {@link #valueFor}'s remaining checks.
+     */
+    private Optional<Object> scalarValueFor(Type type) {
         if (type == short.class || type == Short.class) {
-            return (short) (1 + random.nextInt(Short.MAX_VALUE));
+            return Optional.of((short) (1 + randomInt(Short.MAX_VALUE)));
         }
         if (type == int.class || type == Integer.class) {
-            return 1 + random.nextInt(Integer.MAX_VALUE - 1);
+            return Optional.of(1 + randomInt(Integer.MAX_VALUE - 1));
         }
         if (type == long.class || type == Long.class) {
-            return 1L + random.nextInt(Integer.MAX_VALUE - 1);
+            return Optional.of(1L + randomInt(Integer.MAX_VALUE - 1));
         }
         if (type == byte.class || type == Byte.class) {
-            return (byte) (1 + random.nextInt(Byte.MAX_VALUE));
+            return Optional.of((byte) (1 + randomInt(Byte.MAX_VALUE)));
         }
         if (type == boolean.class || type == Boolean.class) {
-            return true;
+            return Optional.of(true);
         }
         if (type == double.class || type == Double.class) {
-            return 1.0 + random.nextInt(1_000_000);
+            return Optional.of(1.0 + random.nextInt(1_000_000));
         }
         if (type == String.class) {
-            return "value-" + random.nextInt(1_000_000);
+            return Optional.of("value-" + random.nextInt(1_000_000));
         }
         if (type == byte[].class) {
-            byte[] bytes = new byte[4 + random.nextInt(8)];
-            random.nextBytes(bytes);
-            return bytes;
+            return Optional.of(randomBytes());
         }
         if (type == ByteBuffer.class) {
-            return ByteBuffer.wrap((byte[]) valueFor(byte[].class));
+            return Optional.of(ByteBuffer.wrap(randomBytes()));
         }
+        return Optional.empty();
+    }
+
+    private byte[] randomBytes() {
+        byte[] bytes = new byte[4 + random.nextInt(8)];
+        random.nextBytes(bytes);
+        return bytes;
+    }
+
+    /**
+     * Types that hold a variable number of repeated elements: a generated {@code List<T>} field, or an
+     * {@code ImplicitLinkedHashMultiCollection}-based collection. Returns {@link Optional#empty()} for any
+     * other type, deferring to {@link #valueFor}'s remaining checks.
+     */
+    private Optional<Object> containerValueFor(Type type) {
         if (type instanceof ParameterizedType parameterizedType && parameterizedType.getRawType() == List.class) {
-            return listValueFor(parameterizedType.getActualTypeArguments()[0]);
-        }
-        if (type instanceof Class<?> clazz && isUuidType(clazz)) {
-            return newUuid(clazz);
+            return Optional.of(listValueFor(parameterizedType.getActualTypeArguments()[0]));
         }
         if (type instanceof Class<?> clazz && isMultiCollectionType(clazz)) {
-            return collectionValueFor(clazz);
+            return Optional.of(collectionValueFor(clazz));
         }
+        return Optional.empty();
+    }
+
+    private Optional<Object> uuidValueFor(Type type) {
+        if (type instanceof Class<?> clazz && isUuidType(clazz)) {
+            return Optional.of(newUuid(clazz));
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Object> baseRecordsValueFor(Type type) {
         if (type instanceof Class<?> clazz && isBaseRecordsType(clazz)) {
-            return emptyRecords(clazz);
+            return Optional.of(emptyRecords(clazz));
         }
+        return Optional.empty();
+    }
+
+    private Optional<Object> structValueFor(Type type) {
         if (type instanceof Class<?> structClass) {
-            return newStruct(structClass);
+            return Optional.of(newStruct(structClass));
         }
-        throw new UnsupportedOperationException("Don't know how to populate a field of type " + type);
+        return Optional.empty();
+    }
+
+    private int randomInt(int maxValue) {
+        return random.nextInt(maxValue);
     }
 
     private List<Object> listValueFor(Type elementType) {

--- a/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/ReflectiveMessagePopulator.java
+++ b/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/ReflectiveMessagePopulator.java
@@ -5,28 +5,28 @@
  */
 package io.kroxylicious.fidelity;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
-import java.util.Set;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
- * Reflectively populates a generated {@code *Data}/nested-struct instance's own fields with
- * deterministic, non-default values, so fidelity tests can exercise more than default-constructed
- * (all-zero) instances without hand-authoring a fixture per spec.
+ * Reflectively walks a generated {@code *Data}/nested-struct instance's own fields - filtering to the
+ * ones present in its schema at a given version, recursing into nested structs, lists and collections -
+ * and invokes each field's setter, so fidelity tests can exercise more than default-constructed
+ * (all-zero) instances without hand-authoring a fixture per spec. What value each leaf field gets is
+ * delegated to a {@link LeafValueSource}, so this class owns only traversal: which fields exist, in what
+ * shape, not what's a well-formed or malformed value for any of them.
  * <p>
  * Only package-private fields are populated: the generated classes declare every real schema field with
  * default (package) access, and use {@code private} exclusively for the generator's own bookkeeping
@@ -34,96 +34,102 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * field" versus "generator internals", without depending on field naming.
  * <p>
  * Each call gets its own instance: {@link #populate} recurses into nested structs, lists and
- * collections, and every level of that recursion needs the same {@link Random} and target
- * {@code version} - carrying them as instance state avoids threading both through every private method.
+ * collections, and every level of that recursion needs the same {@link Random}, target {@code version},
+ * and {@link LeafValueSource} - carrying them as instance state avoids threading all three through every
+ * private method.
  */
 public final class ReflectiveMessagePopulator {
 
-    // Kroxylicious and Kafka each declare their own copy of these types under the same relative path,
-    // one package per namespace - matched by fully-qualified name rather than an import of either
-    // concrete class, so this harness stays symmetric between the two namespaces it's proving fidelity
-    // between.
-    private static final Set<String> UUID_CLASS_NAMES = Set.of(
-            "io.kroxylicious.kafka.common.Uuid",
-            "org.apache.kafka.common.Uuid");
-    private static final Set<String> MULTI_COLLECTION_CLASS_NAMES = Set.of(
-            "io.kroxylicious.kafka.common.utils.ImplicitLinkedHashMultiCollection",
-            "org.apache.kafka.common.utils.ImplicitLinkedHashMultiCollection");
-    private static final Set<String> BASE_RECORDS_CLASS_NAMES = Set.of(
-            "io.kroxylicious.kafka.common.record.internal.BaseRecords",
-            "org.apache.kafka.common.record.internal.BaseRecords");
-    private static final Set<String> TAGGED_FIELDS_TYPE_NAMES = Set.of(
-            "io.kroxylicious.kafka.common.protocol.types.TaggedFields",
-            "org.apache.kafka.common.protocol.types.TaggedFields");
+    private static final String MULTI_COLLECTION_RELATIVE_NAME = "common.utils.ImplicitLinkedHashMultiCollection";
+    private static final String TAGGED_FIELDS_RELATIVE_NAME = "common.protocol.types.TaggedFields";
 
     private final Random random;
     private final short messageVersion;
+    private final LeafValueSource leafValueSource;
 
-    private ReflectiveMessagePopulator(Random random, short messageVersion) {
+    private ReflectiveMessagePopulator(Random random, short messageVersion, LeafValueSource leafValueSource) {
         this.random = random;
         this.messageVersion = messageVersion;
+        this.leafValueSource = leafValueSource;
     }
 
     /**
-     * Populates {@code message}'s fields with deterministic non-default values, restricted to the
-     * fields actually present in {@code message}'s schema at {@code version} - so the result never
-     * trips the generated {@code write()}'s own version guards for fields introduced later, or
-     * excluded again earlier, than {@code version}.
+     * Populates {@code message}'s fields with deterministic, well-formed, non-default values, restricted
+     * to the fields actually present in {@code message}'s schema at {@code version} - so the result never
+     * trips the generated {@code write()}'s own version guards for fields introduced later, or excluded
+     * again earlier, than {@code version}. Equivalent to
+     * {@code populate(message, version, seed, new InRangeLeafValueSource())}.
      *
      * @param message the instance to populate
      * @param version the wire version {@code message} will be serialised at
      * @param seed the seed controlling the generated values
      */
-    @SuppressFBWarnings("PREDICTABLE_RANDOM") // Deterministic pseudorandomness is the point: reproducible test fixtures, not security relevant
     public static void populate(Object message, short version, long seed) {
-        new ReflectiveMessagePopulator(new Random(seed), version).populate(message);
+        populate(message, version, seed, new InRangeLeafValueSource());
+    }
+
+    /**
+     * As {@link #populate(Object, short, long)}, but with an explicit {@link LeafValueSource} - e.g. to
+     * deliberately construct malformed values for error-parity testing, rather than always well-formed
+     * ones.
+     *
+     * @param message the instance to populate
+     * @param version the wire version {@code message} will be serialised at
+     * @param seed the seed controlling the generated values
+     * @param leafValueSource supplies the value for each leaf field
+     */
+    @SuppressFBWarnings("PREDICTABLE_RANDOM") // Deterministic pseudorandomness is the point: reproducible test fixtures, not security relevant
+    public static void populate(Object message, short version, long seed, LeafValueSource leafValueSource) {
+        new ReflectiveMessagePopulator(new Random(seed), version, leafValueSource).populate(message);
     }
 
     private void populate(Object message) {
-        Set<String> schemaFieldNames = schemaFieldNamesAt(message.getClass(), messageVersion);
+        SchemaFields schemaFields = schemaFieldsAt(message.getClass(), messageVersion);
         // Fields outside the target version's schema (not yet introduced, or dropped again before
         // this version - specs aren't purely additive) must keep their constructor default: it's the
         // only value the generated write() accepts for them at this version.
         Arrays.stream(message.getClass().getDeclaredFields()).filter(field -> {
             int modifiers = field.getModifiers();
             boolean generatorInternal = Modifier.isStatic(modifiers) || Modifier.isPrivate(modifiers);
-            boolean outsideSchema = !schemaFieldNames.contains(field.getName());
+            boolean outsideSchema = !schemaFields.fieldTypeNames().containsKey(field.getName());
             return !generatorInternal && !outsideSchema;
-        }).forEach(field -> invokeSetterForField(message, field));
+        }).forEach(field -> invokeSetterForField(message, field, schemaFields.fieldTypeNames().get(field.getName())));
     }
 
-    private void invokeSetterForField(Object message, Field field) {
+    private void invokeSetterForField(Object message, Field field, String schemaTypeName) {
         String name = field.getName();
         Class<?> type = field.getType();
         try {
             Method setter = message.getClass().getMethod("set" + capitalize(name), type);
-            setter.invoke(message, valueFor(field.getGenericType()));
+            setter.invoke(message, valueFor(field.getGenericType(), new FieldPath(name), schemaTypeName));
         }
         catch (ReflectiveOperationException e) {
             throw new IllegalStateException("Failed to populate field " + field, e);
         }
     }
 
+    private record SchemaFields(Map<String, String> fieldTypeNames) {}
+
     /**
      * Reads the {@code SCHEMAS} array every generated message/struct class declares and returns the
-     * camelCase names of the fields present in the schema at {@code version} - the same set write()
-     * consults internally, so filtering against it keeps populate() from ever setting a field write()
-     * would then refuse to serialise at that version.
+     * camelCase names of the fields present in the schema at {@code version}, mapped to their schema
+     * wire type name - the same set write() consults internally, so filtering against it keeps
+     * populate() from ever setting a field write() would then refuse to serialise at that version.
      */
-    private static Set<String> schemaFieldNamesAt(Class<?> clazz, short version) {
+    private static SchemaFields schemaFieldsAt(Class<?> clazz, short version) {
         try {
             Object[] schemas = (Object[]) clazz.getField("SCHEMAS").get(null);
             if (version < 0 || version >= schemas.length || schemas[version] == null) {
-                return Set.of();
+                return new SchemaFields(Map.of());
             }
             Object schema = schemas[version];
             Object[] boundFields = (Object[]) schema.getClass().getMethod("fields").invoke(schema);
-            Set<String> names = new HashSet<>();
+            Map<String, String> fieldTypeNames = new HashMap<>();
             for (Object boundField : boundFields) {
                 Object fieldDef = boundField.getClass().getField("def").get(boundField);
-                addFieldNames(fieldDef, names);
+                addFieldNames(fieldDef, fieldTypeNames);
             }
-            return names;
+            return new SchemaFields(fieldTypeNames);
         }
         catch (ReflectiveOperationException e) {
             throw new IllegalStateException("Failed to read schema fields for " + clazz + " at version " + version, e);
@@ -136,17 +142,35 @@ public final class ReflectiveMessagePopulator {
      * schema-declared fields (e.g. {@code replicaDirectoryId}) live one level down, keyed by tag, inside
      * its {@code TaggedFields} type.
      */
-    private static void addFieldNames(Object fieldDef, Set<String> names) throws ReflectiveOperationException {
+    private static void addFieldNames(Object fieldDef, Map<String, String> fieldTypeNames) throws ReflectiveOperationException {
         Object type = fieldDef.getClass().getField("type").get(fieldDef);
-        if (TAGGED_FIELDS_TYPE_NAMES.contains(type.getClass().getName())) {
+        if (isTaggedFieldsType(type.getClass())) {
             Map<?, ?> taggedFields = (Map<?, ?>) type.getClass().getMethod("fields").invoke(type);
             for (Object taggedFieldDef : taggedFields.values()) {
-                addFieldNames(taggedFieldDef, names);
+                addFieldNames(taggedFieldDef, fieldTypeNames);
             }
             return;
         }
         String snakeCaseName = (String) fieldDef.getClass().getField("name").get(fieldDef);
-        names.add(toCamelCase(snakeCaseName));
+        String camelCaseName = toCamelCase(snakeCaseName);
+        // Most Type constants (UINT16 among them) are anonymous DocumentedType subclasses, which aren't
+        // themselves public - typeName() must be looked up via the nearest public class in the hierarchy
+        // (DocumentedType, which declares it), or reflection's accessibility check on the anonymous
+        // subclass rejects the call.
+        String typeName = (String) nearestPublicClass(type.getClass()).getMethod("typeName").invoke(type);
+        fieldTypeNames.put(camelCaseName, typeName);
+    }
+
+    private static boolean isTaggedFieldsType(Class<?> clazz) {
+        return KroxyliciousSerdes.isApiType(clazz, TAGGED_FIELDS_RELATIVE_NAME) || KafkaSerdes.isApiType(clazz, TAGGED_FIELDS_RELATIVE_NAME);
+    }
+
+    private static Class<?> nearestPublicClass(Class<?> clazz) {
+        Class<?> candidate = clazz;
+        while (!Modifier.isPublic(candidate.getModifiers())) {
+            candidate = candidate.getSuperclass();
+        }
+        return candidate;
     }
 
     private static String capitalize(String name) {
@@ -163,56 +187,14 @@ public final class ReflectiveMessagePopulator {
         return camelCase.toString();
     }
 
-    private Object valueFor(Type type) {
-        return scalarValueFor(type)
+    private Object valueFor(Type type, FieldPath fieldPath, String schemaTypeName) {
+        Optional<Object> leafValue = (type instanceof Class<?> clazz)
+                ? leafValueSource.valueFor(clazz, fieldPath, schemaTypeName, random)
+                : Optional.empty();
+        return leafValue
                 .or(() -> containerValueFor(type))
-                .or(() -> uuidValueFor(type))
-                .or(() -> baseRecordsValueFor(type))
                 .or(() -> structValueFor(type))
                 .orElseThrow(() -> new UnsupportedOperationException("Don't know how to populate a field of type " + type));
-    }
-
-    /**
-     * Flat, non-recursive leaf values: primitives, their boxed equivalents, and the handful of built-in
-     * reference types ({@code String}, {@code byte[]}, {@code ByteBuffer}) treated as opaque blobs rather
-     * than structures to recurse into. Returns {@link Optional#empty()} for any other type, deferring to
-     * {@link #valueFor}'s remaining checks.
-     */
-    private Optional<Object> scalarValueFor(Type type) {
-        if (type == short.class || type == Short.class) {
-            return Optional.of((short) (1 + randomInt(Short.MAX_VALUE)));
-        }
-        if (type == int.class || type == Integer.class) {
-            return Optional.of(1 + randomInt(Integer.MAX_VALUE - 1));
-        }
-        if (type == long.class || type == Long.class) {
-            return Optional.of(1L + randomInt(Integer.MAX_VALUE - 1));
-        }
-        if (type == byte.class || type == Byte.class) {
-            return Optional.of((byte) (1 + randomInt(Byte.MAX_VALUE)));
-        }
-        if (type == boolean.class || type == Boolean.class) {
-            return Optional.of(true);
-        }
-        if (type == double.class || type == Double.class) {
-            return Optional.of(1.0 + random.nextInt(1_000_000));
-        }
-        if (type == String.class) {
-            return Optional.of("value-" + random.nextInt(1_000_000));
-        }
-        if (type == byte[].class) {
-            return Optional.of(randomBytes());
-        }
-        if (type == ByteBuffer.class) {
-            return Optional.of(ByteBuffer.wrap(randomBytes()));
-        }
-        return Optional.empty();
-    }
-
-    private byte[] randomBytes() {
-        byte[] bytes = new byte[4 + random.nextInt(8)];
-        random.nextBytes(bytes);
-        return bytes;
     }
 
     /**
@@ -230,20 +212,6 @@ public final class ReflectiveMessagePopulator {
         return Optional.empty();
     }
 
-    private Optional<Object> uuidValueFor(Type type) {
-        if (type instanceof Class<?> clazz && isUuidType(clazz)) {
-            return Optional.of(newUuid(clazz));
-        }
-        return Optional.empty();
-    }
-
-    private Optional<Object> baseRecordsValueFor(Type type) {
-        if (type instanceof Class<?> clazz && isBaseRecordsType(clazz)) {
-            return Optional.of(emptyRecords(clazz));
-        }
-        return Optional.empty();
-    }
-
     private Optional<Object> structValueFor(Type type) {
         if (type instanceof Class<?> structClass) {
             return Optional.of(newStruct(structClass));
@@ -251,41 +219,18 @@ public final class ReflectiveMessagePopulator {
         return Optional.empty();
     }
 
-    private int randomInt(int maxValue) {
-        return random.nextInt(maxValue);
-    }
-
     private List<Object> listValueFor(Type elementType) {
         List<Object> elements = new ArrayList<>();
         int size = 1 + random.nextInt(2);
         for (int i = 0; i < size; i++) {
-            elements.add(valueFor(elementType));
+            elements.add(valueFor(elementType, null, null));
         }
         return elements;
     }
 
-    @SuppressWarnings("java:S1872") // No common supertype exists to instanceof against: Kroxylicious's and
-    // Kafka's Uuid are unrelated classes in unrelated packages, matched here by name on purpose.
-    private static boolean isUuidType(Class<?> clazz) {
-        return UUID_CLASS_NAMES.contains(clazz.getName());
-    }
-
-    private Object newUuid(Class<?> uuidClass) {
-        try {
-            Constructor<?> constructor = uuidClass.getDeclaredConstructor(long.class, long.class);
-            return constructor.newInstance(random.nextLong(), random.nextLong());
-        }
-        catch (ReflectiveOperationException e) {
-            throw new IllegalStateException("Failed to construct " + uuidClass + " via its (long, long) constructor", e);
-        }
-    }
-
-    @SuppressWarnings("java:S1872") // No common supertype exists to instanceof against: Kroxylicious's and
-    // Kafka's ImplicitLinkedHashMultiCollection are unrelated classes in unrelated packages, matched here
-    // by name on purpose.
     private static boolean isMultiCollectionType(Class<?> clazz) {
         for (Class<?> ancestor = clazz.getSuperclass(); ancestor != null; ancestor = ancestor.getSuperclass()) {
-            if (MULTI_COLLECTION_CLASS_NAMES.contains(ancestor.getName())) {
+            if (KroxyliciousSerdes.isApiType(ancestor, MULTI_COLLECTION_RELATIVE_NAME) || KafkaSerdes.isApiType(ancestor, MULTI_COLLECTION_RELATIVE_NAME)) {
                 return true;
             }
         }
@@ -299,7 +244,7 @@ public final class ReflectiveMessagePopulator {
             Method add = findSingleArgAddMethod(collectionClass);
             int size = 1 + random.nextInt(2);
             for (int i = 0; i < size; i++) {
-                add.invoke(collection, valueFor(elementType));
+                add.invoke(collection, valueFor(elementType, null, null));
             }
             return collection;
         }
@@ -315,28 +260,6 @@ public final class ReflectiveMessagePopulator {
             }
         }
         throw new IllegalStateException("No single-argument add(...) method found on " + collectionClass);
-    }
-
-    @SuppressWarnings("java:S1872") // No common supertype exists to instanceof against: Kroxylicious's and
-    // Kafka's BaseRecords are unrelated interfaces in unrelated packages, matched here by name on purpose.
-    private static boolean isBaseRecordsType(Class<?> clazz) {
-        return BASE_RECORDS_CLASS_NAMES.contains(clazz.getName());
-    }
-
-    /**
-     * {@code BaseRecords} is an interface with no general-purpose implementation to populate
-     * reflectively; the canonical empty records value is a leaf-value substitution, the same kind of
-     * move as using {@code Uuid.ZERO_UUID}-shaped construction or an empty {@code ByteBuffer} - not an
-     * attempt to fabricate a real record batch.
-     */
-    private static Object emptyRecords(Class<?> baseRecordsClass) {
-        try {
-            Class<?> memoryRecordsClass = Class.forName(baseRecordsClass.getPackageName() + ".MemoryRecords");
-            return memoryRecordsClass.getField("EMPTY").get(null);
-        }
-        catch (ReflectiveOperationException e) {
-            throw new IllegalStateException("Failed to look up MemoryRecords.EMPTY alongside " + baseRecordsClass, e);
-        }
     }
 
     private Object newStruct(Class<?> structClass) {

--- a/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/ReflectiveMessagePopulator.java
+++ b/kroxylicious-fidelity-harness/src/main/java/io/kroxylicious/fidelity/ReflectiveMessagePopulator.java
@@ -13,8 +13,10 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
@@ -50,27 +52,16 @@ public final class ReflectiveMessagePopulator {
     private static final Set<String> BASE_RECORDS_CLASS_NAMES = Set.of(
             "io.kroxylicious.kafka.common.record.internal.BaseRecords",
             "org.apache.kafka.common.record.internal.BaseRecords");
+    private static final Set<String> TAGGED_FIELDS_TYPE_NAMES = Set.of(
+            "io.kroxylicious.kafka.common.protocol.types.TaggedFields",
+            "org.apache.kafka.common.protocol.types.TaggedFields");
 
     private final Random random;
-    private final Short messageVersion;
+    private final short messageVersion;
 
-    private ReflectiveMessagePopulator(Random random, Short messageVersion) {
+    private ReflectiveMessagePopulator(Random random, short messageVersion) {
         this.random = random;
         this.messageVersion = messageVersion;
-    }
-
-    /**
-     * Populates {@code message}'s fields with deterministic non-default values derived from {@code seed}.
-     * No schema/version information is used, so a primitive field left at a constructor-assigned
-     * non-zero default (a schema-declared default value) is not overwritten, on the assumption that such
-     * a value is exactly the one the field must hold below the version it was introduced in.
-     *
-     * @param message the instance to populate
-     * @param seed the seed controlling the generated values
-     */
-    @SuppressFBWarnings("PREDICTABLE_RANDOM") // Deterministic pseudorandomness is the point: reproducible test fixtures, not security relevant
-    public static void populate(Object message, long seed) {
-        new ReflectiveMessagePopulator(new Random(seed), null).populate(message);
     }
 
     /**
@@ -89,34 +80,27 @@ public final class ReflectiveMessagePopulator {
     }
 
     private void populate(Object message) {
-        Set<String> schemaFieldNames = messageVersion == null ? null : schemaFieldNamesAt(message.getClass(), messageVersion);
-        for (Field field : message.getClass().getDeclaredFields()) {
+        Set<String> schemaFieldNames = schemaFieldNamesAt(message.getClass(), messageVersion);
+        // Fields outside the target version's schema (not yet introduced, or dropped again before
+        // this version - specs aren't purely additive) must keep their constructor default: it's the
+        // only value the generated write() accepts for them at this version.
+        Arrays.stream(message.getClass().getDeclaredFields()).filter(field -> {
             int modifiers = field.getModifiers();
             boolean generatorInternal = Modifier.isStatic(modifiers) || Modifier.isPrivate(modifiers);
-            boolean outsideSchema = schemaFieldNames != null && !schemaFieldNames.contains(field.getName());
-            // Fields outside the target version's schema (not yet introduced, or dropped again before
-            // this version - specs aren't purely additive) must keep their constructor default: it's the
-            // only value the generated write() accepts for them at this version.
-            if (generatorInternal || outsideSchema) {
-                continue;
-            }
-            field.setAccessible(true);
-            Class<?> type = field.getType();
-            try {
-                // Without schema information we can't tell whether a primitive's constructor-assigned
-                // non-zero value (e.g. an enum-like byte defaulting to 1) is a schema-declared default
-                // that write() requires below its introduction version, so it's left alone in that case.
-                // Once schemaFieldNames has already restricted us to fields the target version's schema
-                // actually declares, no such guard is needed - the field is safe to overwrite outright.
-                boolean unknownSchemaPrimitiveDefault = schemaFieldNames == null && type.isPrimitive() && !isDefaultPrimitiveValue(type, field.get(message));
-                if (unknownSchemaPrimitiveDefault) {
-                    continue;
-                }
-                field.set(message, valueFor(field.getGenericType()));
-            }
-            catch (IllegalAccessException e) {
-                throw new IllegalStateException("Failed to populate field " + field, e);
-            }
+            boolean outsideSchema = !schemaFieldNames.contains(field.getName());
+            return !generatorInternal && !outsideSchema;
+        }).forEach(field -> invokeSetterForField(message, field));
+    }
+
+    private void invokeSetterForField(Object message, Field field) {
+        String name = field.getName();
+        Class<?> type = field.getType();
+        try {
+            Method setter = message.getClass().getMethod("set" + capitalize(name), type);
+            setter.invoke(message, valueFor(field.getGenericType()));
+        }
+        catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to populate field " + field, e);
         }
     }
 
@@ -137,14 +121,36 @@ public final class ReflectiveMessagePopulator {
             Set<String> names = new HashSet<>();
             for (Object boundField : boundFields) {
                 Object fieldDef = boundField.getClass().getField("def").get(boundField);
-                String snakeCaseName = (String) fieldDef.getClass().getField("name").get(fieldDef);
-                names.add(toCamelCase(snakeCaseName));
+                addFieldNames(fieldDef, names);
             }
             return names;
         }
         catch (ReflectiveOperationException e) {
             throw new IllegalStateException("Failed to read schema fields for " + clazz + " at version " + version, e);
         }
+    }
+
+    /**
+     * A top-level {@code Field} contributes its own name, except a {@code TaggedFieldsSection}, whose
+     * name is the synthetic {@code "_tagged_fields"} marker rather than a real Java field - its actual
+     * schema-declared fields (e.g. {@code replicaDirectoryId}) live one level down, keyed by tag, inside
+     * its {@code TaggedFields} type.
+     */
+    private static void addFieldNames(Object fieldDef, Set<String> names) throws ReflectiveOperationException {
+        Object type = fieldDef.getClass().getField("type").get(fieldDef);
+        if (TAGGED_FIELDS_TYPE_NAMES.contains(type.getClass().getName())) {
+            Map<?, ?> taggedFields = (Map<?, ?>) type.getClass().getMethod("fields").invoke(type);
+            for (Object taggedFieldDef : taggedFields.values()) {
+                addFieldNames(taggedFieldDef, names);
+            }
+            return;
+        }
+        String snakeCaseName = (String) fieldDef.getClass().getField("name").get(fieldDef);
+        names.add(toCamelCase(snakeCaseName));
+    }
+
+    private static String capitalize(String name) {
+        return Character.toUpperCase(name.charAt(0)) + name.substring(1);
     }
 
     private static String toCamelCase(String snakeCaseName) {
@@ -155,28 +161,6 @@ public final class ReflectiveMessagePopulator {
             camelCase.append(Character.toUpperCase(word.charAt(0))).append(word.substring(1));
         }
         return camelCase.toString();
-    }
-
-    private static boolean isDefaultPrimitiveValue(Class<?> type, Object currentValue) {
-        if (type == short.class) {
-            return ((Short) currentValue) == 0;
-        }
-        if (type == int.class) {
-            return ((Integer) currentValue) == 0;
-        }
-        if (type == long.class) {
-            return ((Long) currentValue) == 0L;
-        }
-        if (type == byte.class) {
-            return ((Byte) currentValue) == 0;
-        }
-        if (type == boolean.class) {
-            return !((Boolean) currentValue);
-        }
-        if (type == double.class) {
-            return ((Double) currentValue) == 0.0;
-        }
-        throw new IllegalStateException("Unhandled primitive type " + type);
     }
 
     private Object valueFor(Type type) {

--- a/kroxylicious-fidelity-harness/src/test/java/io/kroxylicious/fidelity/InRangeLeafValueSourceTest.java
+++ b/kroxylicious-fidelity-harness/src/test/java/io/kroxylicious/fidelity/InRangeLeafValueSourceTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.fidelity;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.kafka.common.Uuid;
+import io.kroxylicious.kafka.common.record.internal.BaseRecords;
+import io.kroxylicious.kafka.common.record.internal.MemoryRecords;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InRangeLeafValueSourceTest {
+
+    private static final long SEED = 42L;
+
+    private final InRangeLeafValueSource source = new InRangeLeafValueSource();
+
+    @Test
+    void shouldPopulateShortWithNonZeroValue() {
+        // Given
+        Random random = new Random(SEED);
+
+        // When
+        Optional<Object> value = source.valueFor(short.class, null, null, random);
+
+        // Then
+        assertThat(value).isPresent();
+        assertThat((Short) value.orElseThrow()).isNotZero();
+    }
+
+    @Test
+    void shouldPopulateUint16FieldWithinRange() {
+        // Given - port-style fields are Java int but wire-typed UINT16 (an unsigned short), so the
+        // generated setter rejects anything outside 0..65535, unlike a genuine INT32 field.
+        Random random = new Random(SEED);
+
+        // When
+        Optional<Object> value = source.valueFor(int.class, null, "UINT16", random);
+
+        // Then
+        assertThat(value).isPresent();
+        assertThat((Integer) value.orElseThrow()).isBetween(0, 65535);
+    }
+
+    @Test
+    void shouldPopulatePlainIntWithoutUint16Bounding() {
+        // Given
+        Random random = new Random(SEED);
+
+        // When
+        Optional<Object> value = source.valueFor(int.class, null, "INT32", random);
+
+        // Then
+        assertThat(value).isPresent();
+        assertThat((Integer) value.orElseThrow()).isNotZero();
+    }
+
+    @Test
+    void shouldPopulateNonEmptyString() {
+        // Given
+        Random random = new Random(SEED);
+
+        // When
+        Optional<Object> value = source.valueFor(String.class, null, null, random);
+
+        // Then
+        assertThat(value).isPresent();
+        assertThat((String) value.orElseThrow()).isNotEmpty();
+    }
+
+    @Test
+    void shouldPopulateNonEmptyByteArray() {
+        // Given
+        Random random = new Random(SEED);
+
+        // When
+        Optional<Object> value = source.valueFor(byte[].class, null, null, random);
+
+        // Then
+        assertThat(value).isPresent();
+        assertThat((byte[]) value.orElseThrow()).isNotEmpty();
+    }
+
+    @Test
+    void shouldPopulateNonEmptyByteBuffer() {
+        // Given
+        Random random = new Random(SEED);
+
+        // When
+        Optional<Object> value = source.valueFor(ByteBuffer.class, null, null, random);
+
+        // Then
+        assertThat(value).isPresent();
+        assertThat(((ByteBuffer) value.orElseThrow()).remaining()).isPositive();
+    }
+
+    @Test
+    void shouldConstructNonZeroUuid() {
+        // Given
+        Random random = new Random(SEED);
+
+        // When
+        Optional<Object> value = source.valueFor(Uuid.class, null, null, random);
+
+        // Then
+        assertThat(value).isPresent();
+        assertThat(value.orElseThrow()).isInstanceOf(Uuid.class).isNotEqualTo(Uuid.ZERO_UUID);
+    }
+
+    @Test
+    void shouldSubstituteEmptyRecordsForBaseRecords() {
+        // Given
+        Random random = new Random(SEED);
+
+        // When
+        Optional<Object> value = source.valueFor(BaseRecords.class, null, null, random);
+
+        // Then
+        assertThat(value).contains(MemoryRecords.EMPTY);
+    }
+
+    @Test
+    void shouldReturnEmptyForAnUnhandledType() {
+        // Given
+        Random random = new Random(SEED);
+
+        // When
+        Optional<Object> value = source.valueFor(Object.class, null, null, random);
+
+        // Then
+        assertThat(value).isEmpty();
+    }
+}

--- a/kroxylicious-fidelity-harness/src/test/java/io/kroxylicious/fidelity/KafkaSerdesTest.java
+++ b/kroxylicious-fidelity-harness/src/test/java/io/kroxylicious/fidelity/KafkaSerdesTest.java
@@ -8,8 +8,38 @@ package io.kroxylicious.fidelity;
 import java.util.List;
 
 import org.apache.kafka.common.message.RequestHeaderData;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class KafkaSerdesTest extends AbstractSerdesTest<RequestHeaderData> {
+
+    @Test
+    void shouldBuildFullyQualifiedApiTypeName() {
+        // When
+        String name = KafkaSerdes.apiType("common.Uuid");
+
+        // Then
+        assertThat(name).isEqualTo("org.apache.kafka.common.Uuid");
+    }
+
+    @Test
+    void shouldMatchTheNamedApiType() {
+        // When / Then
+        assertThat(KafkaSerdes.isApiType(org.apache.kafka.common.Uuid.class, "common.Uuid")).isTrue();
+    }
+
+    @Test
+    void shouldNotMatchAnUnrelatedType() {
+        // When / Then
+        assertThat(KafkaSerdes.isApiType(String.class, "common.Uuid")).isFalse();
+    }
+
+    @Test
+    void shouldNotMatchTheOtherNamespacesType() {
+        // When / Then
+        assertThat(KafkaSerdes.isApiType(io.kroxylicious.kafka.common.Uuid.class, "common.Uuid")).isFalse();
+    }
 
     private static RequestHeaderData newMessage() {
         return new RequestHeaderData();

--- a/kroxylicious-fidelity-harness/src/test/java/io/kroxylicious/fidelity/KroxyliciousSerdesTest.java
+++ b/kroxylicious-fidelity-harness/src/test/java/io/kroxylicious/fidelity/KroxyliciousSerdesTest.java
@@ -7,9 +7,40 @@ package io.kroxylicious.fidelity;
 
 import java.util.List;
 
+import org.junit.jupiter.api.Test;
+
 import io.kroxylicious.kafka.common.message.RequestHeaderData;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class KroxyliciousSerdesTest extends AbstractSerdesTest<RequestHeaderData> {
+
+    @Test
+    void shouldBuildFullyQualifiedApiTypeName() {
+        // When
+        String name = KroxyliciousSerdes.apiType("common.Uuid");
+
+        // Then
+        assertThat(name).isEqualTo("io.kroxylicious.kafka.common.Uuid");
+    }
+
+    @Test
+    void shouldMatchTheNamedApiType() {
+        // When / Then
+        assertThat(KroxyliciousSerdes.isApiType(io.kroxylicious.kafka.common.Uuid.class, "common.Uuid")).isTrue();
+    }
+
+    @Test
+    void shouldNotMatchAnUnrelatedType() {
+        // When / Then
+        assertThat(KroxyliciousSerdes.isApiType(String.class, "common.Uuid")).isFalse();
+    }
+
+    @Test
+    void shouldNotMatchTheOtherNamespacesType() {
+        // When / Then
+        assertThat(KroxyliciousSerdes.isApiType(org.apache.kafka.common.Uuid.class, "common.Uuid")).isFalse();
+    }
 
     private static RequestHeaderData newMessage() {
         return new RequestHeaderData();

--- a/kroxylicious-fidelity-harness/src/test/java/io/kroxylicious/fidelity/ReflectiveMessagePopulatorTest.java
+++ b/kroxylicious-fidelity-harness/src/test/java/io/kroxylicious/fidelity/ReflectiveMessagePopulatorTest.java
@@ -9,7 +9,12 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import io.kroxylicious.kafka.common.message.AddPartitionsToTxnRequestData;
+import io.kroxylicious.kafka.common.message.AlterClientQuotasRequestData;
+import io.kroxylicious.kafka.common.message.DescribeClusterRequestData;
+import io.kroxylicious.kafka.common.message.FetchSnapshotRequestData;
 import io.kroxylicious.kafka.common.message.LeaveGroupRequestData;
+import io.kroxylicious.kafka.common.message.ProduceRequestData;
 import io.kroxylicious.kafka.common.message.RequestHeaderData;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,8 +62,8 @@ class ReflectiveMessagePopulatorTest {
         // Then
         assertThat(message.groupId()).isNotNull().isNotEmpty();
         List<LeaveGroupRequestData.MemberIdentity> members = message.members();
-        assertThat(members).isNotEmpty();
-        assertThat(members).allSatisfy(member -> assertThat(member.memberId()).isNotNull().isNotEmpty());
+        assertThat(members).isNotEmpty()
+                .allSatisfy(member -> assertThat(member.memberId()).isNotNull().isNotEmpty());
     }
 
     @Test
@@ -71,6 +76,77 @@ class ReflectiveMessagePopulatorTest {
 
         // Then
         assertThat(message.unknownTaggedFields()).isEmpty();
+    }
+
+    @Test
+    void shouldPopulateDoubleAndBooleanFields() {
+        // Given
+        AlterClientQuotasRequestData.OpData message = new AlterClientQuotasRequestData.OpData();
+
+        // When
+        ReflectiveMessagePopulator.populate(message, 42L);
+
+        // Then
+        assertThat(message.key()).isNotNull().isNotEmpty();
+        assertThat(message.value()).isNotZero();
+        assertThat(message.remove()).isTrue();
+    }
+
+    @Test
+    void shouldPopulateLongUuidAndNestedSingularStructFields() {
+        // Given
+        FetchSnapshotRequestData.PartitionSnapshot message = new FetchSnapshotRequestData.PartitionSnapshot();
+
+        // When
+        ReflectiveMessagePopulator.populate(message, 42L);
+
+        // Then
+        assertThat(message.position()).isNotZero();
+        assertThat(message.replicaDirectoryId()).isNotEqualTo(io.kroxylicious.kafka.common.Uuid.ZERO_UUID);
+        assertThat(message.snapshotId().endOffset()).isNotZero();
+    }
+
+    @Test
+    void shouldNotOverwriteAConstructorAssignedNonZeroDefault() {
+        // Given
+        DescribeClusterRequestData message = new DescribeClusterRequestData();
+
+        // When
+        ReflectiveMessagePopulator.populate(message, 42L);
+
+        // Then - endpointType defaults to (byte) 1 in the constructor; that specific value is the only
+        // one write() accepts below the version it was introduced in, so populate() must leave it alone
+        // rather than overwrite it with an arbitrary non-default value.
+        assertThat(message.endpointType()).isEqualTo((byte) 1);
+    }
+
+    @Test
+    void shouldPopulateBaseRecordsFieldsWithEmptyRecords() {
+        // Given
+        ProduceRequestData.PartitionProduceData message = new ProduceRequestData.PartitionProduceData();
+
+        // When
+        ReflectiveMessagePopulator.populate(message, 42L);
+
+        // Then - BaseRecords is an interface with no general-purpose implementation to populate
+        // reflectively; substituting the canonical empty records is the same kind of leaf-value
+        // substitution as ByteBuffer/Uuid, not an attempt to fabricate a real record batch.
+        assertThat(message.records()).isNotNull();
+    }
+
+    @Test
+    void shouldNotPopulateFieldsExcludedFromTheTargetVersionsSchema() {
+        // Given
+        AddPartitionsToTxnRequestData message = new AddPartitionsToTxnRequestData();
+
+        // When - v3AndBelowTransactionalId and its siblings were dropped from the schema by version 4,
+        // replaced by the transactions field; both are still declared on the Java class (for backward
+        // compatible reads) but only one set is actually part of the highest version's wire schema.
+        ReflectiveMessagePopulator.populate(message, message.highestSupportedVersion(), 42L);
+
+        // Then
+        assertThat(message.v3AndBelowTransactionalId()).isEmpty();
+        assertThat((Iterable<?>) message.transactions()).isNotEmpty();
     }
 
     @Test

--- a/kroxylicious-fidelity-harness/src/test/java/io/kroxylicious/fidelity/ReflectiveMessagePopulatorTest.java
+++ b/kroxylicious-fidelity-harness/src/test/java/io/kroxylicious/fidelity/ReflectiveMessagePopulatorTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.fidelity;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.kafka.common.message.LeaveGroupRequestData;
+import io.kroxylicious.kafka.common.message.RequestHeaderData;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReflectiveMessagePopulatorTest {
+
+    @Test
+    void shouldPopulateFlatPrimitiveAndStringFields() {
+        // Given
+        RequestHeaderData message = new RequestHeaderData();
+
+        // When
+        ReflectiveMessagePopulator.populate(message, 42L);
+
+        // Then
+        assertThat(message.requestApiKey()).isNotZero();
+        assertThat(message.requestApiVersion()).isNotZero();
+        assertThat(message.correlationId()).isNotZero();
+        assertThat(message.clientId()).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    void shouldPopulateKafkaNamespaceFieldsTheSameWay() {
+        // Given
+        org.apache.kafka.common.message.RequestHeaderData message = new org.apache.kafka.common.message.RequestHeaderData();
+
+        // When
+        ReflectiveMessagePopulator.populate(message, 42L);
+
+        // Then
+        assertThat(message.requestApiKey()).isNotZero();
+        assertThat(message.requestApiVersion()).isNotZero();
+        assertThat(message.correlationId()).isNotZero();
+        assertThat(message.clientId()).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    void shouldPopulateNestedStructListFields() {
+        // Given
+        LeaveGroupRequestData message = new LeaveGroupRequestData();
+
+        // When
+        ReflectiveMessagePopulator.populate(message, 42L);
+
+        // Then
+        assertThat(message.groupId()).isNotNull().isNotEmpty();
+        List<LeaveGroupRequestData.MemberIdentity> members = message.members();
+        assertThat(members).isNotEmpty();
+        assertThat(members).allSatisfy(member -> assertThat(member.memberId()).isNotNull().isNotEmpty());
+    }
+
+    @Test
+    void shouldNotFabricateUnknownTaggedFields() {
+        // Given
+        RequestHeaderData message = new RequestHeaderData();
+
+        // When
+        ReflectiveMessagePopulator.populate(message, 42L);
+
+        // Then
+        assertThat(message.unknownTaggedFields()).isEmpty();
+    }
+
+    @Test
+    void shouldBeReproducibleForTheSameSeed() {
+        // Given
+        RequestHeaderData first = new RequestHeaderData();
+        RequestHeaderData second = new RequestHeaderData();
+
+        // When
+        ReflectiveMessagePopulator.populate(first, 42L);
+        ReflectiveMessagePopulator.populate(second, 42L);
+
+        // Then
+        assertThat(second).usingRecursiveComparison().isEqualTo(first);
+    }
+}

--- a/kroxylicious-fidelity-harness/src/test/java/io/kroxylicious/fidelity/ReflectiveMessagePopulatorTest.java
+++ b/kroxylicious-fidelity-harness/src/test/java/io/kroxylicious/fidelity/ReflectiveMessagePopulatorTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.kafka.common.message.AddPartitionsToTxnRequestData;
+import io.kroxylicious.kafka.common.message.AddRaftVoterRequestData;
 import io.kroxylicious.kafka.common.message.AlterClientQuotasRequestData;
 import io.kroxylicious.kafka.common.message.DescribeClusterRequestData;
 import io.kroxylicious.kafka.common.message.FetchSnapshotRequestData;
@@ -149,6 +150,19 @@ class ReflectiveMessagePopulatorTest {
         // Then
         assertThat(message.v3AndBelowTransactionalId()).isEmpty();
         assertThat((Iterable<?>) message.transactions()).isNotEmpty();
+    }
+
+    @Test
+    void shouldPopulateUint16FieldsWithinRange() {
+        // Given
+        AddRaftVoterRequestData.Listener message = new AddRaftVoterRequestData.Listener();
+
+        // When
+        ReflectiveMessagePopulator.populate(message, message.highestSupportedVersion(), SEED);
+
+        // Then - port is wire-typed UINT16 (an unsigned short); the generated setter rejects values
+        // outside 0..65535, unlike a plain INT32 field where any int is valid.
+        assertThat(message.port()).isBetween(0, 65535);
     }
 
     @Test

--- a/kroxylicious-fidelity-harness/src/test/java/io/kroxylicious/fidelity/ReflectiveMessagePopulatorTest.java
+++ b/kroxylicious-fidelity-harness/src/test/java/io/kroxylicious/fidelity/ReflectiveMessagePopulatorTest.java
@@ -21,13 +21,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ReflectiveMessagePopulatorTest {
 
+    private static final long SEED = 42L;
+
     @Test
     void shouldPopulateFlatPrimitiveAndStringFields() {
         // Given
         RequestHeaderData message = new RequestHeaderData();
 
         // When
-        ReflectiveMessagePopulator.populate(message, 42L);
+        ReflectiveMessagePopulator.populate(message, message.highestSupportedVersion(), SEED);
 
         // Then
         assertThat(message.requestApiKey()).isNotZero();
@@ -42,7 +44,7 @@ class ReflectiveMessagePopulatorTest {
         org.apache.kafka.common.message.RequestHeaderData message = new org.apache.kafka.common.message.RequestHeaderData();
 
         // When
-        ReflectiveMessagePopulator.populate(message, 42L);
+        ReflectiveMessagePopulator.populate(message, message.highestSupportedVersion(), SEED);
 
         // Then
         assertThat(message.requestApiKey()).isNotZero();
@@ -57,7 +59,7 @@ class ReflectiveMessagePopulatorTest {
         LeaveGroupRequestData message = new LeaveGroupRequestData();
 
         // When
-        ReflectiveMessagePopulator.populate(message, 42L);
+        ReflectiveMessagePopulator.populate(message, message.highestSupportedVersion(), SEED);
 
         // Then
         assertThat(message.groupId()).isNotNull().isNotEmpty();
@@ -72,7 +74,7 @@ class ReflectiveMessagePopulatorTest {
         RequestHeaderData message = new RequestHeaderData();
 
         // When
-        ReflectiveMessagePopulator.populate(message, 42L);
+        ReflectiveMessagePopulator.populate(message, message.highestSupportedVersion(), SEED);
 
         // Then
         assertThat(message.unknownTaggedFields()).isEmpty();
@@ -84,7 +86,7 @@ class ReflectiveMessagePopulatorTest {
         AlterClientQuotasRequestData.OpData message = new AlterClientQuotasRequestData.OpData();
 
         // When
-        ReflectiveMessagePopulator.populate(message, 42L);
+        ReflectiveMessagePopulator.populate(message, message.highestSupportedVersion(), SEED);
 
         // Then
         assertThat(message.key()).isNotNull().isNotEmpty();
@@ -98,7 +100,7 @@ class ReflectiveMessagePopulatorTest {
         FetchSnapshotRequestData.PartitionSnapshot message = new FetchSnapshotRequestData.PartitionSnapshot();
 
         // When
-        ReflectiveMessagePopulator.populate(message, 42L);
+        ReflectiveMessagePopulator.populate(message, message.highestSupportedVersion(), SEED);
 
         // Then
         assertThat(message.position()).isNotZero();
@@ -111,12 +113,12 @@ class ReflectiveMessagePopulatorTest {
         // Given
         DescribeClusterRequestData message = new DescribeClusterRequestData();
 
-        // When
-        ReflectiveMessagePopulator.populate(message, 42L);
+        // When - endpointType is only part of the schema from version 1 onward; at version 0 it's outside
+        // the schema, so populate() must leave it at its constructor-assigned default rather than fabricate
+        // a value write() would then refuse to serialise below version 1.
+        ReflectiveMessagePopulator.populate(message, (short) 0, SEED);
 
-        // Then - endpointType defaults to (byte) 1 in the constructor; that specific value is the only
-        // one write() accepts below the version it was introduced in, so populate() must leave it alone
-        // rather than overwrite it with an arbitrary non-default value.
+        // Then
         assertThat(message.endpointType()).isEqualTo((byte) 1);
     }
 
@@ -126,7 +128,7 @@ class ReflectiveMessagePopulatorTest {
         ProduceRequestData.PartitionProduceData message = new ProduceRequestData.PartitionProduceData();
 
         // When
-        ReflectiveMessagePopulator.populate(message, 42L);
+        ReflectiveMessagePopulator.populate(message, message.highestSupportedVersion(), SEED);
 
         // Then - BaseRecords is an interface with no general-purpose implementation to populate
         // reflectively; substituting the canonical empty records is the same kind of leaf-value
@@ -142,7 +144,7 @@ class ReflectiveMessagePopulatorTest {
         // When - v3AndBelowTransactionalId and its siblings were dropped from the schema by version 4,
         // replaced by the transactions field; both are still declared on the Java class (for backward
         // compatible reads) but only one set is actually part of the highest version's wire schema.
-        ReflectiveMessagePopulator.populate(message, message.highestSupportedVersion(), 42L);
+        ReflectiveMessagePopulator.populate(message, message.highestSupportedVersion(), SEED);
 
         // Then
         assertThat(message.v3AndBelowTransactionalId()).isEmpty();
@@ -156,8 +158,8 @@ class ReflectiveMessagePopulatorTest {
         RequestHeaderData second = new RequestHeaderData();
 
         // When
-        ReflectiveMessagePopulator.populate(first, 42L);
-        ReflectiveMessagePopulator.populate(second, 42L);
+        ReflectiveMessagePopulator.populate(first, first.highestSupportedVersion(), SEED);
+        ReflectiveMessagePopulator.populate(second, second.highestSupportedVersion(), SEED);
 
         // Then
         assertThat(second).usingRecursiveComparison().isEqualTo(first);

--- a/kroxylicious-wire-fidelity-tests/src/test/java/io/kroxylicious/fidelity/kafka/AllMessagesFidelityCheckTest.java
+++ b/kroxylicious-wire-fidelity-tests/src/test/java/io/kroxylicious/fidelity/kafka/AllMessagesFidelityCheckTest.java
@@ -8,7 +8,6 @@ package io.kroxylicious.fidelity.kafka;
 
 import java.util.Arrays;
 import java.util.Locale;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -69,7 +68,7 @@ class AllMessagesFidelityCheckTest {
     }
 
     @ParameterizedTest
-    @MethodSource("highestVersionMessages")
+    @MethodSource("allMessageVersions")
     void kroxyliciousShouldReadPopulatedKafkaSerialisedMessage(short version, ApiMessage kroxyliciousMessage, org.apache.kafka.common.protocol.ApiMessage kafkaMessage) {
         // Given
         ReflectiveMessagePopulator.populate(kafkaMessage, version, version);
@@ -86,7 +85,7 @@ class AllMessagesFidelityCheckTest {
     }
 
     @ParameterizedTest
-    @MethodSource("highestVersionMessages")
+    @MethodSource("allMessageVersions")
     void kafkaShouldReadPopulatedKroxyliciousSerialisedMessage(short version, ApiMessage kroxyliciousMessage, org.apache.kafka.common.protocol.ApiMessage kafkaMessage) {
         // Given
         ReflectiveMessagePopulator.populate(kroxyliciousMessage, version, version);
@@ -103,43 +102,27 @@ class AllMessagesFidelityCheckTest {
     }
 
     static Stream<Arguments> allMessageVersions() {
-        return allApiKeyMessages(AllMessagesFidelityCheckTest::versionedMessageStream);
-    }
-
-    /**
-     * At each spec's highest supported version, every field the generated class declares is guaranteed
-     * to be part of that version's schema - no field can be "not yet introduced" relative to the max
-     * version. Populated-instance tests are scoped to this one version per spec because populating a
-     * field the target version's schema doesn't include trips the generated write()'s own
-     * UnsupportedVersionException guard; extending populated coverage to every version needs the
-     * populator to be schema/version-aware, which is a separate piece of work.
-     */
-    static Stream<Arguments> highestVersionMessages() {
-        return allApiKeyMessages(AllMessagesFidelityCheckTest::highestVersionMessageStream);
-    }
-
-    private static Stream<Arguments> allApiKeyMessages(BiFunction<String, String, Stream<Arguments>> messageStream) {
         Stream<Arguments> clientApiStream = ApiKeys.clientApis().stream()
-                .flatMap(apiKey -> directionalApiStream(apiKey, messageStream));
+                .flatMap(AllMessagesFidelityCheckTest::directionalApiStream);
         Stream<Arguments> brokerApiStream = ApiKeys.brokerApis().stream()
                 .filter(apiKeys -> !ApiKeys.clientApis().contains(apiKeys))
-                .flatMap(apiKey -> dataOnlyApiStream(apiKey, messageStream));
+                .flatMap(AllMessagesFidelityCheckTest::dataOnlyApiStream);
         Stream<Arguments> controllerApiStream = ApiKeys.controllerApis().stream()
                 .filter(apiKeys -> !ApiKeys.clientApis().contains(apiKeys))
-                .flatMap(apiKey -> directionalApiStream(apiKey, messageStream));
+                .flatMap(AllMessagesFidelityCheckTest::directionalApiStream);
 
         return Stream.concat(clientApiStream, Stream.concat(brokerApiStream, controllerApiStream));
     }
 
-    private static Stream<Arguments> directionalApiStream(ApiKeys apiKey, BiFunction<String, String, Stream<Arguments>> messageStream) {
+    private static Stream<Arguments> directionalApiStream(ApiKeys apiKey) {
         String messageName = apiKeyToMessageName(apiKey);
         return Stream.of("Request", "Response")
-                .flatMap(direction -> messageStream.apply(messageName, direction));
+                .flatMap(direction -> versionedMessageStream(messageName, direction));
     }
 
-    private static Stream<Arguments> dataOnlyApiStream(ApiKeys apiKey, BiFunction<String, String, Stream<Arguments>> messageStream) {
+    private static Stream<Arguments> dataOnlyApiStream(ApiKeys apiKey) {
         String messageName = apiKeyToMessageName(apiKey);
-        return messageStream.apply(messageName, "");
+        return versionedMessageStream(messageName, "");
     }
 
     private static String apiKeyToMessageName(ApiKeys apiKey) {
@@ -180,14 +163,6 @@ class AllMessagesFidelityCheckTest {
                         (short) version,
                         kroxyliciousMessage(messageName, direction),
                         kafkaMessage(messageName, direction)));
-    }
-
-    private static Stream<Arguments> highestVersionMessageStream(String messageName, String direction) {
-        short highest = kafkaMessage(messageName, direction).highestSupportedVersion();
-        return Stream.of(Arguments.argumentSet(messageName + direction + " - v" + highest,
-                highest,
-                kroxyliciousMessage(messageName, direction),
-                kafkaMessage(messageName, direction)));
     }
 
     private static org.apache.kafka.common.protocol.ApiMessage kafkaMessage(String messageName, String direction) {

--- a/kroxylicious-wire-fidelity-tests/src/test/java/io/kroxylicious/fidelity/kafka/AllMessagesFidelityCheckTest.java
+++ b/kroxylicious-wire-fidelity-tests/src/test/java/io/kroxylicious/fidelity/kafka/AllMessagesFidelityCheckTest.java
@@ -8,6 +8,7 @@ package io.kroxylicious.fidelity.kafka;
 
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -18,7 +19,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import io.kroxylicious.fidelity.FidelityCheck;
+import io.kroxylicious.fidelity.KafkaSerdes;
+import io.kroxylicious.fidelity.KroxyliciousSerdes;
 import io.kroxylicious.fidelity.ReadResult;
+import io.kroxylicious.fidelity.ReflectiveMessagePopulator;
 import io.kroxylicious.kafka.common.protocol.ApiMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,28 +68,78 @@ class AllMessagesFidelityCheckTest {
         assertThat(result.message()).usingRecursiveComparison().isEqualTo(kroxyliciousMessage);
     }
 
+    @ParameterizedTest
+    @MethodSource("highestVersionMessages")
+    void kroxyliciousShouldReadPopulatedKafkaSerialisedMessage(short version, ApiMessage kroxyliciousMessage, org.apache.kafka.common.protocol.ApiMessage kafkaMessage) {
+        // Given
+        ReflectiveMessagePopulator.populate(kafkaMessage, version, version);
+        byte[] wireBytes = KafkaSerdes.write((org.apache.kafka.common.protocol.Message) kafkaMessage, version);
+
+        // When
+        ReadResult<?> crossResult = KroxyliciousSerdes.read((io.kroxylicious.kafka.common.protocol.Message) kroxyliciousMessage, wireBytes, version);
+        ReadResult<?> selfResult = KafkaSerdes.read(kafkaMessage(kafkaMessage.getClass()), wireBytes, version);
+
+        // Then
+        assertThat(crossResult.error()).isNull();
+        assertThat(crossResult.unreadBytes()).isZero();
+        assertThat(crossResult.message()).usingRecursiveComparison().isEqualTo(selfResult.message());
+    }
+
+    @ParameterizedTest
+    @MethodSource("highestVersionMessages")
+    void kafkaShouldReadPopulatedKroxyliciousSerialisedMessage(short version, ApiMessage kroxyliciousMessage, org.apache.kafka.common.protocol.ApiMessage kafkaMessage) {
+        // Given
+        ReflectiveMessagePopulator.populate(kroxyliciousMessage, version, version);
+        byte[] wireBytes = KroxyliciousSerdes.write((io.kroxylicious.kafka.common.protocol.Message) kroxyliciousMessage, version);
+
+        // When
+        ReadResult<?> crossResult = KafkaSerdes.read((org.apache.kafka.common.protocol.Message) kafkaMessage, wireBytes, version);
+        ReadResult<?> selfResult = KroxyliciousSerdes.read(kroxyliciousMessage(kroxyliciousMessage.getClass()), wireBytes, version);
+
+        // Then
+        assertThat(crossResult.error()).isNull();
+        assertThat(crossResult.unreadBytes()).isZero();
+        assertThat(crossResult.message()).usingRecursiveComparison().isEqualTo(selfResult.message());
+    }
+
     static Stream<Arguments> allMessageVersions() {
+        return allApiKeyMessages(AllMessagesFidelityCheckTest::versionedMessageStream);
+    }
+
+    /**
+     * At each spec's highest supported version, every field the generated class declares is guaranteed
+     * to be part of that version's schema - no field can be "not yet introduced" relative to the max
+     * version. Populated-instance tests are scoped to this one version per spec because populating a
+     * field the target version's schema doesn't include trips the generated write()'s own
+     * UnsupportedVersionException guard; extending populated coverage to every version needs the
+     * populator to be schema/version-aware, which is a separate piece of work.
+     */
+    static Stream<Arguments> highestVersionMessages() {
+        return allApiKeyMessages(AllMessagesFidelityCheckTest::highestVersionMessageStream);
+    }
+
+    private static Stream<Arguments> allApiKeyMessages(BiFunction<String, String, Stream<Arguments>> messageStream) {
         Stream<Arguments> clientApiStream = ApiKeys.clientApis().stream()
-                .flatMap(AllMessagesFidelityCheckTest::directionalApiStream);
+                .flatMap(apiKey -> directionalApiStream(apiKey, messageStream));
         Stream<Arguments> brokerApiStream = ApiKeys.brokerApis().stream()
                 .filter(apiKeys -> !ApiKeys.clientApis().contains(apiKeys))
-                .flatMap(AllMessagesFidelityCheckTest::dataOnlyApiStream);
+                .flatMap(apiKey -> dataOnlyApiStream(apiKey, messageStream));
         Stream<Arguments> controllerApiStream = ApiKeys.controllerApis().stream()
                 .filter(apiKeys -> !ApiKeys.clientApis().contains(apiKeys))
-                .flatMap(AllMessagesFidelityCheckTest::directionalApiStream);
+                .flatMap(apiKey -> directionalApiStream(apiKey, messageStream));
 
         return Stream.concat(clientApiStream, Stream.concat(brokerApiStream, controllerApiStream));
     }
 
-    private static Stream<Arguments> directionalApiStream(ApiKeys apiKey) {
+    private static Stream<Arguments> directionalApiStream(ApiKeys apiKey, BiFunction<String, String, Stream<Arguments>> messageStream) {
         String messageName = apiKeyToMessageName(apiKey);
         return Stream.of("Request", "Response")
-                .flatMap(direction -> versionedMessageStream(messageName, direction));
+                .flatMap(direction -> messageStream.apply(messageName, direction));
     }
 
-    private static Stream<Arguments> dataOnlyApiStream(ApiKeys apiKey) {
+    private static Stream<Arguments> dataOnlyApiStream(ApiKeys apiKey, BiFunction<String, String, Stream<Arguments>> messageStream) {
         String messageName = apiKeyToMessageName(apiKey);
-        return versionedMessageStream(messageName, "");
+        return messageStream.apply(messageName, "");
     }
 
     private static String apiKeyToMessageName(ApiKeys apiKey) {
@@ -128,6 +182,14 @@ class AllMessagesFidelityCheckTest {
                         kafkaMessage(messageName, direction)));
     }
 
+    private static Stream<Arguments> highestVersionMessageStream(String messageName, String direction) {
+        short highest = kafkaMessage(messageName, direction).highestSupportedVersion();
+        return Stream.of(Arguments.argumentSet(messageName + direction + " - v" + highest,
+                highest,
+                kroxyliciousMessage(messageName, direction),
+                kafkaMessage(messageName, direction)));
+    }
+
     private static org.apache.kafka.common.protocol.ApiMessage kafkaMessage(String messageName, String direction) {
         try {
             Class<?> kafkaClass = loadClass(KAFKA_PACKAGE, messageName, direction);
@@ -156,6 +218,15 @@ class AllMessagesFidelityCheckTest {
     private static Class<?> loadClass(String packageName, String messageName, String direction) throws ClassNotFoundException {
         String className = CLASS_NAME_FORMAT.formatted(packageName, messageName, direction);
         return Class.forName(className);
+    }
+
+    private static ApiMessage kroxyliciousMessage(Class<?> kroxyliciousClass) {
+        try {
+            return (ApiMessage) kroxyliciousClass.getDeclaredConstructor().newInstance();
+        }
+        catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to instantiate " + kroxyliciousClass, e);
+        }
     }
 
     private static org.apache.kafka.common.protocol.ApiMessage kafkaMessage(Class<?> kafkaClass) {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds a `ReflectiveMessagePopulator` to `kroxylicious-fidelity-harness` that reflectively
fills a generated `*Data`/struct instance with deterministic, non-default values, and wires
it into `AllMessagesFidelityCheckTest` so every version of every spec is now proven
byte-compatible with a populated instance, not just a default-constructed (all-zero) one.

The populator handles primitives, `String`, `byte[]`/`ByteBuffer`, `Uuid`, nested singular and
list-of-struct fields, `ImplicitLinkedHashMultiCollection`-based collections, and `BaseRecords`
fields (substituted with the canonical empty records) - all detected generically by simple
name/shape so neither the Kroxylicious nor Kafka namespace needs to be imported directly.

Kafka message specs turned out not to be purely additive: some fields are dropped from the
schema again after being introduced (e.g. `v3AndBelowTransactionalId`), so populating
"whatever the class declares" isn't safe at every version. `populate()` gained a version-aware
overload that filters against each class's own `SCHEMAS[version]` array - the same source
generated `write()` code checks internally - so a field outside the target version's schema
keeps its constructor default instead of tripping `write()`'s version guard. With that in
place, populated-instance coverage runs across every supported version of every spec, the same
range the existing empty-instance tests already cover.

### Additional Context

Part of the fidelity-harness work tracked in #4836 ("Fidelity tests cover all ~198 specs with
populated instances"). Out of scope for this PR, tracked separately:
- Malformed-message/error parity (`FidelityCheck.compareErrorHandling`) - deliberately not
  baked into the shared harness as a "must match Kafka's error" assumption.

### Checklist

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update.
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [ ] For user facing changes, add a logchange entry YAML file to `changelog/unreleased/`.

Relates-to: #4836