### PR TITLE
fix(ci): use full commit SHA for staging image tags

### DIFF
--- a/.github/workflows/build-kroxylicious-container-images.yaml
+++ b/.github/workflows/build-kroxylicious-container-images.yaml
@@ -123,7 +123,7 @@ jobs:
           echo "release_version=${POMS_VERSION}" >> $GITHUB_OUTPUT
           echo "image_created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
           echo "output_tarballs=${{ inputs.output-tarballs }}" >> $GITHUB_OUTPUT
-          SHA_TAG="commit-$(git rev-parse --short "${GITHUB_SHA}")"
+          SHA_TAG="commit-${GITHUB_SHA}"
 
           if [[ "${{ inputs.output-tarballs }}" == "true" ]]; then
             # Tarball mode: amd64-only, no push, use Maven image names for compatibility

--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -216,6 +216,33 @@ jobs:
             exit 1
           fi
 
+      - name: Login to container registry
+        if: ${{ vars.REGISTRY_SERVER != '' }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
+        with:
+          registry: ${{ vars.REGISTRY_SERVER }}
+          username: ${{ vars.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - name: 'Verify staged container images exist'
+        # Fail fast, before anything is published, if a staged manifest referenced
+        # by RELEASE_STATE.json is missing from the registry (see issue #4851).
+        if: ${{ inputs.command == 'promote-release' && vars.REGISTRY_SERVER != '' }}
+        run: |
+          missing=0
+          while IFS= read -r ref; do
+            if skopeo inspect --raw "docker://${ref}" > /dev/null 2>&1; then
+              echo "OK: ${ref}"
+            else
+              echo "::error::staged manifest not found: ${ref}"
+              missing=1
+            fi
+          done < <(jq -r '.stagedArtifacts[].images.manifestImage.ref' RELEASE_STATE.json)
+          if [[ "${missing}" -ne 0 ]]; then
+            echo "One or more staged manifests are missing; aborting before the release is published."
+            exit 1
+          fi
+
       - name: 'Transition Central Publishing Portal to desired state'
         env:
           SONATYPE_TOKEN_USERNAME: ${{ vars.KROXYLICIOUS_SONATYPE_TOKEN_USERNAME }}
@@ -264,14 +291,6 @@ jobs:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
           git push origin --delete "${WORK_BRANCH}-rel" || echo "Branch ${WORK_BRANCH}-rel not found (already deleted?)"
-
-      - name: Login to container registry
-        if: ${{ vars.REGISTRY_SERVER != '' }}
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
-        with:
-          registry: ${{ vars.REGISTRY_SERVER }}
-          username: ${{ vars.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
 
       - name: 'Tag release container images'
         if: ${{ inputs.command == 'promote-release' && vars.REGISTRY_SERVER != '' }}

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -177,7 +177,7 @@ jobs:
           VERSION="${{ github.event.inputs.release-version }}"
           # RELEASE_SHA is the pre-merge release commit; it is also what build-kroxylicious-container-images.yaml tagged
           # images with (GITHUB_SHA on the release branch == this commit).
-          SHA_TAG="commit-$(git rev-parse --short "${RELEASE_SHA}")"
+          SHA_TAG="commit-${RELEASE_SHA}"
           REGISTRY="${{ vars.REGISTRY_SERVER }}"
           ORG="${{ vars.REGISTRY_ORGANISATION }}"
           PROXY="${REGISTRY}/${ORG}/${{ vars.PROXY_IMAGE_NAME }}"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The staging container image tag is derived independently in two jobs using `git rev-parse --short`. With `core.abbrev=auto` the abbreviation length scales with the local repository's object count, so the image-build job and the release-state generation can disagree — e.g. the build pushed `commit-4734967` (7 hex) while stage recorded `commit-473496779` (9 hex) in `RELEASE_STATE.json`. Promote then read the 9-hex ref and failed at "Tag release container images" with `manifest unknown`, **after** the release was already public on GitHub + Maven Central.

This PR:
- Uses the **full commit SHA** (drops `--short`) at both call sites that must agree — `build-kroxylicious-container-images.yaml` and `stage_release.yaml` — so the pushed tag and the recorded tag are byte-identical regardless of checkout/object count. (`git rev-parse` on a full SHA is deterministic; verified identical across shallow and full clones.)
- Adds an early **"Verify staged container images exist"** guard in `promote_release.yaml`, placed *before* "Transition Central Publishing Portal" (the point of no return). It `skopeo inspect`s each staged manifest and fails fast with a clear `::error::` message instead of the opaque skopeo failure — so a mismatch is caught before anything is published.

### Additional Context

Fixes #4851. The 0.24.0 release hit this; its container images were re-tagged manually as recovery.

### Post-merge verification

- [ ] After this PR is merge, we'll test fire the stage-release and ensure that the  confirm the `commit-<sha>` tag pushed by `build-kroxylicious-container-images` is identical to the `manifestImage.ref` recorded in `RELEASE_STATE.json` (both should now be the full 40-hex SHA).

### Checklist

- [ ] New tests written (where applicable). _(N/A — CI workflow change; verified via local determinism check and guard control-flow test.)_
- [ ] If making a user-facing change, documentation is provided... _(N/A — release/CI tooling; ephemeral staging tags only, published `:<version>`/`:latest` tags unchanged.)_
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed...).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.
- [ ] For user facing changes, add a logchange entry... _(N/A — not user-facing.)_
