### PR TITLE
fix(release): preserve changelog/unreleased/.gitkeep across releases

### DIFF
--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -141,7 +141,9 @@ echo "Versioning Kroxylicious as ${RELEASE_VERSION}"
 updateVersions "${INITIAL_VERSION}" "${RELEASE_VERSION}"
 ${SED} -i "s|\\\${changelog.link.prefix}|${CHANGELOG_LINK_PREFIX}|g" changelog/.templates/CHANGELOG.md
 mvn --quiet logchange:release
-git checkout -- changelog/.templates/CHANGELOG.md
+# logchange:release rewrites the CHANGELOG template and empties changelog/unreleased,
+# deleting the .gitkeep that keeps the directory tracked. Restore both.
+git checkout -- changelog/.templates/CHANGELOG.md changelog/unreleased/.gitkeep
 git add changelog/ CHANGELOG.md
 
 replaceInFile "s_:KroxyliciousVersion:.*_:KroxyliciousVersion: ${RELEASE_VERSION}_g" kroxylicious-docs/docs/_assets/attributes.adoc


### PR DESCRIPTION
## Type of change

Bug fix (release tooling)

## Description

`mvn logchange:release` (run by `scripts/stage-release.sh`) empties
`changelog/unreleased/`, which deletes the `.gitkeep` file that keeps the
otherwise-empty directory tracked by git. The subsequent `git add changelog/`
then staged that deletion, so every release removed `.gitkeep`, leaving
contributors without the directory.

This restores `.gitkeep` alongside the CHANGELOG template immediately after
the `logchange:release` step (folded into the existing `git checkout --`),
before the changes are staged. Because the file is restored to its committed
state before `git add changelog/`, the deletion is no longer staged.

Fixes #4842