### PR TITLE
fix(authorizer): suppress remaining Identity deprecation warnings

### DIFF
--- a/kroxylicious-authorizer-api/src/main/java/io/kroxylicious/authorizer/service/AuthorizeResult.java
+++ b/kroxylicious-authorizer-api/src/main/java/io/kroxylicious/authorizer/service/AuthorizeResult.java
@@ -22,6 +22,7 @@ import io.kroxylicious.identity.Identity;
  * @param allowed The allowed actions.
  * @param denied The denied actions.
  */
+@SuppressWarnings({ "java:S5738", "removal" })
 public record AuthorizeResult(
                               Identity subject,
                               List<Action> allowed,

--- a/kroxylicious-authorizer-api/src/main/java/io/kroxylicious/authorizer/service/Authorizer.java
+++ b/kroxylicious-authorizer-api/src/main/java/io/kroxylicious/authorizer/service/Authorizer.java
@@ -21,6 +21,7 @@ import io.kroxylicious.identity.Identity;
  * doesn't prescribe any specific kinds of resource or operations. Instead, resource kinds and the operations they support
  * are represented as subclasses of {@link ResourceType}.</p>
  */
+@SuppressWarnings({ "java:S5738", "removal" })
 public interface Authorizer {
 
     /**

--- a/kroxylicious-authorizer-api/src/test/java/io/kroxylicious/authorizer/service/AuthorizeResultTest.java
+++ b/kroxylicious-authorizer-api/src/test/java/io/kroxylicious/authorizer/service/AuthorizeResultTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import io.kroxylicious.proxy.authentication.Subject;
 import io.kroxylicious.proxy.authentication.User;
 
+@SuppressWarnings({ "java:S5738", "removal" })
 class AuthorizeResultTest {
 
     enum TestResource implements ResourceType<TestResource> {

--- a/kroxylicious-authorizer-providers/kroxylicious-authorizer-acl/src/main/java/io/kroxylicious/authorizer/provider/acl/AclAuthorizer.java
+++ b/kroxylicious-authorizer-providers/kroxylicious-authorizer-acl/src/main/java/io/kroxylicious/authorizer/provider/acl/AclAuthorizer.java
@@ -50,6 +50,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  *     according to a simple grammar (see {@code src/main/antlr4/io/kroxylicious/authorizer/provider/acl/parser/AclRules.g4}).</li>
  * </ul>
  */
+@SuppressWarnings({ "java:S5738", "removal" })
 public class AclAuthorizer implements Authorizer {
 
     record ResourceGrants(

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/SimpleAuthorizer.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/SimpleAuthorizer.java
@@ -21,6 +21,7 @@ import io.kroxylicious.authorizer.service.ResourceType;
 import io.kroxylicious.identity.Identity;
 import io.kroxylicious.identity.Principal;
 
+@SuppressWarnings({ "java:S5738", "removal" })
 class SimpleAuthorizer implements Authorizer {
 
     private final Set<AllowedOperation> allowedOperations;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

PR #4831 made the Authorizer API standalone by bridging to the `forRemoval`-deprecated `io.kroxylicious.identity.Identity` type, but missed adding `@SuppressWarnings({ "java:S5738", "removal" })` on several sites that reference it:

- `Authorizer` (interface)
- `AuthorizeResult` (record)
- `AclAuthorizer` (implementation)
- `SimpleAuthorizer` test double (`kroxylicious-authorization` filter tests)
- `AuthorizeResultTest` (also constructs the deprecated `io.kroxylicious.proxy.authentication.Subject`)

### Additional Context

Follow-up to #4831 to clear the remaining Sonarcloud deprecation warnings that slipped through.

### Checklist

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update.
- [x] Existing unit/integration/system tests passing.
- [x] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see DEV_GUIDE.md).
- [ ] For user facing changes, add a logchange entry YAML file to `changelog/unreleased/` (not applicable — no user-facing behaviour change).